### PR TITLE
Correct Environment File Link in Docker Compose Documentation

### DIFF
--- a/deploy/docker-compose/README.md
+++ b/deploy/docker-compose/README.md
@@ -44,7 +44,7 @@ Options are available for setups with or without HTTPS reverse proxy and Let's E
 
 Download the `.env` file, which includes necessary configurations for Logicle:
 ```
-curl -L https://raw.githubusercontent.com/logicleai/logicle/main/deploy/docker-compose/postgres/.env.postgres.example -o .env
+curl -L https://raw.githubusercontent.com/logicleai/logicle/main/deploy/docker-compose/.env.postgres.example -o .env
 ```
 
 ### Step 4: Configure the .env File


### PR DESCRIPTION
This pull request updates an incorrect link in the Docker Compose documentation for downloading the environment file. The current link leads to a 404 page, causing confusion and hindering the setup process. This update replaces the incorrect link with the correct one, ensuring users can successfully access the required file.