### PR TITLE
Openapi multipart support

### DIFF
--- a/logicle/app/chat/components/ChatMessage.tsx
+++ b/logicle/app/chat/components/ChatMessage.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/accordion'
 import { useTranslation } from 'react-i18next'
 import { IconCheck, IconCopy, IconRepeat } from '@tabler/icons-react'
+import { IconDownload } from '@tabler/icons-react'
 
 export interface ChatMessageProps {
   assistant: dto.UserAssistant
@@ -176,7 +177,7 @@ export const Attachment = ({ file, className }: AttachmentProps) => {
   return (
     <div
       className={cn(
-        'border p-2 flex flex-row items-center gap-2 relative shadow rounded',
+        'border p-2 flex flex-row items-center gap-2 relative shadow rounded relative group/attachment',
         className
       )}
     >
@@ -193,6 +194,18 @@ export const Attachment = ({ file, className }: AttachmentProps) => {
             </div>
           </div>
         )}
+        <div
+          className="rounded-md m-2 absolute top-0 right-0 bg-black bg-opacity-30 invisible group-hover/attachment:visible cursor-pointer"
+          onClick={() => {
+            const link = document.createElement('a')
+            link.download = file.fileName
+            link.href = `/api/files/${file.fileId}/content`
+            link.style.display = 'none'
+            link.click()
+          }}
+        >
+          <IconDownload className="m-2" size={24} color="white"></IconDownload>
+        </div>
       </div>
     </div>
   )

--- a/logicle/lib/tools/openapi/implementation.ts
+++ b/logicle/lib/tools/openapi/implementation.ts
@@ -81,17 +81,6 @@ function expandIfProvisioned(template: string, provisioned: boolean) {
   else return expandEnv(template)
 }
 
-// Helper function to parse headers
-function parseHeaders(rawHeaders: string): Record<string, string> {
-  const headers: Record<string, string> = {}
-  const headerLines = rawHeaders.split('\r\n')
-  for (const line of headerLines) {
-    const [key, ...value] = line.split(':')
-    headers[key.trim()] = value.join(':').trim()
-  }
-  return headers
-}
-
 function convertOpenAPIOperationToToolFunction(
   spec: OpenAPIV3.Document,
   pathKey: string,
@@ -250,7 +239,7 @@ function convertOpenAPIOperationToToolFunction(
         }
 
         let result: string | undefined
-        for await (let part of parseMultipart(response.body!, boundary)) {
+        for await (const part of parseMultipart(response.body!, boundary)) {
           console.log(`name = ${part.name} filename = ${part.filename} type = ${part.mediaType}`)
           // filename comes from... Content-Disposition: attachment
           // so, if there's a filename, we assume it's an attachment, and not the "body", which we want to

--- a/logicle/lib/tools/openapi/implementation.ts
+++ b/logicle/lib/tools/openapi/implementation.ts
@@ -4,13 +4,16 @@ import OpenAPIParser from '@readme/openapi-parser'
 import { OpenAPIV3 } from 'openapi-types'
 import env from '@/lib/env'
 import { JSONSchema7 } from 'json-schema'
-import { getFileWithId } from '@/models/file'
+import { addFile, getFileWithId } from '@/models/file'
 import FormData from 'form-data'
 import { PassThrough } from 'stream'
 import { logger } from '@/lib/logging'
 import { parseDocument } from 'yaml'
 import { expandEnv } from 'templates'
 import { storage } from '@/lib/storage'
+import { parseMultipart } from '@mjackson/multipart-parser'
+import { InsertableFile } from '@/types/dto'
+import { nanoid } from 'nanoid'
 
 export interface OpenApiPluginParams extends Record<string, unknown> {
   spec: string
@@ -76,6 +79,17 @@ function chooseRequestBody(spec?: OpenAPIV3.RequestBodyObject) {
 function expandIfProvisioned(template: string, provisioned: boolean) {
   if (!provisioned) return template
   else return expandEnv(template)
+}
+
+// Helper function to parse headers
+function parseHeaders(rawHeaders: string): Record<string, string> {
+  const headers: Record<string, string> = {}
+  const headerLines = rawHeaders.split('\r\n')
+  for (const line of headerLines) {
+    const [key, ...value] = line.split(':')
+    headers[key.trim()] = value.join(':').trim()
+  }
+  return headers
 }
 
 function convertOpenAPIOperationToToolFunction(
@@ -227,6 +241,43 @@ function convertOpenAPIOperationToToolFunction(
         await uiLink.debugMessage(`Received response`, {
           status: response.status,
         })
+      }
+      const contentType = response.headers.get('content-type')
+      if (contentType && contentType.startsWith('multipart/')) {
+        const boundary = contentType.split('boundary=')[1]
+        if (!boundary) {
+          throw new Error('Boundary not found in Content-Type')
+        }
+
+        let result: string | undefined
+        for await (let part of parseMultipart(response.body!, boundary)) {
+          console.log(`name = ${part.name} filename = ${part.filename} type = ${part.mediaType}`)
+          const name = part.name ?? 'no_name'
+          const mediaType = part.mediaType ?? ''
+          if (!result && /^text\//.test(part.mediaType ?? '')) {
+            result = await part.text()
+          } else {
+            const data = await part.bytes()
+            const path = `${name}-${nanoid()}`
+            await storage.writeBuffer(path, data, env.fileStorage.encryptFiles)
+
+            const dbEntry: InsertableFile = {
+              name,
+              type: mediaType,
+              size: data.byteLength,
+            }
+
+            const dbFile = await addFile(dbEntry, path, env.fileStorage.encryptFiles)
+            await uiLink.newMessage()
+            uiLink.addAttachment({
+              id: dbFile.id,
+              mimetype: mediaType,
+              name: path,
+              size: data.byteLength,
+            })
+          }
+        }
+        return result || 'no response'
       }
       const responseBody = await response.text()
       return responseBody

--- a/logicle/package-lock.json
+++ b/logicle/package-lock.json
@@ -20,6 +20,7 @@
         "@codemirror/lang-yaml": "^6.1.1",
         "@hookform/resolvers": "^3.3.2",
         "@microsoft/fetch-event-source": "^2.0.1",
+        "@mjackson/multipart-parser": "^0.7.0",
         "@radix-ui/react-accordion": "^1.2.1",
         "@radix-ui/react-alert-dialog": "^1.0.5",
         "@radix-ui/react-avatar": "^1.0.4",
@@ -4857,6 +4858,21 @@
       "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
       "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
       "license": "MIT"
+    },
+    "node_modules/@mjackson/headers": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@mjackson/headers/-/headers-0.8.0.tgz",
+      "integrity": "sha512-A6nE9ZKTGX1hTHQOeoYn/f7+xRTgzixHWu9jtZ8zYgZYq30MPtZIRXqEyY8bWaIILr+zWdmUPQg/R/8e+e/8Nw==",
+      "license": "MIT"
+    },
+    "node_modules/@mjackson/multipart-parser": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@mjackson/multipart-parser/-/multipart-parser-0.7.0.tgz",
+      "integrity": "sha512-Nv2CZ32yGbPJVBxMNcdOCT8yJrdjsUem+Sp7YxfqIXVD184rRwOkzLA90dTmYQOa6aT/6y60JLAduh8OgJMS4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@mjackson/headers": "^0.8.0"
+      }
     },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.1.9",

--- a/logicle/package.json
+++ b/logicle/package.json
@@ -32,6 +32,7 @@
     "@codemirror/lang-yaml": "^6.1.1",
     "@hookform/resolvers": "^3.3.2",
     "@microsoft/fetch-event-source": "^2.0.1",
+    "@mjackson/multipart-parser": "^0.7.0",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-avatar": "^1.0.4",


### PR DESCRIPTION
This PR adds to OpenApi tool support for multipart/mixed mime types in response body.
The first text/xxxx part non marked as an attachment (Content-disposition:attachment) is considered as output, and goes to the LLM.
All other parts are stored as "tool-output" in the chat
