### PR TITLE
Openapi handle "attachment-like" response bodies 

### DIFF
--- a/logicle/app/chat/components/ChatMessage.tsx
+++ b/logicle/app/chat/components/ChatMessage.tsx
@@ -93,7 +93,7 @@ const ToolCall = ({ toolCall }: { toolCall: ToolCallMessageEx }) => {
         <AccordionContent>
           <div>{`${t('parameters')}:`}</div>
           {Object.entries(toolCall.args).map(([key, value]) => (
-            <div key={key}>{`${key}:${value}`}</div>
+            <div key={key}>{`${key}:${JSON.stringify(value)}`}</div>
           ))}
         </AccordionContent>
       </AccordionItem>


### PR DESCRIPTION
If the response body looks like an attachment (Content-Disposition tells it all!!!!) we now download it and send it to the user as an attachment