### PR TITLE
Shift from One-to-One to Shared Image Handling

### DIFF
--- a/logicle/app/api/assistants/[assistantId]/clone/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/clone/route.ts
@@ -1,0 +1,42 @@
+import {
+  assistantFiles,
+  assistantToolsEnablement,
+  createAssistant,
+  getAssistant,
+} from '@/models/assistant'
+import { requireSession, SimpleSession } from '@/api/utils/auth'
+import ApiResponses from '@/api/utils/ApiResponses'
+import * as dto from '@/types/dto'
+import { getImageAsDataUri } from '@/models/images'
+
+export const dynamic = 'force-dynamic'
+
+export const POST = requireSession(
+  async (session: SimpleSession, req: Request, params: { assistantId: string }) => {
+    const assistantId = params.assistantId
+    const assistant = await getAssistant(assistantId)
+    if (!assistant) {
+      return ApiResponses.noSuchEntity(`There is no assistant with id ${assistantId}`)
+    }
+    if (assistant.owner !== session.userId) {
+      return ApiResponses.notAuthorized(`You're not authorized to clone assistant ${assistantId}`)
+    }
+    if (assistant.provisioned) {
+      return ApiResponses.notAuthorized(`Can't clone provisioned assistant ${assistantId}`)
+    }
+
+    const assistantWithTools: dto.InsertableAssistant = {
+      ...assistant,
+      iconUri: assistant.imageId ? await getImageAsDataUri(assistant.imageId) : null,
+      tools: await assistantToolsEnablement(assistant.id),
+      files: await assistantFiles(assistant.id),
+      prompts: JSON.parse(assistant.prompts),
+      tags: JSON.parse(assistant.tags),
+    }
+    const created = await createAssistant({
+      ...assistantWithTools,
+      owner: session.userId,
+    })
+    return ApiResponses.created(created)
+  }
+)

