### PR TITLE
Prevent robot indexing

### DIFF
--- a/logicle/app/auth/join/page.tsx
+++ b/logicle/app/auth/join/page.tsx
@@ -1,9 +1,13 @@
 import Signup from './SignUpPanel'
-import { Metadata } from 'next';
+import { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'Sign up',
-};
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 export default async function SignUpPage() {
   return <Signup />

--- a/logicle/app/auth/login/page.tsx
+++ b/logicle/app/auth/login/page.tsx
@@ -6,6 +6,10 @@ import { getUserCount } from '@/models/user'
 
 export const metadata: Metadata = {
   title: 'Login',
+  robots: {
+    index: false,
+    follow: false,
+  },
 }
 
 export default async function LoginPage() {


### PR DESCRIPTION
This PR adds meta information to login / signup page to prevent indexing from robots (i.e. google)
This is what is added in <head> section:

```
        <meta name="robots" content="noindex, nofollow"/>
```

Login and signup pages should really be more than enough, as other pages require authentication