### PR TITLE
Open chat links in new tab / simplify custom anchor rendering 

### DIFF
--- a/logicle/app/chat/components/AssistantMessage.tsx
+++ b/logicle/app/chat/components/AssistantMessage.tsx
@@ -46,7 +46,7 @@ function expandCitations(text: string, citations: string[]): string {
   return text.replace(/\[(\d+)\]/g, (match, numStr) => {
     const num = parseInt(numStr, 10)
     if (num > 0 && num <= citations.length) {
-      return `<citation>[${numStr}](${citations[num - 1]})</citation>`
+      return `[${numStr}](${citations[num - 1]})`
     } else {
       return `[${numStr}]`
     }

--- a/logicle/app/chat/components/AssistantMessageMarkdown.tsx
+++ b/logicle/app/chat/components/AssistantMessageMarkdown.tsx
@@ -22,6 +22,31 @@ export function remarkAddBlockCodeFlag() {
   }
 }
 
+type AnchorProps = React.ComponentPropsWithoutRef<'a'>
+
+const CustomAnchor = ({ children, href, className, ...rest }: AnchorProps) => {
+  // Extract text from children
+  const textContent = React.Children.toArray(children)
+    .filter((child) => typeof child === 'string')
+    .join('')
+  const bracketNumberRegex = /^\d+$/
+  // Test if textContent matches “[number]”
+  const isBracketNumber = bracketNumberRegex.test(textContent)
+  return (
+    <a
+      href={href}
+      className={
+        isBracketNumber
+          ? 'mx-0.5 bg-muted hover:bg-primary_color_hover text-sm px-1 hover:bg-primary_color_hover no-underline'
+          : className
+      }
+      {...rest}
+    >
+      {children}
+    </a>
+  )
+}
+
 export const AssistantMessageMarkdown: React.FC<{
   className: string
   children: string
@@ -72,19 +97,8 @@ export const AssistantMessageMarkdown: React.FC<{
         td({ children }) {
           return <td className="break-words border px-3 py-1 border-foreground">{children}</td>
         },
-        citation({ children }) {
-          return (
-            <span className="">
-              {React.Children.map(children, (child) =>
-                React.isValidElement(child) && child.type === 'a'
-                  ? React.cloneElement(child as React.ReactElement, {
-                      className:
-                        'mx-0.5 bg-muted hover:bg-primary_color_hover text-sm px-1 hover:bg-primary_color_hover no-underline',
-                    })
-                  : 'aaa'
-              )}
-            </span>
-          )
+        a({ children, ...props }) {
+          return <CustomAnchor {...props}>{children}</CustomAnchor>
         },
       }}
     >

--- a/logicle/app/chat/components/AssistantMessageMarkdown.tsx
+++ b/logicle/app/chat/components/AssistantMessageMarkdown.tsx
@@ -100,6 +100,13 @@ export const AssistantMessageMarkdown: React.FC<{
             </span>
           )
         },
+        a: ({ node, ...props }) => (
+          <a
+            {...props}
+            target="_blank" // open link in new tab
+            rel="noopener noreferrer" // security best-practice
+          />
+        ),
       }}
     >
       {markdown}

--- a/logicle/app/chat/components/AssistantMessageMarkdown.tsx
+++ b/logicle/app/chat/components/AssistantMessageMarkdown.tsx
@@ -4,28 +4,12 @@ import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
 import rehypeRaw from 'rehype-raw'
 import ReactMarkdown from 'react-markdown'
+import rehypeExternalLinks from 'rehype-external-links'
 import 'katex/dist/katex.min.css' // `rehype-katex` does not import the CSS for you
 import React, { memo } from 'react'
 
-import { Plugin } from 'unified'
 import { visit } from 'unist-util-visit'
