### PR TITLE
Add a PGP encrypting storage

### DIFF
--- a/logicle/__tests__/storages.ts
+++ b/logicle/__tests__/storages.ts
@@ -1,33 +1,54 @@
 import { MemoryStorage } from '@/lib/storage/MemoryStorage'
 import { CachingStorage } from '@/lib/storage/CachingStorage'
-import { EncryptingStorage } from '@/lib/storage/EncryptingStorage'
+import { AesEncryptingStorage } from '@/ee/AesEncryptingStorage'
+import { PgpEncryptingStorage } from '@/ee/PgpEncryptingStorage'
+
+const fileName = 'test'
+const password = 'my_key'
 
 test('TestMemoryStorage', async () => {
   const storage = new MemoryStorage()
-  await storage.writeBuffer('test', Buffer.from('just testing'))
-  const aaaa = await storage.readBuffer('test')
+  await storage.writeBuffer(fileName, Buffer.from('just testing'))
+  const aaaa = await storage.readBuffer(fileName)
   expect(aaaa.toString()).toBe('just testing')
 })
 
 test('TestCachingStorage', async () => {
   const storage = new CachingStorage(new MemoryStorage(), 1)
-  await storage.writeBuffer('test', Buffer.from('just testing'))
-  const aaaa = await storage.readBuffer('test')
+  await storage.writeBuffer(fileName, Buffer.from('just testing'))
+  const aaaa = await storage.readBuffer(fileName)
   expect(aaaa.toString()).toBe('just testing')
 })
 
