### PR TITLE
Openapi tool edit more improvements

### DIFF
--- a/logicle/__tests__/openapi.ts
+++ b/logicle/__tests__/openapi.ts
@@ -1,4 +1,4 @@
-import { validateSchema } from '@/lib/openapi'
+import { mapErrors, validateSchema } from '@/lib/openapi'
 import { parseDocument } from 'yaml'
 
 const goodSchema = `
@@ -35,6 +35,9 @@ info:
   title: Simple API
   version: 1.0.0
 poths:
+  xxx:
+    - eee
+    - fffz
 paths:
   /hello2:
   /hello:
@@ -71,4 +74,7 @@ test('TestInvalidSchemaOpenApi', () => {
   const doc = parseDocument(badSchemaOpenApi)
   const result = validateSchema(doc.toJSON())
   expect(result.errors).not.toBeNull()
+  if (result.errors) {
+    mapErrors(result.errors, doc)
+  }
 })

--- a/logicle/__tests__/openapi.ts
+++ b/logicle/__tests__/openapi.ts
@@ -75,6 +75,27 @@ paths:
           description: A successful response
 `
 
+const propMustBeObject = `
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  /hello:
+    - hello
+`
+
+const missingProp = `
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  /hello:
+    get:
+      summary: Check if an account has been breached
+`
+
 test('TestGoodSchema_yaml', () => {
   const doc = parseDocument(goodSchema)
   const json = doc.toJSON()
@@ -99,6 +120,24 @@ test('TestInvalidSchemaOpenApi', () => {
 
 test('TestUnknownProp', () => {
   const doc = parseDocument(unknownProp)
+  const result = validateSchema(doc.toJSON())
+  expect(result.errors).not.toBeNull()
+  if (!result.errors) return
+  const mapped = mapErrors(result.errors, doc)
+  console.log(mapped)
+})
+
+test('TestMustBeObject', () => {
+  const doc = parseDocument(propMustBeObject)
+  const result = validateSchema(doc.toJSON())
+  expect(result.errors).not.toBeNull()
+  if (!result.errors) return
+  const mapped = mapErrors(result.errors, doc)
+  console.log(mapped)
+})
+
+test('TestMissingProp', () => {
+  const doc = parseDocument(missingProp)
   const result = validateSchema(doc.toJSON())
   expect(result.errors).not.toBeNull()
   if (!result.errors) return

--- a/logicle/__tests__/openapi.ts
+++ b/logicle/__tests__/openapi.ts
@@ -57,6 +57,24 @@ paths:
                     example: "Hello, World!"
 `
 
+const unknownProp = `
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+poths:
+  xxx:
+    - eee
+    - fffz
+paths:
+  /hello:
+    get:
+      summary: Returns a simple greeting.
+      responses:
+        200:
+          description: A successful response
+`
+
 test('TestGoodSchema_yaml', () => {
   const doc = parseDocument(goodSchema)
   const json = doc.toJSON()
@@ -77,4 +95,13 @@ test('TestInvalidSchemaOpenApi', () => {
   if (result.errors) {
     mapErrors(result.errors, doc)
   }
+})
+
+test('TestUnknownProp', () => {
+  const doc = parseDocument(unknownProp)
+  const result = validateSchema(doc.toJSON())
+  expect(result.errors).not.toBeNull()
+  if (!result.errors) return
+  const mapped = mapErrors(result.errors, doc)
+  console.log(mapped)
 })

--- a/logicle/lib/openapi.ts
+++ b/logicle/lib/openapi.ts
@@ -100,6 +100,12 @@ export function mapErrors(errors: ErrorObject[], doc: YAML.Document.Parsed) {
         if (error.keyword == 'additionalProperties' && rangeMap[path].keyRange) {
           range = rangeMap[path].keyRange!
         }
+        if (error.keyword == 'type' && rangeMap[path].keyRange) {
+          range = rangeMap[path].keyRange!
+        }
+        if (error.keyword == 'required' && rangeMap[path].keyRange) {
+          range = rangeMap[path].keyRange!
+        }
         return {
           error,
           range,


### PR DESCRIPTION
For some errors, it make sense to underline the "key" and not the "value" of an object.
For example:

![image](https://github.com/user-attachments/assets/d6168215-1cdd-4e46-9ab8-f6886bee8848)

Possibly... ajv is not the best validator, but... it's better than nothing
