### PR TITLE
UI fixes pre 0.2.0

### DIFF
--- a/logicle/app/api/assistants/[assistantId]/sharing/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/sharing/route.ts
@@ -5,7 +5,7 @@ import * as dto from '@/types/dto'
 import { Session } from 'next-auth'
 import { db } from '@/db/database'
 
-export const PUT = requireSession(
+export const POST = requireSession(
   async (session: Session, req: Request, route: { params: { assistantId: string } }) => {
     const assistantId = route.params.assistantId
     const assistant = await Assistants.get(assistantId)
@@ -30,6 +30,9 @@ export const PUT = requireSession(
         )
         .execute()
     }
-    return ApiResponses.success()
+
+    const sharingData =
+      (await Assistants.sharingData([route.params.assistantId])).get(route.params.assistantId) || []
+    return ApiResponses.json(sharingData)
   }
 )

--- a/logicle/app/assistants/[id]/page.tsx
+++ b/logicle/app/assistants/[id]/page.tsx
@@ -61,7 +61,9 @@ const AssistantPage = () => {
           } else {
             localStorage.removeItem(id)
           }
-        } catch {}
+        } catch {
+          console.log('Failed recovering assistant from local storage')
+        }
       }
       const response = await get<dto.SelectableAssistantWithTools>(assistantUrl)
       if (response.error) {

--- a/logicle/app/assistants/[id]/page.tsx
+++ b/logicle/app/assistants/[id]/page.tsx
@@ -7,7 +7,7 @@ import toast from 'react-hot-toast'
 import { useTranslation } from 'next-i18next'
 import { AssistantForm } from '../components/AssistantForm'
 import * as dto from '@/types/dto'
-import { get, patch, put } from '@/lib/fetch'
+import { get, patch, post, put } from '@/lib/fetch'
 import { AssistantPreview } from '../components/AssistantPreview'
 import { Button } from '@/components/ui/button'
 import {
@@ -80,8 +80,18 @@ const AssistantPage = () => {
   }
 
   const shareWith = async (sharing: dto.InsertableSharing[]) => {
-    await put(`${assistantUrl}/sharing`, sharing)
-    mutate(assistantUrl)
+    const response = await post<dto.Sharing[]>(`${assistantUrl}/sharing`, sharing)
+    if (response.error) {
+      toast.error(response.error.message)
+    } else {
+      setState({
+        ...state,
+        assistant: {
+          ...assistant!,
+          sharing: response.data,
+        },
+      })
+    }
   }
 
   const isSharedWithWorkspace = (workspaceId: string) => {

--- a/logicle/app/assistants/[id]/page.tsx
+++ b/logicle/app/assistants/[id]/page.tsx
@@ -2,16 +2,13 @@
 import { WithLoadingAndError } from '@/components/ui'
 import { useParams } from 'next/navigation'
 import React, { useEffect, useRef, useState } from 'react'
-import { mutate } from 'swr'
+import { SWRResponse, mutate } from 'swr'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'next-i18next'
 import { AssistantForm } from '../components/AssistantForm'
 import * as dto from '@/types/dto'
-import { patch, put } from '@/lib/fetch'
-import { useSWRJson } from '@/hooks/swr'
-import { ScrollArea } from '@/components/ui/scroll-area'
+import { get, patch, put } from '@/lib/fetch'
 import { AssistantPreview } from '../components/AssistantPreview'
-import { AdminPageTitle } from '@/app/admin/components/AdminPageTitle'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -20,6 +17,13 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { useUserProfile } from '@/components/providers/userProfileContext'
+import { ApiError } from '@/types/base'
+
+interface State {
+  assistant?: dto.SelectableAssistantWithTools
+  isLoading: boolean
+  error?: ApiError
+}
 
 const AssistantPage = () => {
   const { id } = useParams() as { id: string }
@@ -27,31 +31,51 @@ const AssistantPage = () => {
   const profile = useUserProfile()
   const visibleWorkspaces = profile?.workspaces || []
   const assistantUrl = `/api/assistants/${id}`
-  const {
-    data: loadedAssistant,
-    error,
-    isLoading,
-  } = useSWRJson<dto.SelectableAssistantWithTools>(assistantUrl)
   const fireSubmit = useRef<(() => void) | undefined>(undefined)
-  const [assistantState, setAssistantState] = useState<
-    dto.SelectableAssistantWithTools | undefined
-  >(undefined!)
-  const sharing = loadedAssistant?.sharing || []
+  const [state, setState] = useState<State>({
+    isLoading: true,
+  })
+  const { assistant, isLoading, error } = state
+  const sharing = assistant?.sharing || []
 
   useEffect(() => {
-    loadedAssistant && setAssistantState(loadedAssistant)
-  }, [loadedAssistant])
+    const doLoad = async () => {
+      const response = await get<dto.SelectableAssistantWithTools>(assistantUrl)
+      if (response.error) {
+        setState({
+          ...state,
+          isLoading: false,
+          error: response.error,
+        })
+      } else {
+        setState({
+          ...state,
+          isLoading: false,
+          assistant: response.data,
+        })
+      }
+    }
+    doLoad()
+  }, [])
 
-  async function onSubmit(assistant: Partial<dto.InsertableAssistant>) {
+  async function onChange(values: Partial<dto.InsertableAssistant>) {
+    setState({
+      ...state,
+      assistant: { ...assistant!, ...values },
+    })
+  }
+
+  async function onSubmit(values: Partial<dto.InsertableAssistant>) {
+    onChange(values)
     const response = await patch(assistantUrl, {
       ...assistant,
+      ...values,
       sharing: undefined,
     })
     if (response.error) {
       toast.error(response.error.message)
       return
     }
-    mutate(assistantUrl)
     toast.success(t('assistant-successfully-updated'))
   }
 
@@ -112,15 +136,15 @@ const AssistantPage = () => {
   }
   return (
     <WithLoadingAndError isLoading={isLoading} error={error}>
-      {loadedAssistant && (
+      {assistant && (
         <div className="flex flex-col h-full overflow-hidden pl-4 pr-4">
           <div className="flex justify-between items-center">
-            <h1>{`Assistant ${loadedAssistant.name}`}</h1>
+            <h1>{`Assistant ${assistant.name}`}</h1>
             <div className="flex gap-3">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button variant="outline" className="px-2">
-                    {`Shared with ${dumpSharing(loadedAssistant.sharing)}`}
+                    {`Shared with ${dumpSharing(assistant.sharing)}`}
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent className="" sideOffset={5}>
@@ -148,13 +172,18 @@ const AssistantPage = () => {
           </div>
           <div className={`flex-1 min-h-0 grid grid-cols-2 overflow-hidden`}>
             <AssistantForm
-              assistant={loadedAssistant}
+              assistant={assistant}
               onSubmit={onSubmit}
-              onChange={(values) => setAssistantState({ ...loadedAssistant, ...values })}
+              onChange={(values) =>
+                setState({
+                  ...state,
+                  assistant: { ...assistant, ...values },
+                })
+              }
               fireSubmit={fireSubmit}
             />
             <AssistantPreview
-              assistant={assistantState ?? loadedAssistant}
+              assistant={assistant}
               className="pl-4 h-full flex-1 min-w-0"
             ></AssistantPreview>
           </div>

--- a/logicle/app/assistants/components/AssistantForm.tsx
+++ b/logicle/app/assistants/components/AssistantForm.tsx
@@ -91,18 +91,6 @@ export const AssistantForm = ({ assistant, onSubmit, onChange, fireSubmit }: Pro
     },
   })
 
-  useEffect(() => {
-    const handleBeforeUnload = (event) => {
-      //localStorage.setItem('assistant-form', JSON.stringify(form.getValues()))
-      event.preventDefault()
-      event.returnValue = ''
-    }
-    window.addEventListener('beforeunload', handleBeforeUnload)
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload)
-    }
-  }, [])
-
   const updateModels = (backendId: string) => {
     async function getData() {
       abortController.current?.abort()

--- a/logicle/app/assistants/components/AssistantForm.tsx
+++ b/logicle/app/assistants/components/AssistantForm.tsx
@@ -24,7 +24,7 @@ import { Switch } from '@/components/ui/switch'
 import { Upload } from '@/components/app/upload'
 import { post } from '@/lib/fetch'
 import toast from 'react-hot-toast'
-import { IconPlus } from '@tabler/icons-react'
+import { IconAlertCircle, IconExclamationMark, IconPlus } from '@tabler/icons-react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useEnvironment } from '@/app/context/environmentProvider'
 
@@ -46,6 +46,7 @@ export const AssistantForm = ({ assistant, onSubmit, onChange, fireSubmit }: Pro
   const environment = useEnvironment()
   const formRef = useRef<HTMLFormElement>(null)
   const [activeTab, setActiveTab] = useState<TabState>('general')
+  const [haveValidationErrors, setHaveValidationErrors] = useState<boolean>(undefined!)
 
   // Here we store the status of the uploads, which is... form status + progress
   // Form status (files field) is derived from this on change
@@ -118,9 +119,12 @@ export const AssistantForm = ({ assistant, onSubmit, onChange, fireSubmit }: Pro
   }, [assistant.backendId])
 
   useEffect(() => {
-    const subscription = form.watch(() => onChange && onChange(form.getValues()))
+    const subscription = form.watch(() => {
+      onChange?.(form.getValues())
+      setHaveValidationErrors(!form.formState.isValid)
+    })
     return () => subscription.unsubscribe()
-  }, [onChange, form, form.watch])
+  }, [setHaveValidationErrors, onChange, form, form.watch])
 
   const handleSubmit = (values: FormFields) => {
     onSubmit({
@@ -206,7 +210,7 @@ export const AssistantForm = ({ assistant, onSubmit, onChange, fireSubmit }: Pro
     <FormProvider {...form}>
       <form
         ref={formRef}
-        onSubmit={form.handleSubmit(handleSubmit)}
+        onSubmit={form.handleSubmit(handleSubmit, () => setHaveValidationErrors(true))}
         className="space-y-6 h-full flex flex-col p-2 overflow-hidden min-h-0 "
       >
         <div className="flex flex-row gap-1 self-center">
@@ -219,6 +223,7 @@ export const AssistantForm = ({ assistant, onSubmit, onChange, fireSubmit }: Pro
               <TabsTrigger value="general">General</TabsTrigger>
               <TabsTrigger value="instructions">Instructions</TabsTrigger>
               {environment.enableTools && <TabsTrigger value="tools">{t('tools')}</TabsTrigger>}
+              {haveValidationErrors && <IconAlertCircle color="red" />}
             </TabsList>
           </Tabs>
         </div>

--- a/logicle/app/chat/select_assistant/page.tsx
+++ b/logicle/app/chat/select_assistant/page.tsx
@@ -21,6 +21,8 @@ import { mutate } from 'swr'
 import toast from 'react-hot-toast'
 import { useBackends } from '@/hooks/backends'
 
+const EMPTY_ASSISTANT_NAME = ''
+
 type FilteringMode = 'available' | 'mine' | 'workspace'
 
 const Filters: Record<
@@ -65,15 +67,19 @@ const SelectAssistantPage = () => {
   // just simulate a lot of assistants
   //for(let a = 0; a < 5; a++) { assistants = [...assistants, ...assistants] }
   const handleSelect = (assistant: UserAssistant) => {
-    dispatch({ field: 'newChatAssistantId', value: assistant.id })
-    router.push('/chat')
+    if (assistant.name == EMPTY_ASSISTANT_NAME && assistant.owner == profile?.id) {
+      router.push(`/assistants/${assistant.id}`)
+    } else {
+      dispatch({ field: 'newChatAssistantId', value: assistant.id })
+      router.push('/chat')
+    }
   }
 
   const onCreateAssistant = async () => {
     const newAssistant = {
       icon: null,
       description: '',
-      name: '',
+      name: EMPTY_ASSISTANT_NAME,
       backendId: defaultBackend,
       model: '',
       systemPrompt: '',
@@ -94,6 +100,11 @@ const SelectAssistantPage = () => {
     router.push(`/assistants/${response.data.id}`)
   }
 
+  const haveEmptyAssistant =
+    assistants?.find(
+      (assistant) => assistant.owner == profile?.id && assistant.name == EMPTY_ASSISTANT_NAME
+    ) !== undefined
+
   return (
     <WithLoadingAndError isLoading={isLoading} error={error}>
       <div className="flex flex-1 flex-col gap-4">
@@ -112,7 +123,12 @@ const SelectAssistantPage = () => {
               Mine
             </TabsTrigger>
             <div className="flex flex-row justify-center">
-              <Button onClick={() => onCreateAssistant()} variant="ghost" className="margin-auto">
+              <Button
+                disabled={haveEmptyAssistant}
+                onClick={() => onCreateAssistant()}
+                variant="ghost"
+                className="margin-auto"
+              >
                 <IconPlus></IconPlus>
               </Button>
             </div>

--- a/logicle/app/chat/select_assistant/page.tsx
+++ b/logicle/app/chat/select_assistant/page.tsx
@@ -12,6 +12,14 @@ import { useActiveWorkspace } from '@/components/providers/activeWorkspaceContex
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { UserProfileDto } from '@/types/user'
 import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import { IconPlus } from '@tabler/icons-react'
+import { DEFAULT_TEMPERATURE } from '@/lib/const'
+import { post } from '@/lib/fetch'
+import * as dto from '@/types/dto'
+import { mutate } from 'swr'
+import toast from 'react-hot-toast'
+import { useBackends } from '@/hooks/backends'
 
 type FilteringMode = 'available' | 'mine' | 'workspace'
 
@@ -51,12 +59,41 @@ const SelectAssistantPage = () => {
     isLoading,
     error,
   } = useSWRJson<UserAssistant[]>(`/api/user/assistants/explore`)
+  const { data: backends, isLoading: isBackendLoading } = useBackends()
+  const defaultBackend = backends && backends.length > 0 ? backends[0].id : undefined
+
   // just simulate a lot of assistants
   //for(let a = 0; a < 5; a++) { assistants = [...assistants, ...assistants] }
   const handleSelect = (assistant: UserAssistant) => {
     dispatch({ field: 'newChatAssistantId', value: assistant.id })
     router.push('/chat')
   }
+
+  const onCreateAssistant = async () => {
+    const newAssistant = {
+      icon: null,
+      description: '',
+      name: '',
+      backendId: defaultBackend,
+      model: '',
+      systemPrompt: '',
+      tokenLimit: 4000,
+      temperature: DEFAULT_TEMPERATURE,
+      tools: [], // TODO: load available tools from backend
+      files: [],
+    }
+    const url = `/api/assistants`
+    const response = await post<dto.SelectableAssistantWithOwner>(url, newAssistant)
+
+    if (response.error) {
+      toast.error(response.error.message)
+      return
+    }
+    mutate(url)
+    mutate('/api/user/profile') // Let the chat know that there are new assistants!
+    router.push(`/assistants/${response.data.id}`)
+  }
+
   return (
     <WithLoadingAndError isLoading={isLoading} error={error}>
       <div className="flex flex-1 flex-col gap-4">
@@ -74,6 +111,11 @@ const SelectAssistantPage = () => {
             <TabsTrigger onClick={() => setFilteringMode('mine')} value="mine">
               Mine
             </TabsTrigger>
+            <div className="flex flex-row justify-center">
+              <Button onClick={() => onCreateAssistant()} variant="ghost" className="margin-auto">
+                <IconPlus></IconPlus>
+              </Button>
+            </div>
           </TabsList>
         </Tabs>
         <ScrollArea className="flex-1">

--- a/logicle/app/chat/select_assistant/page.tsx
+++ b/logicle/app/chat/select_assistant/page.tsx
@@ -61,7 +61,7 @@ const SelectAssistantPage = () => {
     isLoading,
     error,
   } = useSWRJson<UserAssistant[]>(`/api/user/assistants/explore`)
-  const { data: backends, isLoading: isBackendLoading } = useBackends()
+  const { data: backends } = useBackends()
   const defaultBackend = backends && backends.length > 0 ? backends[0].id : undefined
 
   // just simulate a lot of assistants

--- a/logicle/hooks/assistants.ts
+++ b/logicle/hooks/assistants.ts
@@ -17,6 +17,6 @@ export const useAssistants = () => {
 }
 
 export const mutateAssistants = async () => {
-  const url = `/api/assistants`
-  mutate(url)
+  mutate(`/api/assistants`)
+  mutate(`/api/user/assistants`)
 }

--- a/logicle/models/conversation.ts
+++ b/logicle/models/conversation.ts
@@ -76,9 +76,6 @@ export const getConversations = async (ownerId: string) => {
 }
 
 export const getConversationsWithFolder = async (ownerId: string) => {
-  db.selectFrom('Message').select(({ fn }) =>
-    fn.max<string | null, 'sentAt'>('sentAt').as('lastMsgSentAt')
-  )
   return await db
     .selectFrom('Conversation')
     .leftJoin('ConversationFolderMembership', (join) =>
@@ -96,6 +93,7 @@ export const getConversationsWithFolder = async (ownerId: string) => {
         .as('lastMsgSentAt')
     )
     .where('Conversation.ownerId', '=', ownerId)
+    .orderBy('lastMsgSentAt')
     .execute()
 }
 


### PR DESCRIPTION
Preparing for release 0.2.0, tweaking UI

* Assistants can be added from explore page (but not if there are empty drafts)
* Draft assistants can be opened for chat: clicking on them will open the edit page
* Visual hint for assistant form errors (form error notification might be in different tabs)
* Fixed ordering and refresh of conversations
* Assistant modifications are saved to local storage and are recoverable on load