-import { Root, Node } from 'mdast'
-
-const allowedElements = ['<citation>', '</citation>']
-
-// Define the custom plugin as a TypeScript function
-const filterNodes: Plugin<[], Root> = () => {
-  return (tree) => {
-    visit(tree, (node, index, parent) => {
-      if (node.type === 'html' && !allowedElements.includes(node.value)) {
-        if (parent && typeof index === 'number') {
-          console.log(`Removing node ${node.value}`)
-          parent.children.splice(index, 1) // Remove the node
-        }
-      }
-    })
-  }
-}
+import { Node } from 'mdast'
 
 export function remarkAddBlockCodeFlag() {
   return (tree: Node) => {
@@ -46,8 +30,12 @@ export const AssistantMessageMarkdown: React.FC<{
   return (
     <ReactMarkdown
       className={className}
-      remarkPlugins={[remarkGfm, remarkMath, [filterNodes], [remarkAddBlockCodeFlag]]}
-      rehypePlugins={[rehypeKatex, rehypeRaw]}
+      remarkPlugins={[remarkGfm, remarkMath, [remarkAddBlockCodeFlag]]}
+      rehypePlugins={[
+        [rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] }],
+        rehypeKatex,
+        rehypeRaw,
+      ]}
       components={{
         code({ node, className, children, ...props }) {
           // We want to use SyntaxHighligher only for code blocks, i.e. ```{body}```
@@ -86,27 +74,18 @@ export const AssistantMessageMarkdown: React.FC<{
         },
         citation({ children }) {
           return (
-            <span className=" ">
+            <span className="">
               {React.Children.map(children, (child) =>
                 React.isValidElement(child) && child.type === 'a'
                   ? React.cloneElement(child as React.ReactElement, {
                       className:
                         'mx-0.5 bg-muted hover:bg-primary_color_hover text-sm px-1 hover:bg-primary_color_hover no-underline',
-                      target: '_blank',
-                      rel: 'noopener noreferrer',
                     })
-                  : child
+                  : 'aaa'
               )}
             </span>
           )
         },
-        a: ({ node, ...props }) => (
-          <a
-            {...props}
-            target="_blank" // open link in new tab
-            rel="noopener noreferrer" // security best-practice
-          />
-        ),
       }}
     >
       {markdown}

--- a/logicle/package.json
+++ b/logicle/package.json
@@ -108,6 +108,7 @@
     "react-markdown": "^9.0.0",
     "react-syntax-highlighter": "^15.5.0",
     "recharts": "^2.13.3",
+    "rehype-external-links": "^3.0.0",
     "rehype-katex": "^7.0.0",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "4.0",

--- a/logicle/pnpm-lock.yaml
+++ b/logicle/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
       recharts:
         specifier: ^2.13.3
         version: 2.15.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      rehype-external-links:
+        specifier: ^3.0.0
+        version: 3.0.0
       rehype-katex:
         specifier: ^7.0.0
         version: 7.0.1
@@ -4632,6 +4635,10 @@ packages:
     resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
     engines: {node: '>= 10'}
 
+  is-absolute-url@4.0.1:
+    resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
 
@@ -6381,6 +6388,9 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  rehype-external-links@3.0.0:
+    resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
 
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
@@ -13069,6 +13079,8 @@ snapshots:
 
   ipaddr.js@2.2.0: {}
 
+  is-absolute-url@4.0.1: {}
+
   is-alphabetical@1.0.4: {}
 
   is-alphabetical@2.0.1: {}
@@ -15249,6 +15261,15 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  rehype-external-links@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      hast-util-is-element: 3.0.0
+      is-absolute-url: 4.0.1
+      space-separated-tokens: 2.0.2
+      unist-util-visit: 5.0.0
 
   rehype-katex@7.0.1:
     dependencies:


### PR DESCRIPTION
This PR makes link use _blank (i.e. new tab) as anchor target using rehype-external-links
In addition, custom formatting for sonar (i.e. numbered cross references) has been moved to react, in order to keep the markdown reasonably clean

 