### PR TITLE
Fix preview reset visibility

### DIFF
--- a/logicle/app/assistants/components/AssistantPreview.tsx
+++ b/logicle/app/assistants/components/AssistantPreview.tsx
@@ -119,8 +119,11 @@ export const AssistantPreview = ({ assistant, className, sendDisabled }: Props) 
             className="flex items-center gap-3 group focus:visible"
             onClick={clearConversation}
           >
-            <h3 className="text-center">Preview</h3>
-            <IconRotate size="18" className="invisible group-hover:visible"></IconRotate>
+            <h3 className="text-center">{t('preview')}</h3>
+            <IconRotate
+              size="18"
+              className={chatStatus.state == 'idle' ? '' : 'invisible'}
+            ></IconRotate>
           </Button>
           <Chat className={'flex-1'} assistant={userAssistant}></Chat>
         </div>

--- a/logicle/locales/en/common.json
+++ b/logicle/locales/en/common.json
@@ -197,6 +197,7 @@
   "password-successfully-updated": "Password has been successfully updated",
   "password-updated": "Password updated successfully.",
   "password": "Password",
+  "preview": "Preview",
   "previous-week": "Previous 7 Days",
   "pricing": "Pricing",
   "products": "Products",


### PR DESCRIPTION
Make reset visible not only when hovering.
Moreover, button is disabled when chat is not idle