### PR TITLE
Authentication with api keys

### DIFF
--- a/logicle/app/api/assistants/[assistantId]/sharing/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/sharing/route.ts
@@ -1,18 +1,18 @@
 import Assistants from '@/models/assistant'
-import { requireSession } from '@/api/utils/auth'
+import { requireSession, SimpleSession } from '@/api/utils/auth'
 import ApiResponses from '@/api/utils/ApiResponses'
 import * as dto from '@/types/dto'
 import { Session } from 'next-auth'
 import { db } from '@/db/database'
 
 export const POST = requireSession(
-  async (session: Session, req: Request, params: { assistantId: string }) => {
+  async (session: SimpleSession, req: Request, params: { assistantId: string }) => {
     const assistantId = params.assistantId
     const assistant = await Assistants.get(assistantId)
     if (!assistant) {
       return ApiResponses.noSuchEntity(`There is no assistant with id ${assistantId}`)
     }
-    if (assistant.owner !== session.user.id) {
+    if (assistant.owner !== session.userId) {
       return ApiResponses.notAuthorized(`You're not authorized to modify assistant ${assistantId}`)
     }
     const sharingList = (await req.json()) as dto.Sharing[]

--- a/logicle/app/api/assistants/evaluate/route.ts
+++ b/logicle/app/api/assistants/evaluate/route.ts
@@ -1,4 +1,4 @@
-import { requireSession } from '@/api/utils/auth'
+import { requireSession, SimpleSession } from '@/api/utils/auth'
 import ApiResponses from '@/api/utils/ApiResponses'
 import * as dto from '@/types/dto'
 import { ChatAssistant } from '@/lib/chat'
@@ -13,7 +13,7 @@ interface EvaluateAssistantRequest {
   messages: dto.Message[]
 }
 
-export const POST = requireSession(async (session: Session, req: Request) => {
+export const POST = requireSession(async (session: SimpleSession, req: Request) => {
   const { assistant, messages } = (await req.json()) as EvaluateAssistantRequest
 
   const backend = await getBackend(assistant.backendId)

--- a/logicle/app/api/assistants/route.ts
+++ b/logicle/app/api/assistants/route.ts
@@ -1,5 +1,5 @@
 import Assistants from '@/models/assistant'
-import { requireAdmin, requireSession } from '@/api/utils/auth'
+import { requireAdmin, requireSession, SimpleSession } from '@/api/utils/auth'
 import { NextResponse } from 'next/server'
 import ApiResponses from '@/api/utils/ApiResponses'
 import * as dto from '@/types/dto'
@@ -11,11 +11,11 @@ export const GET = requireAdmin(async () => {
   return NextResponse.json(await Assistants.withOwner({}))
 })
 
-export const POST = requireSession(async (session: Session, req: Request) => {
+export const POST = requireSession(async (session: SimpleSession, req: Request) => {
   const assistant = (await req.json()) as dto.InsertableAssistant
   const created = await Assistants.create({
     ...assistant,
-    owner: session.user.id,
+    owner: session.userId,
   })
   return ApiResponses.created(created)
 })

--- a/logicle/app/api/backends/[backendId]/models/route.ts
+++ b/logicle/app/api/backends/[backendId]/models/route.ts
@@ -1,14 +1,13 @@
-import { requireSession } from '@/api/utils/auth'
+import { requireSession, SimpleSession } from '@/api/utils/auth'
 import { getBackend } from '@/models/backend'
 import { NextResponse } from 'next/server'
 import ApiResponses from '@/app/api/utils/ApiResponses'
-import { Session } from 'next-auth'
 import { getModels } from '@/lib/chat/models'
 
 export const dynamic = 'force-dynamic'
 
 export const GET = requireSession(
-  async (session: Session, req: Request, params: { backendId: string }) => {
+  async (session: SimpleSession, req: Request, params: { backendId: string }) => {
     const backend = await getBackend(params.backendId)
     if (!backend) {
       return ApiResponses.noSuchEntity()

--- a/logicle/app/api/conversations/[conversationId]/messages/route.ts
+++ b/logicle/app/api/conversations/[conversationId]/messages/route.ts
@@ -1,17 +1,17 @@
 import { getConversation, getConversationMessages } from '@/models/conversation'
 import ApiResponses from '@/api/utils/ApiResponses'
-import { requireSession } from '@/app/api/utils/auth'
+import { requireSession, SimpleSession } from '@/app/api/utils/auth'
 
 export const dynamic = 'force-dynamic'
 
 // Get a conversation
 export const GET = requireSession(
-  async (session, req: Request, params: { conversationId: string }) => {
+  async (session: SimpleSession, req: Request, params: { conversationId: string }) => {
     const conversation = await getConversation(params.conversationId)
     if (!conversation) {
       return ApiResponses.noSuchEntity(`No conversation with id ${params.conversationId}`)
     }
-    if (conversation.ownerId != session?.user.id) {
+    if (conversation.ownerId != session.userId) {
       return ApiResponses.forbiddenAction()
     }
     const messages = await getConversationMessages(params.conversationId)

--- a/logicle/app/api/conversations/[conversationId]/route.ts
+++ b/logicle/app/api/conversations/[conversationId]/route.ts
@@ -12,7 +12,7 @@ export const GET = requireSession(
     if (conversation == null) {
       return ApiResponses.noSuchEntity('There is not a conversation with this ID')
     }
-    if (conversation.ownerId != session.user.id) {
+    if (conversation.ownerId != session.userId) {
       return ApiResponses.forbiddenAction(
         `Not authorized to look at conversation with id ${params.conversationId}`
       )
@@ -31,13 +31,13 @@ export const PATCH = requireSession(
     if (!storedConversation) {
       return ApiResponses.noSuchEntity('Trying to modify non existing conversation')
     }
-    if (storedConversation.ownerId != session.user.id) {
+    if (storedConversation.ownerId != session.userId) {
       return ApiResponses.forbiddenAction('Not the owner of this conversation')
     }
     if (data.id && data.id != conversationId) {
       return ApiResponses.forbiddenAction("Can't change the id of the conversation")
     }
-    if (data.ownerId && data.ownerId != session.user.id) {
+    if (data.ownerId && data.ownerId != session.userId) {
       return ApiResponses.forbiddenAction("Can't change the owner of the conversation")
     }
     await updateConversation(conversationId, data)
@@ -52,7 +52,7 @@ export const DELETE = requireSession(
     if (!storedConversation) {
       return ApiResponses.noSuchEntity('Trying to delete a non existing conversation')
     }
-    if (storedConversation.ownerId != session.user.id) {
+    if (storedConversation.ownerId != session.userId) {
       return ApiResponses.forbiddenAction("Can't delete a conversation you don't own")
     }
     await deleteConversation(params.conversationId)

--- a/logicle/app/api/conversations/route.ts
+++ b/logicle/app/api/conversations/route.ts
@@ -8,14 +8,14 @@ export const dynamic = 'force-dynamic'
 
 // Fetch all conversations
 export const GET = requireSession(async (session) => {
-  const conversations = await getConversationsWithFolder(session!.user.id)
+  const conversations = await getConversationsWithFolder(session.userId)
   return ApiResponses.json(conversations)
 })
 
 // Create a new conversation
 export const POST = requireSession(async (session, req: NextRequest) => {
   const body = (await req.json()) as dto.InsertableConversation
-  if (body.ownerId != session?.user.id) {
+  if (body.ownerId != session.userId) {
     return ApiResponses.forbiddenAction("Can't create a conversation on behalf of another user")
   }
   const createdConversation = await createConversation(body)

--- a/logicle/app/api/user/assistants/[assistantId]/route.ts
+++ b/logicle/app/api/user/assistants/[assistantId]/route.ts
@@ -1,6 +1,6 @@
 import Assistants from 'models/assistant'
 import ApiResponses from '@/api/utils/ApiResponses'
-import { requireSession } from '@/app/api/utils/auth'
+import { requireSession, SimpleSession } from '@/app/api/utils/auth'
 import { Session } from 'next-auth'
 import { NextRequest } from 'next/server'
 import * as dto from '@/types/dto'
@@ -9,12 +9,12 @@ import { getUserWorkspaceMemberships } from '@/models/user'
 export const dynamic = 'force-dynamic'
 
 export const GET = requireSession(
-  async (session: Session, req: NextRequest, params: { assistantId: string }) => {
+  async (session: SimpleSession, req: NextRequest, params: { assistantId: string }) => {
     const assistantId = params.assistantId
-    const enabledWorkspaces = await getUserWorkspaceMemberships(session.user.id)
+    const enabledWorkspaces = await getUserWorkspaceMemberships(session.userId)
     const assistants = await Assistants.withUserData({
       assistantId,
-      userId: session.user.id,
+      userId: session.userId,
       workspaceIds: enabledWorkspaces.map((w) => w.id),
     })
     if (assistants.length == 0) {
@@ -25,9 +25,9 @@ export const GET = requireSession(
 )
 
 export const PATCH = requireSession(
-  async (session: Session, req: NextRequest, params: { assistantId: string }) => {
+  async (session: SimpleSession, req: NextRequest, params: { assistantId: string }) => {
     const assistantId = params.assistantId
-    const userId = session.user.id
+    const userId = session.userId
     const userData = (await req.json()) as Partial<dto.AssistantUserDataDto>
     //const currentUserData = Assistants.userData(assistantId, userId)
     await Assistants.updateUserData(assistantId, userId, userData)

--- a/logicle/app/api/user/assistants/explore/route.ts
+++ b/logicle/app/api/user/assistants/explore/route.ts
@@ -6,9 +6,9 @@ import { getUserWorkspaceMemberships } from '@/models/user'
 export const dynamic = 'force-dynamic'
 
 export const GET = requireSession(async (session) => {
-  const enabledWorkspaces = await getUserWorkspaceMemberships(session.user.id)
+  const enabledWorkspaces = await getUserWorkspaceMemberships(session.userId)
   const assistants = await Assistants.withUserData({
-    userId: session.user.id,
+    userId: session.userId,
     workspaceIds: enabledWorkspaces.map((w) => w.id),
   })
   return NextResponse.json(assistants)

--- a/logicle/app/api/user/assistants/route.ts
+++ b/logicle/app/api/user/assistants/route.ts
@@ -6,5 +6,5 @@ export const dynamic = 'force-dynamic'
 
 /// List the assistants created by the session user
 export const GET = requireSession(async (session) => {
-  return NextResponse.json(await Assistants.withOwner({ userId: session.user.id }))
+  return NextResponse.json(await Assistants.withOwner({ userId: session.userId }))
 })

--- a/logicle/app/api/user/folders/route.ts
+++ b/logicle/app/api/user/folders/route.ts
@@ -6,13 +6,13 @@ export const dynamic = 'force-dynamic'
 
 // Fetch folders
 export const GET = requireSession(async (session) => {
-  const folders = await getFolders(session.user.id)
+  const folders = await getFolders(session.userId)
   return ApiResponses.json(folders)
 })
 
 export const POST = requireSession(async (session, req) => {
   const creationRequest = (await req.json()) as dto.InsertableConversationFolder
-  if (creationRequest.ownerId !== session.user.id) {
+  if (creationRequest.ownerId !== session.userId) {
     return ApiResponses.invalidParameter("Can't create folders for other users")
   }
   const folder = await createFolder(creationRequest)

--- a/logicle/app/api/user/password/route.ts
+++ b/logicle/app/api/user/password/route.ts
@@ -14,7 +14,7 @@ export const PUT = requireSession(async (session, req: NextRequest) => {
     newPassword: string
   }
 
-  const user = await getUserById(session.user.id)
+  const user = await getUserById(session.userId)
   if (!user) {
     return ApiResponses.noSuchEntity('No such user')
   }
@@ -26,7 +26,7 @@ export const PUT = requireSession(async (session, req: NextRequest) => {
   await db
     .updateTable('User')
     .set({ password: await hashPassword(newPassword) })
-    .where('id', '=', session.user.id)
+    .where('id', '=', session.userId)
     .execute()
   return ApiResponses.json(user)
 })

--- a/logicle/app/api/user/profile/route.ts
+++ b/logicle/app/api/user/profile/route.ts
@@ -17,13 +17,13 @@ import * as dto from '@/types/dto'
 export const dynamic = 'force-dynamic'
 
 export const GET = requireSession(async (session) => {
-  const user = await getUserById(session.user.id)
+  const user = await getUserById(session.userId)
   if (!user) {
     return ApiResponses.noSuchEntity('Unknown session user')
   }
-  const enabledWorkspaces = await getUserWorkspaceMemberships(session.user.id)
+  const enabledWorkspaces = await getUserWorkspaceMemberships(session.userId)
   const pinnedAssistants = await Assistants.withUserData({
-    userId: session.user.id,
+    userId: session.userId,
     workspaceIds: enabledWorkspaces.map((w) => w.id),
     pinned: true,
   })
@@ -62,7 +62,7 @@ export const PATCH = requireSession(async (session, req) => {
   } as Updateable<schema.User>
 
   // delete the old image
-  await deleteUserImage(session.user.id)
-  await updateUser(session.user.id, dbUser)
+  await deleteUserImage(session.userId)
+  await updateUser(session.userId, dbUser)
   return ApiResponses.success()
 })

--- a/logicle/app/api/user/prompts/[promptId]/route.ts
+++ b/logicle/app/api/user/prompts/[promptId]/route.ts
@@ -6,12 +6,12 @@ import { requireSession } from '@/app/api/utils/auth'
 export const dynamic = 'force-dynamic'
 
 // Fetch prompt
-export const GET = requireSession(async (session, _ , params: { promptId: string }) => {
+export const GET = requireSession(async (session, _, params: { promptId: string }) => {
   const prompt = await getPrompt(params.promptId as string)
   if (!prompt) {
     return ApiResponses.noSuchEntity()
   }
-  if (prompt.ownerId != session.user.id) {
+  if (prompt.ownerId != session.userId) {
     return ApiResponses.forbiddenAction("Can't access the prompt of another user")
   }
   return ApiResponses.json(prompt)
@@ -21,7 +21,7 @@ export const GET = requireSession(async (session, _ , params: { promptId: string
 export const PUT = requireSession(async (session, req, params: { promptId: string }) => {
   const prompt = (await req.json()) as dto.Prompt
   const dbPrompt = await getPrompt(params.promptId)
-  if (dbPrompt && dbPrompt.ownerId != session.user.id) {
+  if (dbPrompt && dbPrompt.ownerId != session.userId) {
     return ApiResponses.forbiddenAction("Can't overwrite the prompt of another user")
   }
   if (params.promptId !== prompt.id) {
@@ -30,7 +30,7 @@ export const PUT = requireSession(async (session, req, params: { promptId: strin
       'The data provided is not consistent with the path. Check the IDs'
     )
   }
-  if (prompt.ownerId !== session.user.id) {
+  if (prompt.ownerId !== session.userId) {
     return ApiResponses.conflict()
   }
   await updatePrompt(prompt.id, prompt)
@@ -38,13 +38,11 @@ export const PUT = requireSession(async (session, req, params: { promptId: strin
 })
 
 // Delete prompt
-export const DELETE = requireSession(
-  async (session, req, params: { promptId: string }) => {
-    const dbPrompt = await getPrompt(params.promptId)
-    if (dbPrompt && dbPrompt.ownerId != session.user.id) {
-      return ApiResponses.forbiddenAction("Can't overwrite the prompt of another user")
-    }
-    await deletePrompt(params.promptId)
-    return ApiResponses.success()
+export const DELETE = requireSession(async (session, req, params: { promptId: string }) => {
+  const dbPrompt = await getPrompt(params.promptId)
+  if (dbPrompt && dbPrompt.ownerId != session.userId) {
+    return ApiResponses.forbiddenAction("Can't overwrite the prompt of another user")
   }
-)
+  await deletePrompt(params.promptId)
+  return ApiResponses.success()
+})

--- a/logicle/app/api/user/prompts/route.ts
+++ b/logicle/app/api/user/prompts/route.ts
@@ -7,7 +7,7 @@ export const dynamic = 'force-dynamic'
 
 // Fetch prompts
 export const GET = requireSession(async (session) => {
-  const prompts = await getPrompts(session.user.id)
+  const prompts = await getPrompts(session.userId)
   return ApiResponses.json(prompts)
 })
 
@@ -15,7 +15,7 @@ export const POST = requireSession(async (session, req) => {
   const prompt = (await req.json()) as dto.InsertablePrompt
   const created = await createPrompt({
     ...prompt,
-    ownerId: session.user.id,
+    ownerId: session.userId,
   })
   return ApiResponses.created(created)
 })

--- a/logicle/app/api/utils/auth.ts
+++ b/logicle/app/api/utils/auth.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '../../../auth'
 import { Session } from 'next-auth'
 import ApiResponses from './ApiResponses'
@@ -7,16 +7,48 @@ import * as dto from '@/types/dto'
 import { cookies } from 'next/headers'
 import { SESSION_TOKEN_NAME } from '@/lib/const'
 import { logger } from '@/lib/logging'
+import { db } from '@/db/database'
 
 export async function isCurrentUser(userId: string): Promise<boolean> {
   const session = await auth()
   return session?.user.id === userId
 }
 
-export function requireAdmin<T extends Record<string, string>>(
-  func: (req: NextRequest, params: T, session: Session) => Promise<Response>
-) {
-  return mapExceptions(async (req: NextRequest, route: { params: any }) => {
+export async function findUserByApiKey(apiKey: string) {
+  return await db
+    .selectFrom('ApiKey')
+    .innerJoin('User', (join) => join.onRef('User.id', '=', 'ApiKey.userId'))
+    .select(['User.id', 'User.role'])
+    .where('ApiKey.key', '=', apiKey)
+    .executeTakeFirst()
+}
+export interface SimpleSession {
+  userId: string
+  userRole: string
+}
+
+type AuthResult = { success: true; value: SimpleSession } | { success: false; error: NextResponse }
+
+const authenticate = async (req: NextRequest): Promise<AuthResult> => {
+  const authorizationHeader = req.headers.get('Authorization')
+  let simpleSession: SimpleSession | undefined
+
+  if (authorizationHeader) {
+    if (authorizationHeader.startsWith('Bearer ')) {
+      const apiKey = authorizationHeader.substring(7)
+      const user = await findUserByApiKey(apiKey)
+      if (!user) {
+        return { success: false, error: ApiResponses.notAuthorized('Invalid Api Key') }
+      }
+      return { success: true, value: { userId: user.id, userRole: user.role } }
+    } else {
+      return {
+        success: false,
+        error: ApiResponses.notAuthorized('Unsupported auth scheme (use Bearer <api-key>)'),
+      }
+    }
+  }
+  if (!simpleSession) {
     const session = await auth()
     if (!session) {
       const cookieStore = await cookies()
@@ -24,37 +56,37 @@ export function requireAdmin<T extends Record<string, string>>(
         logger.info('Deleting invalid cookie')
         cookieStore.delete(SESSION_TOKEN_NAME)
       }
-      return ApiResponses.notAuthorized()
+      return { success: false, error: ApiResponses.notAuthorized() }
     }
-    if (session?.user.role != dto.UserRole.ADMIN) {
-      return ApiResponses.forbiddenAction()
-    }
-    return await func(req, await route.params, session)
-  })
+    return { success: true, value: { userId: session.user.id, userRole: session.user.role } }
+  }
+  return { success: false, error: ApiResponses.notAuthorized() }
 }
 
-export interface SimpleSession {
-  userId: string
-  userRole: string
+export function requireAdmin<T extends Record<string, string>>(
+  func: (req: NextRequest, params: T, session: SimpleSession) => Promise<Response>
+) {
+  return mapExceptions(async (req: NextRequest, route: { params: any }) => {
+    const authResult = await authenticate(req)
+    if (!authResult.success) {
+      return authResult.error
+    }
+    if (authResult.value.userRole != dto.UserRole.ADMIN) {
+      return ApiResponses.forbiddenAction()
+    }
+    return await func(req, await route.params, authResult.value)
+  })
 }
 
 export function requireSession<T extends Record<string, string>>(
   func: (session: SimpleSession, req: NextRequest, params: T) => Promise<Response>
 ) {
   return mapExceptions(async (req: NextRequest, route: { params: any }) => {
-    const session = await auth()
-    if (!session) {
-      const cookieStore = await cookies()
-      if (cookieStore.has(SESSION_TOKEN_NAME)) {
-        logger.info('Deleting invalid cookie')
-        cookieStore.delete(SESSION_TOKEN_NAME)
-      }
-      return ApiResponses.notAuthorized()
+    const authResult = await authenticate(req)
+    if (!authResult.success) {
+      return authResult.error
+    } else {
+      return await func(authResult.value, req, await route.params)
     }
-    return await func(
-      { userId: session.user.id, userRole: session.user.role },
-      req,
-      await route.params
-    )
   })
 }

--- a/logicle/app/api/utils/auth.ts
+++ b/logicle/app/api/utils/auth.ts
@@ -33,8 +33,13 @@ export function requireAdmin<T extends Record<string, string>>(
   })
 }
 
+export interface SimpleSession {
+  userId: string
+  userRole: string
+}
+
 export function requireSession<T extends Record<string, string>>(
-  func: (session: Session, req: NextRequest, params: T) => Promise<Response>
+  func: (session: SimpleSession, req: NextRequest, params: T) => Promise<Response>
 ) {
   return mapExceptions(async (req: NextRequest, route: { params: any }) => {
     const session = await auth()
@@ -46,6 +51,10 @@ export function requireSession<T extends Record<string, string>>(
       }
       return ApiResponses.notAuthorized()
     }
-    return await func(session, req, await route.params)
+    return await func(
+      { userId: session.user.id, userRole: session.user.role },
+      req,
+      await route.params
+    )
   })
 }

--- a/logicle/db/migrations.ts
+++ b/logicle/db/migrations.ts
@@ -31,6 +31,7 @@ export async function migrateToLatest() {
       './migrations/20241118-backend_tool_provisioning'
     ),
     '20241119-userrole_dbenum': await import('./migrations/20241119-userrole_dbenum'),
+    '20241123-apikeys': await import('./migrations/20241123-apikeys'),
   }
 
   const dialect = await createDialect()

--- a/logicle/db/migrations/20241123-apikeys.ts
+++ b/logicle/db/migrations/20241123-apikeys.ts
@@ -9,6 +9,7 @@ export async function up(db: Kysely<any>): Promise<void> {
     .addColumn('id', 'text', (col) => col.notNull().primaryKey())
     .addColumn('key', string, (col) => col.notNull())
     .addColumn('userId', string, (col) => col.notNull().references('User.id'))
+    .addColumn('description', string, (col) => col.notNull())
     .addColumn('provisioned', 'integer', (col) => col.notNull().defaultTo(0))
     .execute()
 }

--- a/logicle/db/migrations/20241123-apikeys.ts
+++ b/logicle/db/migrations/20241123-apikeys.ts
@@ -8,5 +8,7 @@ export async function up(db: Kysely<any>): Promise<void> {
     .createTable('ApiKey')
     .addColumn('id', 'text', (col) => col.notNull().primaryKey())
     .addColumn('key', string, (col) => col.notNull())
+    .addColumn('userId', string, (col) => col.notNull().references('User.id'))
+    .addColumn('provisioned', 'integer', (col) => col.notNull().defaultTo(0))
     .execute()
 }

--- a/logicle/db/migrations/20241123-apikeys.ts
+++ b/logicle/db/migrations/20241123-apikeys.ts
@@ -1,0 +1,12 @@
+import { Dialect, Kysely, SqliteAdapter, SqliteDialect } from 'kysely'
+
+const string = 'text'
+const timestamp = 'text'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable('ApiKey')
+    .addColumn('id', 'text', (col) => col.notNull().primaryKey())
+    .addColumn('key', string, (col) => col.notNull())
+    .execute()
+}

--- a/logicle/db/schema.ts
+++ b/logicle/db/schema.ts
@@ -224,6 +224,7 @@ export interface ApiKey {
   id: string
   key: string
   userId: string
+  provisioned: number
 }
 
 export interface DB {

--- a/logicle/db/schema.ts
+++ b/logicle/db/schema.ts
@@ -220,8 +220,15 @@ export interface AssistantToolAssociation {
   toolId: string
 }
 
+export interface ApiKey {
+  id: string
+  key: string
+  userId: string
+}
+
 export interface DB {
   Account: Account
+  ApiKey: ApiKey
   Assistant: Assistant
   AssistantFile: AssistantFile
   AssistantSharing: AssistantSharing

--- a/logicle/db/schema.ts
+++ b/logicle/db/schema.ts
@@ -224,6 +224,7 @@ export interface ApiKey {
   id: string
   key: string
   userId: string
+  description: string
   provisioned: number
 }
 

--- a/logicle/lib/provision.ts
+++ b/logicle/lib/provision.ts
@@ -6,7 +6,7 @@ import { createToolWithId, getTool, updateTool } from '@/models/tool'
 import { parseDocument } from 'yaml'
 import { createBackendWithId, getBackend, updateBackend } from '@/models/backend'
 import { logger } from './logging'
-import { createApiKeyWithId, updateApiKey } from '@/models/apikey'
+import { createApiKeyWithId, getApiKey, updateApiKey } from '@/models/apikey'
 
 interface Provision {
   tools: Record<string, dto.InsertableToolDTO>
@@ -37,26 +37,26 @@ export async function provisionFile(path: string) {
   const content = fs.readFileSync(path)
   const provisionData = parseDocument(content.toString('utf-8')).toJSON() as Provision
   for (const id in provisionData.tools) {
-    const toolDef = provisionData.tools[id]
+    const provisioned = provisionData.tools[id]
     const existing = await getTool(id)
     if (existing) {
-      await updateTool(id, toolDef)
+      await updateTool(id, provisioned)
     } else {
-      await createToolWithId(id, toolDef, true)
+      await createToolWithId(id, provisioned, true)
     }
   }
   for (const id in provisionData.backends) {
-    const backendDef = provisionData.backends[id]
+    const provisioned = provisionData.backends[id]
     const existing = await getBackend(id)
     if (existing) {
-      await updateBackend(id, backendDef)
+      await updateBackend(id, provisioned)
     } else {
-      await createBackendWithId(id, backendDef, true)
+      await createBackendWithId(id, provisioned, true)
     }
   }
   for (const id in provisionData.apiKeys) {
     const provisioned = provisionData.apiKeys[id]
-    const existing = await getBackend(id)
+    const existing = await getApiKey(id)
     if (existing) {
       await updateApiKey(id, provisioned)
     } else {

--- a/logicle/models/apikey.ts
+++ b/logicle/models/apikey.ts
@@ -1,0 +1,37 @@
+import { db } from 'db/database'
+import * as dto from '@/types/dto'
+
+export const getApiKey = async (id: string) => {
+  return await db.selectFrom('ApiKey').selectAll().where('id', '=', id).executeTakeFirst()
+}
+
+export const createApiKeyWithId = async (
+  id: string,
+  apiKey: dto.InsertableApiKey,
+  provisioned: Boolean
+) => {
+  await db
+    .insertInto('ApiKey')
+    .values({
+      ...apiKey,
+      id: id,
+      provisioned: provisioned ? 1 : 0,
+    })
+    .executeTakeFirstOrThrow()
+}
+
+export const updateApiKey = async (id: string, data: Partial<dto.InsertableApiKey>) => {
+  const apiKey = await getApiKey(id)
+  if (!apiKey) {
+    throw new Error('Backend not found')
+  }
+  return db
+    .updateTable('ApiKey')
+    .set({
+      ...data,
+      id: undefined,
+      provisioned: undefined, // protect against malicious API usage
+    })
+    .where('id', '=', id)
+    .execute()
+}

--- a/logicle/types/dto.ts
+++ b/logicle/types/dto.ts
@@ -75,3 +75,6 @@ export interface BackendModels {
 }
 
 export { UserRole } from '@/db/schema'
+
+export type ApiKey = schema.ApiKey
+export type InsertableApiKey = Omit<ApiKey, 'provisioned' | 'id'>


### PR DESCRIPTION
Added API key based authentication to APIs.
The rationale is.. being able to access the APIs from another server / non next.js application

Example of a provisioned API key (the example uses a "normal" user, but as a matter of fact, we expect provisioned API keys to refer to provisioned users)
```
apiKeys:
  test:
    id: test
    key: test
    description: ""
    userId: wusuRBocF9INIAGJI3ak_
```


Example of a call using API keys:
```
 curl -H "Authorization: Bearer test" http://localhost:3000/api/user/profile
```


