### PR TITLE
Crash when tools not enabled

### DIFF
--- a/logicle/components/ui/tabs.tsx
+++ b/logicle/components/ui/tabs.tsx
@@ -52,6 +52,7 @@ const TabsList = React.forwardRef<React.ElementRef<typeof TabsPrimitive.List>, T
         // Just make compiler/linter happy...
         // The type of child is something like React.i18next something
         // i18next is doing something really fishy with children attribute
+        if (!child) return null
         return React.cloneElement(child as React.ReactElement, { direction })
       })}
     </TabsPrimitive.List>


### PR DESCRIPTION
TabsList was not resilient to falsy children, which may appear in conditional such as

```
<TabsList>
              <TabsTrigger value="general">
                {t('general')} {tabErrors.general && <IconAlertCircle color="red" />}
              </TabsTrigger>
              <TabsTrigger value="instructions">
                {t('instructions')} {tabErrors.instructions && <IconAlertCircle color="red" />}
              </TabsTrigger>
              {environment.enableTools && (
                <TabsTrigger value="tools">
                  {' '}
                  {t('tools')} {tabErrors.tools && <IconAlertCircle color="red" />}
                </TabsTrigger>
              )}
  
</TabsList>
```

As this is a very common pattern in React... i preferred to fix TabsList instead of fixing the AssistantForm, where the code fragment above is