### PR TITLE
Fix rendering of inline code blocks

### DIFF
--- a/logicle/tailwind.config.js
+++ b/logicle/tailwind.config.js
@@ -156,6 +156,25 @@ module.exports = {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
       },
+      typography: {
+        DEFAULT: {
+          css: {
+            'code::before': { content: '""' },
+            'code::after': { content: '""' },
+            // Optionally, you can also adjust code styling:
+            code: {
+              color: '#4B5563',
+              borderRadius: '0.25rem',
+
+              backgroundColor: '#F3F4F6',
+              'padding-top': '0.3rem',
+              'padding-bottom': '0.3rem',
+              'padding-left': '0.15rem',
+              'padding-right': '0.15rem',
+            },
+          },
+        },
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
PR #361 broke the rendering of inline code blocks (i.e. single backticks), which were rendered as... syntax highlighted blocks.
As React Markdown removed support for the "inline" blocks, I had to re-insert the inline vs non-inline information at mdast level.

Moreover, this PR makes rendering of inline code blocks more similar to ChatGPT (i.e. grayed blocks), ins

![image](https://github.com/user-attachments/assets/be13e1d9-67ba-4041-a8c6-881307c3caf0)
