### PR TITLE
Delete Session cookie if invalid

### DIFF
--- a/logicle/app/api/utils/auth.ts
+++ b/logicle/app/api/utils/auth.ts
@@ -5,6 +5,7 @@ import ApiResponses from './ApiResponses'
 import { mapExceptions } from './mapExceptions'
 import * as dto from '@/types/dto'
 import { cookies } from 'next/headers'
+import { SESSION_TOKEN_NAME } from '@/lib/const'
 
 export async function isCurrentUser(userId: string): Promise<boolean> {
   const session = await auth()
@@ -18,9 +19,9 @@ export function requireAdmin(
     const session = await auth()
     if (!session) {
       const cookieStore = cookies()
-      if (cookieStore.has('authjs.session-token')) {
+      if (cookieStore.has(SESSION_TOKEN_NAME)) {
         console.log('Deleting invalid cookie')
-        cookieStore.delete('authjs.session-token')
+        cookieStore.delete(SESSION_TOKEN_NAME)
       }
       return ApiResponses.notAuthorized()
     }
@@ -38,9 +39,9 @@ export function requireSession(
     const session = await auth()
     if (!session) {
       const cookieStore = cookies()
-      if (cookieStore.has('authjs.session-token')) {
+      if (cookieStore.has(SESSION_TOKEN_NAME)) {
         console.log('Deleting invalid cookie')
-        cookieStore.delete('authjs.session-token')
+        cookieStore.delete(SESSION_TOKEN_NAME)
       }
       return ApiResponses.notAuthorized()
     }

--- a/logicle/authOptions.ts
+++ b/logicle/authOptions.ts
@@ -15,6 +15,7 @@ import NodeCache from 'node-cache'
 import * as dto from '@/types/dto'
 import * as schema from '@/db/schema'
 import { Session } from 'next-auth'
+import { SESSION_TOKEN_NAME } from './lib/const'
 export const dynamic = 'force-dynamic'
 
 const userCache = new NodeCache({ stdTTL: 10 })
@@ -256,7 +257,7 @@ export const authOptions: any = {
       },
     },
     sessionToken: {
-      name: `authjs.session-token`,
+      name: SESSION_TOKEN_NAME,
       options: {
         httpOnly: true,
         sameSite: 'lax',

--- a/logicle/lib/const.ts
+++ b/logicle/lib/const.ts
@@ -3,3 +3,4 @@ export const DEFAULT_SYSTEM_PROMPT =
   "You are ChatGPT, a large language model trained by OpenAI. Follow the user's instructions carefully. Respond using markdown."
 
 export const DEFAULT_TEMPERATURE = parseFloat(process.env.NEXT_PUBLIC_DEFAULT_TEMPERATURE || '0.5')
+export const SESSION_TOKEN_NAME = 'authjs.session-token'

--- a/logicle/middleware.ts
+++ b/logicle/middleware.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import micromatch from 'micromatch'
+import { SESSION_TOKEN_NAME } from './lib/const'
 
 // API routes will manage authentication by themselves
 const unAuthenticatedRoutes = ['/api/**', '/auth/**', '/internals/**', '_next/*']
@@ -7,7 +8,6 @@ const unAuthenticatedRoutes = ['/api/**', '/auth/**', '/internals/**', '_next/*'
 // Middleware redirects all app routes which require authentication
 // to login if session token is missing
 export async function middleware(req: NextRequest) {
-
   // Don't mess with routes that don't require authentication
   const { pathname } = req.nextUrl
   if (micromatch.isMatch(pathname, unAuthenticatedRoutes)) {
@@ -17,7 +17,7 @@ export async function middleware(req: NextRequest) {
   // TODO: use shared constants for cookie names (see authOptions)
   // This is just a pre-check. But auth() call does not seem to work
   // on node. API routes will use auth()
-  const sessionToken = req.cookies.get('authjs.session-token')
+  const sessionToken = req.cookies.get(SESSION_TOKEN_NAME)
   if (!sessionToken) {
     const url = new URL('/auth/login', req.url)
     url.searchParams.set('callbackUrl ', encodeURI(req.url))
@@ -29,5 +29,5 @@ export async function middleware(req: NextRequest) {
 // We disable middleware altogether for API routes, as middleware
 // caches the entire request body (not very clever for file uploads)
 export const config = {
-  matcher: ["/((?!api|_next/static|_next/image|assets|favicon.ico).*)"],
+  matcher: ['/((?!api|_next/static|_next/image|assets|favicon.ico).*)'],
 }


### PR DESCRIPTION
APIs are currently not managed by NextAuth (i.e. no middleware).
So... when we return a 401, we must request cookie deletion is we detect that they're not valid
