### PR TITLE
Better choice of file extension for codeblock download

### DIFF
--- a/logicle/app/chat/components/AssistantMessageMarkdown.tsx
+++ b/logicle/app/chat/components/AssistantMessageMarkdown.tsx
@@ -72,7 +72,7 @@ export const AssistantMessageMarkdown: React.FC<{
             return (
               <CodeBlock
                 key={Math.random()}
-                language={match ? match[1] : ''}
+                language={match ? match[1] : undefined}
                 value={String(children).replace(/\n$/, '')}
                 forExport={forExport}
                 {...props}

--- a/logicle/app/chat/components/markdown/CodeBlock.tsx
+++ b/logicle/app/chat/components/markdown/CodeBlock.tsx
@@ -5,12 +5,22 @@ import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 
 import { useTranslation } from 'react-i18next'
 
-import { generateRandomString, programmingLanguages } from '@/lib/codeblock'
+import { generateRandomString, fileExtensionsForLanguage } from '@/lib/codeblock'
 
 interface Props {
-  language: string
+  language?: string
   value: string
   forExport?: boolean
+}
+
+const computeExtensionForLanguage = (language?: string) => {
+  if (language === undefined) {
+    return '.file'
+  } else if (fileExtensionsForLanguage[language]) {
+    return fileExtensionsForLanguage[language]
+  } else {
+    return `.${language}`
+  }
 }
 
 export const CodeBlock: FC<Props> = memo(({ language, value, forExport }) => {
@@ -30,8 +40,9 @@ export const CodeBlock: FC<Props> = memo(({ language, value, forExport }) => {
       }, 2000)
     })
   }
+
   const downloadAsFile = () => {
-    const fileExtension = programmingLanguages[language] || '.file'
+    const fileExtension = computeExtensionForLanguage(language)
     const suggestedFileName = `file-${generateRandomString(3, true)}${fileExtension}`
     const fileName = window.prompt(t('Enter file name') || '', suggestedFileName)
 

--- a/logicle/lib/codeblock.ts
+++ b/logicle/lib/codeblock.ts
@@ -2,7 +2,7 @@ interface languageMap {
   [key: string]: string | undefined
 }
 
-export const programmingLanguages: languageMap = {
+export const fileExtensionsForLanguage: languageMap = {
   javascript: '.js',
   python: '.py',
   java: '.java',
@@ -26,6 +26,8 @@ export const programmingLanguages: languageMap = {
   sql: '.sql',
   html: '.html',
   css: '.css',
+  bash: '.sh',
+  csv: '.csv',
   // add more file extensions here, make sure the key is same as language prop in CodeBlock.tsx component
 }
 


### PR DESCRIPTION
If the language is unkwown (i.e. not mapped) we can simply use the language as an extension.
I wonder what will happen if there are spaces or weird characters in the language