### PR TITLE
Do not require all attributes in provisioning files

### DIFF
--- a/logicle/lib/provision.ts
+++ b/logicle/lib/provision.ts
@@ -33,12 +33,12 @@ export type ProvisionableAssistant = Omit<
 export type ProvisionableAssistantSharing = Omit<AssistantSharing, 'id' | 'provisioned'>
 
 interface Provision {
-  tools: Record<string, ProvisionableTool>
-  backends: Record<string, ProvisionableBackend>
-  users: Record<string, ProvisionableUser>
-  apiKeys: Record<string, ProvisionableApiKey>
-  assistants: Record<string, ProvisionableAssistant>
-  assistantSharing: Record<string, ProvisionableAssistantSharing>
+  tools?: Record<string, ProvisionableTool>
+  backends?: Record<string, ProvisionableBackend>
+  users?: Record<string, ProvisionableUser>
+  apiKeys?: Record<string, ProvisionableApiKey>
+  assistants?: Record<string, ProvisionableAssistant>
+  assistantSharing?: Record<string, ProvisionableAssistantSharing>
 }
 
 export async function provision() {
@@ -176,10 +176,11 @@ export async function provisionFile(path: string) {
 
   provisionSchema.parse(provisionData)
 
-  await provisionTools(provisionData.tools)
-  await provisionBackends(provisionData.backends)
-  await provisionUsers(provisionData.users)
-  await provisionApiKeys(provisionData.apiKeys)
-  await provisionAssistants(provisionData.assistants)
-  await provisionAssistantSharing(provisionData.assistantSharing)
+  provisionData.tools && (await provisionTools(provisionData.tools))
+  provisionData.backends && (await provisionBackends(provisionData.backends))
+  provisionData.users && (await provisionUsers(provisionData.users))
+  provisionData.apiKeys && (await provisionApiKeys(provisionData.apiKeys))
+  provisionData.assistants && (await provisionAssistants(provisionData.assistants))
+  provisionData.assistantSharing &&
+    (await provisionAssistantSharing(provisionData.assistantSharing))
 }

--- a/logicle/lib/provision.ts
+++ b/logicle/lib/provision.ts
@@ -176,11 +176,11 @@ export async function provisionFile(path: string) {
 
   provisionSchema.parse(provisionData)
 
-  provisionData.tools && (await provisionTools(provisionData.tools))
-  provisionData.backends && (await provisionBackends(provisionData.backends))
-  provisionData.users && (await provisionUsers(provisionData.users))
-  provisionData.apiKeys && (await provisionApiKeys(provisionData.apiKeys))
-  provisionData.assistants && (await provisionAssistants(provisionData.assistants))
-  provisionData.assistantSharing &&
-    (await provisionAssistantSharing(provisionData.assistantSharing))
+  if (provisionData.tools) await provisionTools(provisionData.tools)
+  if (provisionData.backends) await provisionBackends(provisionData.backends)
+  if (provisionData.users) await provisionUsers(provisionData.users)
+  if (provisionData.apiKeys) await provisionApiKeys(provisionData.apiKeys)
+  if (provisionData.assistants) await provisionAssistants(provisionData.assistants)
+  if (provisionData.assistantSharing)
+    await provisionAssistantSharing(provisionData.assistantSharing)
 }

--- a/logicle/lib/provision_schema.ts
+++ b/logicle/lib/provision_schema.ts
@@ -55,10 +55,10 @@ export const provisionedAssistantSharingSchema = z
   .strict()
 
 export const provisionSchema = z.object({
-  tools: z.record(z.string(), provisionedToolSchema),
-  backends: z.record(z.string(), provisionedBackendSchema),
-  users: z.record(z.string(), provisionedUserSchema),
-  apiKeys: z.record(z.string(), provisionedApiKeySchema),
-  assistants: z.record(z.string(), provisionedAssistantSchema),
-  assistantSharing: z.record(z.string(), provisionedAssistantSharingSchema),
+  tools: z.record(z.string(), provisionedToolSchema).optional(),
+  backends: z.record(z.string(), provisionedBackendSchema).optional(),
+  users: z.record(z.string(), provisionedUserSchema).optional(),
+  apiKeys: z.record(z.string(), provisionedApiKeySchema).optional(),
+  assistants: z.record(z.string(), provisionedAssistantSchema).optional(),
+  assistantSharing: z.record(z.string(), provisionedAssistantSharingSchema).optional(),
 })


### PR DESCRIPTION
A huge bug prevented provisioning if any key (such as: "assistant") was not specified
