### PR TITLE
Keep knowledge when duplicating assistants

### DIFF
--- a/logicle/app/chat/assistants/mine/page.tsx
+++ b/logicle/app/chat/assistants/mine/page.tsx
@@ -133,12 +133,12 @@ const MyAssistantPage = () => {
       tokenLimit: assistantToClone.tokenLimit,
       temperature: assistantToClone.temperature,
       tools: assistantToClone.tools,
-      files: [],
-      iconUri: null,
+      files: assistantToClone.files,
+      iconUri: assistantToClone.iconUri,
       owner: null,
-      tags: [],
-      prompts: [],
-      reasoning_effort: null,
+      tags: assistantToClone.tags,
+      prompts: assistantToClone.prompts,
+      reasoning_effort: assistantToClone.reasoning_effort,
     } as dto.InsertableAssistant
     const url = `/api/assistants`
     const response = await post<dto.AssistantWithOwner>(url, newAssistant)


### PR DESCRIPTION
In order to be able to share knowledge between assistants without duplicating the files, unused files (i.e. files which have been uploaded to an assistant and not used anymore) are not deleted anymore.
Cloning knowledge when an assistant is clone is now... trivial
 