### PR TITLE
Gemini 2.0 models

### DIFF
--- a/logicle/lib/chat/models/logicle.ts
+++ b/logicle/lib/chat/models/logicle.ts
@@ -8,7 +8,7 @@ import {
 } from './anthropic'
 import { gpt4oMiniModel, gpt4oModel, gpt35Model, o1MiniModel, o1Model, o3MiniModel } from './openai'
 import { sonarModel, sonarProModel } from './perplexity'
-import { gemini15FlashModel, gemini15ProModel } from './vertex'
+import { vertexModels } from './vertex'
 
 export const logicleModels: LlmModel[] = [
   gpt4oModel,
@@ -22,8 +22,7 @@ export const logicleModels: LlmModel[] = [
   { ...claude3OpusModel, id: 'claude-3-opus' },
   claude3SonnetModel,
   claude3HaikuModel,
-  gemini15ProModel,
-  gemini15FlashModel,
+  ...vertexModels,
   sonarModel,
   sonarProModel,
 ]

--- a/logicle/lib/chat/models/vertex.ts
+++ b/logicle/lib/chat/models/vertex.ts
@@ -23,4 +23,48 @@ export const gemini15FlashModel: LlmModel = {
   },
 }
 
-export const vertexModels: LlmModel[] = [gemini15ProModel, gemini15FlashModel]
+export const gemini20FlashModel: LlmModel = {
+  name: 'Gemini 2.0 Flash',
+  description:
+    'A Gemini 2.0 Flash model delivering enhanced multimodal capabilities, native tool use, and low latency for agentic applications.',
+  id: 'gemini-2.0-flash',
+  owned_by: 'google',
+  context_length: 1048576,
+  capabilities: {
+    vision: true,
+    function_calling: true,
+  },
+}
+
+export const gemini20FlashLiteModel: LlmModel = {
+  name: 'Gemini 2.0 Flash Lite',
+  description: 'A Gemini 2.0 Flash model optimized for cost efficiency and low latency',
+  id: 'gemini-2.0-flash-lite-preview-02-05',
+  owned_by: 'google',
+  context_length: 1048576,
+  capabilities: {
+    vision: false,
+    function_calling: false,
+  },
+}
+
+export const gemini20ProModel: LlmModel = {
+  name: 'Gemini 2.0 Pro',
+  description:
+    'An experimental Gemini 2.0 model optimized for complex tasks and coding, featuring a 2M token context window and enhanced reasoning capabilities.',
+  id: 'gemini-2.0-pro-exp-02-05',
+  owned_by: 'google',
+  context_length: 2097152,
+  capabilities: {
+    vision: true,
+    function_calling: true,
+  },
+}
+
+export const vertexModels: LlmModel[] = [
+  gemini15ProModel,
+  gemini15FlashModel,
+  gemini20ProModel,
+  gemini20FlashModel,
+  gemini20FlashLiteModel,
+]


### PR DESCRIPTION
Added Gemini 2.0 models to Vertex / Logicle provider, 
Model ids are:

* gemini-2.0-flash
* gemini-2.0-flash-lite-preview-02-05
* gemini-2.0-pro-exp-02-05

The pro / flash-lite labels will possibly change shortly