### PR TITLE
Add support for OpenApi http security scheme

### DIFF
--- a/logicle/lib/openapi.ts
+++ b/logicle/lib/openapi.ts
@@ -12,6 +12,8 @@ export const extractApiKeysFromOpenApiSchema = async (schemaText: string): Promi
     const value = securitySchemes[key] as OpenAPIV3.SecuritySchemeObject
     if (value.type == 'apiKey') {
       result.set(key, value as OpenAPIV3.SecuritySchemeObject)
+    } else if (key == 'auth' && value.type == 'http') {
+      result.set(key, value as OpenAPIV3.SecuritySchemeObject)
     }
   }
   return Array.from(result.keys())


### PR DESCRIPTION
Http security schemes in OpenAPI schemes are now supported.
Something like:

```
components:
  securitySchemes:
    auth:
      type: http
      scheme: "bearer"
```

will cause a "auth" option to appear.
The value will be stored as "auth" and used in the tool invocation

Note that in the case of bearer tokens, the "Bearer " prefix must be specified

