### PR TITLE
Safari compat - avoid using methods not available in ES2017

### DIFF
--- a/logicle/app/admin/analytics/most-active-users.tsx
+++ b/logicle/app/admin/analytics/most-active-users.tsx
@@ -7,15 +7,18 @@ export function MostActiveUsers() {
   const activityByUser = (data ?? []).slice(0, 5)
   return (
     <div className="space-y-8">
-      {activityByUser.toSorted((a,b)=>b.messages - a.messages).map((t) => (
-        <div className="flex items-center" key={t.userId}>
-          <LetterAvatar name="OM"></LetterAvatar>
-          <div className="ml-4 space-y-1">
-            <p className="text-sm font-medium leading-none">{t.name ?? t.userId}</p>
+      {activityByUser
+        .slice()
+        .sort((a, b) => b.messages - a.messages)
+        .map((t) => (
+          <div className="flex items-center" key={t.userId}>
+            <LetterAvatar name="OM"></LetterAvatar>
+            <div className="ml-4 space-y-1">
+              <p className="text-sm font-medium leading-none">{t.name ?? t.userId}</p>
+            </div>
+            <div className="ml-auto font-medium">{t.messages}</div>
           </div>
-          <div className="ml-auto font-medium">{t.messages}</div>
-        </div>
-      ))}
+        ))}
     </div>
   )
 }

--- a/logicle/app/admin/analytics/overview.tsx
+++ b/logicle/app/admin/analytics/overview.tsx
@@ -15,8 +15,8 @@ export function Overview() {
         total: d.messages,
       }
     })
-    .toSorted((d1, d2) => d1.name.localeCompare(d2.name))
-
+    .slice() // create a shallow copy
+    .sort((d1, d2) => d1.name.localeCompare(d2.name))
   React.useEffect(() => {
     // Get the computed style of the body
     const computedStyle = getComputedStyle(document.body)

--- a/logicle/app/chat/assistants/mine/page.tsx
+++ b/logicle/app/chat/assistants/mine/page.tsx
@@ -185,7 +185,8 @@ const MyAssistantPage = () => {
               {(assistants ?? [])
                 .filter((assistant) => canEditAssistant(assistant, profile))
                 .filter(filterWithSearch)
-                .toSorted((a, b) => -a.updatedAt.localeCompare(b.updatedAt))
+                .slice()
+                .sort((a, b) => -a.updatedAt.localeCompare(b.updatedAt))
                 .map((assistant) => {
                   return (
                     <div key={assistant.id} className="flex group align-center gap-2 items-center">

--- a/logicle/app/chat/components/ChatPageContextProvider.tsx
+++ b/logicle/app/chat/components/ChatPageContextProvider.tsx
@@ -33,9 +33,9 @@ export const ChatPageContextProvider: FC<Props> = ({ initialState, children }) =
   const nonStateSelectedConversation = useRef<string | undefined>()
   const runningChats = useRef<Map<string, RunningChatState>>(new Map<string, RunningChatState>())
   console.debug(`
-    running chats: ${runningChats.current.keys().toArray()}
-    selected conversation: ${selectedConversation?.id}
-    chatState: ${JSON.stringify(chatStatus)}`)
+      running chats: ${Array.from(runningChats.current.keys())}
+      selected conversation: ${selectedConversation?.id}
+      chatState: ${JSON.stringify(chatStatus)}`)
   const { t } = useTranslation()
 
   // Memoized function to prevent re-renders

--- a/logicle/app/chat/components/chatbar/Chatbar.tsx
+++ b/logicle/app/chat/components/chatbar/Chatbar.tsx
@@ -40,9 +40,9 @@ export const Chatbar = () => {
   })
 
   let { data: conversations } = useSWRJson<dto.ConversationWithFolder[]>(`/api/conversations`)
-  conversations = (conversations ?? []).toSorted((a, b) =>
-    (a.lastMsgSentAt ?? a.createdAt) < (b.lastMsgSentAt ?? b.createdAt) ? 1 : -1
-  )
+  conversations = (conversations ?? [])
+    .slice()
+    .sort((a, b) => ((a.lastMsgSentAt ?? a.createdAt) < (b.lastMsgSentAt ?? b.createdAt) ? 1 : -1))
 
   useEffect(() => {
     const selectedConversation = chatState.selectedConversation

--- a/logicle/components/ui/stringlist.tsx
+++ b/logicle/components/ui/stringlist.tsx
@@ -41,7 +41,7 @@ export const StringList = ({ value, onChange, addNewPlaceHolder, maxItems }: Str
               variant="secondary"
               onClick={(evt) => {
                 evt.preventDefault()
-                onChange(value.toSpliced(index, 1))
+                onChange(value.slice(0, index).concat(value.slice(index + 1)))
               }}
             >
               <IconX size="18"></IconX>

--- a/logicle/db/exception.ts
+++ b/logicle/db/exception.ts
@@ -10,9 +10,7 @@ export enum KnownDbErrorCode {
 export class KnownDbError extends Error {
   code: KnownDbErrorCode
   constructor(code: KnownDbErrorCode, message: string) {
-    super(message, {
-      cause: 22,
-    })
+    super(message)
     this.code = code
   }
 }

--- a/logicle/lib/chat/conversationUtils.ts
+++ b/logicle/lib/chat/conversationUtils.ts
@@ -15,7 +15,7 @@ export function extractLinearConversation(
     list.push(from)
     from = msgMap[from.parent ?? 'none']
   } while (from)
-  return list.toReversed()
+  return list.slice().reverse()
 }
 
 // Extract from a message tree, the thread, i.e. a linear sequence of messages,

--- a/logicle/lib/openapi.ts
+++ b/logicle/lib/openapi.ts
@@ -41,7 +41,7 @@ function buildPath(base: string, key: string | number): string {
     return `${base}[${key}]` // Array index
   }
   if (typeof key == 'string') {
-    key = key.replaceAll('/', '~1')
+    key = key.split('/').join('~1') // replace all '/' with '~1'
   }
   return base ? `${base}/${key}` : key // Nested key
 }

--- a/logicle/tsconfig.json
+++ b/logicle/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "types": ["node", "jest"],
     "target": "es2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
In order to avoid messing with available features (on node.js and browser) and polyfills, all code requiring > ES2017 has been converted to fit in the ES2017 language / lib specs.

