### PR TITLE
Fix race condition when uploading file, using xhr state instead of upload progress

### DIFF
--- a/logicle/app/admin/tools/components/ToolForm.tsx
+++ b/logicle/app/admin/tools/components/ToolForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useTranslation } from 'next-i18next'
-import React, { FC, useEffect, useState } from 'react'
+import React, { FC, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { zodResolver } from '@hookform/resolvers/zod'
 import * as z from 'zod'

--- a/logicle/app/assistants/components/AssistantForm.tsx
+++ b/logicle/app/assistants/components/AssistantForm.tsx
@@ -121,6 +121,7 @@ export const AssistantForm = ({ assistant, onSubmit, onChange, onValidate, fireS
         fileSize: f.size,
         fileType: f.type,
         progress: 1,
+        done: true,
       }
     })
   )
@@ -245,6 +246,7 @@ export const AssistantForm = ({ assistant, onSubmit, onChange, onValidate, fireS
         fileType: file.type,
         fileSize: file.size,
         progress: 0,
+        done: false,
       },
       ...uploadStatus.current,
     ]
@@ -253,7 +255,6 @@ export const AssistantForm = ({ assistant, onSubmit, onChange, onValidate, fireS
     xhr.open('PUT', `/api/files/${id}/content`, true)
     xhr.upload.addEventListener('progress', (evt) => {
       const progress = 0.9 * (evt.loaded / file.size)
-      console.debug(`progress = ${progress}`)
       uploadStatus.current = uploadStatus.current.map((u) => {
         return u.fileId == id ? { ...u, progress } : u
       })
@@ -263,7 +264,7 @@ export const AssistantForm = ({ assistant, onSubmit, onChange, onValidate, fireS
       // TODO: handle errors!
       if (xhr.readyState == XMLHttpRequest.DONE) {
         uploadStatus.current = uploadStatus.current.map((u) => {
-          return u.fileId == id ? { ...u, progress: 1 } : u
+          return u.fileId == id ? { ...u, progress: 1, done: true } : u
         })
         updateFormFiles()
       }

--- a/logicle/app/chat/components/AssistantMessage.tsx
+++ b/logicle/app/chat/components/AssistantMessage.tsx
@@ -55,6 +55,7 @@ export const AssistantMessage: FC<Props> = ({ message }) => {
           fileName: attachment.name,
           fileSize: attachment.size,
           fileType: attachment.mimetype,
+          done: true,
         }
         return <Attachment key={attachment.id} file={upload}></Attachment>
       })}

--- a/logicle/app/chat/components/ChatInput.tsx
+++ b/logicle/app/chat/components/ChatInput.tsx
@@ -49,7 +49,7 @@ export const ChatInput = ({ onSend, disabled, disabledMsg, textAreaRef }: Props)
 
   const uploadedFiles = useRef<Upload[]>([])
   const [, setRefresh] = useState<number>(0)
-  const anyUploadRunning = !!uploadedFiles.current.find((u) => u.progress != 1)
+  const anyUploadRunning = !!uploadedFiles.current.find((u) => !u.done)
   const msgEmpty = (chatInput.trim().length ?? 0) == 0 && uploadedFiles.current.length == 0
 
   useEffect(() => {
@@ -160,6 +160,7 @@ export const ChatInput = ({ onSend, disabled, disabledMsg, textAreaRef }: Props)
         fileType: file.type,
         fileSize: file.size,
         progress: 0,
+        done: false,
       },
       ...uploadedFiles.current,
     ]
@@ -168,6 +169,9 @@ export const ChatInput = ({ onSend, disabled, disabledMsg, textAreaRef }: Props)
     xhr.open('PUT', `/api/files/${id}/content`, true)
     xhr.upload.addEventListener('progress', (evt) => {
       const progress = evt.loaded / file.size
+      if (progress == 1) {
+        console.log('progress 1')
+      }
       uploadedFiles.current = uploadedFiles.current.map((u) => {
         return u.fileId == id ? { ...u, progress } : u
       })
@@ -176,6 +180,10 @@ export const ChatInput = ({ onSend, disabled, disabledMsg, textAreaRef }: Props)
     xhr.onreadystatechange = function () {
       // TODO: handle errors!
       if (xhr.readyState == XMLHttpRequest.DONE) {
+        console.log('upload done')
+        uploadedFiles.current = uploadedFiles.current.map((u) => {
+          return u.fileId == id ? { ...u, done: true } : u
+        })
         setRefresh(Math.random())
       }
     }

--- a/logicle/app/chat/components/ChatInput.tsx
+++ b/logicle/app/chat/components/ChatInput.tsx
@@ -169,9 +169,6 @@ export const ChatInput = ({ onSend, disabled, disabledMsg, textAreaRef }: Props)
     xhr.open('PUT', `/api/files/${id}/content`, true)
     xhr.upload.addEventListener('progress', (evt) => {
       const progress = evt.loaded / file.size
-      if (progress == 1) {
-        console.log('progress 1')
-      }
       uploadedFiles.current = uploadedFiles.current.map((u) => {
         return u.fileId == id ? { ...u, progress } : u
       })
@@ -180,7 +177,6 @@ export const ChatInput = ({ onSend, disabled, disabledMsg, textAreaRef }: Props)
     xhr.onreadystatechange = function () {
       // TODO: handle errors!
       if (xhr.readyState == XMLHttpRequest.DONE) {
-        console.log('upload done')
         uploadedFiles.current = uploadedFiles.current.map((u) => {
           return u.fileId == id ? { ...u, done: true } : u
         })

--- a/logicle/app/chat/components/ChatMessage.tsx
+++ b/logicle/app/chat/components/ChatMessage.tsx
@@ -232,6 +232,7 @@ export const ChatMessage: FC<ChatMessageProps> = ({ assistant, group, isLast }) 
       ? group.messages[0].attachments.map((attachment) => {
           return {
             progress: 1,
+            done: true,
             fileId: attachment.id,
             fileName: attachment.name,
             fileSize: attachment.size,

--- a/logicle/components/app/upload.tsx
+++ b/logicle/components/app/upload.tsx
@@ -36,7 +36,7 @@ export const Upload = ({ file, className, onDelete }: UploadProps) => {
         </Button>
       )}
       <div className="shrink-0">
-        {file.progress == 1 ? (
+        {file.done ? (
           <div className="bg-primary_color p-2 rounded">
             <IconFile color="white" size="24"></IconFile>
           </div>

--- a/logicle/components/app/upload.tsx
+++ b/logicle/components/app/upload.tsx
@@ -9,6 +9,7 @@ export interface Upload {
   fileSize: number
   fileType: string
   progress: number
+  done: boolean
 }
 
 interface UploadProps {


### PR DESCRIPTION
Message could be sent when all data had been sent but server had not replied.
So... it could happen that the updated file was not available if requested immediately (which is typical for images!)
