### PR TITLE
SAML Audience Update and CSRF Cookie Fix for Cisco Duo SSO

### DIFF
--- a/logicle/authOptions.ts
+++ b/logicle/authOptions.ts
@@ -262,7 +262,7 @@ export const authOptions: any = {
       name: `next-auth.pkce.code_verifier`,
       options: {
         httpOnly: true,
-        sameSite: 'lax',
+        sameSite: 'none',
         path: '/',
         secure: env.isHttps,
         maxAge: 3 * 60, // 3 minutes should more than enough for an authentication

--- a/logicle/lib/env.ts
+++ b/logicle/lib/env.ts
@@ -18,7 +18,7 @@ const env = {
 
   // SAML Jackson configuration
   saml: {
-    issuer: 'https://saml.logicle.com',
+    issuer: `${process.env.APP_URL}`,
     path: '/api/oauth/saml',
     callback: `${process.env.APP_URL}`,
     redirectUrl: `${process.env.APP_URL}` + '/api/oauth/saml',


### PR DESCRIPTION
This PR includes two updates:
- The SAML audience now matches the APP_URL
- Fixed a CSRF error in Cisco Duo SAML SSO by setting the CSRF cookie's SameSite policy to 'None'.