### PR TITLE
Hide backend in navbar if backends are locked

### DIFF
--- a/logicle/app/admin/layout.tsx
+++ b/logicle/app/admin/layout.tsx
@@ -23,10 +23,11 @@ const navEntries = (env: Environment) => {
       title: 'workspaces',
       href: '/admin/workspaces',
     })
-  entries.push({
-    title: 'backends',
-    href: '/admin/backends',
-  })
+  !env.backendConfigLock &&
+    entries.push({
+      title: 'backends',
+      href: '/admin/backends',
+    })
 
   env.enableTools &&
     entries.push({


### PR DESCRIPTION
Resource will still be reachable with direct URL... but locked, nonetheless