### PR TITLE
[ISSUE-42] misleading error message for incorrect login credentials

### DIFF
--- a/logicle/app/auth/login/LoginPanel.tsx
+++ b/logicle/app/auth/login/LoginPanel.tsx
@@ -58,13 +58,15 @@ const Login: FC<Props> = ({ connections }) => {
     try {
       const res = await signinWithCredentials(email, password)
       const json = await res.json()
-      const error = new URL(json.url).searchParams.get('error')
+      const redirectUrl = new URL(json.url)
+      const error = redirectUrl.searchParams.get('error')
+      const code = redirectUrl.searchParams.get('code')
       if (!error) {
         // We need this because using router would not reload the session
         window.location.href = redirectAfterSignIn
       } else {
         // Redirecting to signin?error=... would also be possible here
-        showError(t(error))
+        showError(t(code ?? error))
       }
     } catch (e) {
       showError(t('remote_auth_failure'))
@@ -118,7 +120,11 @@ const Login: FC<Props> = ({ connections }) => {
               className="w-full"
               type="submit"
               color="primary"
-              disabled={!form.formState.isValid || form.formState.isSubmitting || form.formState.isValidating}
+              disabled={
+                !form.formState.isValid ||
+                form.formState.isSubmitting ||
+                form.formState.isValidating
+              }
               size="default"
             >
               {t('sign-in')}

--- a/logicle/authOptions.ts
+++ b/logicle/authOptions.ts
@@ -4,6 +4,7 @@ import { getAccount } from 'models/account'
 import { createUser, getUserByEmail, getUserById } from 'models/user'
 import { Account, AuthError } from 'next-auth'
 import { KyselyAdapter, Database } from '@auth/kysely-adapter'
+import { CredentialsSignin } from '@auth/core/errors' // import is specific to your framework
 import { db } from '@/db/database'
 import { Kysely } from 'kysely'
 import BoxyHQSAMLProvider from 'next-auth/providers/boxyhq-saml'
@@ -52,8 +53,11 @@ const wrappedAdapter = {
   },
 }
 
-class InvalidCredentialsError extends AuthError {
-  static type = 'Invalid Credentials'
+class InvalidCredentialsError extends CredentialsSignin {
+  constructor(code: string) {
+    super(code)
+    this.code = code
+  }
 }
 
 export const authOptions: any = {


### PR DESCRIPTION
Recent nextauth implementations allow to add a "code" to an authentication failure redirect.
Let's use that!

Fixes #42 