### PR TITLE
Provisioning

### DIFF
--- a/logicle/app/api/backends/[backendId]/route.ts
+++ b/logicle/app/api/backends/[backendId]/route.ts
@@ -40,6 +40,13 @@ export const DELETE = requireAdmin(async (req: Request, params: { backendId: str
   if (env.backends.locked) {
     return ApiResponses.forbiddenAction('Unable to delete the backend: configuration locked')
   }
+  const backend = await getBackend(params.backendId)
+  if (!backend) {
+    return ApiResponses.noSuchEntity('No such backend')
+  }
+  if (backend.provisioned) {
+    return ApiResponses.forbiddenAction("Can't delete a provisioned backend")
+  }
   try {
     await deleteBackend(params.backendId)
   } catch (e) {

--- a/logicle/app/api/backends/[backendId]/route.ts
+++ b/logicle/app/api/backends/[backendId]/route.ts
@@ -20,34 +20,37 @@ export const GET = requireAdmin(async (req: Request, params: { backendId: string
   return ApiResponses.json(protectApiKey(backend))
 })
 
-export const PATCH = requireAdmin(
-  async (req: Request, params: { backendId: string }) => {
-    if (env.backends.locked) {
-      return ApiResponses.forbiddenAction('Unable to modify the backend: configuration locked')
-    }
-    const data = await req.json()
-    await updateBackend(params.backendId, data)
-    return ApiResponses.success()
+export const PATCH = requireAdmin(async (req: Request, params: { backendId: string }) => {
+  if (env.backends.locked) {
+    return ApiResponses.forbiddenAction('Unable to modify the backend: configuration locked')
   }
-)
+  const backend = await getBackend(params.backendId)
+  if (!backend) {
+    return ApiResponses.noSuchEntity('No such backend')
+  }
+  if (backend.provisioned) {
+    return ApiResponses.forbiddenAction("Can't modify a provisioned backend")
+  }
+  const data = await req.json()
+  await updateBackend(params.backendId, data)
+  return ApiResponses.success()
+})
 
-export const DELETE = requireAdmin(
-  async (req: Request, params: { backendId: string }) => {
-    if (env.backends.locked) {
-      return ApiResponses.forbiddenAction('Unable to delete the backend: configuration locked')
-    }
-    try {
-      await deleteBackend(params.backendId)
-    } catch (e) {
-      const interpretedException = interpretDbException(e)
-      if (
-        interpretedException instanceof KnownDbError &&
-        interpretedException.code == KnownDbErrorCode.CONSTRAINT_FOREIGN_KEY
-      ) {
-        return ApiResponses.foreignKey('Backend is in use')
-      }
-      return defaultErrorResponse(interpretedException)
-    }
-    return ApiResponses.success()
+export const DELETE = requireAdmin(async (req: Request, params: { backendId: string }) => {
+  if (env.backends.locked) {
+    return ApiResponses.forbiddenAction('Unable to delete the backend: configuration locked')
   }
-)
+  try {
+    await deleteBackend(params.backendId)
+  } catch (e) {
+    const interpretedException = interpretDbException(e)
+    if (
+      interpretedException instanceof KnownDbError &&
+      interpretedException.code == KnownDbErrorCode.CONSTRAINT_FOREIGN_KEY
+    ) {
+      return ApiResponses.foreignKey('Backend is in use')
+    }
+    return defaultErrorResponse(interpretedException)
+  }
+  return ApiResponses.success()
+})

--- a/logicle/app/api/tools/[toolId]/route.ts
+++ b/logicle/app/api/tools/[toolId]/route.ts
@@ -31,6 +31,7 @@ export const PATCH = requireAdmin(async (req: Request, params: { toolId: string 
     ...data,
     id: undefined,
     type: undefined,
+    provisioned: undefined, // protect against malicious API usage
     createdAt: undefined,
     updatedAt: new Date().toISOString(),
   })

--- a/logicle/app/api/tools/[toolId]/route.ts
+++ b/logicle/app/api/tools/[toolId]/route.ts
@@ -20,6 +20,13 @@ export const GET = requireAdmin(async (req: Request, params: { toolId: string })
 
 export const PATCH = requireAdmin(async (req: Request, params: { toolId: string }) => {
   const data = await req.json()
+  const existingTool = await getTool(params.toolId)
+  if (!existingTool) {
+    return ApiResponses.noSuchEntity('No such backend')
+  }
+  if (existingTool.provisioned) {
+    return ApiResponses.forbiddenAction("Can't modify a provisioned tool")
+  }
   await updateTool(params.toolId, {
     ...data,
     id: undefined,
@@ -31,6 +38,13 @@ export const PATCH = requireAdmin(async (req: Request, params: { toolId: string 
 })
 
 export const DELETE = requireAdmin(async (req: Request, params: { toolId: string }) => {
+  const existingTool = await getTool(params.toolId)
+  if (!existingTool) {
+    return ApiResponses.noSuchEntity('No such backend')
+  }
+  if (existingTool.provisioned) {
+    return ApiResponses.forbiddenAction("Can't delete a provisioned tool")
+  }
   try {
     await deleteTool(params.toolId)
   } catch (e) {

--- a/logicle/app/chat/assistants/mine/page.tsx
+++ b/logicle/app/chat/assistants/mine/page.tsx
@@ -212,16 +212,16 @@ const MyAssistantPage = () => {
                         <Action
                           icon={IconEdit}
                           onClick={async () => {
-                            await onDuplicate(assistant)
+                            onEdit(assistant)
                           }}
                           text={t('edit')}
                         />
                         <Action
                           icon={IconCopy}
                           onClick={async () => {
-                            onEdit(assistant)
+                            await onDuplicate(assistant)
                           }}
-                          text={t('edit')}
+                          text={t('duplicate')}
                         />
                         <Action
                           icon={IconTrash}

--- a/logicle/db/migrations.ts
+++ b/logicle/db/migrations.ts
@@ -17,6 +17,9 @@ export async function migrateToLatest() {
     '20240804-assistant_tags': await import('./migrations/20240804-assistant_tags'),
     '20240904-assistant_prompts': await import('./migrations/20240904-assistant_prompts'),
     '20240930-generic_backend_config': await import('./migrations/20240930-generic_backend_config'),
+    '20241118-backend_tool_provisioning': await import(
+      './migrations/20241118-backend_tool_provisioning'
+    ),
   }
 
   const db = new Kysely<any>({

--- a/logicle/db/migrations/20241118-backend_tool_provisioning.ts
+++ b/logicle/db/migrations/20241118-backend_tool_provisioning.ts
@@ -1,0 +1,14 @@
+import { Kysely } from 'kysely'
+
+const string = 'text'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('Backend')
+    .addColumn('provisioned', 'integer', (col) => col.notNull().defaultTo(0))
+    .execute()
+  await db.schema
+    .alterTable('Tool')
+    .addColumn('provisioned', 'integer', (col) => col.notNull().defaultTo(0))
+    .execute()
+}

--- a/logicle/db/schema.ts
+++ b/logicle/db/schema.ts
@@ -57,6 +57,7 @@ export interface Backend {
   name: string
   providerType: ProviderType
   configuration: string
+  provisioned: number
 }
 
 export interface Conversation {
@@ -183,6 +184,7 @@ export interface Tool {
   type: string
   name: string
   configuration: string
+  provisioned: number
   createdAt: string
   updatedAt: string
 }

--- a/logicle/instrumentation.ts
+++ b/logicle/instrumentation.ts
@@ -2,5 +2,7 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     const sd = await import('./db/migrations')
     await sd.migrateToLatest()
+    const provision = await import('./lib/provision')
+    await provision.provision()
   }
 }

--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -13,6 +13,7 @@ import { ToolUiLinkImpl } from './ToolUiLinkImpl'
 import { ChatState } from './ChatState'
 import { ToolFunction, ToolUILink } from './tools'
 import { logger } from '@/lib/logging'
+import { expandEnv } from 'templates'
 
 export interface Usage {
   promptTokens: number
@@ -107,17 +108,19 @@ export class ChatAssistant {
       case 'openai':
         return openai.createOpenAI({
           compatibility: 'strict', // strict mode, enable when using the OpenAI API
-          apiKey: params.apiKey,
+          apiKey: params.provisioned ? expandEnv(params.apiKey) : params.apiKey,
           //fetch: loggingFetch,
         })
       case 'anthropic':
         return anthropic.createAnthropic({
-          apiKey: params.apiKey,
+          apiKey: params.provisioned ? expandEnv(params.apiKey) : params.apiKey,
         })
       case 'gcp-vertex': {
         let credentials: JWTInput
         try {
-          credentials = JSON.parse(params.credentials) as JWTInput
+          credentials = JSON.parse(
+            params.provisioned ? expandEnv(params.credentials) : params.credentials
+          ) as JWTInput
         } catch (e) {
           throw new Error('Invalid gcp configuration, it must be a JSON object')
         }
@@ -132,7 +135,7 @@ export class ChatAssistant {
       case 'logiclecloud': {
         return openai.createOpenAI({
           compatibility: 'strict', // strict mode, enable when using the OpenAI API
-          apiKey: params.apiKey,
+          apiKey: params.provisioned ? expandEnv(params.apiKey) : params.apiKey,
           baseURL: params.endPoint,
         })
       }

--- a/logicle/lib/chat/tools.ts
+++ b/logicle/lib/chat/tools.ts
@@ -42,5 +42,6 @@ export interface ToolImplementation {
 }
 
 export type ToolBuilder = (
-  params: Record<string, any>
+  params: Record<string, any>,
+  provisioned: boolean
 ) => Promise<ToolImplementation> | ToolImplementation

--- a/logicle/lib/env.ts
+++ b/logicle/lib/env.ts
@@ -87,7 +87,7 @@ const env = {
     },
   },
   provision: {
-    source: process.env.PROVISION_URL,
+    source: process.env.PROVISION_PATH,
   },
 }
 

--- a/logicle/lib/env.ts
+++ b/logicle/lib/env.ts
@@ -86,6 +86,9 @@ const env = {
       maxImgDimPx: parseInt(process.env.CHAT_ATTACHMENTS_MAX_IMG_DIM_PX ?? '2048'),
     },
   },
+  provision: {
+    source: process.env.PROVISION_URL,
+  },
 }
 
 export default env

--- a/logicle/lib/logging.ts
+++ b/logicle/lib/logging.ts
@@ -2,8 +2,8 @@ import winston, { format } from 'winston'
 
 const bufferToTruncatedStringArray = (buffer: Buffer, maxLen: number) => {
   const truncated = Array.from(buffer.subarray(0, maxLen)) as any[]
-  if(buffer.length >= maxLen) {
-    truncated[truncated.length - 1] = "..."
+  if (buffer.length >= maxLen) {
+    truncated[truncated.length - 1] = '...'
   }
   return truncated
 }
@@ -14,8 +14,7 @@ const truncateFormat = format((info) => {
     const value = info[key]
     if (typeof value === 'string' && value.length > maxLength) {
       info[key] = value.substring(0, maxLength) + '...'
-    }
-    else if(Buffer.isBuffer(value)) {
+    } else if (Buffer.isBuffer(value)) {
       info[key] = bufferToTruncatedStringArray(value, maxLength / 4)
     }
   }

--- a/logicle/lib/provision.ts
+++ b/logicle/lib/provision.ts
@@ -23,10 +23,10 @@ export async function provision() {
     const children = fs.readdirSync(provisionPath).sort()
     for (const child of children) {
       const childPath = path.resolve(provisionPath, child)
-      provisionFile(childPath)
+      await provisionFile(childPath)
     }
   } else {
-    provisionFile(provisionPath)
+    await provisionFile(provisionPath)
   }
 }
 

--- a/logicle/lib/provision.ts
+++ b/logicle/lib/provision.ts
@@ -1,0 +1,30 @@
+import fs from 'fs'
+import { InsertableToolDTO } from '@/types/dto'
+import env from './env'
+import { createToolWithId, getTool, updateTool } from '@/models/tool'
+import { log } from 'console'
+import { logger } from './logging'
+import { parseDocument } from 'yaml'
+
+interface Provision {
+  tools: Record<string, InsertableToolDTO>
+}
+
+export async function provision() {
+  const url = env.provision.source
+  if (!url) return
+  if (!fs.existsSync(url)) {
+    //throw new Error(`No provisioning file at ${url}`)
+  }
+  const content = fs.readFileSync(url)
+  const provisionData = parseDocument(content.toString('utf-8')).toJSON() as Provision
+  for (const id in provisionData.tools) {
+    const toolDef = provisionData.tools[id]
+    const existing = await getTool(id)
+    if (existing) {
+      updateTool(id, toolDef)
+    } else {
+      createToolWithId(id, toolDef)
+    }
+  }
+}

--- a/logicle/lib/provision.ts
+++ b/logicle/lib/provision.ts
@@ -24,7 +24,7 @@ export async function provision() {
     if (existing) {
       updateTool(id, toolDef)
     } else {
-      createToolWithId(id, toolDef)
+      createToolWithId(id, toolDef, true)
     }
   }
   for (const id in provisionData.backends) {

--- a/logicle/lib/provision.ts
+++ b/logicle/lib/provision.ts
@@ -1,13 +1,13 @@
 import fs from 'fs'
-import { InsertableToolDTO } from '@/types/dto'
+import { InsertableBackend, InsertableToolDTO } from '@/types/dto'
 import env from './env'
 import { createToolWithId, getTool, updateTool } from '@/models/tool'
-import { log } from 'console'
-import { logger } from './logging'
 import { parseDocument } from 'yaml'
+import { createBackendWithId, getBackend, updateBackend } from '@/models/backend'
 
 interface Provision {
   tools: Record<string, InsertableToolDTO>
+  backends: Record<string, InsertableBackend>
 }
 
 export async function provision() {
@@ -25,6 +25,15 @@ export async function provision() {
       updateTool(id, toolDef)
     } else {
       createToolWithId(id, toolDef)
+    }
+  }
+  for (const id in provisionData.backends) {
+    const backendDef = provisionData.backends[id]
+    const existing = await getBackend(id)
+    if (existing) {
+      updateBackend(id, backendDef)
+    } else {
+      createBackendWithId(id, backendDef)
     }
   }
 }

--- a/logicle/lib/provision.ts
+++ b/logicle/lib/provision.ts
@@ -33,7 +33,7 @@ export async function provision() {
     if (existing) {
       updateBackend(id, backendDef)
     } else {
-      createBackendWithId(id, backendDef)
+      createBackendWithId(id, backendDef, true)
     }
   }
 }

--- a/logicle/lib/provision.ts
+++ b/logicle/lib/provision.ts
@@ -22,18 +22,18 @@ export async function provision() {
     const toolDef = provisionData.tools[id]
     const existing = await getTool(id)
     if (existing) {
-      updateTool(id, toolDef)
+      await updateTool(id, toolDef)
     } else {
-      createToolWithId(id, toolDef, true)
+      await createToolWithId(id, toolDef, true)
     }
   }
   for (const id in provisionData.backends) {
     const backendDef = provisionData.backends[id]
     const existing = await getBackend(id)
     if (existing) {
-      updateBackend(id, backendDef)
+      await updateBackend(id, backendDef)
     } else {
-      createBackendWithId(id, backendDef, true)
+      await createBackendWithId(id, backendDef, true)
     }
   }
 }

--- a/logicle/lib/tools/dall-e/implementation.ts
+++ b/logicle/lib/tools/dall-e/implementation.ts
@@ -6,20 +6,21 @@ import { addFile } from '@/models/file'
 import { nanoid } from 'nanoid'
 import { InsertableFile } from '@/types/dto'
 import env from '@/lib/env'
+import { expandEnv } from 'templates'
 
 export interface Params {
   prompt: string
 }
 
 export class Dall_ePlugin extends Dall_ePluginInterface implements ToolImplementation {
-  static builder: ToolBuilder = (params: Record<string, any>) =>
-    new Dall_ePlugin(params as Dall_ePluginParams) // TODO: need a better validation
+  static builder: ToolBuilder = (params: Record<string, any>, provisioned: boolean) =>
+    new Dall_ePlugin(params as Dall_ePluginParams, provisioned) // TODO: need a better validation
   params: Dall_ePluginParams
-  constructor(params: Dall_ePluginParams) {
+  provisioned: boolean
+  constructor(params: Dall_ePluginParams, provisioned: boolean) {
     super()
-    this.params = {
-      ...params,
-    }
+    this.params = params
+    this.provisioned = provisioned
   }
 
   functions: Record<string, ToolFunction> = {
@@ -41,7 +42,7 @@ export class Dall_ePlugin extends Dall_ePluginInterface implements ToolImplement
       },
       invoke: async ({ params, uiLink }) => {
         const openai = new OpenAI({
-          apiKey: this.params.apiKey,
+          apiKey: this.provisioned ? expandEnv(this.params.apiKey) : this.params.apiKey,
           baseURL: env.logicleCloud.images.proxyBaseUrl,
         }) // Make sure your OpenAI API key is set in environment variables
         const fileStorageLocation = process.env.FILE_STORAGE_LOCATION

--- a/logicle/lib/tools/enumerate.ts
+++ b/logicle/lib/tools/enumerate.ts
@@ -11,18 +11,17 @@ import { Dall_ePlugin } from './dall-e/implementation'
 export const buildToolImplementationFromDbInfo = async (
   tool: dto.ToolDTO
 ): Promise<ToolImplementation | undefined> => {
+  const provisioned = tool.provisioned ? true : false
   if (tool.type == ChatGptRetrievalPlugin.toolName) {
-    return await ChatGptRetrievalPlugin.builder({
-      ...tool.configuration,
-    })
+    return await ChatGptRetrievalPlugin.builder(tool.configuration, provisioned)
   } else if (tool.type == TimeOfDay.toolName) {
-    return await TimeOfDay.builder(tool.configuration)
+    return await TimeOfDay.builder(tool.configuration, provisioned)
   } else if (tool.type == OpenApiPlugin.toolName) {
-    return await OpenApiPlugin.builder(tool.configuration)
+    return await OpenApiPlugin.builder(tool.configuration, provisioned)
   } else if (tool.type == FileManagerPlugin.toolName) {
-    return await FileManagerPlugin.builder(tool.configuration)
+    return await FileManagerPlugin.builder(tool.configuration, provisioned)
   } else if (tool.type == Dall_ePlugin.toolName) {
-    return await Dall_ePlugin.builder(tool.configuration)
+    return await Dall_ePlugin.builder(tool.configuration, provisioned)
   } else {
     return undefined
   }

--- a/logicle/lib/tools/openapi/implementation.ts
+++ b/logicle/lib/tools/openapi/implementation.ts
@@ -10,6 +10,7 @@ import FormData from 'form-data'
 import { PassThrough } from 'stream'
 import { logger } from '@/lib/logging'
 import { parseDocument } from 'yaml'
+import { expandEnv } from 'templates'
 
 async function formDataToBuffer(form: FormData): Promise<Buffer> {
   return new Promise((resolve, reject) => {
@@ -160,9 +161,9 @@ function convertOpenAPIOperationToToolFunction(
         for (const securitySchemeId in securitySchemes) {
           const securityScheme = securitySchemes[securitySchemeId] as OpenAPIV3.SecuritySchemeObject
           if (securityScheme.type == 'apiKey') {
-            headers[securityScheme.name] = toolParams[securitySchemeId]
+            headers[securityScheme.name] = expandEnv(toolParams[securitySchemeId])
           } else if (securityScheme.type == 'http') {
-            headers['Authorization'] = toolParams[securitySchemeId]
+            headers['Authorization'] = expandEnv(toolParams[securitySchemeId])
           }
         }
       }

--- a/logicle/models/backend.ts
+++ b/logicle/models/backend.ts
@@ -70,7 +70,7 @@ export const updateBackend = async (id: string, data: Partial<dto.InsertableBack
         ...JSON.parse(backend.configuration),
         ...configuration,
       }),
-      provisioned: undefined, // avoid changing the provisioned flag!!!!
+      provisioned: undefined, // protect against malicious API usage
     })
     .where('id', '=', id)
     .execute()

--- a/logicle/models/backend.ts
+++ b/logicle/models/backend.ts
@@ -28,7 +28,10 @@ export const getBackend = async (
 }
 
 export const createBackend = async (backend: dto.InsertableBackend) => {
-  const id = nanoid()
+  return await createBackendWithId(nanoid(), backend)
+}
+
+export const createBackendWithId = async (id: string, backend: dto.InsertableBackend) => {
   const { name, providerType, ...configuration } = backend
   await db
     .insertInto('Backend')

--- a/logicle/models/backend.ts
+++ b/logicle/models/backend.ts
@@ -28,10 +28,14 @@ export const getBackend = async (
 }
 
 export const createBackend = async (backend: dto.InsertableBackend) => {
-  return await createBackendWithId(nanoid(), backend)
+  return await createBackendWithId(nanoid(), backend, false)
 }
 
-export const createBackendWithId = async (id: string, backend: dto.InsertableBackend) => {
+export const createBackendWithId = async (
+  id: string,
+  backend: dto.InsertableBackend,
+  provisioned: Boolean
+) => {
   const { name, providerType, ...configuration } = backend
   await db
     .insertInto('Backend')
@@ -40,6 +44,7 @@ export const createBackendWithId = async (id: string, backend: dto.InsertableBac
       name,
       providerType,
       configuration: JSON.stringify(configuration),
+      provisioned: provisioned ? 1 : 0,
     })
     .executeTakeFirstOrThrow()
   const created = await getBackend(id)
@@ -65,6 +70,7 @@ export const updateBackend = async (id: string, data: Partial<dto.InsertableBack
         ...JSON.parse(backend.configuration),
         ...configuration,
       }),
+      provisioned: undefined, // avoid changing the provisioned flag!!!!
     })
     .where('id', '=', id)
     .execute()

--- a/logicle/models/tool.ts
+++ b/logicle/models/tool.ts
@@ -28,17 +28,22 @@ export const getTool = async (toolId: schema.Tool['id']): Promise<dto.ToolDTO | 
 }
 
 export const createTool = async (tool: dto.InsertableToolDTO): Promise<dto.ToolDTO> => {
-  const id = nanoid()
-  await db
-    .insertInto('Tool')
-    .values({
-      ...tool,
-      configuration: JSON.stringify(tool.configuration),
-      id: id,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    })
-    .executeTakeFirstOrThrow()
+  return await createToolWithId(nanoid(), tool)
+}
+
+export const createToolWithId = async (
+  id: string,
+  tool: dto.InsertableToolDTO
+): Promise<dto.ToolDTO> => {
+  const dbTool: schema.Tool = {
+    ...tool,
+    configuration: JSON.stringify(tool.configuration),
+    id: id,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+
+  await db.insertInto('Tool').values(dbTool).executeTakeFirstOrThrow()
   const created = await getTool(id)
   if (!created) {
     throw new Error('Creation failed')

--- a/logicle/models/tool.ts
+++ b/logicle/models/tool.ts
@@ -28,17 +28,19 @@ export const getTool = async (toolId: schema.Tool['id']): Promise<dto.ToolDTO | 
 }
 
 export const createTool = async (tool: dto.InsertableToolDTO): Promise<dto.ToolDTO> => {
-  return await createToolWithId(nanoid(), tool)
+  return await createToolWithId(nanoid(), tool, false)
 }
 
 export const createToolWithId = async (
   id: string,
-  tool: dto.InsertableToolDTO
+  tool: dto.InsertableToolDTO,
+  provisioned: Boolean
 ): Promise<dto.ToolDTO> => {
   const dbTool: schema.Tool = {
     ...tool,
     configuration: JSON.stringify(tool.configuration),
     id: id,
+    provisioned: provisioned ? 1 : 0,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   }

--- a/logicle/templates.ts
+++ b/logicle/templates.ts
@@ -1,0 +1,5 @@
+export function expandEnv(template: string) {
+  return template.replace(/\${(\w*)}/g, (match, key) => {
+    return process.env[key] || ''
+  })
+}

--- a/logicle/types/dto.ts
+++ b/logicle/types/dto.ts
@@ -21,7 +21,7 @@ export type Property = schema.Property
 export type Session = schema.Session
 export type Workspace = schema.Workspace
 
-export type InsertableBackend = Omit<Backend, 'id'>
+export type InsertableBackend = Omit<Backend, 'id' | 'provisioned'>
 export type InsertableConversation = Omit<schema.Conversation, 'id' | 'createdAt'>
 export type InsertableConversationFolder = Omit<schema.ConversationFolder, 'id'>
 export type InsertablePrompt = Omit<schema.Prompt, 'id'>

--- a/logicle/types/dto.ts
+++ b/logicle/types/dto.ts
@@ -32,7 +32,7 @@ export type InsertableFile = Omit<schema.File, 'id' | 'createdAt' | 'path' | 'up
 export type ToolDTO = Omit<schema.Tool, 'configuration'> & {
   configuration: Record<string, any>
 }
-export type InsertableToolDTO = Omit<ToolDTO, 'id' | 'createdAt' | 'updatedAt'>
+export type InsertableToolDTO = Omit<ToolDTO, 'id' | 'provisioned' | 'createdAt' | 'updatedAt'>
 export type UpdateableToolDTO = Partial<Omit<InsertableToolDTO, 'type'>>
 
 export interface UserAssistant {

--- a/logicle/types/provider.ts
+++ b/logicle/types/provider.ts
@@ -6,25 +6,25 @@ export enum ProviderType {
 }
 
 export interface BaseProviderConfig {
-  providerType: ProviderType
+  provisioned: number
 }
 
-export interface ProviderConfigOpenAI {
+export interface ProviderConfigOpenAI extends BaseProviderConfig {
   providerType: ProviderType.OpenAI
   apiKey: string
 }
 
-export interface ProviderConfigAnthropic {
+export interface ProviderConfigAnthropic extends BaseProviderConfig {
   providerType: ProviderType.Anthropic
   apiKey: string
 }
 
-export interface ProviderConfigGcpVertex {
+export interface ProviderConfigGcpVertex extends BaseProviderConfig {
   providerType: ProviderType.GcpVertex
   credentials: string
 }
 
-export interface ProviderConfigLogicleCloud {
+export interface ProviderConfigLogicleCloud extends BaseProviderConfig {
   providerType: ProviderType.LogicleCloud
   apiKey: string
   endPoint: string


### PR DESCRIPTION
This PR marks the introduction of provisioning, i.e. the setup of the db from an externally provided file.
Implemente features implemented are:

* Provisioning for backends / tools
* Either single files or directory (depends on the path configured in ENV)
* Format is YAML, using simple DTOs
* provisioned tool / backends can expand variables using ${env.variable} syntax

The location for provisioning file(s) is specified by environment variable PROVISION_PATH

Note: provisioned data is still visible to admins, but editing is blocked by the APIs. A UI oriented PR will follow.

A not so simple example....
``` yaml
tools:
  hibp:
    type: openapi
    name: Have I Been Pwned
    configuration:
      spec: |
        openapi: 3.0.0
        info:
          title: Have I Been Pwned API
          description: API to check if an account (email or phone number) has been involved in known data breaches.
          version: 3.0.0
          contact:
            name: Have I Been Pwned
            url: https://haveibeenpwned.com

        servers:
          - url: https://haveibeenpwned.com/api/v3

        security:
          - hibpApiKey: []

        paths:
          /breachedaccount/{account}:
            get:
              summary: Check if an account has been breached
              operationId: getDataBreaches
              description: Retrieves a list of all breaches an account has been involved in.
              security:
                - hibpApiKey: []
              parameters:
                - in: path
                  name: account
                  required: true
                  schema:
                    type: string
                  description: The account to check. Can be an email address or a phone number in E.164 format without the '+' symbol.
                - in: query
                  name: truncateResponse
                  required: true
                  schema:
                    type: boolean
                    default: false
                  description: When set to true, returns a truncated response with less data.
              responses:
                '200':
                  description: Successfully retrieved breach information
                  content:
                    application/json:
                      schema:
                        type: array
                        items:
                          type: object
                          description: Breach information
                '400':
                  description: Bad request (invalid account format)
                '401':
                  description: Unauthorized (invalid or missing API key)
                '403':
                  description: Forbidden (no permission to access this resource)
                '404':
                  description: Not found (account has not been breached or doesn't exist)
                '429':
                  description: Too many requests (rate limit exceeded)

        components:
          securitySchemes:
            hibpApiKey:
              type: apiKey
              in: header
              name: hibp-api-key
      hibpApiKey: ${HIBP_API_KEY}
backends:
  openai:
    name: openai
    providerType: openai
    apiKey: ${OPENAI_API_KEY}

```


