### PR TITLE
Fix gemini model ids

### DIFF
--- a/logicle/lib/chat/models/logicle.ts
+++ b/logicle/lib/chat/models/logicle.ts
@@ -8,7 +8,13 @@ import {
 } from './anthropic'
 import { gpt4oMiniModel, gpt4oModel, gpt35Model, o1MiniModel, o1Model, o3MiniModel } from './openai'
 import { perplexityModels } from './perplexity'
-import { vertexModels } from './vertex'
+import {
+  gemini15FlashModel,
+  gemini15ProModel,
+  gemini20FlashLiteModel,
+  gemini20FlashModel,
+  gemini20ProModel,
+} from './vertex'
 
 export const logicleModels: LlmModel[] = [
   gpt4oModel,
@@ -22,6 +28,10 @@ export const logicleModels: LlmModel[] = [
   { ...claude3OpusModel, id: 'claude-3-opus' },
   claude3SonnetModel,
   claude3HaikuModel,
-  ...vertexModels,
+  gemini15ProModel,
+  gemini15FlashModel,
+  gemini20ProModel,
+  gemini20FlashModel,
+  gemini20FlashLiteModel,
   ...perplexityModels,
 ]

--- a/logicle/lib/chat/models/vertex.ts
+++ b/logicle/lib/chat/models/vertex.ts
@@ -39,7 +39,7 @@ export const gemini20FlashModel: LlmModel = {
 export const gemini20FlashLiteModel: LlmModel = {
   name: 'Gemini 2.0 Flash Lite',
   description: 'A Gemini 2.0 Flash model optimized for cost efficiency and low latency',
-  id: 'gemini-2.0-flash-lite-preview-02-05',
+  id: 'gemini-2.0-flash-lite',
   owned_by: 'google',
   context_length: 1048576,
   capabilities: {
@@ -52,7 +52,7 @@ export const gemini20ProModel: LlmModel = {
   name: 'Gemini 2.0 Pro',
   description:
     'An experimental Gemini 2.0 model optimized for complex tasks and coding, featuring a 2M token context window and enhanced reasoning capabilities.',
-  id: 'gemini-2.0-pro-exp-02-05',
+  id: 'gemini-2.0-pro',
   owned_by: 'google',
   context_length: 2097152,
   capabilities: {

--- a/logicle/lib/chat/models/vertex.ts
+++ b/logicle/lib/chat/models/vertex.ts
@@ -64,7 +64,7 @@ export const gemini20ProModel: LlmModel = {
 export const vertexModels: LlmModel[] = [
   gemini15ProModel,
   gemini15FlashModel,
-  gemini20ProModel,
+  { ...gemini20ProModel, id: 'gemini-2.0-pro-exp-02-05' }, // Temporary ID for the experimental model
   gemini20FlashModel,
   gemini20FlashLiteModel,
 ]


### PR DESCRIPTION
gemini-2.0-flash-lite is not anymore in preview.
gemini-2.0-flash-pro is still experimental, we use -exp-02-05 only for vertex backends
