### PR TITLE
Bump docker image to node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@
 # This is the build stage where we build the NextJS application.
 FROM node:22-alpine AS builder
 
+RUN apk add --no-cache \
+    python3 \
+    make \
+    gcc
+
 ENV BUILD_STANDALONE=true
 # Temporarily setting the DATABASE_URL to a file in /tmp to ensure accessibility to the db directory during the build process.
 ENV DATABASE_URL=file:///tmp/logicle.sqlite

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,8 @@
 # This is the build stage where we build the NextJS application.
 FROM node:22-alpine AS builder
 
-RUN apk add --no-cache \
-    python3 \
-    make \
-    gcc \
-    py3-distutils
+RUN apk add --no-cache python3 make g++ py3-pip py3-setuptools \
+    && ln -sf python3 /usr/bin/python
 
 RUN npm install -g node-gyp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apk add --no-cache \
     make \
     gcc
 
+RUN npm install -g node-gyp
+
 ENV BUILD_STANDALONE=true
 # Temporarily setting the DATABASE_URL to a file in /tmp to ensure accessibility to the db directory during the build process.
 ENV DATABASE_URL=file:///tmp/logicle.sqlite

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Stage 1: Builder
 # ---------------------
 # This is the build stage where we build the NextJS application.
-FROM node:20.18.0-alpine AS builder
+FROM node:22-alpine AS builder
 
 ENV BUILD_STANDALONE=true
 # Temporarily setting the DATABASE_URL to a file in /tmp to ensure accessibility to the db directory during the build process.
@@ -29,7 +29,7 @@ RUN NODE_ENV=production npm run build
 # Final Stage: Runtime
 # ---------------------
 # This is the final production stage where we prepare the runtime environment.
-FROM node:20.9.0-alpine
+FROM node:22-alpine
 
 # Set the working directory inside the Docker image
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ FROM node:22-alpine AS builder
 RUN apk add --no-cache \
     python3 \
     make \
-    gcc
+    gcc \
+    py3-distutils
 
 RUN npm install -g node-gyp
 


### PR DESCRIPTION
Upgraded docker image to node 22.
Node 22... seems to come without python.
So... I had to add it, along with c++, but only in the build stage.
It is reasonable that the second stage image will be smaller
