### PR TITLE
Filter Enhancement for OpenAI Models

### DIFF
--- a/logicle/app/api/backends/[backendId]/models/route.ts
+++ b/logicle/app/api/backends/[backendId]/models/route.ts
@@ -10,17 +10,20 @@ export const dynamic = 'force-dynamic'
 // Function to filter only specific GPT models
 function filterGptModels(backendResponse) {
   const allowedGptModels = [
-    'gpt-3.5-turbo', 
-    'gpt-4-turbo-preview', 
+    'gpt-4-turbo-preview',
     'gpt-4', 
-    'gpt-4-32k'
+    'gpt-4-32k',
+    'gpt-3.5-turbo'
   ];
+
+  // Map over the allowedGptModels and, for each one, find the corresponding model in backendResponse.data
+  const reorderedModels = allowedGptModels
+    .map(allowedModel => backendResponse.data.find(item => item.id === allowedModel))
+    .filter(item => item !== undefined); // Filter out any undefined entries (in case some models aren't in the response)
 
   const filteredModels = {
     ...backendResponse,
-    data: backendResponse.data.filter((item) =>
-      allowedGptModels.includes(item.id)
-    ),
+    data: reorderedModels,
   };
 
   return filteredModels;

--- a/logicle/app/api/backends/[backendId]/models/route.ts
+++ b/logicle/app/api/backends/[backendId]/models/route.ts
@@ -7,13 +7,23 @@ import { ModelDetectionMode } from '@/types/provider'
 
 export const dynamic = 'force-dynamic'
 
-// Function to filter GPT models, this is just a temporary solution
+// Function to filter only specific GPT models
 function filterGptModels(backendResponse) {
-  const gptModels = {
+  const allowedGptModels = [
+    'gpt-3.5-turbo', 
+    'gpt-4-turbo-preview', 
+    'gpt-4', 
+    'gpt-4-32k'
+  ];
+
+  const filteredModels = {
     ...backendResponse,
-    data: backendResponse.data.filter((item) => item.id.startsWith('gpt')),
-  }
-  return gptModels
+    data: backendResponse.data.filter((item) =>
+      allowedGptModels.includes(item.id)
+    ),
+  };
+
+  return filteredModels;
 }
 
 export const GET = requireAdmin(async (req: Request, route: { params: { backendId: string } }) => {


### PR DESCRIPTION
Enhances the OpenAI provider model filtering to exclusively show gpt-3.5-turbo, gpt-4-turbo-preview, gpt-4, and gpt-4-32k, and sorts them by relevance to simplify user selection.