### PR TITLE
Implement CI Workflow for Stable Releases to GHCR and Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=sha,format=long
             type=semver,pattern={{raw}}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -41,8 +42,6 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'release' }}
-          tags: |
-            ghcr.io/logicleai/logicle:${{ github.sha }}
-            ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'release' }}
+          push: ${{ github.event_name == 'workflow_dispatch' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
           push: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'release' }}
           tags: |
             ghcr.io/logicleai/logicle:${{ github.sha }}
-            ${{ (github.event_name == 'release') && steps.meta.outputs.tags || '' }}
-            ${{ (github.event_name == 'release') && 'ghcr.io/logicleai/logicle:latest' || '' }}
+            ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,9 @@
-name: Basic CI
+name: Publish Release to GitHub Container Registry
 
 on:
-  push:
+  release:
+    types: [published, edited]
   workflow_dispatch:
-
-env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   docker:
@@ -27,20 +22,28 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: |
+            ghcr.io/${{ github.repository }}
+            ${{ github.repository }}
           tags: |
-            type=sha,format=long
+            type=semver,pattern={{raw}}
+            type=raw,value=latest
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name == 'workflow_dispatch' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
This PR introduces a new Continuous Integration (CI) workflow aimed at streamlining the process of releasing new stable versions. It automates the building, testing, and deployment phases, pushing the final artifacts to both GitHub Container Registry (GHCR) and Docker Hub. Key features include:

- Automatic tagging of releases with 'latest' and semantic versioning tags ('vX.X.X').
- Manual trigger capability for the workflow, allowing flexibility in the release process.