### PR TITLE
Limited visualization count of masked backend api key characters

### DIFF
--- a/logicle/app/admin/backends/BackendPage.tsx
+++ b/logicle/app/admin/backends/BackendPage.tsx
@@ -57,7 +57,7 @@ const BackendPage = () => {
         {backend.name}
       </Link>
     )),
-    column(t('table-column-apikey'), (backend) => masked(backend.apiKey)),
+    column(t('table-column-apikey'), (backend) => masked(backend.apiKey, '.', 3)),
     column(t('table-column-apiendpoint'), (backend) => backend.endPoint),
     column(t('table-column-actions'), (backend) => (
       <DeleteButton

--- a/logicle/types/secure.ts
+++ b/logicle/types/secure.ts
@@ -22,11 +22,11 @@ export function protect(str: string) {
   }
 }
 
-export function masked(protect: string | Protected) {
+export function masked(protect: string | Protected, mask?: string, unmaskLen?: number) {
   if (typeof protect === 'string') {
     return protect
   }
-  return protect.prefix + 'x'.repeat(protect.hidden) + protect.suffix
+  return protect.prefix + (mask ?? '.').repeat(unmaskLen ?? protect.hidden) + protect.suffix
 }
 
 export function protectBackend(backend: dto.Backend) {


### PR DESCRIPTION
Probably the solution is simply... overkill
Anyway, fixes #74 
