### PR TITLE
Add an endpoint with minimal assistant info + shared chat messages

### DIFF
--- a/logicle/app/api/share/[shareId]/route.ts
+++ b/logicle/app/api/share/[shareId]/route.ts
@@ -1,0 +1,35 @@
+import { getConversationMessages } from '@/models/conversation'
+import ApiResponses from '@/api/utils/ApiResponses'
+import { requireSession, SimpleSession } from '@/app/api/utils/auth'
+import { db } from '@/db/database'
+import { extractLinearConversation } from '@/lib/chat/conversationUtils'
+
+export const GET = requireSession(
+  async (session: SimpleSession, req: Request, params: { shareId: string }) => {
+    const conversation = await db
+      .selectFrom('ConversationSharing')
+      .innerJoin('Message as LastMessage', (join) =>
+        join.onRef('LastMessage.id', '=', 'ConversationSharing.lastMessageId')
+      )
+      .innerJoin('Conversation', (join) =>
+        join.onRef('Conversation.id', '=', 'LastMessage.conversationId')
+      )
+      .innerJoin('Assistant', (join) => join.onRef('Assistant.id', '=', 'Conversation.assistantId'))
+      .where('ConversationSharing.id', '=', params.shareId)
+      .selectAll()
+      .executeTakeFirstOrThrow()
+    const messages = await getConversationMessages(conversation.conversationId)
+    const linear = extractLinearConversation(
+      messages,
+      messages.find((m) => m.id == conversation.lastMessageId)!
+    )
+    return ApiResponses.json({
+      assistant: {
+        id: conversation.assistantId,
+        iconUri: conversation.imageId ? `/api/images/${conversation.imageId}` : null,
+        name: conversation.name,
+      },
+      messages: linear,
+    })
+  }
+)

--- a/logicle/app/assistants/components/AssistantPreview.tsx
+++ b/logicle/app/assistants/components/AssistantPreview.tsx
@@ -106,7 +106,7 @@ export const AssistantPreview = ({ assistant, className, sendDisabled }: Props) 
         <div className={`flex flex-col overflow-hidden ${className ?? ''}`}>
           <StartChatFromHere
             className="flex-1"
-            assistant={{ ...userAssistant }}
+            assistant={userAssistant}
             onPrompt={(prompt) => {
               setChatInput(prompt)
               textareaRef?.current?.focus()

--- a/logicle/app/chat/components/Chat.tsx
+++ b/logicle/app/chat/components/Chat.tsx
@@ -9,7 +9,7 @@ import * as dto from '@/types/dto'
 import { ChatMessage } from './ChatMessage'
 
 export interface ChatProps {
-  assistant: dto.UserAssistant
+  assistant: dto.AssistantIdentification
   className?: string
 }
 

--- a/logicle/app/chat/components/ChatMessage.tsx
+++ b/logicle/app/chat/components/ChatMessage.tsx
@@ -26,7 +26,7 @@ import { IconDownload } from '@tabler/icons-react'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 
 export interface ChatMessageProps {
-  assistant: dto.UserAssistant
+  assistant: dto.AssistantIdentification
   group: MessageGroup
   isLast: boolean
 }

--- a/logicle/app/share/[shareId]/page.tsx
+++ b/logicle/app/share/[shareId]/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 import { useParams } from 'next/navigation'
 import React from 'react'
-import { useTranslation } from 'react-i18next'
 import * as dto from '@/types/dto'
 import { useSWRJson } from '@/hooks/swr'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -12,8 +11,8 @@ import { defaultChatPageState } from '@/app/chat/components/state'
 
 const SharePage = () => {
   const { shareId } = useParams() as { shareId: string }
-  const { data: messages_ } = useSWRJson<dto.Message[]>(`/api/share/${shareId}/messages`)
-  const messages = messages_ ?? []
+  const { data: sharedConversation } = useSWRJson<dto.SharedConversation>(`/api/share/${shareId}`)
+  const messages = sharedConversation?.messages ?? []
   const groupList = groupMessages(messages)
 
   const chatPageContext = {
@@ -22,6 +21,9 @@ const SharePage = () => {
     setNewChatAssistantId: () => {},
   } as unknown as ChatPageContextProps
 
+  if (!sharedConversation) {
+    return <></>
+  }
   return (
     <ChatPageContext.Provider value={chatPageContext}>
       <ScrollArea className="flex h-full scroll-workaround">
@@ -29,7 +31,7 @@ const SharePage = () => {
           {groupList.map((group, index) => (
             <ChatMessage
               key={index}
-              assistant={{ id: 'kkk', name: 'kkk' } as dto.UserAssistant}
+              assistant={sharedConversation.assistant}
               group={group}
               isLast={index + 1 == groupList.length}
             />

--- a/logicle/components/app/Avatars.tsx
+++ b/logicle/components/app/Avatars.tsx
@@ -1,10 +1,10 @@
-import { UserAssistant } from '@/types/dto'
+import * as dto from '@/types/dto'
 import { Avatar, avatarVariants } from '@/components/ui/avatar'
 import { stringToHslColor } from '@/components/ui/LetterAvatar'
 import { VariantProps } from 'class-variance-authority'
 
 interface Props extends VariantProps<typeof avatarVariants> {
-  assistant: UserAssistant
+  assistant: dto.AssistantIdentification
   className?: string
 }
 

--- a/logicle/types/dto.ts
+++ b/logicle/types/dto.ts
@@ -41,11 +41,14 @@ export type ToolDTO = Omit<schema.Tool, 'configuration'> & {
 export type InsertableToolDTO = Omit<ToolDTO, 'id' | 'provisioned' | 'createdAt' | 'updatedAt'>
 export type UpdateableToolDTO = Partial<Omit<InsertableToolDTO, 'type'>>
 
-export interface UserAssistant {
+export interface AssistantIdentification {
   id: string
   name: string
-  description: string
   iconUri?: string | null
+}
+
+export interface UserAssistant extends AssistantIdentification {
+  description: string
   pinned: boolean
   lastUsed: string | null
   owner: string

--- a/logicle/types/dto/chat.ts
+++ b/logicle/types/dto/chat.ts
@@ -10,6 +10,11 @@ export interface Attachment {
   size: number
 }
 
+export type SharedConversation = {
+  assistant: dto.AssistantIdentification
+  messages: dto.Message[]
+}
+
 export interface ToolCall {
   toolCallId: string
   toolName: string


### PR DESCRIPTION
Shared chats need a little bit of information about the assistant (id, name, image).
Added an endpoint with that, and used it in the shared message page