### PR TITLE
Avoid json-encoding tool results twice 

### DIFF
--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -27,8 +27,7 @@ function loggingFetch(
   input: string | URL | globalThis.Request,
   init?: RequestInit
 ): Promise<Response> {
-  logger.info(`Sending to LLM: ${init?.body}`)
-  //input = 'blabla'
+  console.log(`Sending to LLM: ${init?.body}`)
   return fetch(input, init)
 }
 
@@ -117,7 +116,6 @@ export class ChatAssistant {
         return openai.createOpenAI({
           compatibility: 'strict', // strict mode, enable when using the OpenAI API
           apiKey: params.provisioned ? expandEnv(params.apiKey) : params.apiKey,
-          fetch: loggingFetch,
         })
       case 'anthropic':
         return anthropic.createAnthropic({
@@ -268,11 +266,11 @@ export class ChatAssistant {
     chatHistory: dto.Message[],
     toolUILink: ToolUILink
   ) {
-    let stringResult: string
+    let result: any
     try {
       const args = toolCall.args
       logger.info(`Invoking tool '${toolCall.toolName}'`, { args: args })
-      stringResult = await func.invoke({
+      result = await func.invoke({
         messages: chatHistory,
         assistantId: this.assistantParams.assistantId,
         params: args,
@@ -281,9 +279,8 @@ export class ChatAssistant {
       })
     } catch (e) {
       logger.error(`Failed invoking tool "${toolCall.toolName}" : ${e}`, e)
-      stringResult = 'Tool invocation failed'
+      result = 'Tool invocation failed'
     }
-    const result = ChatAssistant.createToolResultFromString(stringResult)
     logger.info(`Invoked tool '${toolCall.toolName}'`, { result: result })
     return result
   }
@@ -296,9 +293,9 @@ export class ChatAssistant {
   ) {
     const functionDef = this.functions[toolCall.toolName]
     if (!functionDef) {
-      return ChatAssistant.createToolResultFromString(`No such function: ${functionDef}`)
+      return `No such function: ${functionDef}`
     } else if (!toolCallAuthResponse.allow) {
-      return ChatAssistant.createToolResultFromString(`User denied access to function`)
+      return `User denied access to function`
     } else {
       return await this.invokeFunction(toolCall, functionDef, dbMessages, toolUILink)
     }

--- a/logicle/lib/chat/tools.ts
+++ b/logicle/lib/chat/tools.ts
@@ -19,7 +19,7 @@ export interface ToolInvokeParams {
 export interface ToolFunction {
   description: string
   parameters?: JSONSchema7
-  invoke: (params: ToolInvokeParams) => Promise<string>
+  invoke: (params: ToolInvokeParams) => Promise<any>
   requireConfirm?: boolean
 }
 

--- a/logicle/lib/tools/openapi/implementation.ts
+++ b/logicle/lib/tools/openapi/implementation.ts
@@ -289,8 +289,11 @@ function convertOpenAPIOperationToToolFunction(
         }
         return result || 'no response'
       }
-      const responseBody = await response.text()
-      return responseBody
+      if (contentType && contentType == 'application/json') {
+        return await response.json()
+      } else {
+        return await response.text()
+      }
     },
     requireConfirm: env.tools.openApi.requireConfirmation,
   }


### PR DESCRIPTION
Completion APIs want a string for tool call result.
But Vercel AI SDK loves objects, and JSON.encode everything. Even if it's a string.
So... we must JSON.parse the output of the tool, if it JSON, to avoid the Vercel SDK to JSON.encode it twice.
The previous workaround (detecting a leading '{') was horrible and not generic enough, as some services might return an array for example.
I changed the signature of tool invoke function to "any", and the parsing is done in the openapi tool (the only one which can currently return JSON objects)

