### PR TITLE
Prevent creation of unsupported providers

### DIFF
--- a/logicle/app/admin/backends/BackendsPage.tsx
+++ b/logicle/app/admin/backends/BackendsPage.tsx
@@ -101,18 +101,6 @@ export const BackendsPage = () => {
               <DropdownMenuButton onClick={() => onProviderSelect(ProviderType.OpenAI)}>
                 {t('openai-backend')}
               </DropdownMenuButton>
-              <DropdownMenuButton onClick={() => onProviderSelect(ProviderType.Anthropic)}>
-                {t('anthropic-backend')}
-              </DropdownMenuButton>
-              <DropdownMenuButton onClick={() => onProviderSelect(ProviderType.TogetherAI)}>
-                {t('togetherai-backend')}
-              </DropdownMenuButton>
-              <DropdownMenuButton onClick={() => onProviderSelect(ProviderType.Groq)}>
-                {t('groq-backend')}
-              </DropdownMenuButton>
-              <DropdownMenuButton onClick={() => onProviderSelect(ProviderType.LocalAI)}>
-                {t('localai-backend')}
-              </DropdownMenuButton>
               <DropdownMenuButton onClick={() => onProviderSelect(ProviderType.LogicleCloud)}>
                 {t('logiclecloud-backend')}
               </DropdownMenuButton>

--- a/logicle/locales/en/common.json
+++ b/logicle/locales/en/common.json
@@ -192,7 +192,7 @@
   "no-api-key-title": "You haven't created any API Keys yet",
   "no-credentials": "No credentials found.",
   "older": "Older",
-  "openai-backend": "OpenAI API",
+  "openai-backend": "OpenAI",
   "or-sign-in-with": "Or Sign In With",
   "password-is-required": "The Password field is required",
   "password-reset-link-sent": "Password reset link sent",


### PR DESCRIPTION
We're migrating towards an external LLM broker.
So... let's restrict creatable backends to providers:
* OpenAI
* Logicle Cloud