### PR TITLE
Assistant deletion

### DIFF
--- a/logicle/app/admin/tools/components/ToolForm.tsx
+++ b/logicle/app/admin/tools/components/ToolForm.tsx
@@ -100,7 +100,7 @@ const ToolForm: FC<Props> = ({ type, tool, onSubmit }) => {
       try {
         const apiKeys = await extractApiKeysFromOpenApiSchema(docObject)
         setApiKeys(apiKeys)
-      } catch (e) {
+      } catch {
         console.log(`Failed extracting API keys...`)
         setApiKeys([])
       }

--- a/logicle/app/admin/workspaces/components/WorkspaceSettings.tsx
+++ b/logicle/app/admin/workspaces/components/WorkspaceSettings.tsx
@@ -18,7 +18,7 @@ export const LoadFeedBack = ({
   children: ReactNode | ReactNode[]
 }) => {
   if (error) {
-    return <Error message={error.message} />
+    return <Error>{error.message}</Error>
   }
   if (isLoading) {
     return <ContentLoader>{children}</ContentLoader>

--- a/logicle/app/api/assistants/[assistantId]/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/route.ts
@@ -10,12 +10,6 @@ import {
 } from '@/models/assistant'
 import { requireSession, SimpleSession } from '@/api/utils/auth'
 import ApiResponses from '@/api/utils/ApiResponses'
-import {
-  KnownDbError,
-  KnownDbErrorCode,
-  defaultErrorResponse,
-  interpretDbException,
-} from '@/db/exception'
 import * as dto from '@/types/dto'
 import { db } from '@/db/database'
 import { getTool } from '@/models/tool'

--- a/logicle/app/api/assistants/[assistantId]/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/route.ts
@@ -5,6 +5,7 @@ import {
   assistantToolsEnablement,
   deleteAssistant,
   getAssistant,
+  setAssistantDeleted,
   updateAssistant,
 } from '@/models/assistant'
 import { requireSession, SimpleSession } from '@/api/utils/auth'
@@ -175,14 +176,7 @@ export const DELETE = requireSession(
     try {
       await deleteAssistant(params.assistantId) // Use the helper function
     } catch (e) {
-      const interpretedException = interpretDbException(e)
-      if (
-        interpretedException instanceof KnownDbError &&
-        interpretedException.code == KnownDbErrorCode.CONSTRAINT_FOREIGN_KEY
-      ) {
-        return ApiResponses.foreignKey('Assistant is in use')
-      }
-      return defaultErrorResponse(interpretedException)
+      setAssistantDeleted(params.assistantId)
     }
     return ApiResponses.success()
   }

--- a/logicle/app/api/assistants/[assistantId]/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/route.ts
@@ -170,7 +170,7 @@ export const DELETE = requireSession(
     try {
       await deleteAssistant(params.assistantId) // Use the helper function
     } catch (e) {
-      setAssistantDeleted(params.assistantId)
+      await setAssistantDeleted(params.assistantId)
     }
     return ApiResponses.success()
   }

--- a/logicle/app/api/assistants/[assistantId]/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/route.ts
@@ -168,8 +168,9 @@ export const DELETE = requireSession(
       )
     }
     try {
-      await deleteAssistant(params.assistantId) // Use the helper function
-    } catch (e) {
+      // This will fail if the assistant has been used in some conversations
+      await deleteAssistant(params.assistantId)
+    } catch {
       await setAssistantDeleted(params.assistantId)
     }
     return ApiResponses.success()

--- a/logicle/app/api/backends/route.ts
+++ b/logicle/app/api/backends/route.ts
@@ -17,7 +17,7 @@ export const POST = requireAdmin(async (req: Request) => {
   try {
     const created = await createBackend(await req.json())
     return ApiResponses.created(created)
-  } catch (e) {
+  } catch {
     return ApiResponses.internalServerError('Creation failed')
   }
 })

--- a/logicle/app/api/chat/route.ts
+++ b/logicle/app/api/chat/route.ts
@@ -101,6 +101,9 @@ export const POST = requireSession(async (session, req) => {
   if (conversation.ownerId !== session.userId) {
     return ApiResponses.forbiddenAction('Trying to add a message to a non owned conversation')
   }
+  if (conversation.deleted) {
+    return ApiResponses.forbiddenAction('This assistant has been deleted')
+  }
 
   const dbMessages = await getMessages(userMessage.conversationId)
   const linearThread = extractLinearConversation(dbMessages, userMessage)

--- a/logicle/app/api/tools/route.ts
+++ b/logicle/app/api/tools/route.ts
@@ -13,7 +13,7 @@ export const POST = requireAdmin(async (req: Request) => {
     const body = (await req.json()) as dto.InsertableToolDTO
     const created = await createTool(body)
     return ApiResponses.created(created)
-  } catch (e) {
+  } catch {
     return ApiResponses.internalServerError('Creation failed')
   }
 })

--- a/logicle/app/assistants/components/AssistantPreview.tsx
+++ b/logicle/app/assistants/components/AssistantPreview.tsx
@@ -10,11 +10,12 @@ import { useRef, useState } from 'react'
 import { ChatStatus } from '@/app/chat/components/ChatStatus'
 import { Button } from '@/components/ui/button'
 import { IconRotate } from '@tabler/icons-react'
-import { appendMessage, fetchChatResponse } from '@/services/chat'
+import { fetchChatResponse } from '@/services/chat'
 import { StartChatFromHere } from '@/app/chat/components/StartChatFromHere'
 import { ChatInput } from '@/app/chat/components/ChatInput'
 import { useTranslation } from 'react-i18next'
 import { flatten } from '@/lib/chat/conversationUtils'
+import { ConversationWithMessages } from '@/lib/chat/types'
 
 interface Props {
   assistant: dto.AssistantWithTools
@@ -34,7 +35,7 @@ export const AssistantPreview = ({ assistant, className, sendDisabled }: Props) 
     ownerName: '',
   }
 
-  const [conversation, setConversation] = useState<dto.ConversationWithMessages>({
+  const [conversation, setConversation] = useState<ConversationWithMessages>({
     assistantId: '',
     id: '',
     name: '',

--- a/logicle/app/assistants/components/AssistantPreview.tsx
+++ b/logicle/app/assistants/components/AssistantPreview.tsx
@@ -82,7 +82,8 @@ export const AssistantPreview = ({ assistant, className, sendDisabled }: Props) 
       conversation,
       userMessage,
       setChatStatus,
-      setConversation
+      setConversation,
+      t
     )
   }
 

--- a/logicle/app/assistants/components/AssistantPreview.tsx
+++ b/logicle/app/assistants/components/AssistantPreview.tsx
@@ -73,16 +73,14 @@ export const AssistantPreview = ({ assistant, className, sendDisabled }: Props) 
     } as dto.Message
 
     const conversationWithUserMsg = appendMessage(conversation, userMessage)
-    setConversation(conversationWithUserMsg)
-
     await fetchChatResponse(
       '/api/assistants/evaluate',
       JSON.stringify({
         assistant: assistant,
         messages: flatten(conversationWithUserMsg.messages),
       }),
-      conversationWithUserMsg,
-      userMsgId,
+      conversation,
+      userMessage,
       setChatStatus,
       setConversation
     )

--- a/logicle/app/assistants/components/AssistantPreview.tsx
+++ b/logicle/app/assistants/components/AssistantPreview.tsx
@@ -72,12 +72,11 @@ export const AssistantPreview = ({ assistant, className, sendDisabled }: Props) 
       attachments: msg.role == 'user' ? msg.attachments ?? [] : [],
     } as dto.Message
 
-    const conversationWithUserMsg = appendMessage(conversation, userMessage)
     await fetchChatResponse(
       '/api/assistants/evaluate',
       JSON.stringify({
         assistant: assistant,
-        messages: flatten(conversationWithUserMsg.messages),
+        messages: flatten([...conversation.messages, userMessage]),
       }),
       conversation,
       userMessage,

--- a/logicle/app/auth/login/LoginPanel.tsx
+++ b/logicle/app/auth/login/LoginPanel.tsx
@@ -35,7 +35,7 @@ const Login: FC<Props> = ({ connections, enableSignup }) => {
   const redirectAfterSignIn = '/chat'
 
   const searchParams = useSearchParams()
-  const [errorMessage, setErrorMessage] = useState<string>(searchParams.get('error') ?? '')
+  const [errorMessage, setErrorMessage] = useState<string | null>(searchParams.get('error'))
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     mode: 'onChange',
@@ -86,7 +86,7 @@ const Login: FC<Props> = ({ connections, enableSignup }) => {
   }
   return (
     <div className="flex flex-col">
-      {errorMessage.length > 0 && <Error message={t(errorMessage)} />}
+      {errorMessage && <Error>{t(errorMessage)}</Error>}
       <div className="flex flex-col rounded p-6 border gap-3">
         <Form
           {...form}

--- a/logicle/app/chat/components/Chat.tsx
+++ b/logicle/app/chat/components/Chat.tsx
@@ -118,7 +118,15 @@ export const Chat = ({ assistant, className }: ChatProps) => {
         onSend={({ content, attachments }) => {
           setAutoScrollEnabled(true)
           messagesEndRef.current?.scrollIntoView()
-          handleSend({ msg: { role: 'user', content, attachments } })
+          handleSend({
+            msg: { role: 'user', content, attachments },
+            conversation: {
+              ...selectedConversation,
+              messages: selectedConversation.messages.filter((msg) => {
+                return msg.role != 'unsent'
+              }),
+            },
+          })
         }}
       />
     </div>

--- a/logicle/app/chat/components/Chat.tsx
+++ b/logicle/app/chat/components/Chat.tsx
@@ -123,7 +123,7 @@ export const Chat = ({ assistant, className }: ChatProps) => {
             conversation: {
               ...selectedConversation,
               messages: selectedConversation.messages.filter((msg) => {
-                return msg.role != 'unsent'
+                return msg.error
               }),
             },
           })

--- a/logicle/app/chat/components/ChatHeader.tsx
+++ b/logicle/app/chat/components/ChatHeader.tsx
@@ -12,10 +12,7 @@ import { mutate } from 'swr'
 import { useTranslation } from 'react-i18next'
 import {
   IconChevronDown,
-  IconDetails,
-  IconEdit,
   IconInfoCircle,
-  IconListDetails,
   IconPinned,
   IconPinnedOff,
   IconSettings,

--- a/logicle/app/chat/components/ChatMessage.tsx
+++ b/logicle/app/chat/components/ChatMessage.tsx
@@ -134,6 +134,7 @@ const compareChatMessage = (
 
 const ChatMessageBody = memo(
   ({ message, isLastMessage }: { message: MessageExt; isLastMessage: boolean }) => {
+    const { t } = useTranslation()
     // Uncomment to verify that memoization is working
     //console.log(`Render message ${message.id} ${message.content.substring(0, 50)}`)
     // Note that message instances can be compared because we
@@ -161,6 +162,13 @@ const ChatMessageBody = memo(
         return <AssistantMessage message={message}></AssistantMessage>
       case 'error':
         return <ErrorMessage msg={message}></ErrorMessage>
+      case 'unsent':
+        return (
+          <>
+            <UserMessage message={{ ...message, role: 'user' }} enableActions={false}></UserMessage>
+            <div>{`Failed delivering message ${t(message.reason)}`}</div>
+          </>
+        )
       default:
         return <div>{`Unsupported role ${message['role']}`}</div>
     }

--- a/logicle/app/chat/components/ChatMessage.tsx
+++ b/logicle/app/chat/components/ChatMessage.tsx
@@ -13,7 +13,7 @@ import ChatPageContext from './context'
 import { cn } from '@/lib/utils'
 import { IconFile } from '@tabler/icons-react'
 import { stringToHslColor } from '@/components/ui/LetterAvatar'
-import { MessageExt, MessageGroup, ToolCallMessageExt } from '@/lib/chat/conversationUtils'
+import { MessageWithErrorExt, MessageGroup, ToolCallMessageEx } from '@/lib/chat/types'
 import {
   Accordion,
   AccordionContent,
@@ -23,6 +23,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import { IconCheck, IconCopy, IconRepeat } from '@tabler/icons-react'
 import { IconDownload } from '@tabler/icons-react'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 
 export interface ChatMessageProps {
   assistant: dto.UserAssistant
@@ -31,6 +32,22 @@ export interface ChatMessageProps {
 }
 
 const showAllMessages = false
+
+const findAncestorUserMessage = (
+  messages: dto.Message[],
+  msgId: string
+): dto.UserMessage | undefined => {
+  const idToMessage = Object.fromEntries(messages.map((m) => [m.id, m]))
+  let msg = idToMessage[msgId]
+  while (msg) {
+    if (msg.role == 'user') {
+      return msg
+    }
+    if (!msg.parent) break
+    msg = idToMessage[msg.parent]
+  }
+  return undefined
+}
 
 const ErrorMessage = ({ msg }: { msg: dto.ErrorMessage }) => {
   return <div>{msg.content}</div>
@@ -58,7 +75,7 @@ const AuthorizeMessage = ({ isLast }: { isLast: boolean }) => {
   )
 }
 
-const ToolCall = ({ toolCall }: { toolCall: ToolCallMessageExt }) => {
+const ToolCall = ({ toolCall }: { toolCall: ToolCallMessageEx }) => {
   const { t } = useTranslation()
   return (
     <Accordion type="single" collapsible>
@@ -126,19 +143,68 @@ const ToolCallAuthResponse = ({
 }
 
 const compareChatMessage = (
-  a: { message: MessageExt; isLastMessage: boolean },
-  b: { message: MessageExt; isLastMessage: boolean }
+  a: { message: MessageWithErrorExt; isLastMessage: boolean },
+  b: { message: MessageWithErrorExt; isLastMessage: boolean }
 ) => {
   return a.message == b.message && a.isLastMessage == b.isLastMessage
 }
 
 const ChatMessageBody = memo(
-  ({ message, isLastMessage }: { message: MessageExt; isLastMessage: boolean }) => {
+  ({
+    message,
+    isLastMessage,
+    showAlerts,
+  }: {
+    message: MessageWithErrorExt
+    isLastMessage: boolean
+    showAlerts: boolean
+  }) => {
     const { t } = useTranslation()
+    const { handleSend, state } = useContext(ChatPageContext)
     // Uncomment to verify that memoization is working
     //console.log(`Render message ${message.id} ${message.content.substring(0, 50)}`)
     // Note that message instances can be compared because we
     // never modify messages (see fetchChatResponse)
+    if (showAlerts && message.error) {
+      return (
+        <>
+          <ChatMessageBody
+            message={{ ...message, error: undefined }}
+            isLastMessage={isLastMessage}
+            showAlerts={false}
+          ></ChatMessageBody>
+          <Alert variant="destructive" className="mt-2">
+            <AlertDescription>
+              <div className="flex items-center">
+                <div className="flex-1">{t(message.error)} </div>
+                <Button
+                  size="small"
+                  className="shrink-0"
+                  onClick={() => {
+                    const messageToRepeat = findAncestorUserMessage(
+                      state.selectedConversation?.messages ?? [],
+                      message.id
+                    )
+                    if (messageToRepeat) {
+                      handleSend({
+                        msg: {
+                          role: messageToRepeat.role,
+                          content: messageToRepeat.content,
+                          attachments: messageToRepeat.attachments,
+                        },
+                        repeating: messageToRepeat,
+                      })
+                    }
+                  }}
+                >
+                  {t('retry')}
+                </Button>
+              </div>
+            </AlertDescription>
+          </Alert>
+        </>
+      )
+    }
     switch (message.role) {
       case 'tool-auth-response':
         return showAllMessages ? (
@@ -147,7 +213,7 @@ const ChatMessageBody = memo(
           <></>
         )
       case 'user':
-        return <UserMessage message={message}></UserMessage>
+        return <UserMessage message={message} enableActions={!message.error}></UserMessage>
       case 'tool-call':
         return <ToolCall toolCall={message}></ToolCall>
       case 'assistant':
@@ -162,13 +228,6 @@ const ChatMessageBody = memo(
         return <AssistantMessage message={message}></AssistantMessage>
       case 'error':
         return <ErrorMessage msg={message}></ErrorMessage>
-      case 'unsent':
-        return (
-          <>
-            <UserMessage message={{ ...message, role: 'user' }} enableActions={false}></UserMessage>
-            <div>{`Failed delivering message ${t(message.reason)}`}</div>
-          </>
-        )
       default:
         return <div>{`Unsupported role ${message['role']}`}</div>
     }
@@ -250,21 +309,11 @@ export const ChatMessage: FC<ChatMessageProps> = ({ assistant, group, isLast }) 
     })
   }
 
-  const findAncestorUserMessage = (msgId: string): dto.UserMessage | undefined => {
-    if (!selectedConversation) return undefined
-    const idToMessage = Object.fromEntries(selectedConversation.messages.map((m) => [m.id, m]))
-    let msg = idToMessage[msgId]
-    while (msg) {
-      if (msg.role == 'user') {
-        return msg
-      }
-      if (!msg.parent) break
-      msg = idToMessage[msg.parent]
-    }
-    return undefined
-  }
   const onRepeatLastMessage = () => {
-    const messageToRepeat = findAncestorUserMessage(group.messages[0].id)
+    const messageToRepeat = findAncestorUserMessage(
+      selectedConversation?.messages ?? [],
+      group.messages[0].id
+    )
     if (messageToRepeat) {
       handleSend({
         msg: {
@@ -315,6 +364,7 @@ export const ChatMessage: FC<ChatMessageProps> = ({ assistant, group, isLast }) 
                 key={message.id}
                 message={message}
                 isLastMessage={isLast && index + 1 == group.messages.length}
+                showAlerts={true}
               ></ChatMessageBody>
             )
           })}

--- a/logicle/app/chat/components/ChatPageContextProvider.tsx
+++ b/logicle/app/chat/components/ChatPageContextProvider.tsx
@@ -83,14 +83,11 @@ export const ChatPageContextProvider: FC<Props> = ({ initialState, children }) =
       parent = conversation.messages[conversation.messages.length - 1].id
     }
     const userMessage = createDtoMessage(msg, conversation.id, parent)
-    conversation = appendMessage(conversation, userMessage)
-    setSelectedConversation(conversation)
-
     await fetchChatResponse(
       '/api/chat',
       JSON.stringify(userMessage),
       conversation,
-      userMessage.id,
+      userMessage,
       setChatStatus,
       setSelectedConversation
     )

--- a/logicle/app/chat/components/ChatPageContextProvider.tsx
+++ b/logicle/app/chat/components/ChatPageContextProvider.tsx
@@ -6,8 +6,9 @@ import { FC, ReactNode } from 'react'
 import { ChatStatus } from './ChatStatus'
 import { nanoid } from 'nanoid'
 import * as dto from '@/types/dto'
-import { appendMessage, fetchChatResponse } from '@/services/chat'
+import { fetchChatResponse } from '@/services/chat'
 import { useTranslation } from 'react-i18next'
+import { ConversationWithMessages } from '@/lib/chat/types'
 
 interface Props {
   children: ReactNode
@@ -32,7 +33,7 @@ export const ChatPageContextProvider: FC<Props> = ({ initialState, children }) =
     dispatch({ field: 'newChatAssistantId', value: assistantId })
   }
 
-  const setSelectedConversation = (conversation: dto.ConversationWithMessages | undefined) => {
+  const setSelectedConversation = (conversation: ConversationWithMessages | undefined) => {
     dispatch({ field: 'selectedConversation', value: conversation })
   }
 

--- a/logicle/app/chat/components/ChatPageContextProvider.tsx
+++ b/logicle/app/chat/components/ChatPageContextProvider.tsx
@@ -7,6 +7,7 @@ import { ChatStatus } from './ChatStatus'
 import { nanoid } from 'nanoid'
 import * as dto from '@/types/dto'
 import { appendMessage, fetchChatResponse } from '@/services/chat'
+import { useTranslation } from 'react-i18next'
 
 interface Props {
   children: ReactNode
@@ -22,6 +23,8 @@ export const ChatPageContextProvider: FC<Props> = ({ initialState, children }) =
     state: { selectedConversation },
     dispatch,
   } = contextValue
+
+  const { t } = useTranslation()
 
   //console.debug(`rendering ChatPageContextProvider, selected = ${selectedConversation?.id}`)
 
@@ -89,7 +92,8 @@ export const ChatPageContextProvider: FC<Props> = ({ initialState, children }) =
       conversation,
       userMessage,
       setChatStatus,
-      setSelectedConversation
+      setSelectedConversation,
+      t
     )
   }
 

--- a/logicle/app/chat/components/UserMessage.tsx
+++ b/logicle/app/chat/components/UserMessage.tsx
@@ -8,21 +8,20 @@ import * as dto from '@/types/dto'
 
 interface UserMessageProps {
   message: dto.UserMessage
+  enableActions?: boolean
 }
 
-export const UserMessage: FC<UserMessageProps> = ({ message }) => {
+export const UserMessage: FC<UserMessageProps> = ({ message, enableActions: enableActions_ }) => {
   const { t } = useTranslation()
   const [isEditing, setIsEditing] = useState<boolean>(false)
   const [isTyping, setIsTyping] = useState<boolean>(false)
   const { handleSend } = useContext(ChatPageContext)
-
   const toggleEditing = () => {
     setIsEditing(!isEditing)
   }
-
   const [messageContent, setMessageContent] = useState(message.content)
-
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const enableActions = enableActions_ ?? true
 
   const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setMessageContent(event.target.value)
@@ -104,11 +103,16 @@ export const UserMessage: FC<UserMessageProps> = ({ message }) => {
       ) : (
         <>
           <div className="prose whitespace-pre-wrap">{message.content}</div>
-          <div className="mt-2 ml-1 flex flex-row gap-1 items-center justify-start">
-            <button className="invisible group-hover:visible focus:visible" onClick={toggleEditing}>
-              <IconEdit size={20} className="opacity-50 hover:opacity-100" />
-            </button>
-          </div>
+          {enableActions && (
+            <div className="mt-2 ml-1 flex flex-row gap-1 items-center justify-start">
+              <button
+                className="invisible group-hover:visible focus:visible"
+                onClick={toggleEditing}
+              >
+                <IconEdit size={20} className="opacity-50 hover:opacity-100" />
+              </button>
+            </div>
+          )}
         </>
       )}
     </div>

--- a/logicle/app/chat/components/chatbar/Chatbar.tsx
+++ b/logicle/app/chat/components/chatbar/Chatbar.tsx
@@ -53,23 +53,25 @@ export const Chatbar = () => {
     if (!matchingConversation) {
       return
     }
-    const lastMsgSentAt = selectedConversation.messages
-      .map((a) => a.sentAt)
-      .reduce((a, b) => (a > b ? a : b), '')
-    if (lastMsgSentAt != matchingConversation.lastMsgSentAt) {
-      const patchedConversations = conversations.map((c) => {
-        if (c.id == selectedConversation.id) {
-          return {
-            ...c,
-            lastMsgSentAt,
+    if (selectedConversation.messages.length) {
+      const lastMsgSentAt = selectedConversation.messages
+        .map((a) => a.sentAt)
+        .reduce((a, b) => (a > b ? a : b), '')
+      if (lastMsgSentAt != matchingConversation.lastMsgSentAt) {
+        const patchedConversations = conversations.map((c) => {
+          if (c.id == selectedConversation.id) {
+            return {
+              ...c,
+              lastMsgSentAt,
+            }
+          } else {
+            return c
           }
-        } else {
-          return c
-        }
-      })
-      void mutate('/api/conversations', patchedConversations, {
-        revalidate: false,
-      })
+        })
+        void mutate('/api/conversations', patchedConversations, {
+          revalidate: false,
+        })
+      }
     }
   }, [chatState.selectedConversation, conversations])
 

--- a/logicle/app/chat/components/context.tsx
+++ b/logicle/app/chat/components/context.tsx
@@ -2,20 +2,21 @@ import { createContext } from 'react'
 import { ChatPageState } from './state'
 import { ChatStatus } from '@/app/chat/components/ChatStatus'
 import * as dto from '@/types/dto'
+import { ConversationWithMessages } from '@/lib/chat/types'
 
 export interface SendMessageParams {
   msg:
     | { role: 'user'; content: string; attachments?: dto.Attachment[] }
     | { role: 'tool-auth-response'; allow: boolean }
-  repeating?: dto.Message
-  conversation?: dto.ConversationWithMessages
+  repeating?: dto.UserMessage
+  conversation?: ConversationWithMessages
 }
 
 export interface ChatPageContextProps {
   state: ChatPageState
   setChatInput: (chatInput: string) => void
   setChatStatus: (chatStatus: ChatStatus) => void
-  setSelectedConversation: (conversation: dto.ConversationWithMessages | undefined) => void
+  setSelectedConversation: (conversation: ConversationWithMessages | undefined) => void
   setNewChatAssistantId: (assistantId: string | null) => void
   handleSend: (params: SendMessageParams) => void
 }

--- a/logicle/app/chat/components/state.tsx
+++ b/logicle/app/chat/components/state.tsx
@@ -1,10 +1,10 @@
 import { ChatStatus } from '@/app/chat/components/ChatStatus'
-import * as dto from '@/types/dto'
+import { ConversationWithMessages } from '@/lib/chat/types'
 
 export interface ChatPageState {
   chatInput: string
   chatStatus: ChatStatus
-  selectedConversation?: dto.ConversationWithMessages
+  selectedConversation?: ConversationWithMessages
   newChatAssistantId: string | null
   userImageUrl?: string
   assistantUrl?: string

--- a/logicle/components/ui/Error.tsx
+++ b/logicle/components/ui/Error.tsx
@@ -2,18 +2,17 @@ import { useTranslation } from 'react-i18next'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 
 interface ErrorProps {
-  message?: string
+  children?: string
   hidden?: boolean
 }
 
-const Error = (props: ErrorProps) => {
-  const { message } = props
+const Error = ({ children: msg, hidden }: ErrorProps) => {
   const { t } = useTranslation()
 
   return (
-    <Alert variant="destructive" className={props.hidden ? 'invisible' : 'visible'}>
+    <Alert variant="destructive" className={hidden ? 'invisible' : 'visible'}>
       <AlertDescription>
-        <p>{message || t('unknown-error')}</p>
+        <p>{msg || t('unknown-error')}</p>
       </AlertDescription>
     </Alert>
   )

--- a/logicle/components/ui/WithLoadingAndError.tsx
+++ b/logicle/components/ui/WithLoadingAndError.tsx
@@ -15,7 +15,7 @@ const WithLoadingAndError: FC<WithLoadingAndErrorProps> = (props: WithLoadingAnd
   }
 
   if (error) {
-    return <Error message={error.message} />
+    return <Error>{error.message}</Error>
   }
 
   return <>{children}</>

--- a/logicle/db/migrations.ts
+++ b/logicle/db/migrations.ts
@@ -39,7 +39,7 @@ export async function migrateToLatest() {
     '20241211-user_preferences': await import('./migrations/20241211-user_preferences'),
     '20250212-lowercase_email': await import('./migrations/20250212-lowercase_email'),
     '20250215-id_assistantsharing': await import('./migrations/20250215-id_assistantsharing'),
-    '20250216-conversation_indexes': await import('./migrations/20250216-conversation_indexes'),
+    '20250216-conversation_indexes': await import('./migrations/20250217-assistant_status'),
   }
 
   const dialect = await createDialect()

--- a/logicle/db/migrations.ts
+++ b/logicle/db/migrations.ts
@@ -39,7 +39,8 @@ export async function migrateToLatest() {
     '20241211-user_preferences': await import('./migrations/20241211-user_preferences'),
     '20250212-lowercase_email': await import('./migrations/20250212-lowercase_email'),
     '20250215-id_assistantsharing': await import('./migrations/20250215-id_assistantsharing'),
-    '20250216-conversation_indexes': await import('./migrations/20250217-assistant_status'),
+    '20250216-conversation_indexes': await import('./migrations/20250216-conversation_indexes'),
+    '20250217-assistant_status': await import('./migrations/20250217-assistant_status'),
   }
 
   const dialect = await createDialect()

--- a/logicle/db/migrations/20250217-assistant_status.ts
+++ b/logicle/db/migrations/20250217-assistant_status.ts
@@ -1,0 +1,28 @@
+import { Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<any>, dialect: 'sqlite' | 'postgresql'): Promise<void> {
+  await db.schema
+    .alterTable('Assistant')
+    .addColumn('deleted', 'integer', (col) => col.notNull().defaultTo('0'))
+    .execute()
+  /*
+  // An example of enums 
+  if (dialect == 'sqlite') {
+    await db.schema
+      .alterTable('Assistant')
+      .addColumn('status', 'text', (col) =>
+        col
+          .notNull()
+          .defaultTo('enabled')
+          .check(sql`status IN ('enabled', 'disabled')`)
+      )
+      .execute()
+  } else {
+    await db.schema.createType('AssistantStatus').asEnum(['enabled', 'disabled']).execute()
+    await db.schema
+      .alterTable('Assistant')
+      .addColumn('status', sql`"AssistantStatus"`, (col) => col.defaultTo('enabled'))
+      .execute()
+  }
+*/
+}

--- a/logicle/db/schema.ts
+++ b/logicle/db/schema.ts
@@ -44,6 +44,7 @@ export interface Assistant {
   createdAt: string
   updatedAt: string
   provisioned: number
+  deleted: number
 }
 
 export interface AssistantSharing {

--- a/logicle/lib/chat/types.ts
+++ b/logicle/lib/chat/types.ts
@@ -1,0 +1,28 @@
+import * as dto from '@/types/dto'
+
+// MessageWithError is a dto.Message enriched with an error which may be added
+// when fetching
+export type MessageWithError = dto.Message & { error?: string }
+
+export type ConversationWithMessages = dto.Conversation & { messages: MessageWithError[] }
+
+export type ToolCallMessageEx = dto.ToolCallMessage & {
+  status: 'completed' | 'need-auth' | 'running'
+}
+
+export type MessageWithErrorExt = (
+  | dto.UserMessage
+  | dto.AssistantMessage
+  | dto.ErrorMessage
+  | dto.DebugMessage
+  | dto.ToolCallAuthRequestMessage
+  | dto.ToolCallAuthResponseMessage
+  | dto.ToolOutputMessage
+  | ToolCallMessageEx
+  | dto.ToolResultMessage
+) & { error?: string }
+
+export interface MessageGroup {
+  actor: 'user' | 'assistant'
+  messages: MessageWithErrorExt[]
+}

--- a/logicle/locales/en/logicle.json
+++ b/logicle/locales/en/logicle.json
@@ -157,6 +157,8 @@
   "events-description": "You can choose which events are sent to which endpoint. By default, all messages are sent to all endpoints.",
   "events-to-send": "Events to send",
   "everyone_in_the_company": "Everyone in the company",
+  "failed_sending_message": "Failed sending message",
+  "failed_sending_message_not_authorized": "You're not authorized to add messages to this conversation",
   "features": "Features",
   "found_an_unsaved_version": "Found an unsaved version",
   "frequently-asked": "Frequently asked questions",

--- a/logicle/locales/en/logicle.json
+++ b/logicle/locales/en/logicle.json
@@ -58,6 +58,7 @@
   "change-password": "Change password",
   "change_role": "Change role",
   "chat": "Chat",
+  "chat_response_failure": "An error happened while reading the server response",
   "choose-new-provider-type-description": "Choose the type of LLM provider for the new backend",
   "choose-new-provider-type": "Choose the provider type",
   "choose-workspace": "Choose your workspace",

--- a/logicle/locales/it/logicle.json
+++ b/logicle/locales/it/logicle.json
@@ -58,6 +58,7 @@
   "change-password": "Cambia password",
   "change_role": "Cambia ruolo",
   "chat": "Chat",
+  "chat_response_failure": "Si è verificato un errore durante la ricezione della risposta",
   "choose-new-provider-type-description": "Scegli il tipo di provider LLM per il nuovo backend",
   "choose-new-provider-type": "Scegli il tipo di provider",
   "choose-workspace": "Scegli il tuo workspace",

--- a/logicle/locales/it/logicle.json
+++ b/logicle/locales/it/logicle.json
@@ -157,6 +157,8 @@
   "events-description": "Puoi scegliere quali eventi inviare a quali endpoint. Per impostazione predefinita, tutti i messaggi vengono inviati a tutti gli endpoint.",
   "events-to-send": "Eventi da inviare",
   "everyone_in_the_company": "Tutta l'azienda",
+  "failed_sending_message": "Errore nell'invio del messaggio",
+  "failed_sending_message_not_authorized": "Non sei autorizzato ad aggiungere messaggi a questa conversazione",
   "features": "Caratteristiche",
   "found_an_unsaved_version": "Ho trovato una versione salvata",
   "frequently-asked": "Domande frequenti",

--- a/logicle/models/assistant.ts
+++ b/logicle/models/assistant.ts
@@ -193,6 +193,7 @@ export const createAssistantWithId = async (
     tags: JSON.stringify(assistant.tags),
     prompts: JSON.stringify(assistant.prompts),
     provisioned: provisioned ? 1 : 0,
+    deleted: 0,
   }
   await db.insertInto('Assistant').values(withoutTools).executeTakeFirstOrThrow()
   const tools = toAssistantToolAssociation(id, assistant.tools)

--- a/logicle/models/assistant.ts
+++ b/logicle/models/assistant.ts
@@ -33,10 +33,6 @@ function toAssistantToolAssociation(
       }
     })
 }
-export const allAssistants = async () => {
-  return db.selectFrom('Assistant').selectAll().execute()
-}
-
 // list all ToolFile for a given assistant / tool
 export const assistantToolFiles = async (
   assistantId: schema.Assistant['id']
@@ -76,6 +72,7 @@ export const getUserAssistants = async ({
     .leftJoin('User', (join) => join.onRef('User.id', '=', 'Assistant.owner'))
     .selectAll('Assistant')
     .select(['AssistantUserData.pinned', 'AssistantUserData.lastUsed', 'User.name as ownerName'])
+    .where('deleted', '=', 0)
     .where((eb) => {
       const conditions: Expression<SqlBool>[] = []
       if (!assistantId) {
@@ -151,6 +148,7 @@ export const getAssistantsWithOwner = async ({
     .leftJoin('User', (join) => join.onRef('User.id', '=', 'Assistant.owner'))
     .selectAll('Assistant')
     .select('User.name as ownerName')
+    .where('deleted', '=', 0)
     .where((eb) => {
       const conditions: Expression<SqlBool>[] = []
       if (userId) {
@@ -349,6 +347,14 @@ export const deleteAssistant = async (assistantId: string) => {
 
 export const deleteAssistantToolAssociations = async (assistantId: string) => {
   await db.deleteFrom('AssistantToolAssociation').where('assistantId', '=', assistantId).execute()
+}
+
+export const setAssistantDeleted = async (assistantId: string) => {
+  return await db
+    .updateTable('Assistant')
+    .set('deleted', 1)
+    .where('id', '=', assistantId)
+    .executeTakeFirstOrThrow()
 }
 
 // list all tools with enable flag for a given assistant

--- a/logicle/models/assistant.ts
+++ b/logicle/models/assistant.ts
@@ -72,7 +72,6 @@ export const getUserAssistants = async ({
     .leftJoin('User', (join) => join.onRef('User.id', '=', 'Assistant.owner'))
     .selectAll('Assistant')
     .select(['AssistantUserData.pinned', 'AssistantUserData.lastUsed', 'User.name as ownerName'])
-    .where('deleted', '=', 0)
     .where((eb) => {
       const conditions: Expression<SqlBool>[] = []
       if (!assistantId) {
@@ -105,6 +104,8 @@ export const getUserAssistants = async ({
           )
         }
         conditions.push(eb.or(oredAccessibilityConditions))
+        // Deletion is enforced only when no assistant id is provided
+        conditions.push(eb('Assistant.deleted', '=', 0))
       }
       if (pinned) {
         conditions.push(eb('AssistantUserData.pinned', '=', 1))

--- a/logicle/models/conversation.ts
+++ b/logicle/models/conversation.ts
@@ -49,6 +49,7 @@ export const getConversationWithBackendAssistant = async (
       'Assistant.tokenLimit',
       'Assistant.model',
       'Assistant.temperature',
+      'Assistant.deleted',
       'Backend.providerType',
       'Backend.configuration as providerConfiguration',
       'Backend.provisioned as providerProvisioned',

--- a/logicle/services/chat.ts
+++ b/logicle/services/chat.ts
@@ -123,14 +123,14 @@ export const fetchChatResponse = async (
       setConversation(
         appendMessage(conversationWithoutUserMessage, {
           ...userMsg,
-          error: translation(e instanceof BackendError ? e.message : 'network_error'),
+          error: translation(e instanceof BackendError ? e.message : 'chat_response_failure'),
         })
       )
     } else {
       setConversation(
         appendMessage(conversation, {
           ...currentResponse,
-          error: 'network_error',
+          error: 'chat_response_failure',
         })
       )
     }

--- a/logicle/types/dto/assistants.ts
+++ b/logicle/types/dto/assistants.ts
@@ -25,7 +25,7 @@ export type AssistantWithTools = Omit<schema.Assistant, 'imageId' | 'tags' | 'pr
 
 export type InsertableAssistant = Omit<
   schema.Assistant,
-  'id' | 'imageId' | 'createdAt' | 'updatedAt' | 'tags' | 'prompts' | 'provisioned'
+  'id' | 'imageId' | 'createdAt' | 'updatedAt' | 'tags' | 'prompts' | 'provisioned' | 'deleted'
 > & {
   tools: AssistantTool[]
   files: AssistantFile[]

--- a/logicle/types/dto/chat.ts
+++ b/logicle/types/dto/chat.ts
@@ -84,14 +84,6 @@ export type Message =
   | ToolResultMessage
 
 export type InsertableMessage = Omit<Message, 'id'>
-
-export type UnsentMessage = BaseMessage & {
-  role: 'unsent'
-  reason: string
-}
-
-export type MessageEx = Message | UnsentMessage
-export type ConversationWithMessages = Conversation & { messages: MessageEx[] }
 export type ConversationWithFolder = Conversation & { folderId: string }
 
 /**

--- a/logicle/types/dto/chat.ts
+++ b/logicle/types/dto/chat.ts
@@ -84,7 +84,14 @@ export type Message =
   | ToolResultMessage
 
 export type InsertableMessage = Omit<Message, 'id'>
-export type ConversationWithMessages = Conversation & { messages: Message[] }
+
+export type UnsentMessage = BaseMessage & {
+  role: 'unsent'
+  reason: string
+}
+
+export type MessageEx = Message | UnsentMessage
+export type ConversationWithMessages = Conversation & { messages: MessageEx[] }
 export type ConversationWithFolder = Conversation & { folderId: string }
 
 /**


### PR DESCRIPTION
Assistants may now be deleted even if they have been using in some conversations (fairly typical)
Deletion is signaled by a "deleted" property of the instance itself.
When an assistant is deleted:

* It is not included in assistant listing APIs
* It is included in assistant single retrieve (conversations need things such as icons and similar!)
* It's not possible to continue chats made with it

This PR also improves a lot the way chat API failures are handled.

 