### PR TITLE
Change the Administrator Settings button default redirect location

### DIFF
--- a/logicle/components/app/app-menu.tsx
+++ b/logicle/components/app/app-menu.tsx
@@ -58,7 +58,7 @@ export const AppMenu: FC<Params> = () => {
             {t('my-profile')}
           </DropdownMenuLink>
           {userProfile?.role == dto.UserRoleName.ADMIN && (
-            <DropdownMenuLink href="/admin/assistants" icon={IconSettings}>
+            <DropdownMenuLink href="/admin/analytics" icon={IconSettings}>
               {t('administrator-settings')}
             </DropdownMenuLink>
           )}


### PR DESCRIPTION
In this PR:
- Change the Administrator Settings button default redirect location to the admin analytics page