### PR TITLE
Improve assistant draft management

### DIFF
--- a/logicle/app/admin/analytics/most-active-users.tsx
+++ b/logicle/app/admin/analytics/most-active-users.tsx
@@ -8,7 +8,7 @@ interface TokensByUser {
 }
 
 export function MostActiveUsers() {
-  const { isLoading, error, data } = useSWRJson<TokensByUser[]>('/api/analytics/usage/byuser')
+  const { data } = useSWRJson<TokensByUser[]>('/api/analytics/usage/byuser')
   const tokensByUser = data ?? []
   return (
     <div className="space-y-8">

--- a/logicle/app/admin/assistants/components/AssistantsPage.tsx
+++ b/logicle/app/admin/assistants/components/AssistantsPage.tsx
@@ -6,7 +6,6 @@ import toast from 'react-hot-toast'
 import React, { useState } from 'react'
 import { useConfirmationContext } from '@/components/providers/confirmationContext'
 import { Column, ScrollableTable, column } from '@/components/ui/tables'
-import { useBackends } from '@/hooks/backends'
 import { delete_ } from '@/lib/fetch'
 import * as dto from '@/types/dto'
 import { useSWRJson } from '@/hooks/swr'
@@ -27,7 +26,6 @@ export const AssistantsPage = () => {
   const { data: users_ } = useUsers()
   const users = users_ || []
 
-  const { data: backends, isLoading: isBackendLoading } = useBackends()
   const [searchTerm, setSearchTerm] = useState<string>('')
   const [assistantSelectingOwner, setAssistantSelectingOwner] = useState<
     dto.AssistantWithOwner | undefined
@@ -96,7 +94,7 @@ export const AssistantsPage = () => {
   ]
 
   return (
-    <AdminPage isLoading={isLoading || isBackendLoading} error={error} title={t('all-assistants')}>
+    <AdminPage isLoading={isLoading} error={error} title={t('all-assistants')}>
       <SearchBarWithButtonsOnRight
         searchTerm={searchTerm}
         onSearchTermChange={setSearchTerm}

--- a/logicle/app/admin/sso/[clientId]/page.tsx
+++ b/logicle/app/admin/sso/[clientId]/page.tsx
@@ -1,5 +1,4 @@
 'use client'
-import { WithLoadingAndError } from '@/components/ui'
 import { useParams, useRouter } from 'next/navigation'
 import { mutate } from 'swr'
 import toast from 'react-hot-toast'

--- a/logicle/app/api/analytics/activity/route.ts
+++ b/logicle/app/api/analytics/activity/route.ts
@@ -1,10 +1,9 @@
 import { requireSession } from '@/api/utils/auth'
 import ApiResponses from '@/api/utils/ApiResponses'
-import { Session } from 'next-auth'
 import { db } from '@/db/database'
 export const dynamic = 'force-dynamic'
 
-export const GET = requireSession(async (session: Session, req: Request) => {
+export const GET = requireSession(async () => {
   const startOfMonth = new Date()
   startOfMonth.setDate(1)
   const endOfMonth = new Date(startOfMonth)

--- a/logicle/app/api/sso/saml/route.ts
+++ b/logicle/app/api/sso/saml/route.ts
@@ -1,9 +1,7 @@
 import env from '@/lib/env'
 import jackson from '@/lib/jackson'
 import { requireAdmin } from '@/api/utils/auth'
-import { NextRequest } from 'next/server'
 import ApiResponses from '@/api/utils/ApiResponses'
-import { UpdateSAMLConnectionParams } from '@foosoftsrl/saml-jackson'
 
 export const dynamic = 'force-dynamic'
 

--- a/logicle/app/chat/assistants/mine/page.tsx
+++ b/logicle/app/chat/assistants/mine/page.tsx
@@ -18,6 +18,7 @@ import { useConfirmationContext } from '@/components/providers/confirmationConte
 import { ActionList } from '@/components/ui/actionlist'
 import { SearchBarWithButtonsOnRight } from '@/components/app/SearchBarWithButtons'
 import { useState } from 'react'
+import { stringToHslColor } from '@/components/ui/LetterAvatar'
 
 const EMPTY_ASSISTANT_NAME = ''
 
@@ -166,6 +167,7 @@ const MyAssistantPage = () => {
                         size="big"
                         url={assistant.iconUri ?? undefined}
                         fallback={assistant.name}
+                        fallbackColor={stringToHslColor(assistant.id)}
                       />
                       <div className="flex flex-col flex-1 h-full">
                         <div className="font-bold">{assistant.name}</div>

--- a/logicle/app/chat/assistants/mine/page.tsx
+++ b/logicle/app/chat/assistants/mine/page.tsx
@@ -140,11 +140,6 @@ const MyAssistantPage = () => {
     toast.success(t('assistant-deleted'))
   }
 
-  const haveDrafts =
-    assistants?.find(
-      (assistant) => assistant.owner == profile?.id && assistant.name == EMPTY_ASSISTANT_NAME
-    ) !== undefined
-
   return (
     <WithLoadingAndError isLoading={isLoading} error={error}>
       <div className="flex flex-1 flex-col gap-2 items-center px-4 py-6">
@@ -153,11 +148,7 @@ const MyAssistantPage = () => {
             <h1 className="mb-4">{t('my_assistants')}</h1>
           </div>
           <SearchBarWithButtonsOnRight searchTerm={searchTerm} onSearchTermChange={setSearchTerm}>
-            <Button
-              disabled={haveDrafts || !defaultBackend}
-              onClick={() => onCreateNew()}
-              variant="primary"
-            >
+            <Button disabled={!defaultBackend} onClick={() => onCreateNew()} variant="primary">
               {t('create_new')}
             </Button>
           </SearchBarWithButtonsOnRight>
@@ -166,6 +157,7 @@ const MyAssistantPage = () => {
               {(assistants ?? [])
                 .filter((assistant) => isMine(assistant, profile))
                 .filter(filterWithSearch)
+                .toSorted((a, b) => -a.updatedAt.localeCompare(b.updatedAt))
                 .map((assistant) => {
                   return (
                     <div key={assistant.id} className="flex group align-center gap-2 items-center">

--- a/logicle/app/chat/assistants/select/page.tsx
+++ b/logicle/app/chat/assistants/select/page.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { SearchBarWithButtonsOnRight } from '@/components/app/SearchBarWithButtons'
 import * as dto from '@/types/dto'
+import { stringToHslColor } from '@/components/ui/LetterAvatar'
 
 const EMPTY_ASSISTANT_NAME = ''
 
@@ -94,6 +95,7 @@ const SelectAssistantPage = () => {
                         size="big"
                         url={assistant.iconUri ?? undefined}
                         fallback={assistant.name}
+                        fallbackColor={stringToHslColor(assistant.id)}
                       />
                       <div className="flex flex-col flex-1 h-full">
                         <div className="font-bold">{assistant.name}</div>

--- a/logicle/app/chat/components/AssistantDescription.tsx
+++ b/logicle/app/chat/components/AssistantDescription.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react'
 import * as dto from '@/types/dto'
 import { Avatar } from '@/components/ui/avatar'
 import { AssistantPin } from './AssistantPin'
+import { stringToHslColor } from '@/components/ui/LetterAvatar'
 
 interface Props {
   assistant: dto.UserAssistant
@@ -10,7 +11,12 @@ interface Props {
 const AssistantDescription: FC<Props> = ({ assistant }) => {
   return (
     <div className="group flex flex-row justify-center gap-3 h-16 items-center">
-      <Avatar size="big" url={assistant.iconUri ?? undefined} fallback={assistant?.name ?? ''} />
+      <Avatar
+        size="big"
+        url={assistant.iconUri ?? undefined}
+        fallback={assistant.name}
+        fallbackColor={stringToHslColor(assistant.id)}
+      />
       <h2 className=" flex justify-center py-2 bg-background">{assistant?.name ?? ''}</h2>
       <AssistantPin assistant={assistant}></AssistantPin>
     </div>

--- a/logicle/app/chat/components/StartChatFromHere.tsx
+++ b/logicle/app/chat/components/StartChatFromHere.tsx
@@ -3,6 +3,7 @@ import { IconSend } from '@tabler/icons-react'
 import { Avatar } from '@/components/ui/avatar'
 import * as dto from '@/types/dto'
 import { AssistantPin } from './AssistantPin'
+import { stringToHslColor } from '@/components/ui/LetterAvatar'
 
 interface SplashParams {
   assistant: dto.UserAssistant
@@ -20,7 +21,8 @@ export const StartChatFromHere = ({ assistant, className }: SplashParams) => {
             <div className="flex flex-col items-center">
               <Avatar
                 url={assistant.iconUri ?? undefined}
-                fallback={assistant?.name ?? ''}
+                fallback={assistant.name}
+                fallbackColor={stringToHslColor(assistant.id)}
                 size="big"
               ></Avatar>
               <h3 className="text-center">{assistant?.name}</h3>

--- a/logicle/app/chat/components/chatbar/Chatbar.tsx
+++ b/logicle/app/chat/components/chatbar/Chatbar.tsx
@@ -12,6 +12,7 @@ import dayjs from 'dayjs'
 import { useUserProfile } from '@/components/providers/userProfileContext'
 import { mutate } from 'swr'
 import * as dto from '@/types/dto'
+import { stringToHslColor } from '@/components/ui/LetterAvatar'
 
 export const Chatbar = () => {
   const { t } = useTranslation('common')
@@ -141,8 +142,9 @@ export const Chatbar = () => {
                 >
                   <Avatar
                     className="shrink-0"
-                    url={assistant?.iconUri ?? undefined}
-                    fallback={assistant.name ?? ''}
+                    url={assistant.iconUri ?? undefined}
+                    fallback={assistant.name}
+                    fallbackColor={stringToHslColor(assistant.id)}
                   />
                   <div
                     key={assistant.id}

--- a/logicle/components/ui/LetterAvatar.tsx
+++ b/logicle/components/ui/LetterAvatar.tsx
@@ -19,14 +19,17 @@ const variants = cva(
   }
 )
 
-function stringToHslColor(str, saturation, luminance) {
+export function stringToHslColor_(str: string, saturation: number, luminance: number) {
   let hash = 0
   for (let i = 0; i < str.length; i++) {
     hash = str.charCodeAt(i) + ((hash << 5) - hash)
   }
-
   const h = hash % 360
   return 'hsl(' + h + ', ' + saturation + '%, ' + luminance + '%)'
+}
+
+export function stringToHslColor(str: string) {
+  return stringToHslColor_(str, 100, 40)
 }
 
 interface Props extends VariantProps<typeof variants> {
@@ -46,7 +49,7 @@ const LetterAvatar: FC<Props> = ({ name, size, fill, color, border }: Props) => 
     .join('')
     .toUpperCase()
     .substring(0, maxLength)
-  const backgroundColor = fill ?? stringToHslColor(name, 100, 40)
+  const backgroundColor = fill ?? stringToHslColor(name)
 
   return (
     <div

--- a/logicle/components/ui/avatar.tsx
+++ b/logicle/components/ui/avatar.tsx
@@ -20,16 +20,18 @@ const avatarVariants = cva('flex rounded-full h-full w-full overflow-hidden bord
 interface Props extends VariantProps<typeof avatarVariants> {
   url?: string
   fallback: string
+  fallbackColor?: string
   className?: string
 }
 
-export const Avatar = ({ url, size, fallback, className }: Props) => {
+export const Avatar = ({ url, size, fallback, fallbackColor, className }: Props) => {
+  console.log(`fallbackColor = ${fallbackColor}`)
   return (
     <div className={cn(avatarVariants({ size }), className)}>
       {url ? (
         <img src={url} className="object-cover"></img>
       ) : (
-        <LetterAvatar size="fillParent" name={fallback}></LetterAvatar>
+        <LetterAvatar size="fillParent" name={fallback} fill={fallbackColor}></LetterAvatar>
       )}
     </div>
   )

--- a/logicle/db/migrations.ts
+++ b/logicle/db/migrations.ts
@@ -12,6 +12,7 @@ export async function migrateToLatest() {
     '20240404-workspaces': await import('./migrations/20240404-workspaces'),
     '20240531-messageaudit': await import('./migrations/20240531-messageaudit'),
     '20240603-images': await import('./migrations/20240603-images'),
+    '20240624-assistant_timestamps': await import('./migrations/20240624-assistant_timestamps'),
   }
 
   const db = new Kysely<any>({

--- a/logicle/db/migrations/20240624-assistant_timestamps.ts
+++ b/logicle/db/migrations/20240624-assistant_timestamps.ts
@@ -1,0 +1,22 @@
+import { Kysely } from 'kysely'
+
+const string = 'text'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('Assistant')
+    .addColumn('createdAt', string, (col) => col.notNull().defaultTo(new Date(0).toISOString()))
+    .execute()
+  await db.schema
+    .alterTable('Assistant')
+    .addColumn('updatedAt', string, (col) => col.notNull().defaultTo(new Date(0).toISOString()))
+    .execute()
+  const now = new Date()
+  await db
+    .updateTable('Assistant')
+    .set({
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+    })
+    .execute()
+}

--- a/logicle/db/schema.ts
+++ b/logicle/db/schema.ts
@@ -27,6 +27,8 @@ export interface Assistant {
   temperature: number
   tokenLimit: number
   owner: string | null
+  createdAt: string
+  updatedAt: string
 }
 
 export interface AssistantSharing {

--- a/logicle/tsconfig.json
+++ b/logicle/tsconfig.json
@@ -19,7 +19,6 @@
     "noImplicitAny": false,
     "paths": {
       "@/lib/*": ["lib/*"],
-      "@/models/*": ["models/*"],
       "@/components/*": ["components/*"],
       "@/services/*": ["services/*"],
       "@/utils/*": ["utils/*"],

--- a/logicle/types/dto.ts
+++ b/logicle/types/dto.ts
@@ -40,6 +40,8 @@ export interface UserAssistant {
   lastUsed: string | null
   owner: string
   sharing: Sharing[]
+  createdAt: string
+  updatedAt: string
 }
 
 export interface AddWorkspaceMemberRequest {

--- a/logicle/types/dto/assistants.ts
+++ b/logicle/types/dto/assistants.ts
@@ -21,7 +21,10 @@ export type AssistantWithTools = Omit<schema.Assistant, 'imageId'> & {
   iconUri: string | null
 }
 
-export type InsertableAssistant = Omit<schema.Assistant, 'id' | 'imageId'> & {
+export type InsertableAssistant = Omit<
+  schema.Assistant,
+  'id' | 'imageId' | 'createdAt' | 'updatedAt'
+> & {
   tools: AssistantTool[]
   files: AssistantFile[]
   iconUri: string | null


### PR DESCRIPTION
It is now possible to create more than one assistant drafts.
To avoid the user not noticing that drafts exist... they are simply order by update time (decreasing), which makes a lot of sense.

Moreover.. the rule for (fallback) avatar colors has been changed: color is derived from id, avoiding the ridiculous colour change when it was derived by name

Note: DB schema change!!!!!
