### PR TITLE
Reduced log severity when the client goes away

### DIFF
--- a/logicle/lib/chat/TextStreamPartController.ts
+++ b/logicle/lib/chat/TextStreamPartController.ts
@@ -1,4 +1,5 @@
 import * as dto from '@/types/dto'
+import { ClientGoneException } from './exceptions'
 
 export class TextStreamPartController {
   controller: ReadableStreamDefaultController<string>
@@ -8,7 +9,11 @@ export class TextStreamPartController {
 
   // Wrap the enqueue method to encode the data as JSON before enqueueing
   enqueue(streamPart: dto.TextStreamPart) {
-    this.controller.enqueue(`data: ${JSON.stringify(streamPart)} \n\n`) // Enqueue the JSON-encoded chunk
+    try {
+      this.controller.enqueue(`data: ${JSON.stringify(streamPart)} \n\n`) // Enqueue the JSON-encoded chunk
+    } catch (e) {
+      throw new ClientGoneException('Client is gone')
+    }
   }
 
   enqueueNewMessage(msg: dto.Message) {

--- a/logicle/lib/chat/exceptions.ts
+++ b/logicle/lib/chat/exceptions.ts
@@ -1,0 +1,14 @@
+export class ClientException extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = this.constructor.name
+  }
+}
+
+// Th
+export class ClientGoneException extends ClientException {
+  constructor(message: string) {
+    super(message)
+    this.name = this.constructor.name
+  }
+}


### PR DESCRIPTION
Errors caused by the client going away are now detected, and a "warn" is logged instead of an error
