### PR TITLE
Avoid form submit logic on enter key press

### DIFF
--- a/logicle/app/admin/backends/components/BackendForm.tsx
+++ b/logicle/app/admin/backends/components/BackendForm.tsx
@@ -42,7 +42,7 @@ const BackendForm: FC<Props> = ({ backend, onSubmit, creating }) => {
   }
 
   return (
-    <Form {...form} onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+    <Form {...form} onSubmit={(evt) => evt.preventDefault()} className="space-y-6">
       <FormField
         control={form.control}
         name="name"
@@ -92,7 +92,11 @@ const BackendForm: FC<Props> = ({ backend, onSubmit, creating }) => {
           )}
         />
       )}
-      <Button disabled={environment.backendConfigLock} type="submit">
+      <Button
+        disabled={environment.backendConfigLock}
+        type="button"
+        onClick={form.handleSubmit(handleSubmit)}
+      >
         {creating ? t('create-backend') : t('save')}
       </Button>
     </Form>

--- a/logicle/app/admin/tools/components/ToolForm.tsx
+++ b/logicle/app/admin/tools/components/ToolForm.tsx
@@ -138,7 +138,7 @@ const ToolForm: FC<Props> = ({ type, tool, onSubmit }) => {
   }
 
   return (
-    <Form {...form} onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+    <Form {...form} onSubmit={(evt) => evt.preventDefault()} className="space-y-6">
       <FormField
         control={form.control}
         name="name"
@@ -231,7 +231,9 @@ const ToolForm: FC<Props> = ({ type, tool, onSubmit }) => {
           />
         </>
       )}
-      <Button type="submit">{t('submit')}</Button>
+      <Button type="button" onClick={form.handleSubmit(handleSubmit)}>
+        {t('submit')}
+      </Button>
     </Form>
   )
 }

--- a/logicle/app/assistants/components/AssistantForm.tsx
+++ b/logicle/app/assistants/components/AssistantForm.tsx
@@ -406,7 +406,6 @@ export const KnowledgeTabPanel = ({
 export const AssistantForm = ({ assistant, onSubmit, onChange, onValidate, fireSubmit }: Props) => {
   const { t } = useTranslation()
   const { data: models } = useBackendsModels()
-  const environment = useEnvironment()
   const formRef = useRef<HTMLFormElement>(null)
   const [activeTab, setActiveTab] = useState<TabState>('general')
   const backendModels = models || []
@@ -545,15 +544,13 @@ export const AssistantForm = ({ assistant, onSubmit, onChange, onValidate, fireS
     )
   }
 
-  fireSubmit.current = () => {
-    formRef?.current?.requestSubmit()
-  }
+  fireSubmit.current = form.handleSubmit(handleSubmit, () => setTabErrors(computeTabErrors()))
 
   return (
     <FormProvider {...form}>
       <form
         ref={formRef}
-        onSubmit={form.handleSubmit(handleSubmit, () => setTabErrors(computeTabErrors()))}
+        onSubmit={(e) => e.preventDefault()}
         className="space-y-6 h-full flex flex-col p-2 overflow-hidden min-h-0 "
       >
         <div className="flex flex-row gap-1 self-center">

--- a/logicle/components/ui/password-input.tsx
+++ b/logicle/components/ui/password-input.tsx
@@ -22,6 +22,7 @@ const PasswordInput = (props: Props) => {
         value={props.value}
       />
       <button
+        type="button"
         className="border-none absolute right-4 cursor-pointer opacity-50"
         onClick={(evt) => {
           togglePassword()


### PR DESCRIPTION
This PR changes enter key handling in the following forms:
* Assistants
* Backends
* Tools
Submission is now possible only clicking on the submit button