### PR TITLE
Assistant provisioning

### DIFF
--- a/logicle/app/api/assistants/[assistantId]/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/route.ts
@@ -113,6 +113,9 @@ export const PATCH = requireSession(
     if (!assistant) {
       return ApiResponses.noSuchEntity(`There is no assistant with id ${params.assistantId}`)
     }
+    if (assistant.provisioned) {
+      return ApiResponses.forbiddenAction("Can't modify a provisioned assistant")
+    }
 
     // Note: we need the admin to be able to modify the assistant owner
     // So... the API is a bit more open than reasonable

--- a/logicle/app/api/assistants/[assistantId]/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/route.ts
@@ -154,6 +154,9 @@ export const DELETE = requireSession(
     if (!assistant) {
       return ApiResponses.noSuchEntity(`There is no assistant with id ${params.assistantId}`)
     }
+    if (assistant.provisioned) {
+      return ApiResponses.forbiddenAction("Can't delete a provisioned assistant")
+    }
     // Note: we need the admin to be able to modify the assistant owner
     // So... the API is a bit more open than reasonable
     if (assistant.owner !== session.userId && session.userRole != 'ADMIN') {

--- a/logicle/db/migrations.ts
+++ b/logicle/db/migrations.ts
@@ -34,6 +34,7 @@ export async function migrateToLatest() {
     '20241123-apikeys_and_userprovision': await import(
       './migrations/20241123-apikeys_and_userprovision'
     ),
+    '20241209-assistant_provisioning': await import('./migrations/20241209-assistant_provisioning'),
   }
 
   const dialect = await createDialect()

--- a/logicle/db/migrations/20241209-assistant_provisioning.ts
+++ b/logicle/db/migrations/20241209-assistant_provisioning.ts
@@ -1,0 +1,8 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('Assistant')
+    .addColumn('provisioned', 'integer', (col) => col.notNull().defaultTo(0))
+    .execute()
+}

--- a/logicle/db/schema.ts
+++ b/logicle/db/schema.ts
@@ -43,6 +43,7 @@ export interface Assistant {
   prompts: string
   createdAt: string
   updatedAt: string
+  provisioned: number
 }
 
 export interface AssistantSharing {

--- a/logicle/lib/provision.ts
+++ b/logicle/lib/provision.ts
@@ -8,12 +8,14 @@ import { createBackendWithId, getBackend, updateBackend } from '@/models/backend
 import { logger } from './logging'
 import { createApiKeyWithId, getApiKey, updateApiKey } from '@/models/apikey'
 import { createUserRawWithId, getUserById, updateUser } from '@/models/user'
+import Assistants from '@/models/assistant'
 
 interface Provision {
   tools: Record<string, dto.InsertableToolDTO>
   backends: Record<string, dto.InsertableBackend>
   users: Record<string, dto.InsertableUser>
   apiKeys: Record<string, dto.InsertableApiKey>
+  assistants: Record<string, dto.InsertableAssistant>
 }
 
 export async function provision() {
@@ -72,6 +74,18 @@ export async function provisionFile(path: string) {
       await updateApiKey(id, provisioned)
     } else {
       await createApiKeyWithId(id, provisioned, true)
+    }
+  }
+  for (const id in provisionData.assistants) {
+    const provisioned = {
+      ...provisionData.assistants[id],
+      files: [],
+    }
+    const existing = await Assistants.get(id)
+    if (existing) {
+      await Assistants.update(id, provisioned)
+    } else {
+      await Assistants.createWithId(id, provisioned, true)
     }
   }
 }

--- a/logicle/models/assistant.ts
+++ b/logicle/models/assistant.ts
@@ -125,6 +125,14 @@ export default class Assistants {
 
   static create = async (assistant: dto.InsertableAssistant) => {
     const id = nanoid()
+    return Assistants.createWithId(id, assistant, false)
+  }
+
+  static createWithId = async (
+    id: string,
+    assistant: dto.InsertableAssistant,
+    provisioned: boolean
+  ) => {
     const now = new Date().toISOString()
     const withoutTools = {
       ...assistant,
@@ -136,6 +144,7 @@ export default class Assistants {
       updatedAt: now,
       tags: JSON.stringify(assistant.tags),
       prompts: JSON.stringify(assistant.prompts),
+      provisioned: provisioned ? 1 : 0,
     }
     await db.insertInto('Assistant').values(withoutTools).executeTakeFirstOrThrow()
     const tools = Assistants.toAssistantToolAssociation(id, assistant.tools)

--- a/logicle/types/dto/assistants.ts
+++ b/logicle/types/dto/assistants.ts
@@ -25,7 +25,7 @@ export type AssistantWithTools = Omit<schema.Assistant, 'imageId' | 'tags' | 'pr
 
 export type InsertableAssistant = Omit<
   schema.Assistant,
-  'id' | 'imageId' | 'createdAt' | 'updatedAt' | 'tags' | 'prompts'
+  'id' | 'imageId' | 'createdAt' | 'updatedAt' | 'tags' | 'prompts' | 'provisioned'
 > & {
   tools: AssistantTool[]
   files: AssistantFile[]


### PR DESCRIPTION
Assistants may now be provisioned.
This feature is currently thought for testing, but it may be useful sooner or later..

Here an example of the assistants section in the provision file

```
assistants:
  test:
    name: test
    description: test
    model: gpt-4o
    backendId: openai
    systemPrompt: "You're an helpful assistant"
    tokenLimit: 4096
    temperature: .5
    tools:
      - id: timeofday
        enabled: true
    prompts:
      - test1
      - test2
    owner: robot
    tags:
      - robot
```
