### PR TITLE
Compatibility of db maintenance script with postgres

### DIFF
--- a/logicle/db/migrations/20240603-images.ts
+++ b/logicle/db/migrations/20240603-images.ts
@@ -62,7 +62,7 @@ export async function up(db: Kysely<any>): Promise<void> {
   await db.schema
     .createTable('Image')
     .addColumn('id', string, (col) => col.notNull().primaryKey())
-    .addColumn('data', 'binary', (col) => col.notNull())
+    .addColumn('data', 'bytea', (col) => col.notNull())
     .addColumn('mimeType', string)
     .execute()
   await migrateUsers(db)


### PR DESCRIPTION
For binary columns... 'bytea' is the postgresql type.
Sqlite seems happy (I suspect that unknown types are treated as binary
 