--- a/logicle/app/api/assistants/[assistantId]/clone/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/clone/route.ts
@@ -27,6 +27,7 @@ export const POST = requireSession(
 
     const assistantWithTools: dto.InsertableAssistant = {
       ...assistant,
+      name: 'Copy of' + ' ' + assistant.name,
       iconUri: assistant.imageId ? await getImageAsDataUri(assistant.imageId) : null,
       tools: await assistantToolsEnablement(assistant.id),
       files: await assistantFiles(assistant.id),

--- a/logicle/app/api/assistants/[assistantId]/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/route.ts
@@ -46,6 +46,7 @@ export const GET = requireSession(
     if (!assistant) {
       return ApiResponses.noSuchEntity(`There is no assistant with id ${assistantId}`)
     }
+    const { imageId, ...assistantWithoutImage } = assistant
     const sharingData = await assistantSharingData(assistant.id)
     const workspaceMemberships = await getUserWorkspaceMemberships(userId)
     if (assistant.owner !== session.userId && !isSharedWithMe(sharingData, workspaceMemberships)) {
@@ -53,7 +54,7 @@ export const GET = requireSession(
     }
 
     const assistantWithTools: dto.AssistantWithTools = {
-      ...assistant,
+      ...assistantWithoutImage,
       iconUri: assistant.imageId ? `/api/images/${assistant.imageId}` : null,
       tools: await assistantToolsEnablement(assistant.id),
       files: await assistantFiles(assistant.id),

--- a/logicle/app/api/user/profile/route.ts
+++ b/logicle/app/api/user/profile/route.ts
@@ -1,9 +1,4 @@
-import {
-  deleteUserImage,
-  getUserById,
-  getUserWorkspaceMemberships,
-  updateUser,
-} from '@/models/user'
+import { getUserById, getUserWorkspaceMemberships, updateUser } from '@/models/user'
 import ApiResponses from '@/api/utils/ApiResponses'
 import { KeysEnum, sanitize } from '@/lib/sanitize'
 import { requireSession } from '../../utils/auth'
@@ -11,7 +6,7 @@ import { getUserAssistants } from '@/models/assistant'
 import { WorkspaceRole } from '@/types/workspace'
 import { Updateable } from 'kysely'
 import * as schema from '@/db/schema'
-import { createImageFromDataUriIfNotNull } from '@/models/images'
+import { getOrCreateImageFromDataUri } from '@/models/images'
 import * as dto from '@/types/dto'
 
 export const dynamic = 'force-dynamic'
@@ -58,16 +53,15 @@ export const PATCH = requireSession(async (session, req) => {
   const sanitizedUser = sanitize<dto.UpdateableUserSelf>(await req.json(), UpdateableUserSelfKeys)
 
   // extract the image field, we will handle it separately, and discard unwanted fields
-  const createdImage = await createImageFromDataUriIfNotNull(sanitizedUser.image)
+  const imageId = sanitizedUser.image ? getOrCreateImageFromDataUri(sanitizedUser.image) : null
   const dbUser = {
     ...sanitizedUser,
     image: undefined,
     preferences: sanitizedUser.preferences ? JSON.stringify(sanitizedUser.preferences) : undefined,
-    imageId: createdImage?.id ?? null,
+    imageId,
   } as Updateable<schema.User>
 
   // delete the old image
-  await deleteUserImage(session.userId)
   await updateUser(session.userId, dbUser)
   return ApiResponses.success()
 })

--- a/logicle/app/api/user/profile/route.ts
+++ b/logicle/app/api/user/profile/route.ts
@@ -52,14 +52,14 @@ const UpdateableUserSelfKeys: KeysEnum<dto.UpdateableUserSelf> = {
 export const PATCH = requireSession(async (session, req) => {
   const sanitizedUser = sanitize<dto.UpdateableUserSelf>(await req.json(), UpdateableUserSelfKeys)
 
+  const { image, ...sanitizedUserWithoutImage } = sanitizedUser
   // extract the image field, we will handle it separately, and discard unwanted fields
-  const imageId = sanitizedUser.image ? getOrCreateImageFromDataUri(sanitizedUser.image) : null
-  const dbUser = {
-    ...sanitizedUser,
-    image: undefined,
+  const imageId = image ? await getOrCreateImageFromDataUri(image) : null
+  const dbUser: Updateable<schema.User> = {
+    ...sanitizedUserWithoutImage,
     preferences: sanitizedUser.preferences ? JSON.stringify(sanitizedUser.preferences) : undefined,
     imageId,
-  } as Updateable<schema.User>
+  }
 
   // delete the old image
   await updateUser(session.userId, dbUser)

--- a/logicle/app/assistants/[id]/page.tsx
+++ b/logicle/app/assistants/[id]/page.tsx
@@ -98,12 +98,19 @@ const AssistantPage = () => {
 
   async function onSubmit(values: Partial<dto.InsertableAssistant>) {
     await onChange(values)
-    if (!values?.iconUri?.startsWith('data')) {
+    if (values?.iconUri !== undefined) {
+      let iconUri: string | null | undefined = values.iconUri
+      if (iconUri === '') {
+        iconUri = null
+      } else if (!iconUri?.startsWith('data')) {
+        iconUri = undefined
+      }
       values = {
         ...values,
-        iconUri: undefined,
+        iconUri,
       }
     }
+
     const response = await patch(assistantUrl, {
       ...assistant,
       ...values,

--- a/logicle/app/chat/assistants/mine/page.tsx
+++ b/logicle/app/chat/assistants/mine/page.tsx
@@ -117,36 +117,13 @@ const MyAssistantPage = () => {
   }
 
   async function onDuplicate(assistant: dto.UserAssistant) {
-    const assistantUrl = `/api/assistants/${assistant.id}`
-    const getResponse = await get<dto.AssistantWithTools>(assistantUrl)
-    if (getResponse.error) {
-      toast.error(getResponse.error.message)
-      return
-    }
-    const assistantToClone = getResponse.data
-    const newAssistant = {
-      description: assistantToClone.description,
-      name: 'Copy of' + ' ' + assistantToClone.name,
-      backendId: assistantToClone.backendId,
-      model: assistantToClone.model,
-      systemPrompt: assistantToClone.systemPrompt,
-      tokenLimit: assistantToClone.tokenLimit,
-      temperature: assistantToClone.temperature,
-      tools: assistantToClone.tools,
-      files: assistantToClone.files,
-      iconUri: assistantToClone.iconUri,
-      owner: null,
-      tags: assistantToClone.tags,
-      prompts: assistantToClone.prompts,
-      reasoning_effort: assistantToClone.reasoning_effort,
-    } as dto.InsertableAssistant
-    const url = `/api/assistants`
-    const response = await post<dto.AssistantWithOwner>(url, newAssistant)
+    const assistantUrl = `/api/assistants/${assistant.id}/clone`
+    const response = await post<dto.AssistantWithOwner>(assistantUrl)
     if (response.error) {
       toast.error(response.error.message)
       return
     }
-    await mutate(url)
+    await mutate(`/api/assistants`)
     await mutate('/api/user/profile') // Let the chat know that there are new assistants!
     router.push(`/assistants/${response.data.id}`)
   }

--- a/logicle/lib/uris.ts
+++ b/logicle/lib/uris.ts
@@ -5,3 +5,7 @@ export function splitDataUri(dataURI: string) {
     mimeType: split[0].split(':')[1].split(';')[0],
   }
 }
+
+export function toDataUri(data: Buffer, mimeType: string) {
+  return `data:${mimeType};base64,${data.toString('base64')}`
+}

--- a/logicle/models/user.ts
+++ b/logicle/models/user.ts
@@ -131,13 +131,3 @@ export const updateUser = async (userId: string, user: Partial<schema.User>) => 
   } as Partial<schema.User>
   await db.updateTable('User').set(userWithFixedDates).where('id', '=', userId).execute()
 }
-
-export const deleteUserImage = async (userId: string) => {
-  const deleteResult = await db
-    .deleteFrom('Image')
-    .where('Image.id', 'in', (eb) =>
-      eb.selectFrom('User').select('User.imageId').where('User.id', '=', userId)
-    )
-    .executeTakeFirstOrThrow()
-  logger.debug(`Deleted ${deleteResult.numDeletedRows} images`)
-}


### PR DESCRIPTION
This PR radically changes the way we deal with images: they're not bound to the entity which uses them (Assistant / User), but they may be shared.

On the DTO / provisioning side, we use data urls, which are hashed and converted to a hopefully unique imageId.
So... the API consumer... does not know anything about this sharing!

Deleting unused entries will be a bit more complicate, but still feasible.