### PR TITLE
Use Body parameter for Body in OpenAPI calls

### DIFF
--- a/logicle/app/chat/components/ChatMessage.tsx
+++ b/logicle/app/chat/components/ChatMessage.tsx
@@ -73,7 +73,7 @@ const ToolCall = ({ toolCall }: { toolCall: ToolCallMessageExt }) => {
           <AccordionContent>
             <div>{`${t('parameters')}:`}</div>
             {Object.entries(toolCall.args).map(([key, value]) => (
-              <div key={key}>{`${key}:${value}`}</div>
+              <div key={key}>{`${key}:${JSON.stringify(value)}`}</div>
             ))}
           </AccordionContent>
         </AccordionItem>

--- a/logicle/lib/tools/openapi/implementation.ts
+++ b/logicle/lib/tools/openapi/implementation.ts
@@ -77,6 +77,15 @@ function expandIfProvisioned(template: string, provisioned: boolean) {
   else return expandEnv(template)
 }
 
+function dumpTruncatedBodyContent(body: RequestInit['body']): String {
+  if (!body) return '<no body>'
+  if (typeof body === 'string') {
+    return body.substring(0, 100)
+  } else {
+    return '<not a string>'
+  }
+}
+
 function convertOpenAPIOperationToToolFunction(
   spec: OpenAPIV3.Document,
   pathKey: string,
@@ -156,6 +165,7 @@ function convertOpenAPIOperationToToolFunction(
       await uiLink.debugMessage(`Calling HTTP endpoint ${url}`, {
         method,
         headers,
+        body: dumpTruncatedBodyContent(body),
       })
     }
     const response = await fetch(url, requestInit)

--- a/logicle/lib/tools/openapi/implementation.ts
+++ b/logicle/lib/tools/openapi/implementation.ts
@@ -148,9 +148,9 @@ function convertOpenAPIOperationToToolFunction(
       body = res.body
       headers = { ...headers, ...res.headers }
     }
-    let securityHeaders: Record<string, any> = {}
+    let sensitiveHeaders: Record<string, any> = {}
     if (securitySchemes) {
-      securityHeaders = computeSecurityHeaders(
+      sensitiveHeaders = computeSecurityHeaders(
         securitySchemes as Record<string, OpenAPIV3.SecuritySchemeObject>,
         toolParams,
         provisioned
@@ -160,22 +160,20 @@ function convertOpenAPIOperationToToolFunction(
     if (queryParams.length) {
       url = `${url}?${queryParams.join('&')}`
     }
-    const headersIncludedSecurity = { ...headers, ...securityHeaders }
-
+    const allHeaders = { ...headers, ...sensitiveHeaders }
     const requestInit: RequestInit = {
       method: method.toUpperCase(),
-      headers: headersIncludedSecurity,
+      headers: allHeaders,
       body: body,
     }
     logger.info(`Invoking ${requestInit.method} at ${url}`, {
       body: body,
-      headers: headersIncludedSecurity,
+      headers: allHeaders,
     })
     if (debug) {
-      const redactedHeaders = { ...headers, ...hideSecurityHeaders(securityHeaders) }
       await uiLink.debugMessage(`Calling HTTP endpoint ${url}`, {
         method,
-        redactedHeaders,
+        headers: { ...headers, ...hideSecurityHeaders(sensitiveHeaders) },
         body: dumpTruncatedBodyContent(body),
       })
     }


### PR DESCRIPTION
Due to un unfortunate choice, schema object of request body, which could only be a body, was split in a collection of parameters, in order to send a "flat" schema to LLM.
But as a matter of fact, this operation wasn't needed and prevented non-object json bodies (arrays / strings / ...).
This PR simplifies the schema sent to LLM, which is the composition of "body" / path params / query params.

