### PR TITLE
Renamed migration files, in order to force db reset

### DIFF
--- a/logicle/db/migrations.ts
+++ b/logicle/db/migrations.ts
@@ -7,8 +7,8 @@ export async function migrateToLatest() {
   // * migrations are execute in lexicographical order
   // * if name is changed, migration will fail
   const migrations: Record<string, Migration> = {
-    '20240223-initialschema': await import('./migrations/20240325-initialschema'),
-    '20240223-jackson': await import('./migrations/20240325-jackson'),
+    '20240325-initialschema': await import('./migrations/20240325-initialschema'),
+    '20240325-jackson': await import('./migrations/20240325-jackson'),
   }
 
   const db = new Kysely<any>({


### PR DESCRIPTION
Follow up of #43
Simply renamed the Kisely migration entries to force a db reinig