### PR TITLE
Fix scroll in User selector dialog

### DIFF
--- a/logicle/components/app/UserSelectorDialog.tsx
+++ b/logicle/components/app/UserSelectorDialog.tsx
@@ -2,10 +2,10 @@ import { useTranslation } from 'next-i18next'
 import { useUsers } from '@/hooks/users'
 import { useState } from 'react'
 import ConfirmationDialog from '../ui/ConfirmationDialog'
-import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
+import { Popover, PopoverContentNoPortal, PopoverTrigger } from '../ui/popover'
 import { Button } from '../ui/button'
 import { cn } from '@/lib/utils'
-import { Command, CommandEmpty, CommandInput, CommandItem, CommandList } from '../ui/command'
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from '../ui/command'
 import { Check, ChevronsUpDown } from 'lucide-react'
 
 interface Props {
@@ -41,7 +41,7 @@ export const UserSelectorDialog = ({ initialUserId, title, onUpdate, onClose }: 
             <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="text-body1 w-[--radix-popover-trigger-width] p-0">
+        <PopoverContentNoPortal className="text-body1 w-[--radix-popover-trigger-width] p-0">
           <Command
             filter={(value, search) => {
               if (value.includes(search)) return 1
@@ -50,7 +50,7 @@ export const UserSelectorDialog = ({ initialUserId, title, onUpdate, onClose }: 
           >
             <CommandInput placeholder="Search user..." />
             <CommandEmpty>{t('no_such_user')}</CommandEmpty>
-            <CommandList>
+            <CommandGroup className="max-h-64 overflow-x-hidden overflow-y-auto">
               {users.map((user) => (
                 <CommandItem
                   key={user.id}
@@ -67,9 +67,9 @@ export const UserSelectorDialog = ({ initialUserId, title, onUpdate, onClose }: 
                   {user.name}
                 </CommandItem>
               ))}
-            </CommandList>
+            </CommandGroup>
           </Command>
-        </PopoverContent>
+        </PopoverContentNoPortal>
       </Popover>
     </ConfirmationDialog>
   )

--- a/logicle/components/ui/popover.tsx
+++ b/logicle/components/ui/popover.tsx
@@ -26,4 +26,21 @@ const PopoverContent = React.forwardRef<
 ))
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
-export { Popover, PopoverTrigger, PopoverContent }
+const PopoverContentNoPortal = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      className
+    )}
+    {...props}
+  />
+))
+PopoverContentNoPortal.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverContentNoPortal }


### PR DESCRIPTION
ShadCn's popover always uses portal, and this breaks scrolling with mouse wheel (and possibly causes scrollbar to not show up on hover on macos)

See https://github.com/shadcn-ui/ui/issues/607

Using radix-ui show-on-hover scrollbar (nice!) require a bit of work. Not this time

