### PR TITLE
Disable vision and tools if model does not support them

### DIFF
--- a/logicle/app/assistants/components/AssistantForm.tsx
+++ b/logicle/app/assistants/components/AssistantForm.tsx
@@ -30,7 +30,7 @@ import { StringList } from '@/components/ui/stringlist'
 import { IconUpload } from '@tabler/icons-react'
 import { AddToolsDialog } from './AddToolsDialog'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { isReasoningModel } from '@/lib/chat/models'
+import { isReasoningModel, isToolCallingModel } from '@/lib/chat/models'
 
 const DEFAULT = '__DEFAULT__'
 const fileSchema = z.object({
@@ -570,9 +570,11 @@ export const AssistantForm = ({ assistant, onSubmit, onChange, onValidate, fireS
               <TabsTrigger value="instructions">
                 {t('instructions')} {tabErrors.instructions && <IconAlertCircle color="red" />}
               </TabsTrigger>
-              <TabsTrigger value="tools">
-                {t('tools')} {tabErrors.tools && <IconAlertCircle color="red" />}
-              </TabsTrigger>
+              {isToolCallingModel(form.getValues().model.split('@')[0]) && (
+                <TabsTrigger value="tools">
+                  {t('tools')} {tabErrors.tools && <IconAlertCircle color="red" />}
+                </TabsTrigger>
+              )}
               {showKnowledge && (
                 <TabsTrigger value="knowledge">
                   {t('knowledge')} {tabErrors.knowledge && <IconAlertCircle color="red" />}

--- a/logicle/lib/chat/ChatState.ts
+++ b/logicle/lib/chat/ChatState.ts
@@ -2,12 +2,17 @@ import * as dto from '@/types/dto'
 import { nanoid } from 'nanoid'
 import * as ai from 'ai'
 import { dtoMessageToLlmMessage } from './conversion'
+import { LlmModelCapabilities } from './models'
 
 export class ChatState {
   llmMessages: ai.CoreMessage[]
   chatHistory: dto.Message[]
   conversationId: string
-  constructor(chatHistory: dto.Message[], llmMessages: ai.CoreMessage[]) {
+  constructor(
+    chatHistory: dto.Message[],
+    llmMessages: ai.CoreMessage[],
+    private llmModelCapabilities: LlmModelCapabilities
+  ) {
     this.llmMessages = llmMessages
     this.chatHistory = chatHistory
     this.conversationId = chatHistory[0].conversationId
@@ -15,7 +20,7 @@ export class ChatState {
 
   async push(msg: dto.Message): Promise<dto.Message> {
     this.chatHistory = [...this.chatHistory, msg]
-    const llmMsg = await dtoMessageToLlmMessage(msg)
+    const llmMsg = await dtoMessageToLlmMessage(msg, this.llmModelCapabilities)
     if (llmMsg) {
       this.llmMessages = [...this.llmMessages, llmMsg]
     }

--- a/logicle/lib/chat/models/index.ts
+++ b/logicle/lib/chat/models/index.ts
@@ -11,6 +11,12 @@ export interface LlmModelCapabilities {
   reasoning: boolean
 }
 
+export const llmModelNoCapabilities: LlmModelCapabilities = {
+  vision: false,
+  function_calling: false,
+  reasoning: false,
+}
+
 // This EngineOwner is currently used to enable "owner" specific APIs (read: reasoning)
 // in logicle mode.
 export type EngineOwner = 'openai' | 'perplexity' | 'anthropic' | 'google' | 'meta' | 'mistral'
@@ -65,4 +71,13 @@ export const isVisionModel = (modelId: string) => {
     }
   }
   return false
+}
+
+export const findLlmModelById = (modelId: string) => {
+  for (const model of allModels) {
+    if (model.id == modelId) {
+      return model
+    }
+  }
+  return undefined
 }

--- a/logicle/lib/chat/models/index.ts
+++ b/logicle/lib/chat/models/index.ts
@@ -64,6 +64,15 @@ export const isReasoningModel = (modelId: string) => {
   return false
 }
 
+export const isToolCallingModel = (modelId: string) => {
+  for (const model of allModels) {
+    if (model.id == modelId) {
+      return model.capabilities.function_calling
+    }
+  }
+  return false
+}
+
 export const isVisionModel = (modelId: string) => {
   for (const model of allModels) {
     if (model.id == modelId) {


### PR DESCRIPTION
This PR prevents invocations of LLMs with incoherent (wrt model capabilties) parameters regarding:

* Tools
* Image attachments

Vercel's SDK limits somehow "bad usages" for providers as OpenAI, Perplexity, etc... but can't do anything for Logicle Cloud models, for which a "OpenAI compatible" provider is used

