### PR TITLE
MCP client POC

### DIFF
--- a/logicle/lib/tools/enumerate.ts
+++ b/logicle/lib/tools/enumerate.ts
@@ -8,6 +8,7 @@ import { FileManagerPlugin } from './retrieve-file/implementation'
 import { Dall_ePlugin } from './dall-e/implementation'
 import env from '../env'
 import { AssistantKnowledgePlugin } from './assistantKnowledge/implementation'
+import { McpPlugin } from './mcp/implementation'
 
 export const buildToolImplementationFromDbInfo = async (
   tool: dto.ToolDTO
@@ -17,6 +18,8 @@ export const buildToolImplementationFromDbInfo = async (
     return await TimeOfDay.builder(tool.configuration, provisioned)
   } else if (tool.type == OpenApiPlugin.toolName) {
     return await OpenApiPlugin.builder(tool.configuration, provisioned)
+  } else if (tool.type == McpPlugin.toolName) {
+    return await McpPlugin.builder(tool.configuration, provisioned)
   } else if (tool.type == FileManagerPlugin.toolName) {
     return await FileManagerPlugin.builder(tool.configuration, provisioned)
   } else if (tool.type == Dall_ePlugin.toolName) {

--- a/logicle/lib/tools/mcp/implementation.ts
+++ b/logicle/lib/tools/mcp/implementation.ts
@@ -1,0 +1,61 @@
+import {
+  ToolBuilder,
+  ToolFunction,
+  ToolFunctions,
+  ToolImplementation,
+  ToolInvokeParams,
+} from '@/lib/chat/tools'
+import { McpInterface } from './interface'
+import { JSONSchema7 } from 'json-schema'
+import { logger } from '@/lib/logging'
+import * as ai from 'ai'
+
+export interface McpPluginParams extends Record<string, unknown> {
+  url: string
+}
+
+async function convertMcpSpecToToolFunctions(
+  toolParams: McpPluginParams,
+  provisioned: boolean
+): Promise<ToolFunctions> {
+  try {
+    const client = await ai.experimental_createMCPClient({
+      transport: { type: 'sse', url: toolParams.url },
+    })
+    const tools = await client.tools()
+    const result: ToolFunctions = {}
+    for (const [name, tool] of Object.entries(tools)) {
+      result[name] = {
+        description: tool.description ?? '',
+        // the code below is highly unsafe... but it's a start
+        parameters: tool.parameters!['jsonSchema'] as JSONSchema7,
+        invoke: async ({ params }: ToolInvokeParams) => {
+          return tool.execute(params, {
+            toolCallId: '',
+            messages: [],
+          })
+          throw new Error('Not implemented')
+        },
+      }
+    }
+    return result
+  } catch (error) {
+    logger.error(`Error parsing Mcp string: ${error}`)
+    return {}
+  }
+}
+
+export class McpPlugin extends McpInterface implements ToolImplementation {
+  static builder: ToolBuilder = async (params: Record<string, unknown>, provisioned: boolean) => {
+    const toolParams = params as McpPluginParams
+    const functions = await convertMcpSpecToToolFunctions(toolParams, provisioned)
+    return new McpPlugin(functions) // TODO: need a better validation
+  }
+
+  functions: ToolFunctions
+
+  constructor(functions: ToolFunctions) {
+    super()
+    this.functions = functions
+  }
+}

--- a/logicle/lib/tools/mcp/interface.ts
+++ b/logicle/lib/tools/mcp/interface.ts
@@ -1,0 +1,7 @@
+export interface McpParams {
+  url: string
+}
+
+export class McpInterface {
+  static toolName: string = 'mcp'
+}


### PR DESCRIPTION
Just a proof of concept of an MCP based (only SSE) client

I provisioned this:
```
tools:
  mcp:
    type: mcp
    name: McpTest
    configuration:
      url: http://127.0.0.1:8080/sse
...
...
```

And started the sample server at https://github.com/vercel/ai/tree/main/examples/mcp with a simple
    
    pnpm sse:server

