### PR TITLE
[ISSUE-24] - Generic Error (Error messages too generic)

### DIFF
--- a/logicle/app/admin/assistants/page.tsx
+++ b/logicle/app/admin/assistants/page.tsx
@@ -25,6 +25,7 @@ const Assistants = () => {
   const { isLoading, error, data: assistants } = useAssistants()
   const { data: backends, isLoading: isBackendLoading } = useBackends()
   const router = useRouter()
+  const defaultBackend = backends && backends.length > 0 ? backends[0].id : undefined
 
   const modalContext = useConfirmationContext()
   async function onDelete(assistant: Assistant) {
@@ -45,7 +46,6 @@ const Assistants = () => {
   }
 
   const onCreate = async () => {
-    const defaultBackend = backends && backends.length > 0 ? backends[0].id : ''
     const newAssistant = {
       icon: null,
       description: '',
@@ -70,10 +70,6 @@ const Assistants = () => {
     router.push(`/admin/assistants/${response.data.id}`)
   }
 
-  /*function getBackendName(backendId: string) {
-    return backends?.find((backend) => backend.id === backendId)?.name ?? '???'
-  }*/
-
   const columns: Column<Assistant>[] = [
     column(t('table-column-name'), (assistant: Assistant) => (
       <Link variant="ghost" href={`/admin/assistants/${assistant.id}`}>
@@ -95,17 +91,24 @@ const Assistants = () => {
 
   return (
     <WithLoadingAndError isLoading={isLoading || isBackendLoading} error={error}>
-      <div className="h-full flex flex-col">
-        <AdminPageTitle title={t('all-assistants')}>
-          <CreateButton onClick={onCreate} />
-        </AdminPageTitle>
-        <ScrollableTable
-          className="flex-1 text-body1"
-          columns={columns}
-          rows={assistants ?? []}
-          keygen={(t) => t.id}
-        />
-      </div>
+      {backends?.length != 0 ? (
+        <div className="h-full flex flex-col">
+          <AdminPageTitle title={t('all-assistants')}>
+            <CreateButton onClick={onCreate} />
+          </AdminPageTitle>
+          <ScrollableTable
+            className="flex-1 text-body1"
+            columns={columns}
+            rows={assistants ?? []}
+            keygen={(t) => t.id}
+          />
+        </div>
+      ) : (
+        <div className="h-full">
+          <AdminPageTitle title={t('all-assistants')}></AdminPageTitle>
+          {t('cant_create_assistant_if_no_backend')}
+        </div>
+      )}
     </WithLoadingAndError>
   )
 }

--- a/logicle/app/api/assistants/[assistantId]/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/route.ts
@@ -118,7 +118,7 @@ export const DELETE = requireAdmin(
       const interpretedException = interpretDbException(e)
       if (
         interpretedException instanceof KnownDbError &&
-        interpretedException.code == KnownDbErrorCode.CANT_UPDATE_DELETE_FOREIGN_KEY
+        interpretedException.code == KnownDbErrorCode.CONSTRAINT_FOREIGN_KEY
       ) {
         return ApiResponses.foreignKey('Assistant is in use')
       }

--- a/logicle/app/api/backends/[backendId]/route.ts
+++ b/logicle/app/api/backends/[backendId]/route.ts
@@ -35,7 +35,7 @@ export const DELETE = requireAdmin(
       const interpretedException = interpretDbException(e)
       if (
         interpretedException instanceof KnownDbError &&
-        interpretedException.code == KnownDbErrorCode.CANT_UPDATE_DELETE_FOREIGN_KEY
+        interpretedException.code == KnownDbErrorCode.CONSTRAINT_FOREIGN_KEY
       ) {
         return ApiResponses.foreignKey('Backend is in use')
       }

--- a/logicle/app/api/tools/[toolId]/route.ts
+++ b/logicle/app/api/tools/[toolId]/route.ts
@@ -37,7 +37,7 @@ export const DELETE = requireAdmin(async (req: Request, route: { params: { toolI
     const interpretedException = interpretDbException(e)
     if (
       interpretedException instanceof KnownDbError &&
-      interpretedException.code == KnownDbErrorCode.CANT_UPDATE_DELETE_FOREIGN_KEY
+      interpretedException.code == KnownDbErrorCode.CONSTRAINT_FOREIGN_KEY
     ) {
       return ApiResponses.foreignKey('Tool is in use')
     }

--- a/logicle/app/api/users/[userId]/route.ts
+++ b/logicle/app/api/users/[userId]/route.ts
@@ -24,7 +24,7 @@ export const DELETE = requireAdmin(async (req: Request, route: { params: { userI
     const interpretedException = interpretDbException(e)
     if (
       interpretedException instanceof KnownDbError &&
-      interpretedException.code == KnownDbErrorCode.CANT_UPDATE_DELETE_FOREIGN_KEY
+      interpretedException.code == KnownDbErrorCode.CONSTRAINT_FOREIGN_KEY
     ) {
       return ApiResponses.foreignKey('User has some activitity which is not deletable')
     }

--- a/logicle/db/exception.ts
+++ b/logicle/db/exception.ts
@@ -1,7 +1,6 @@
 import ApiResponses from 'app/api/utils/ApiResponses'
 
 export enum KnownDbErrorCode {
-  CANT_UPDATE_DELETE_FOREIGN_KEY = 'foreignKey',
   DUPLICATE_KEY = 'duplicateKey',
   CONSTRAINT_NOT_NULL = 'constraintNotNull',
   CONSTRAINT_FOREIGN_KEY = 'constraintForeignKey',
@@ -20,17 +19,12 @@ export class KnownDbError extends Error {
 export const interpretDbException = (e: any): Error => {
   const { code } = e as any
   switch (code) {
-    case '23503':
-      return new KnownDbError(
-        KnownDbErrorCode.CANT_UPDATE_DELETE_FOREIGN_KEY,
-        'Foreign key violation'
-      )
     case '23505':
-      return new KnownDbError(KnownDbErrorCode.DUPLICATE_KEY, 'Duplicate Key')
     case 'SQLITE_CONSTRAINT_UNIQUE':
       return new KnownDbError(KnownDbErrorCode.DUPLICATE_KEY, 'Duplicate Key')
     case 'SQLITE_CONSTRAINT_NOTNULL':
       return new KnownDbError(KnownDbErrorCode.CONSTRAINT_NOT_NULL, 'Constraint not null')
+    case '23503':
     case 'SQLITE_CONSTRAINT_FOREIGNKEY':
       return new KnownDbError(
         KnownDbErrorCode.CONSTRAINT_FOREIGN_KEY,
@@ -43,7 +37,7 @@ export const interpretDbException = (e: any): Error => {
 export const defaultErrorResponse = (e: Error) => {
   if (e instanceof KnownDbError) {
     switch (e.code) {
-      case KnownDbErrorCode.CANT_UPDATE_DELETE_FOREIGN_KEY:
+      case KnownDbErrorCode.CONSTRAINT_FOREIGN_KEY:
         return ApiResponses.foreignKey(e.message)
       case KnownDbErrorCode.DUPLICATE_KEY:
         return ApiResponses.conflict(e.message)

--- a/logicle/locales/en/common.json
+++ b/logicle/locales/en/common.json
@@ -35,6 +35,7 @@
   "create_assistant_field_system_prompt_description": "The prompt used to initialize conversations",
   "token-limit": "Token Limit",
   "create_assistant_field_token_limit_placeholder": "Indicate a token limit",
+  "cant_create_assistant_if_no_backend": "Can't create an assistant if no backend is defined",
   "temperature": "Temperature",
   "create_assistant_field_temperature_placeholder": "A number from 0 to 1, where 0 means fully repeatable and one means 'creative'",
   "create_assistant_field_temperature_description": "Assistant Temperature (creativity)",


### PR DESCRIPTION
Issue #24 

case 1: try to add a new assistant without any backend configured

The assistant creation is now prevented, and a message (improvable) is shown

case 2: try to delete a backend (openAI) already configured with an assistant connected

The message is now "Backend is in use".

##Note:
As the migration script has been patched, it is necessary to recreate the DB from scratch. Incredibly enough, SQLITE does not support dropping and recreating constraints

Fixes #24