### PR TITLE
User provisioning

### DIFF
--- a/logicle/app/api/scim/v2.0/[...directory].ts
+++ b/logicle/app/api/scim/v2.0/[...directory].ts
@@ -53,6 +53,7 @@ const handleEvents = async (event: DirectorySyncEvent) => {
         role: dto.UserRole.USER,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
+        provisioned: 0,
       })
       .onConflict((oc) =>
         oc.column('email').doUpdateSet({
@@ -75,6 +76,7 @@ const handleEvents = async (event: DirectorySyncEvent) => {
           role: dto.UserRole.USER,
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
+          provisioned: 0,
         })
         .onConflict((oc) =>
           oc.column('email').doUpdateSet({

--- a/logicle/app/api/tools/[toolId]/route.ts
+++ b/logicle/app/api/tools/[toolId]/route.ts
@@ -31,7 +31,6 @@ export const PATCH = requireAdmin(async (req: Request, params: { toolId: string 
     ...data,
     id: undefined,
     type: undefined,
-    provisioned: undefined, // protect against malicious API usage
     createdAt: undefined,
     updatedAt: new Date().toISOString(),
   })

--- a/logicle/app/api/users/[userId]/password/route.ts
+++ b/logicle/app/api/users/[userId]/password/route.ts
@@ -13,7 +13,9 @@ export const PUT = requireAdmin(async (req: Request, params: { userId: string })
   if (!user) {
     return ApiResponses.noSuchEntity('No such user')
   }
-
+  if (user.provisioned) {
+    return ApiResponses.forbiddenAction("Can't modify a provisioned user")
+  }
   await db
     .updateTable('User')
     .set({ password: await hashPassword(newPassword) })

--- a/logicle/app/api/users/[userId]/route.ts
+++ b/logicle/app/api/users/[userId]/route.ts
@@ -81,7 +81,6 @@ export const PATCH = requireAdmin(async (req: Request, params: { userId: string 
     ...user,
     image: undefined,
     imageId: createdImage?.id ?? null,
-    provisioned: undefined, // protect against malicious API usage
   } as Updateable<schema.User>
 
   await deleteUserImage(params.userId)

--- a/logicle/app/api/users/[userId]/route.ts
+++ b/logicle/app/api/users/[userId]/route.ts
@@ -19,6 +19,13 @@ export const DELETE = requireAdmin(async (req: Request, params: { userId: string
   if (await isCurrentUser(params.userId)) {
     return ApiResponses.forbiddenAction('You cannot delete your own account')
   }
+  const currentUser = await getUserById(params.userId)
+  if (!currentUser) {
+    return ApiResponses.noSuchEntity(`There is no user with id ${params.userId}`)
+  }
+  if (currentUser.provisioned) {
+    return ApiResponses.forbiddenAction("Can't modify a provisioned user")
+  }
 
   try {
     await deleteUserById(params.userId)
@@ -57,6 +64,13 @@ const UpdateableUserKeys: KeysEnum<dto.UpdateableUser> = {
 
 export const PATCH = requireAdmin(async (req: Request, params: { userId: string }) => {
   const user = sanitize<dto.UpdateableUser>(await req.json(), UpdateableUserKeys)
+  const currentUser = await getUserById(params.userId)
+  if (!currentUser) {
+    return ApiResponses.noSuchEntity(`There is no user with id ${params.userId}`)
+  }
+  if (currentUser.provisioned) {
+    return ApiResponses.forbiddenAction("Can't modify a provisioned user")
+  }
   if ((await isCurrentUser(params.userId)) && user.role) {
     return ApiResponses.forbiddenAction("Can't update self role")
   }

--- a/logicle/app/api/users/[userId]/route.ts
+++ b/logicle/app/api/users/[userId]/route.ts
@@ -81,6 +81,7 @@ export const PATCH = requireAdmin(async (req: Request, params: { userId: string 
     ...user,
     image: undefined,
     imageId: createdImage?.id ?? null,
+    provisioned: undefined, // protect against malicious API usage
   } as Updateable<schema.User>
 
   await deleteUserImage(params.userId)

--- a/logicle/db/migrations.ts
+++ b/logicle/db/migrations.ts
@@ -31,7 +31,9 @@ export async function migrateToLatest() {
       './migrations/20241118-backend_tool_provisioning'
     ),
     '20241119-userrole_dbenum': await import('./migrations/20241119-userrole_dbenum'),
-    '20241123-apikeys': await import('./migrations/20241123-apikeys'),
+    '20241123-apikeys_and_userprovision': await import(
+      './migrations/20241123-apikeys_and_userprovision'
+    ),
   }
 
   const dialect = await createDialect()

--- a/logicle/db/migrations/20241123-apikeys_and_userprovision.ts
+++ b/logicle/db/migrations/20241123-apikeys_and_userprovision.ts
@@ -12,4 +12,8 @@ export async function up(db: Kysely<any>): Promise<void> {
     .addColumn('description', string, (col) => col.notNull())
     .addColumn('provisioned', 'integer', (col) => col.notNull().defaultTo(0))
     .execute()
+  await db.schema
+    .alterTable('User')
+    .addColumn('provisioned', 'integer', (col) => col.notNull().defaultTo(0))
+    .execute()
 }

--- a/logicle/db/schema.ts
+++ b/logicle/db/schema.ts
@@ -161,6 +161,7 @@ export interface User {
   name: string
   password: string | null
   role: UserRole
+  provisioned: number
   updatedAt: string
 }
 
@@ -252,7 +253,6 @@ export interface DB {
   Workspace: Workspace
   WorkspaceMember: WorkspaceMember
   User: User
-  UserRole: UserRole
   JacksonStore: JacksonStore
   JacksonIndex: JacksonIndex
 }

--- a/logicle/lib/provision.ts
+++ b/logicle/lib/provision.ts
@@ -7,10 +7,12 @@ import { parseDocument } from 'yaml'
 import { createBackendWithId, getBackend, updateBackend } from '@/models/backend'
 import { logger } from './logging'
 import { createApiKeyWithId, getApiKey, updateApiKey } from '@/models/apikey'
+import { createUserRawWithId, getUserById, updateUser } from '@/models/user'
 
 interface Provision {
   tools: Record<string, dto.InsertableToolDTO>
   backends: Record<string, dto.InsertableBackend>
+  users: Record<string, dto.InsertableUser>
   apiKeys: Record<string, dto.InsertableApiKey>
 }
 
@@ -52,6 +54,15 @@ export async function provisionFile(path: string) {
       await updateBackend(id, provisioned)
     } else {
       await createBackendWithId(id, provisioned, true)
+    }
+  }
+  for (const id in provisionData.users) {
+    const provisioned = provisionData.users[id]
+    const existing = await getUserById(id)
+    if (existing) {
+      await updateUser(id, provisioned)
+    } else {
+      await createUserRawWithId(id, provisioned, true)
     }
   }
   for (const id in provisionData.apiKeys) {

--- a/logicle/models/tool.ts
+++ b/logicle/models/tool.ts
@@ -57,6 +57,7 @@ export const updateTool = async (id: string, data: dto.UpdateableToolDTO) => {
   const update = {
     ...data,
     configuration: data.configuration ? JSON.stringify(data.configuration) : undefined,
+    provisioned: undefined, // protect against malicious API usage
   }
   return db.updateTable('Tool').set(update).where('id', '=', id).execute()
 }

--- a/logicle/models/user.ts
+++ b/logicle/models/user.ts
@@ -116,6 +116,7 @@ export const deleteUserByEmail = async (email: string) => {
 export const updateUser = async (userId: string, user: Partial<schema.User>) => {
   const userWithFixedDates = {
     ...user,
+    provisioned: undefined, // protect against malicious API usage
     createdAt: undefined,
     updatedAt: new Date().toISOString(),
   } as Partial<schema.User>

--- a/logicle/models/user.ts
+++ b/logicle/models/user.ts
@@ -10,6 +10,14 @@ export const createUserRaw = async (
   user: Omit<schema.User, 'id' | 'createdAt' | 'imageId' | 'updatedAt'>
 ) => {
   const id = nanoid()
+  return createUserRawWithId(id, user, false)
+}
+
+export const createUserRawWithId = async (
+  id: string,
+  user: Omit<schema.User, 'id' | 'createdAt' | 'imageId' | 'updatedAt'>,
+  provisioned: boolean
+) => {
   await db
     .insertInto('User')
     .values({
@@ -17,6 +25,7 @@ export const createUserRaw = async (
       id,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
+      provisioned: provisioned ? 1 : 0,
     })
     .execute()
   const createdUser = await getUserById(id)

--- a/logicle/models/user.ts
+++ b/logicle/models/user.ts
@@ -7,7 +7,7 @@ import * as schema from '@/db/schema'
 import { logger } from '@/lib/logging'
 
 export const createUserRaw = async (
-  user: Omit<schema.User, 'id' | 'createdAt' | 'imageId' | 'updatedAt'>
+  user: Omit<schema.User, 'id' | 'createdAt' | 'imageId' | 'updatedAt' | 'provisioned'>
 ) => {
   const id = nanoid()
   return createUserRawWithId(id, user, false)
@@ -15,7 +15,7 @@ export const createUserRaw = async (
 
 export const createUserRawWithId = async (
   id: string,
-  user: Omit<schema.User, 'id' | 'createdAt' | 'imageId' | 'updatedAt'>,
+  user: Omit<schema.User, 'id' | 'createdAt' | 'imageId' | 'updatedAt' | 'provisioned'>,
   provisioned: boolean
 ) => {
   await db

--- a/logicle/types/dto.ts
+++ b/logicle/types/dto.ts
@@ -77,4 +77,4 @@ export interface BackendModels {
 export { UserRole } from '@/db/schema'
 
 export type ApiKey = schema.ApiKey
-export type InsertableApiKey = Omit<ApiKey, 'provisioned' | 'id'>
+export type InsertableApiKey = Omit<ApiKey, 'id' | 'provisioned'>

--- a/logicle/types/dto/user.ts
+++ b/logicle/types/dto/user.ts
@@ -4,8 +4,8 @@ import * as schema from '@/db/schema'
 export type User = Omit<schema.User, 'imageId'> & {
   image: string | null
 }
-export type InsertableUser = Omit<User, 'createdAt' | 'updatedAt'>
-export type UpdateableUser = Omit<InsertableUser, 'id'>
+export type InsertableUser = Omit<User, 'id' | 'createdAt' | 'updatedAt' | 'provisioned'>
+export type UpdateableUser = InsertableUser
 export type UpdateableUserSelf = Omit<UpdateableUser, 'role'>
 
 export interface WorkspaceMembership {


### PR DESCRIPTION
This PR allows user provisioning.
It is expected that provisioned users will be password-less, and used only for server-to-server communication (or anyway... not by the standard logicle UI)
Consistently with other provisioned entities, it is not possible to modify with APIs properties which are under provisioning process control.
But... it will still be possible to add a provisioned user to a workspace!

Example of users provisioning section:

```
users:
  robot:
    name: robot
    email: ""
    role: User
```
