### PR TITLE
Open login page (client side) if any API fails with 401

### DIFF
--- a/logicle/hooks/swr.ts
+++ b/logicle/hooks/swr.ts
@@ -4,6 +4,16 @@ const fetcher = async (url: string) => {
   const response = await fetch(url)
   const json = await response.json()
 
+  if (response.status == 401) {
+    const url = new URL(window.location.href)
+    if (!url.pathname.startsWith('/auth')) {
+      const redirectUrl = new URL(url.href)
+      redirectUrl.pathname = '/auth/login'
+      url.searchParams.set('callbackUrl ', encodeURI(url.href))
+      window.open(url, '_self')
+    }
+  }
+
   if (!response.ok) {
     throw new Error(json.error.message || 'An error occurred while fetching the data')
   }

--- a/logicle/lib/fetch/index.ts
+++ b/logicle/lib/fetch/index.ts
@@ -62,6 +62,15 @@ export async function fetchApiResponse<T>(
         values: {},
       },
     } as ApiResponse<T>
+    if (response.status == 401) {
+      const url = new URL(window.location.href)
+      if (!url.pathname.startsWith('/auth')) {
+        const redirectUrl = new URL(url.href)
+        redirectUrl.pathname = '/auth/login'
+        url.searchParams.set('callbackUrl ', encodeURI(url.href))
+        window.open(url, '_self')
+      }
+    }
   }
   return apiResponse
 }


### PR DESCRIPTION
If an API fails for missing authentication, next.js won't do anything... because authentication is verified when we load a page.
It is much better... to redirect to login page.
This should greatly reduce the impact of the issue we're having with token expiring on SAML sessions (but the problem is still there...)
When we transition to server components, there will be no APIs, and there will be no need for such logic 