### PR TITLE
Make shared assistants editable

### DIFF
--- a/logicle/app/api/user/assistants/[assistantId]/route.ts
+++ b/logicle/app/api/user/assistants/[assistantId]/route.ts
@@ -3,15 +3,15 @@ import ApiResponses from '@/api/utils/ApiResponses'
 import { requireSession } from '@/app/api/utils/auth'
 import { Session } from 'next-auth'
 import { NextRequest } from 'next/server'
-import { getUserWorkspaces } from '@/models/user'
 import * as dto from '@/types/dto'
+import { getUserWorkspaceMemberships } from '@/models/user'
 
 export const dynamic = 'force-dynamic'
 
 export const GET = requireSession(
   async (session: Session, req: NextRequest, route: { params: { assistantId: string } }) => {
     const assistantId = route.params.assistantId
-    const enabledWorkspaces = await getUserWorkspaces(session.user.id)
+    const enabledWorkspaces = await getUserWorkspaceMemberships(session.user.id)
     const assistants = await Assistants.withUserData({
       assistantId,
       userId: session.user.id,

--- a/logicle/app/api/user/assistants/explore/route.ts
+++ b/logicle/app/api/user/assistants/explore/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server'
 import Assistants from '@/models/assistant'
 import { requireSession } from '@/api/utils/auth'
-import { getUserWorkspaces } from '@/models/user'
+import { getUserWorkspaceMemberships } from '@/models/user'
 
 export const dynamic = 'force-dynamic'
 
 export const GET = requireSession(async (session) => {
-  const enabledWorkspaces = await getUserWorkspaces(session.user.id)
+  const enabledWorkspaces = await getUserWorkspaceMemberships(session.user.id)
   const assistants = await Assistants.withUserData({
     userId: session.user.id,
     workspaceIds: enabledWorkspaces.map((w) => w.id),

--- a/logicle/app/api/user/profile/route.ts
+++ b/logicle/app/api/user/profile/route.ts
@@ -1,4 +1,9 @@
-import { deleteUserImage, getUserById, getUserWorkspaces, updateUser } from '@/models/user'
+import {
+  deleteUserImage,
+  getUserById,
+  getUserWorkspaceMemberships,
+  updateUser,
+} from '@/models/user'
 import ApiResponses from '@/api/utils/ApiResponses'
 import { KeysEnum, sanitize } from '@/lib/sanitize'
 import { requireSession } from '../../utils/auth'
@@ -20,7 +25,7 @@ export const GET = requireSession(async (session) => {
   if (!roleName) {
     return ApiResponses.internalServerError('Invalid user role')
   }
-  const enabledWorkspaces = await getUserWorkspaces(session.user.id)
+  const enabledWorkspaces = await getUserWorkspaceMemberships(session.user.id)
   const pinnedAssistants = await Assistants.withUserData({
     userId: session.user.id,
     workspaceIds: enabledWorkspaces.map((w) => w.id),

--- a/logicle/app/assistants/[id]/page.tsx
+++ b/logicle/app/assistants/[id]/page.tsx
@@ -13,6 +13,7 @@ import { ApiError } from '@/types/base'
 import { useConfirmationContext } from '@/components/providers/confirmationContext'
 import { IconArrowLeft } from '@tabler/icons-react'
 import { SelectSharingDialog } from '../components/SelectSharingDialog'
+import { useUserProfile } from '@/components/providers/userProfileContext'
 
 interface State {
   assistant?: dto.AssistantWithTools
@@ -34,7 +35,7 @@ const AssistantPage = () => {
   const { assistant, isLoading, error } = state
   const sharing = assistant?.sharing || []
   const router = useRouter()
-
+  const userProfile = useUserProfile()
   useEffect(() => {
     const doLoad = async () => {
       const stored = localStorage.getItem(id)
@@ -144,9 +145,15 @@ const AssistantPage = () => {
           <h1>{`Assistant ${assistant.name}`}</h1>
         </div>
         <div className="flex gap-3">
-          <Button variant="outline" className="px-2" onClick={() => setSelectSharingVisible(true)}>
-            Sharing
-          </Button>
+          {assistant.owner == userProfile?.id && (
+            <Button
+              variant="outline"
+              className="px-2"
+              onClick={() => setSelectSharingVisible(true)}
+            >
+              Sharing
+            </Button>
+          )}
           <Button onClick={() => fireSubmit.current?.()}>Submit</Button>
         </div>
       </div>

--- a/logicle/app/assistants/[id]/page.tsx
+++ b/logicle/app/assistants/[id]/page.tsx
@@ -76,7 +76,7 @@ const AssistantPage = () => {
         })
       }
     }
-    if (state.assistant === undefined && !state.isLoading) {
+    if (state.assistant === undefined && !state.isLoading && !state.error) {
       setState({
         ...state,
         isLoading: true,

--- a/logicle/app/chat/assistants/mine/page.tsx
+++ b/logicle/app/chat/assistants/mine/page.tsx
@@ -41,7 +41,7 @@ const MyAssistantPage = () => {
   const [searchTerm, setSearchTerm] = useState<string>('')
 
   /**
-   * @param assistant 
+   * @param assistant
    * @param profile the user profile
    * @returns whether the user can edit the assistant
    */
@@ -50,15 +50,20 @@ const MyAssistantPage = () => {
     // - he is the owner
     // - he has the WorkspaceRole Editor role in the same workspace where the assistant has been shared
     //   (if the assistant has been shared to all it is editable only by the owner)
-    if (assistant.owner == profile?.id) return true;
+    if (assistant.owner == profile?.id) return true
 
-    return assistant.sharing.some(s => {
-      if (dto.isAllSharingType(s)) return false;
+    return assistant.sharing.some((s) => {
+      if (dto.isAllSharingType(s)) return false
 
-      return profile?.workspaces.some(w => {
-        return w.id == s.workspaceId && w.role == WorkspaceRole.EDITOR
-      });
-    });
+      return profile?.workspaces.some((w) => {
+        return (
+          w.id == s.workspaceId &&
+          (w.role == WorkspaceRole.EDITOR ||
+            w.role == WorkspaceRole.OWNER ||
+            w.role == WorkspaceRole.ADMIN)
+        )
+      })
+    })
   }
 
   const {

--- a/logicle/app/chat/assistants/select/page.tsx
+++ b/logicle/app/chat/assistants/select/page.tsx
@@ -76,7 +76,7 @@ const SelectAssistantPage = () => {
         <div className="flex flex-1 flex-col gap-2 max-w-[960px] w-3/4 px-4 py-6">
           <h1 className="text-center">{t('select_assistant')}</h1>
           <SearchBarWithButtonsOnRight searchTerm={searchTerm} onSearchTermChange={setSearchTerm}>
-            <Button onClick={gotoMyAssistants}>My assistants</Button>
+            <Button onClick={gotoMyAssistants}>{t('my-assistants')}</Button>
           </SearchBarWithButtonsOnRight>
 
           <ScrollArea className="flex-1">

--- a/logicle/db/schema.ts
+++ b/logicle/db/schema.ts
@@ -1,5 +1,12 @@
 import { ModelDetectionMode, ProviderType } from '@/types/provider'
 
+enum WorkspaceRole {
+  ADMIN = 'ADMIN',
+  OWNER = 'OWNER',
+  MEMBER = 'MEMBER',
+  EDITOR = 'EDITOR',
+}
+
 export interface Account {
   access_token: string | null
   expires_at: number | null
@@ -137,7 +144,7 @@ export interface WorkspaceMember {
   id: string
   userId: string
   workspaceId: string
-  role: string
+  role: WorkspaceRole
   createdAt: string
   updatedAt: string
 }

--- a/logicle/models/assistant.ts
+++ b/logicle/models/assistant.ts
@@ -44,7 +44,7 @@ export default class Assistants {
     })
   }
 
-  static get = async (assistantId: dto.Assistant['id']) => {
+  static get = async (assistantId: dto.Assistant['id']): Promise<schema.Assistant | undefined> => {
     return db.selectFrom('Assistant').selectAll().where('id', '=', assistantId).executeTakeFirst()
   }
 
@@ -204,7 +204,16 @@ export default class Assistants {
       .executeTakeFirst()
   }
 
-  static sharingData = async (assistantIds: string[]) => {
+  static sharingDataSingle = async (assistantId: string): Promise<dto.Sharing[]> => {
+    const sharingDataMapPerAssistantId = await Assistants.sharingData([assistantId])
+    const sharingData = sharingDataMapPerAssistantId.get(assistantId)
+    if (!sharingData) {
+      throw new Error('Failed loading workspace sharing data')
+    }
+    return sharingData
+  }
+
+  static sharingData = async (assistantIds: string[]): Promise<Map<String, dto.Sharing[]>> => {
     const result = new Map<String, dto.Sharing[]>()
     if (assistantIds.length == 0) {
       return result

--- a/logicle/models/user.ts
+++ b/logicle/models/user.ts
@@ -57,13 +57,16 @@ export const getUserCount = async () => {
   return result.count
 }
 
-export const getUserWorkspaces = async (userId: string) => {
+export const getUserWorkspaceMemberships = async (
+  userId: string
+): Promise<dto.WorkspaceMembership[]> => {
   return await db
     .selectFrom('WorkspaceMember')
     .innerJoin('Workspace', (join) =>
       join.onRef('Workspace.id', '=', 'WorkspaceMember.workspaceId')
     )
-    .selectAll('Workspace')
+    .select('Workspace.id')
+    .select('Workspace.name')
     .select('WorkspaceMember.role')
     .where('WorkspaceMember.userId', '=', userId)
     .execute()

--- a/logicle/types/dto/sharing.ts
+++ b/logicle/types/dto/sharing.ts
@@ -10,3 +10,7 @@ interface WorkspaceSharingType {
 
 export type Sharing = AllSharingType | WorkspaceSharingType
 export type InsertableSharing = AllSharingType | Omit<WorkspaceSharingType, 'workspaceName'>
+
+export function isAllSharingType(sharing: AllSharingType | WorkspaceSharingType): sharing is AllSharingType {
+  return sharing.type == 'all';
+}

--- a/logicle/types/workspace.ts
+++ b/logicle/types/workspace.ts
@@ -4,12 +4,12 @@ export enum WorkspaceRole {
   ADMIN = 'ADMIN',
   OWNER = 'OWNER',
   MEMBER = 'MEMBER',
-  EDITOR = 'EDITOR'
+  EDITOR = 'EDITOR',
 }
 
 export const workspaceRoles: WorkspaceRole[] = [
   WorkspaceRole.MEMBER,
   WorkspaceRole.ADMIN,
   WorkspaceRole.OWNER,
-  WorkspaceRole.EDITOR
+  WorkspaceRole.EDITOR,
 ]

--- a/logicle/types/workspace.ts
+++ b/logicle/types/workspace.ts
@@ -4,10 +4,12 @@ export enum WorkspaceRole {
   ADMIN = 'ADMIN',
   OWNER = 'OWNER',
   MEMBER = 'MEMBER',
+  EDITOR = 'EDITOR'
 }
 
 export const workspaceRoles: WorkspaceRole[] = [
   WorkspaceRole.MEMBER,
   WorkspaceRole.ADMIN,
   WorkspaceRole.OWNER,
+  WorkspaceRole.EDITOR
 ]


### PR DESCRIPTION
* Added the Editor role to the WorkspaceRole enum and tweaked the my assistants list visibility filter.
* Updated RBAC for API /api/assistants/[id]
* Assistant sharing button is visible only for owner

fixes #199 