### PR TITLE
Re-add anthropic to available backend providers

### DIFF
--- a/logicle/app/admin/backends/BackendsPage.tsx
+++ b/logicle/app/admin/backends/BackendsPage.tsx
@@ -101,6 +101,9 @@ export const BackendsPage = () => {
               <DropdownMenuButton onClick={() => onProviderSelect(ProviderType.OpenAI)}>
                 {t('openai-backend')}
               </DropdownMenuButton>
+              <DropdownMenuButton onClick={() => onProviderSelect(ProviderType.Anthropic)}>
+                {t('anthropic-backend')}
+              </DropdownMenuButton>{' '}
               <DropdownMenuButton onClick={() => onProviderSelect(ProviderType.LogicleCloud)}>
                 {t('logiclecloud-backend')}
               </DropdownMenuButton>


### PR DESCRIPTION
The available providers will be:
* OpenAI
* Anthropic
* Gemini (not yet there)
* Logicle AI 