### PR TITLE
Add mime multipart support to OpenAPI tool (attachments supported)

### DIFF
--- a/logicle/app/chat/components/ChatInput.tsx
+++ b/logicle/app/chat/components/ChatInput.tsx
@@ -131,7 +131,7 @@ export const ChatInput = ({ onSend, disabled, disabledMsg, textAreaRef }: Props)
       name: fileName,
     }
     if (!environment.chatAttachmentsAllowedFormats.includes(file.type)) {
-      toast(`Unsupported file format: ${fileName}`)
+      toast(`Can't upload file '${fileName}'. Unsupported file format ${file.type}`)
       return
     }
     const response = await post<dto.File>('/api/files', insertRequest)

--- a/logicle/lib/chat/ToolUiLinkImpl.ts
+++ b/logicle/lib/chat/ToolUiLinkImpl.ts
@@ -17,8 +17,8 @@ export class ToolUiLinkImpl implements ToolUILink {
     this.controller = controller
     this.saveMessage = saveMessage
   }
-  newMessage() {
-    this.closeCurrentMessage()
+  async newMessage() {
+    await this.closeCurrentMessage()
     const toolCallOuputMsg: dto.Message = this.chatState.createToolOutputMsg()
     this.controller.enqueueNewMessage(toolCallOuputMsg)
     this.currentMsg = toolCallOuputMsg
@@ -32,14 +32,14 @@ export class ToolUiLinkImpl implements ToolUILink {
     this.controller.enqueueAttachment(attachment)
   }
 
-  close() {
-    this.closeCurrentMessage()
+  async close() {
+    await this.closeCurrentMessage()
   }
 
-  closeCurrentMessage() {
+  async closeCurrentMessage() {
     if (this.currentMsg) {
       this.chatState.push(this.currentMsg)
-      this.saveMessage(this.currentMsg)
+      await this.saveMessage(this.currentMsg)
       this.currentMsg = undefined
     }
   }

--- a/logicle/lib/chat/conversion.ts
+++ b/logicle/lib/chat/conversion.ts
@@ -65,6 +65,10 @@ export const dtoMessageToLlmMessage = async (
     const imageParts = (
       await Promise.all(
         m.attachments.map(async (a) => {
+          messageParts.push({
+            type: 'text',
+            text: `Uploaded file ${a.name} id ${a.id} type ${a.mimetype}`,
+          })
           const fileEntry = await getFileWithId(a.id)
           if (!fileEntry) {
             console.warn(`Can't find entry for attachment ${a.id}`)

--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -179,7 +179,7 @@ export class ChatAssistant {
             chatHistory,
             toolUILink
           )
-          toolUILink.close()
+          await toolUILink.close()
 
           const toolCallResultDtoMessage = chatState.addToolCallResultMsg(authRequest, funcResult)
           await this.saveMessage(toolCallResultDtoMessage)
@@ -329,7 +329,7 @@ export class ChatAssistant {
         chatState.chatHistory,
         toolUILink
       )
-      toolUILink.close()
+      await toolUILink.close()
 
       const toolCallResultMessage = chatState.addToolCallResultMsg(toolCall, funcResult)
       await this.saveMessage(toolCallResultMessage)

--- a/logicle/lib/chat/tools.ts
+++ b/logicle/lib/chat/tools.ts
@@ -2,7 +2,7 @@ import * as dto from '@/types/dto'
 import { JSONSchema7 } from 'json-schema'
 
 export interface ToolUILink {
-  newMessage: () => void
+  newMessage: () => Promise<void>
   appendText: (text: string) => void
   addAttachment: (attachment: dto.Attachment) => void
 }

--- a/logicle/lib/tools/dall-e/implementation.ts
+++ b/logicle/lib/tools/dall-e/implementation.ts
@@ -83,7 +83,7 @@ export class Dall_ePlugin extends Dall_ePluginInterface implements ToolImplement
           size: imgBinaryData.byteLength,
         }
         addFile(id, dbEntry, path)
-        uiLink.newMessage()
+        await uiLink.newMessage()
         uiLink.addAttachment({
           id,
           mimetype: mimeType,

--- a/logicle/lib/tools/timeofday/implementation.ts
+++ b/logicle/lib/tools/timeofday/implementation.ts
@@ -19,7 +19,7 @@ export class TimeOfDay extends TimeOfDayInterface implements ToolImplementation 
       requireConfirm: false,
       invoke: async () => {
         /*
-          uiLink.newMessage()
+          await uiLink.newMessage()
           for (let i = 0; i < 10; i++) {
             await new Promise((f) => setTimeout(f, 200))
             uiLink.appendText(`${i}...`)


### PR DESCRIPTION
This PR adds to OpenAPI tool support for services which accept request bodies of type mime multipart.
First tool is... a transcription tool based on whisper APIs.
In order to let the LLM know about attachments, simple lines such as:
            `Uploaded file ${a.name} id ${a.id} type ${a.mimetype}`,
are appended to message body (in a dedicated message part, actually)


