### PR TITLE
Show message actions for last message

### DIFF
--- a/logicle/app/chat/components/AssistantMessage.tsx
+++ b/logicle/app/chat/components/AssistantMessage.tsx
@@ -15,6 +15,7 @@ import 'katex/dist/katex.min.css' // `rehype-katex` does not import the CSS for 
 
 interface Props {
   message: dto.Message
+  isLast: boolean
 }
 
 function convertMathToKatexSyntax(text: string) {
@@ -32,7 +33,7 @@ function convertMathToKatexSyntax(text: string) {
   return res
 }
 
-export const AssistantMessage: FC<Props> = ({ message }) => {
+export const AssistantMessage: FC<Props> = ({ message, isLast }) => {
   const [messagedCopied, setMessageCopied] = useState(false)
   const {
     state: { chatStatus, selectedConversation },
@@ -61,12 +62,9 @@ export const AssistantMessage: FC<Props> = ({ message }) => {
   if (chatStatus.state == 'receiving' && chatStatus.messageId === message.id) {
     className += ' result-streaming'
   }
-  const messages = selectedConversation?.messages
-  const canRegenerate =
-    chatStatus.state === 'idle' &&
-    messages &&
-    messages.length > 0 &&
-    messages[messages.length - 1].id == message.id
+
+  // The action bar is not even inserted for last element
+  const insertActionBar = !isLast || chatStatus.state === 'idle'
   return (
     <div className="flex flex-col relative">
       {message.content.length == 0 ? (
@@ -116,23 +114,25 @@ export const AssistantMessage: FC<Props> = ({ message }) => {
           {convertMathToKatexSyntax(message.content)}
         </ReactMarkdown>
       )}
-      <div className="mt-2 md:-mr-8 ml-1 md:ml-0 flex flex-col md:flex-row gap-4 md:gap-1 items-center md:items-start justify-end md:justify-start">
-        {messagedCopied ? (
-          <IconCheck size={20} className="text-green-500" />
-        ) : (
-          <button className="invisible group-hover:visible focus:visible" onClick={onClickCopy}>
-            <IconCopy size={20} className="opacity-50 hover:opacity-100" />
-          </button>
-        )}
-        {canRegenerate && (
-          <button
-            className="invisible group-hover:visible focus:visible"
-            onClick={onRepeatLastMessage}
-          >
-            <IconRepeat size={20} className="opacity-50 hover:opacity-100" />
-          </button>
-        )}
-      </div>
+      {insertActionBar && (
+        <div className="mt-2 md:-mr-8 ml-1 md:ml-0 flex flex-col md:flex-row gap-4 md:gap-1 items-center md:items-start justify-end md:justify-start">
+          {messagedCopied ? (
+            <IconCheck size={20} className="text-green-500" />
+          ) : (
+            <button
+              className={`${isLast ? 'visible' : 'invisible group-hover:visible'} focus:visible`}
+              onClick={onClickCopy}
+            >
+              <IconCopy size={20} className="opacity-50 hover:opacity-100" />
+            </button>
+          )}
+          {isLast && (
+            <button onClick={onRepeatLastMessage}>
+              <IconRepeat size={20} className={`opacity-50 hover:opacity-100`} />
+            </button>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/logicle/app/chat/components/Chat.tsx
+++ b/logicle/app/chat/components/Chat.tsx
@@ -85,7 +85,7 @@ export const Chat = ({ assistant, className }: ChatProps) => {
     return <></>
   }
   const assistantImageUrl = assistant.iconUri ?? undefined
-
+  const messageList = flatten(selectedConversation).messages
   return (
     <div className={`flex flex-col overflow-hidden ${className ?? ''}`}>
       <ScrollArea
@@ -94,12 +94,13 @@ export const Chat = ({ assistant, className }: ChatProps) => {
         onScroll={handleScroll}
       >
         <div className="max-w-[700px] mx-auto">
-          {flatten(selectedConversation).messages.map((message, index) => (
+          {messageList.map((message, index) => (
             <MemoizedChatMessage
               key={index}
               assistant={assistant}
               assistantImageUrl={assistantImageUrl}
               message={message}
+              isLast={index + 1 == messageList.length}
             />
           ))}
           <div className="h-[1px]" ref={messagesEndRef} />

--- a/logicle/app/chat/components/ChatMessage.tsx
+++ b/logicle/app/chat/components/ChatMessage.tsx
@@ -12,10 +12,11 @@ export interface ChatMessageProps {
   message: dto.Message
   assistantImageUrl?: string
   assistant: dto.UserAssistant
+  isLast: boolean
 }
 
 export const ChatMessage: FC<ChatMessageProps> = memo(
-  ({ assistant, message, assistantImageUrl }) => {
+  ({ assistant, message, assistantImageUrl, isLast }) => {
     const userProfile = useUserProfile()
     const avatarUrl = message.role === 'user' ? userProfile?.image : assistantImageUrl
     const avatarFallback = message.role === 'user' ? userProfile?.name ?? '' : assistant.name
@@ -47,7 +48,7 @@ export const ChatMessage: FC<ChatMessageProps> = memo(
             {message.role === 'user' ? (
               <UserMessage message={message}></UserMessage>
             ) : (
-              <AssistantMessage message={message}></AssistantMessage>
+              <AssistantMessage message={message} isLast={isLast}></AssistantMessage>
             )}
           </div>
         </div>

--- a/logicle/components/ui/avatar.tsx
+++ b/logicle/components/ui/avatar.tsx
@@ -25,7 +25,6 @@ interface Props extends VariantProps<typeof avatarVariants> {
 }
 
 export const Avatar = ({ url, size, fallback, fallbackColor, className }: Props) => {
-  console.log(`fallbackColor = ${fallbackColor}`)
   return (
     <div className={cn(avatarVariants({ size }), className)}>
       {url ? (


### PR DESCRIPTION
Modified the logic with which copy / regenerate actions appear:

* Last message being streamed: show nothing (and take no vertical space)
* Last message complete: show actions
* Other messages: show actions on mouse hover