### PR TITLE
Auto-select a reasonable backend for summarization

### DIFF
--- a/logicle/.env
+++ b/logicle/.env
@@ -15,6 +15,8 @@ ENABLE_TOOLS=0
 ENABLE_CHAT_ATTACHMENTS=1
 ENABLE_SIGNUP=1
 ENABLE_CHAT_AUTOSUMMARY=1
+# Use the chat backend/model for autosummary. If set to 0, a reasonable backend/model is found and used
+CHAT_AUTOSUMMARY_USE_CHAT_BACKEND=0
 CHAT_ATTACHMENTS_ALLOWED_FORMATS=image/jpeg,image/png,image/webp,image/gif
 ENABLE_LOGICLE_CLOUD_IMAGE_PROXY=0
 FILE_STORAGE_ENCRYPTION_KEY=CHANGEIT

--- a/logicle/app/layout.tsx
+++ b/logicle/app/layout.tsx
@@ -41,7 +41,7 @@ export default async function RootLayout({
     enableChatAttachments: env.chat.attachments.enable,
     chatAttachmentsAllowedFormats: env.chat.attachments.allowedFormats,
     enableSignup: env.signup.enable,
-    enableAutoSummary: env.chat.enableAutoSummary,
+    enableAutoSummary: env.chat.autoSummary.enable,
     enableChatSharing: env.chat.enableSharing,
     maxImgAttachmentDimPx: env.chat.attachments.maxImgDimPx,
     enableApiKeys: env.apiKeys.enable,

--- a/logicle/lib/env.ts
+++ b/logicle/lib/env.ts
@@ -83,9 +83,12 @@ const env = {
     enable: process.env.ENABLE_SIGNUP == '1',
   },
   chat: {
-    enableAutoSummary: process.env.ENABLE_CHAT_AUTOSUMMARY == '1',
     enableSharing: process.env.ENABLE_CHAT_SHARING == '1',
-    autoSummaryMaxLength: 500,
+    autoSummary: {
+      enable: process.env.ENABLE_CHAT_AUTOSUMMARY == '1',
+      useChatBackend: process.env.CHAT_AUTOSUMMARY_USE_CHAT_BACKEND == '1',
+      maxLength: 500,
+    },
     attachments: {
       enable: process.env.ENABLE_CHAT_ATTACHMENTS == '1',
       allowedFormats: process.env.CHAT_ATTACHMENTS_ALLOWED_FORMATS ?? '',


### PR DESCRIPTION
This PR lets the backend select a reasonable LLM backend model for summarization, instead of the one used by the chat's assistant.
The reason is that... some models are really not capable of doing summarization (Perplexity reasoning, for example).
This feature may be disabled setting env
   CHAT_AUTOSUMMARY_USE_CHAT_BACKEND=1

