### PR TITLE
[ISSUE-40] - User Message Icon Missing in Assistant Chat Preview

### DIFF
--- a/logicle/app/chat/components/ChatMessage.tsx
+++ b/logicle/app/chat/components/ChatMessage.tsx
@@ -3,10 +3,10 @@ import { FC, memo, useContext } from 'react'
 import React from 'react'
 import { UserMessage } from './UserMessage'
 import { AssistantMessage } from './AssistantMessage'
-import ChatPageContext from '@/app/chat/components/context'
 import { MessageDTO, UserAssistant } from '@/types/chat'
 import { Avatar } from '@/components/ui/avatar'
 import { Upload } from '@/components/app/upload'
+import { useUserProfile } from '@/components/providers/userProfileContext'
 
 export interface ChatMessageProps {
   message: MessageDTO
@@ -16,9 +16,9 @@ export interface ChatMessageProps {
 
 export const ChatMessage: FC<ChatMessageProps> = memo(
   ({ assistant, message, assistantImageUrl }) => {
-    const { state } = useContext(ChatPageContext)
-    const avatarUrl = message.role === 'user' ? state.userImageUrl : assistantImageUrl
-    const avatarFallback = message.role === 'user' ? state.userName : assistant.name
+    const userProfile = useUserProfile()
+    const avatarUrl = message.role === 'user' ? userProfile?.avatarUrl : assistantImageUrl
+    const avatarFallback = message.role === 'user' ? userProfile?.name ?? '' : assistant.name
     const messageTitle = message.role === 'user' ? 'You' : assistant.name
     const uploads = message.attachments.map((attachment) => {
       return {

--- a/logicle/app/chat/components/state.tsx
+++ b/logicle/app/chat/components/state.tsx
@@ -7,11 +7,9 @@ export interface ChatPageState {
   newChatAssistantId: string | null
   userImageUrl?: string
   assistantUrl?: string
-  userName: string
 }
 
 export const defaultChatPageState: ChatPageState = {
   chatStatus: { state: 'idle' },
   newChatAssistantId: null,
-  userName: '',
 }

--- a/logicle/app/chat/layout.tsx
+++ b/logicle/app/chat/layout.tsx
@@ -7,37 +7,19 @@ import { ChatPageState, defaultChatPageState } from '@/app/chat/components/state
 import { MainLayout } from '@/app/layouts/MainLayout'
 import { useSWRJson } from '@/hooks/swr'
 import { BackendConfigurationNeeded } from './components/BackendConfigurationNeeded'
-import { SelectableUserDTO } from '@/types/user'
-
-function dataURLtoBlob(dataurl) {
-  const arr = dataurl.split(',')
-  const mime = arr[0].match(/:(.*?);/)[1]
-  const bstr = atob(arr[1])
-  let n = bstr.length
-  const u8arr = new Uint8Array(n)
-  while (n--) {
-    u8arr[n] = bstr.charCodeAt(n)
-  }
-  return new Blob([u8arr], { type: mime })
-}
 
 export default function ChatLayout({ children }) {
   const { data: assistants } = useSWRJson<UserAssistant[]>(`/api/user/assistants`)
-  const { data: user } = useSWRJson<SelectableUserDTO>(`/api/user/profile`)
 
-  if (!assistants || !user) {
+  if (!assistants) {
     // it is very important to initialize ChatPageContextProvider only once,
     // so I return here an empty page (should be a "loading" page)
     return <></>
   }
 
-  const userImageUrl = user.image ? URL.createObjectURL(dataURLtoBlob(user.image)) : undefined
-
   const initialState: ChatPageState = {
     ...defaultChatPageState,
     newChatAssistantId: assistants.length > 0 ? assistants[0].id : null,
-    userImageUrl,
-    userName: user.name,
   }
 
   return (

--- a/logicle/app/layout.tsx
+++ b/logicle/app/layout.tsx
@@ -3,9 +3,9 @@ import '../styles/globals.css'
 import ConfirmationModalContextProvider from '@/components/providers/confirmationContext'
 import ClientSessionProvider from './context/client-session-provider'
 import ClientI18nProvider from './context/client-i18n-provider'
-import ThemeProvider from '@/components/providers/themeprovider'
+import ThemeProvider from '@/components/providers/themeContext'
 import { auth } from '../auth'
-import { Metadata } from 'next';
+import { Metadata } from 'next'
 import { Red_Hat_Display } from 'next/font/google'
 
 const openSans = Red_Hat_Display({
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
     template: '%s • Logicle',
     default: 'Logicle',
   },
-};
+}
 
 export default async function RootLayout({
   // Layouts must accept a children prop.

--- a/logicle/app/layouts/MainLayout.tsx
+++ b/logicle/app/layouts/MainLayout.tsx
@@ -13,56 +13,59 @@ export interface Props {
 }
 
 import { Button } from '@/components/ui/button'
+import UserProfileProvider from '@/components/providers/userProfileContext'
 
 export const MainLayout: React.FC<Props> = ({ leftBar, rightBar, children }) => {
   const LeftBar = leftBar
   const isMobile = useMediaQuery({ query: '(max-width: 768px)' })
   const [showDrawer, setShowDrawer] = useState<boolean>(false)
   return (
-    <main
-      className={`"grid lg:grid-cols-5 flex h-screen w-screen flex-row text-sm overflow-hidden divide-x`}
-    >
-      <div className="flex flex-col justify-between align-center justify-center gap-3 p-2">
-        <div className="flex flex-col flex-1 items-center gap-3">
-          {isMobile && (
-            <Button size="icon" variant="ghost" onClick={() => setShowDrawer(true)}>
-              <IconMenu2 size={32}></IconMenu2>
-            </Button>
-          )}
-          <Link href="/chat">
-            <IconMessage size={32}></IconMessage>
-          </Link>
-          <Link href="/chat/select_assistant">
-            <IconGlobe size={32}></IconGlobe>
-          </Link>
+    <UserProfileProvider>
+      <main
+        className={`"grid lg:grid-cols-5 flex h-screen w-screen flex-row text-sm overflow-hidden divide-x`}
+      >
+        <div className="flex flex-col justify-between align-center justify-center gap-3 p-2">
+          <div className="flex flex-col flex-1 items-center gap-3">
+            {isMobile && (
+              <Button size="icon" variant="ghost" onClick={() => setShowDrawer(true)}>
+                <IconMenu2 size={32}></IconMenu2>
+              </Button>
+            )}
+            <Link href="/chat">
+              <IconMessage size={32}></IconMessage>
+            </Link>
+            <Link href="/chat/select_assistant">
+              <IconGlobe size={32}></IconGlobe>
+            </Link>
+          </div>
+          <div>
+            <AppMenu />
+          </div>
         </div>
-        <div>
-          <AppMenu />
-        </div>
-      </div>
-      {leftBar && !isMobile && (
-        <div className="w-[260px] flex shrink-0 flex-col text-foreground overflow-hidden">
-          {leftBar}
-        </div>
-      )}
-      {children}
-      {rightBar && !isMobile && (
-        <div className="w-[260px] flex shrink-0 text-foreground overflow-hidden">{rightBar}</div>
-      )}
-      {isMobile && LeftBar && (
-        <Dialog.Root open={showDrawer}>
-          <Dialog.Portal>
-            <Dialog.Overlay />
-            <Dialog.Content
-              className="border absolute left-0 top-0 bottom-0 md:w-[260px] w-[260px] max-w-[80%] md:max-w-[80%] overflow-hidden p-0 translate-x-[0%] translate-y-[0%] slide-in-from-left"
-              onInteractOutside={() => setShowDrawer(false)}
-              onPointerDownOutside={() => setShowDrawer(false)}
-            >
-              {leftBar}
-            </Dialog.Content>
-          </Dialog.Portal>
-        </Dialog.Root>
-      )}
-    </main>
+        {leftBar && !isMobile && (
+          <div className="w-[260px] flex shrink-0 flex-col text-foreground overflow-hidden">
+            {leftBar}
+          </div>
+        )}
+        {children}
+        {rightBar && !isMobile && (
+          <div className="w-[260px] flex shrink-0 text-foreground overflow-hidden">{rightBar}</div>
+        )}
+        {isMobile && LeftBar && (
+          <Dialog.Root open={showDrawer}>
+            <Dialog.Portal>
+              <Dialog.Overlay />
+              <Dialog.Content
+                className="border absolute left-0 top-0 bottom-0 md:w-[260px] w-[260px] max-w-[80%] md:max-w-[80%] overflow-hidden p-0 translate-x-[0%] translate-y-[0%] slide-in-from-left"
+                onInteractOutside={() => setShowDrawer(false)}
+                onPointerDownOutside={() => setShowDrawer(false)}
+              >
+                {leftBar}
+              </Dialog.Content>
+            </Dialog.Portal>
+          </Dialog.Root>
+        )}
+      </main>
+    </UserProfileProvider>
   )
 }

--- a/logicle/components/app/app-menu.tsx
+++ b/logicle/components/app/app-menu.tsx
@@ -14,11 +14,11 @@ import React from 'react'
 
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
 import { cn } from '@/lib/utils'
-import { useSWRJson } from '@/hooks/swr'
-import { SelectableUserDTO, UserRoleName } from '@/types/user'
+import { UserRoleName } from '@/types/user'
 import { IconLogout, IconSettings } from '@tabler/icons-react'
 import { IconUser } from '@tabler/icons-react'
 import { Avatar } from '../ui/avatar'
+import { useUserProfile } from '../providers/userProfileContext'
 
 interface Params {}
 
@@ -43,21 +43,21 @@ DropdownMenuContent.displayName = 'DropdownMenuContent'
 export const AppMenu: FC<Params> = () => {
   const { t } = useTranslation('common')
   const dropdownContainer = createRef<HTMLDivElement>()
-  const { data: user } = useSWRJson<SelectableUserDTO>(`/api/user/profile`)
-  const userName = user?.name
+  const userProfile = useUserProfile()
+  const userName = userProfile?.name
   return (
     <div className="relative p-1 appmenu" ref={dropdownContainer}>
       <DropdownMenu>
         <DropdownMenuTrigger className="w-full">
           <div className="flex flex-row w-full items-center justify-center">
-            <Avatar url={user?.image ?? undefined} fallback={userName ?? ''} />
+            <Avatar url={userProfile?.avatarUrl ?? undefined} fallback={userName ?? ''} />
           </div>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
           <DropdownMenuLink href="/profile" icon={IconUser}>
             {t('my-profile')}
           </DropdownMenuLink>
-          {user?.role == UserRoleName.ADMIN && (
+          {userProfile?.role == UserRoleName.ADMIN && (
             <DropdownMenuLink href="/admin/assistants" icon={IconSettings}>
               {t('administrator-settings')}
             </DropdownMenuLink>

--- a/logicle/components/providers/confirmationContext.tsx
+++ b/logicle/components/providers/confirmationContext.tsx
@@ -2,7 +2,7 @@
 import { useContext, useRef, useState } from 'react'
 import ConfirmationDialog from '@/components/ui/ConfirmationDialog'
 import React from 'react'
-import { useTheme } from './themeprovider'
+import { useTheme } from './themeContext'
 
 interface ModalContextParams {
   title: string

--- a/logicle/components/providers/themeContext.tsx
+++ b/logicle/components/providers/themeContext.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 type Theme = 'dark' | 'light'
 
-type ModalContextType = {
+type ContextType = {
   theme: Theme
   setTheme: (theme: Theme) => void
 }
@@ -13,12 +13,12 @@ type Props = {
   children: React.ReactNode
 }
 
-const Theme = React.createContext<ModalContextType>({} as ModalContextType)
+const Theme = React.createContext<ContextType>({} as ContextType)
 
 const ThemeProvider: React.FC<Props> = ({ children }) => {
   const [theme, setTheme] = useState<Theme>('dark')
 
-  const modalContext: ModalContextType = {
+  const modalContext: ContextType = {
     theme: theme,
     setTheme: setTheme,
   }
@@ -26,7 +26,7 @@ const ThemeProvider: React.FC<Props> = ({ children }) => {
   return <Theme.Provider value={modalContext}>{children}</Theme.Provider>
 }
 
-const useTheme = (): ModalContextType => useContext(Theme)
+const useTheme = (): ContextType => useContext(Theme)
 
 export { useTheme }
 

--- a/logicle/components/providers/userProfileContext.tsx
+++ b/logicle/components/providers/userProfileContext.tsx
@@ -1,0 +1,47 @@
+'use client'
+import { useSWRJson } from '@/hooks/swr'
+import { SelectableUserDTO } from '@/types/user'
+import { useContext } from 'react'
+import React from 'react'
+
+type Props = {
+  children: React.ReactNode
+}
+
+type ContextType =
+  | (SelectableUserDTO & {
+      avatarUrl: string | undefined
+    })
+  | undefined
+
+function dataURLtoBlob(dataurl) {
+  const arr = dataurl.split(',')
+  const mime = arr[0].match(/:(.*?);/)[1]
+  const bstr = atob(arr[1])
+  let n = bstr.length
+  const u8arr = new Uint8Array(n)
+  while (n--) {
+    u8arr[n] = bstr.charCodeAt(n)
+  }
+  return new Blob([u8arr], { type: mime })
+}
+
+const UserProfileContext = React.createContext<ContextType>({} as ContextType)
+
+const UserProfileProvider: React.FC<Props> = ({ children }) => {
+  let { data: user } = useSWRJson<ContextType>(`/api/user/profile`)
+  if (user) {
+    const avatarUrl = user.image ? URL.createObjectURL(dataURLtoBlob(user.image)) : undefined
+    user = {
+      ...user,
+      avatarUrl: avatarUrl ?? undefined,
+    }
+  }
+  return <UserProfileContext.Provider value={user}>{children}</UserProfileContext.Provider>
+}
+
+const useUserProfile = (): ContextType => useContext(UserProfileContext)
+
+export { useUserProfile }
+
+export default UserProfileProvider


### PR DESCRIPTION
The issue has been fixed creating a almost app-wide context with the output of /api/user/profile
While it is tempting to use NextAuth Session (which is inserted in HTML), it has two downsides:

* Storing the image in Session is simply unreasonable
* Tracking icon / name changes is not very straightforward

 Fixes #40