### PR TITLE
Prevent sending messages when text is empty (or whitespace only)

### DIFF
--- a/logicle/app/chat/components/ChatInput.tsx
+++ b/logicle/app/chat/components/ChatInput.tsx
@@ -35,6 +35,8 @@ export const ChatInput = ({ onSend, disabled, disabledMsg }: Props) => {
 
   const uploadedFiles = useRef<Upload[]>([])
   const [, setRefresh] = useState<number>(0)
+  const anyUploadRunning = !!uploadedFiles.current.find((u) => !u.fileId)
+  const msgEmpty = (content?.trim().length ?? 0) == 0 && uploadedFiles.current.length == 0
 
   useEffect(() => {
     textareaRef.current?.focus()
@@ -90,7 +92,7 @@ export const ChatInput = ({ onSend, disabled, disabledMsg }: Props) => {
   }
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !isTyping && !isMobile() && !e.shiftKey) {
+    if (e.key === 'Enter' && !isTyping && !isMobile() && !e.shiftKey && !msgEmpty) {
       e.preventDefault()
       handleSend()
     }
@@ -143,9 +145,6 @@ export const ChatInput = ({ onSend, disabled, disabledMsg }: Props) => {
     xhr.responseType = 'json'
     xhr.send(file)
   }
-
-  const anyUploadRunning = !!uploadedFiles.current.find((u) => !u.fileId)
-  const msgEmpty = (content?.length ?? 0) == 0 && uploadedFiles.current.length == 0
 
   if (disabled) {
     return (


### PR DESCRIPTION
Fixes #175

Note that ChatGPT behaviour is quite weird... it prevents sending empty messages, but one newline is ok.
So if you hit newline two times, a message containing a single new line is sent.
