### PR TITLE
Remove Workflow Dispatch from release.yml to Prevent Incorrect 'latest' Tag Assignment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Publish Release to GitHub Container Registry
 on:
   release:
     types: [published, edited]
-  workflow_dispatch:
 
 jobs:
   docker:


### PR DESCRIPTION
This PR addresses the issue where manually triggered workflows were incorrectly assigned the 'latest' tag, which should be reserved for the most recent semantically versioned release. By removing the workflow dispatch mode from the `release.yml` CI configuration, we eliminate the possibility of accidental pushes that could lead to this erroneous behavior.