-test('TestEncryptingStorageShortString', async () => {
-  const storage = await EncryptingStorage.create(new MemoryStorage(), 'my_key')
+test('TestAesEncryptingStorageShortString', async () => {
+  const storage = await AesEncryptingStorage.create(new MemoryStorage(), password)
   const text = 'just testing'
-  await storage.writeBuffer('test', Buffer.from(text))
-  const buf = await storage.readBuffer('test')
+  await storage.writeBuffer(fileName, Buffer.from(text))
+  const buf = await storage.readBuffer(fileName)
   expect(buf.toString()).toBe(text)
 })
 
-test('TestEncryptingStorageNotSoShortString', async () => {
-  const storage = await EncryptingStorage.create(new MemoryStorage(), 'my_key')
+test('TestAesEncryptingStorageNotSoShortString', async () => {
+  const storage = await AesEncryptingStorage.create(new MemoryStorage(), password)
   const text = 'just testing just testing just testing just testing just testing'
-  await storage.writeBuffer('test', Buffer.from(text))
-  const buf = await storage.readBuffer('test')
+  await storage.writeBuffer(fileName, Buffer.from(text))
+  const buf = await storage.readBuffer(fileName)
+  expect(buf.toString()).toBe(text)
+})
+
+test('TestPgpEncryptingStorageShortString', async () => {
+  const memoryStorage = new MemoryStorage()
+  const storage = await PgpEncryptingStorage.create(memoryStorage, password)
+  const text = 'just testing'
+  await storage.writeBuffer(fileName, Buffer.from(text))
+  const buf = await storage.readBuffer(fileName)
+  expect(buf.toString()).toBe(text)
+})
+
+test('TestPgpEncryptingStorageNotSoShortString', async () => {
+  const storage = await PgpEncryptingStorage.create(new MemoryStorage(), password)
+  const text = 'just testing just testing just testing just testing just testing'
+  await storage.writeBuffer(fileName, Buffer.from(text))
+  const buf = await storage.readBuffer(fileName)
   expect(buf.toString()).toBe(text)
 })

--- a/logicle/ee/AesEncryptingStorage.ts
+++ b/logicle/ee/AesEncryptingStorage.ts
@@ -56,7 +56,7 @@ const getHashPrefix = async (text: string, ivLength: number) => {
   return hash.subarray(0, ivLength)
 }
 
-export class EncryptingStorage extends BaseStorage {
+export class AesEncryptingStorage extends BaseStorage {
   innerStorage: Storage
   key: CryptoKey
   constructor(innerStorage: Storage, key: CryptoKey) {
@@ -75,7 +75,7 @@ export class EncryptingStorage extends BaseStorage {
       true, // Whether the key is extractable
       ['encrypt', 'decrypt'] // Usages for the key
     )
-    return new EncryptingStorage(innerStorage, cryptoKey)
+    return new AesEncryptingStorage(innerStorage, cryptoKey)
   }
 
   async readStream(path: string): Promise<ReadableStream<Uint8Array>> {

--- a/logicle/ee/PgpEncryptingStorage.ts
+++ b/logicle/ee/PgpEncryptingStorage.ts
@@ -1,0 +1,91 @@
+import { logger } from '@/lib/logging'
+import { Storage, BaseStorage } from '@/lib/storage/api'
+import * as openpgp from 'openpgp'
+
+const concatenate = (chunks: Uint8Array[]) => {
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0)
+  const concatenatedBuffer = new Uint8Array(totalLength)
+  let offset = 0
+  for (const chunk of chunks) {
+    concatenatedBuffer.set(chunk, offset)
+    offset += chunk.length
+  }
+  return concatenatedBuffer
+}
+
+const rollIv = (iv: Uint8Array, increment: number = 1): void => {
+  if (increment < 0) {
+    throw new Error('Increment must be non-negative')
+  }
+
+  const view = new DataView(iv.buffer, iv.byteOffset, iv.byteLength)
+
+  // Increment the IV starting from the least significant byte
+  for (let i = iv.length - 1; i >= 0; i--) {
+    const current = view.getUint8(i)
+    const result = current + increment
+
+    // Update the current byte
+    view.setUint8(i, result % 256)
+
+    // Calculate carry for the next byte
+    increment = Math.floor(result / 256)
+
+    if (increment === 0) {
+      break // Exit early if no carry is left
+    }
+  }
+
+  if (increment > 0) {
+    throw new Error('IV overflowed beyond its length')
+  }
+}
+
+// Concatenate all the chunks
+const assembleChunks = (chunks: Uint8Array[]) => {
+  const concatenatedBuffer = concatenate(chunks)
+  const totalLength = concatenatedBuffer.length
+  const blockSize = 16
+  const roundedLength = Math.floor(totalLength / blockSize) * blockSize
+  const concatenated = concatenatedBuffer.subarray(0, roundedLength) // No copying
+  const remainder = concatenatedBuffer.subarray(roundedLength) // No copying
+  return { concatenated, remainder }
+}
+
+export class PgpEncryptingStorage extends BaseStorage {
+  innerStorage: Storage
+  passPhrase: string
+  constructor(innerStorage: Storage, passPhrase: string) {
+    super()
+    this.innerStorage = innerStorage
+    crypto.subtle.importKey
+    this.passPhrase = passPhrase
+  }
+
+  static async create(innerStorage: Storage, passPhrase: string) {
+    return new PgpEncryptingStorage(innerStorage, passPhrase)
+  }
+
+  async readStream(path: string): Promise<ReadableStream<Uint8Array>> {
+    const encryptedStream = await this.innerStorage.readStream(path)
+    const { data: clearStream } = await openpgp.decrypt({
+      message: await openpgp.readMessage({ binaryMessage: encryptedStream }),
+      passwords: [this.passPhrase], // Use the passphrase for encryption
+      format: 'binary', // Use 'binary' format for streaming
+    })
+    return clearStream
+  }
+
+  async writeStream(path: string, stream: ReadableStream<Uint8Array>, size: number): Promise<void> {
+    const encryptedStream = await openpgp.encrypt({
+      message: await openpgp.createMessage({ binary: stream }),
+      passwords: [this.passPhrase], // Use the passphrase for encryption
+      format: 'binary', // Use 'binary' format for streaming
+    })
+    return this.innerStorage.writeStream(path, encryptedStream, size)
+  }
+
+  rm(path: string): Promise<void> {
+    return this.innerStorage.rm(path)
+  }
+}

--- a/logicle/lib/env.ts
+++ b/logicle/lib/env.ts
@@ -92,6 +92,7 @@ const env = {
   fileStorage: {
     location: process.env.FILE_STORAGE_LOCATION,
     cacheSizeInMb: parseFloat(process.env.FILE_STORAGE_CACHE_SIZE_MB ?? '0'),
+    encryptionProvider: process.env.FILE_STORAGE_ENCRYPTION_PROVIDER || 'pgp',
     encryptionKey: process.env.FILE_STORAGE_ENCRYPTION_KEY,
   },
   apiKeys: {

--- a/logicle/package-lock.json
+++ b/logicle/package-lock.json
@@ -68,6 +68,7 @@
         "node-cache": "^5.1.2",
         "nodemailer": "6.9.4",
         "openai": "^4.72.0",
+        "openpgp": "^6.0.1",
         "react": "^18.2.0",
         "react-circular-progressbar": "^2.1.0",
         "react-content-loader": "^7.0.0",
@@ -18738,6 +18739,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/openpgp": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-6.0.1.tgz",
+      "integrity": "sha512-3lReDKjgWsKFArZT4Y/yj7/Q0q6/VhXarn4WqKEkyiBWckNjrThSGoB1t0IKo3Ke0ClvBpyQfTwumkGUkxOwww==",
+      "license": "LGPL-3.0+",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/logicle/package.json
+++ b/logicle/package.json
@@ -80,6 +80,7 @@
     "node-cache": "^5.1.2",
     "nodemailer": "6.9.4",
     "openai": "^4.72.0",
+    "openpgp": "^6.0.1",
     "react": "^18.2.0",
     "react-circular-progressbar": "^2.1.0",
     "react-content-loader": "^7.0.0",


### PR DESCRIPTION
This PR adds support for file encryption based on PGP, which becomes the default encryption implementation.

The two environment variables which govern encryption are:

```
FILE_STORAGE_ENCRYPTION_KEY=[a_passphrase]
FILE_STORAGE_ENCRYPTION_PROVIDER=[pgp/aes]
```

the key is a human readable passphrase.

Encrypted files can be easily decrypted with gpg:

```
gpg --decrypt --batch --passphrase [passphrase] [fileName]
```

and encrypted (useful for migrations)

```
gpg --symmetric --batch --passphrase [passphrase] --output [encrypted_path] [clear_path]
```


