### PR TITLE
[ISSUE-20] - Pinned Assistants Display Incorrectly with Long Names

### DIFF
--- a/logicle/app/chat/components/chatbar/Chatbar.tsx
+++ b/logicle/app/chat/components/chatbar/Chatbar.tsx
@@ -106,7 +106,10 @@ export const Chatbar = () => {
                     url={assistant?.icon ?? undefined}
                     fallback={assistant.name ?? ''}
                   />
-                  <div key={assistant.id} className="flex-1 text-left px-2">
+                  <div
+                    key={assistant.id}
+                    className="flex-1 min-w-0 text-left overflow-hidden text-ellipsis px-2"
+                  >
                     {assistant.name}
                   </div>
                 </Button>


### PR DESCRIPTION
Flex layout do not like children with intrinsic width (i.e. min-width) larger than the parent.
Easy solution: min-width: 0px
