### PR TITLE
Store lowercased email

### DIFF
--- a/logicle/app/api/scim/v2.0/[...directory].ts
+++ b/logicle/app/api/scim/v2.0/[...directory].ts
@@ -48,7 +48,7 @@ const handleEvents = async (event: DirectorySyncEvent) => {
       .values({
         id: nanoid(),
         name: `${data.first_name} ${data.last_name}`,
-        email: data.email,
+        email: data.email.toLowerCase(),
         password: await hashPassword(createRandomString()),
         role: dto.UserRole.USER,
         createdAt: new Date().toISOString(),
@@ -72,7 +72,7 @@ const handleEvents = async (event: DirectorySyncEvent) => {
         .values({
           id: nanoid(),
           name: `${data.first_name} ${data.last_name}`,
-          email: data.email,
+          email: data.email.toLowerCase(),
           password: await hashPassword(createRandomString()),
           role: dto.UserRole.USER,
           createdAt: new Date().toISOString(),

--- a/logicle/authOptions.ts
+++ b/logicle/authOptions.ts
@@ -82,7 +82,7 @@ export const authOptions: any = {
           return null
         }
 
-        const user = await getUserByEmail(email! as string)
+        const user = await getUserByEmail(email as string)
 
         if (!user) {
           throw new InvalidCredentialsError('invalid-credentials')

--- a/logicle/db/migrations.ts
+++ b/logicle/db/migrations.ts
@@ -37,6 +37,7 @@ export async function migrateToLatest() {
     '20241209-assistant_provisioning': await import('./migrations/20241209-assistant_provisioning'),
     '20241210-file_encryption': await import('./migrations/20241210-file_encryption'),
     '20241211-user_preferences': await import('./migrations/20241211-user_preferences'),
+    '20250212-lowercase_email': await import('./migrations/20250212-lowercase_email'),
   }
 
   const dialect = await createDialect()

--- a/logicle/db/migrations/20250212-lowercase_email.ts
+++ b/logicle/db/migrations/20250212-lowercase_email.ts
@@ -1,0 +1,8 @@
+import { Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db
+    .updateTable('User')
+    .set('email', sql`LOWER("email")`)
+    .execute()
+}

--- a/logicle/models/user.ts
+++ b/logicle/models/user.ts
@@ -22,6 +22,7 @@ export const createUserRawWithId = async (
     .insertInto('User')
     .values({
       ...user,
+      email: user.email.toLowerCase(),
       id,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -57,7 +58,11 @@ export const getUserById = async (id: string): Promise<schema.User | undefined> 
 }
 
 export const getUserByEmail = async (email: string): Promise<schema.User | undefined> => {
-  return db.selectFrom('User').selectAll().where('email', '=', email).executeTakeFirst()
+  return db
+    .selectFrom('User')
+    .selectAll()
+    .where('email', '=', email.toLowerCase())
+    .executeTakeFirst()
 }
 
 export const getUserCount = async () => {
@@ -111,7 +116,7 @@ export const deleteUserById = async (id: string) => {
 }
 
 export const deleteUserByEmail = async (email: string) => {
-  return db.deleteFrom('User').where('email', '=', email).execute()
+  return db.deleteFrom('User').where('email', '=', email.toLowerCase()).execute()
 }
 
 export const updateUser = async (userId: string, user: Partial<schema.User>) => {


### PR DESCRIPTION
In order to avoid quirks such as:

* multiple accounts with same email but different casing
* login failures due to non matching casing

we cut it short, and store lowercased emails.
the function used for lowercase conversion is toLowerCase().
There should be no mysterious failures for new users, as the same function is used in insertion and search.
For older users... I can only hope that the conversion performed by SQL LOWER() matches.

