### PR TITLE
Assistant sharing provisioning

### DIFF
--- a/logicle/app/api/assistants/[assistantId]/sharing/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/sharing/route.ts
@@ -15,6 +15,16 @@ export const POST = requireSession(
     if (assistant.owner !== session.userId) {
       return ApiResponses.notAuthorized(`You're not authorized to modify assistant ${assistantId}`)
     }
+    const currentSharingProvisioned = await db
+      .selectFrom('AssistantSharing')
+      .where('assistantId', '=', assistantId)
+      .where('provisioned', '=', 1)
+      .execute()
+    if (currentSharingProvisioned.length != 0) {
+      return ApiResponses.notAuthorized(
+        `You're not authorized to modify provisioned sharing of ${assistantId}`
+      )
+    }
     const sharingList = (await req.json()) as dto.Sharing[]
     await db.deleteFrom('AssistantSharing').where('assistantId', '=', assistantId).execute()
     if (sharingList.length != 0) {

--- a/logicle/app/api/assistants/[assistantId]/sharing/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/sharing/route.ts
@@ -17,6 +17,7 @@ export const POST = requireSession(
     }
     const currentSharingProvisioned = await db
       .selectFrom('AssistantSharing')
+      .selectAll()
       .where('assistantId', '=', assistantId)
       .where('provisioned', '=', 1)
       .execute()

--- a/logicle/app/api/assistants/[assistantId]/sharing/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/sharing/route.ts
@@ -26,6 +26,7 @@ export const POST = requireSession(
               id: nanoid(),
               assistantId: assistantId,
               workspaceId: sharing.type == 'workspace' ? sharing.workspaceId : null,
+              provisioned: 0,
             }
           })
         )

--- a/logicle/app/api/assistants/[assistantId]/sharing/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/sharing/route.ts
@@ -3,6 +3,7 @@ import { requireSession, SimpleSession } from '@/api/utils/auth'
 import ApiResponses from '@/api/utils/ApiResponses'
 import * as dto from '@/types/dto'
 import { db } from '@/db/database'
+import { nanoid } from 'nanoid'
 
 export const POST = requireSession(
   async (session: SimpleSession, req: Request, params: { assistantId: string }) => {
@@ -22,6 +23,7 @@ export const POST = requireSession(
         .values(
           sharingList.map((sharing) => {
             return {
+              id: nanoid(),
               assistantId: assistantId,
               workspaceId: sharing.type == 'workspace' ? sharing.workspaceId : null,
             }

--- a/logicle/db/migrations.ts
+++ b/logicle/db/migrations.ts
@@ -38,6 +38,7 @@ export async function migrateToLatest() {
     '20241210-file_encryption': await import('./migrations/20241210-file_encryption'),
     '20241211-user_preferences': await import('./migrations/20241211-user_preferences'),
     '20250212-lowercase_email': await import('./migrations/20250212-lowercase_email'),
+    '20250215-id_assistantsharing': await import('./migrations/20250215-id_assistantsharing'),
   }
 
   const dialect = await createDialect()

--- a/logicle/db/migrations/20250215-id_assistantsharing.ts
+++ b/logicle/db/migrations/20250215-id_assistantsharing.ts
@@ -4,6 +4,8 @@ import { nanoid } from 'nanoid'
 const string = 'text'
 
 export async function up(db: Kysely<any>): Promise<void> {
+  // Recreate the entire table.
+  // SQLITE does not allow to add a Primary Key to a table
   const sharingList = await db.selectFrom('AssistantSharing').selectAll().execute()
   await db.schema.dropTable('AssistantSharing').execute()
   await db.schema

--- a/logicle/db/migrations/20250215-id_assistantsharing.ts
+++ b/logicle/db/migrations/20250215-id_assistantsharing.ts
@@ -1,0 +1,44 @@
+import { Kysely, sql } from 'kysely'
+import { nanoid } from 'nanoid'
+
+const string = 'text'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  const sharingList = await db.selectFrom('AssistantSharing').selectAll().execute()
+  await db.schema.dropTable('AssistantSharing').execute()
+  await db.schema
+    .createTable('AssistantSharing')
+    .addColumn('id', string, (col) => col.notNull().primaryKey())
+    .addColumn('assistantId', string, (col) => col.notNull())
+    .addColumn('workspaceId', string)
+    .addForeignKeyConstraint(
+      'fk_AssistantSharing_Assistant',
+      ['assistantId'],
+      'Assistant',
+      ['id'],
+      (cb) => cb.onDelete('cascade')
+    )
+    .addForeignKeyConstraint(
+      'fk_AssistantSharing_Workspace',
+      ['workspaceId'],
+      'Workspace',
+      ['id'],
+      (cb) => cb.onDelete('cascade')
+    )
+    .execute()
+  await db.schema
+    .createIndex('AssistantSharing_assistantId_workspaceId')
+    .on('AssistantSharing')
+    .columns(['assistantId', 'workspaceId'])
+    .execute()
+
+  if (sharingList.length != 0) {
+    const sharingListWithId = sharingList.map((v) => {
+      return {
+        id: nanoid(),
+        ...v,
+      }
+    })
+    await db.insertInto('AssistantSharing').values(sharingListWithId).execute()
+  }
+}

--- a/logicle/db/migrations/20250215-id_assistantsharing.ts
+++ b/logicle/db/migrations/20250215-id_assistantsharing.ts
@@ -1,4 +1,4 @@
-import { Kysely, sql } from 'kysely'
+import { Kysely } from 'kysely'
 import { nanoid } from 'nanoid'
 
 const string = 'text'

--- a/logicle/db/migrations/20250215-id_assistantsharing.ts
+++ b/logicle/db/migrations/20250215-id_assistantsharing.ts
@@ -13,6 +13,7 @@ export async function up(db: Kysely<any>): Promise<void> {
     .addColumn('id', string, (col) => col.notNull().primaryKey())
     .addColumn('assistantId', string, (col) => col.notNull())
     .addColumn('workspaceId', string)
+    .addColumn('provisioned', 'integer', (col) => col.notNull().defaultTo(0))
     .addForeignKeyConstraint(
       'fk_AssistantSharing_Assistant',
       ['assistantId'],
@@ -38,6 +39,7 @@ export async function up(db: Kysely<any>): Promise<void> {
     const sharingListWithId = sharingList.map((v) => {
       return {
         id: nanoid(),
+        provisioned: 0,
         ...v,
       }
     })

--- a/logicle/db/schema.ts
+++ b/logicle/db/schema.ts
@@ -47,8 +47,10 @@ export interface Assistant {
 }
 
 export interface AssistantSharing {
+  id: string
   assistantId: string
   workspaceId: string | null
+  provisioned: number
 }
 
 export interface AssistantUserData {


### PR DESCRIPTION
Assistant sharing may now be provisioned.

An example:

```
assistants:
  test:
    name: test
    description: test
    model: gpt-4o
    backendId: openai
    systemPrompt: "You're an helpful assistant"
    tokenLimit: 4096
    temperature: .5
    tools:
      - id: timeofday
        enabled: true
    prompts:
      - test1
      - test2
    owner: robot
    tags:
      - robot
assistantSharing:
  test:
    assistantId: "test"
    workspaceId: null
```

