### PR TITLE
All non provisioned assistant may be duplicated

### DIFF
--- a/logicle/app/api/assistants/[assistantId]/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/route.ts
@@ -106,8 +106,7 @@ export const DELETE = requireSession(
     if (assistant.provisioned) {
       return ApiResponses.forbiddenAction("Can't delete a provisioned assistant")
     }
-    // Note: we need the admin to be able to modify the assistant owner
-    // So... the API is a bit more open than reasonable
+    // Only owner and admin can delete an assistant
     if (assistant.owner !== session.userId && session.userRole != 'ADMIN') {
       return ApiResponses.notAuthorized(
         `You're not authorized to delete assistant ${params.assistantId}`

--- a/logicle/app/assistants/components/AssistantPreview.tsx
+++ b/logicle/app/assistants/components/AssistantPreview.tsx
@@ -33,6 +33,7 @@ export const AssistantPreview = ({ assistant, className, sendDisabled }: Props) 
     sharing: [],
     owner: '',
     ownerName: '',
+    cloneable: false,
   }
 
   const [conversation, setConversation] = useState<ConversationWithMessages>({

--- a/logicle/app/chat/assistants/mine/page.tsx
+++ b/logicle/app/chat/assistants/mine/page.tsx
@@ -19,7 +19,7 @@ import { SearchBarWithButtonsOnRight } from '@/components/app/SearchBarWithButto
 import { useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { AssistantAvatar } from '@/components/app/Avatars'
-import { WorkspaceRole } from '@/types/workspace'
+import { canDeleteAssistant, canEditAssistant } from '@/lib/rbac'
 
 const EMPTY_ASSISTANT_NAME = ''
 
@@ -39,32 +39,6 @@ const MyAssistantPage = () => {
   const profile = useUserProfile()
   const modalContext = useConfirmationContext()
   const [searchTerm, setSearchTerm] = useState<string>('')
-
-  /**
-   * @param assistant
-   * @param profile the user profile
-   * @returns whether the user can edit the assistant
-   */
-  const canEditAssistant = (assistant: dto.UserAssistant, profile: dto.UserProfile | undefined) => {
-    // A user can edit the assistant if:
-    // - he is the owner
-    // - he has the WorkspaceRole Editor role in the same workspace where the assistant has been shared
-    //   (if the assistant has been shared to all it is editable only by the owner)
-    if (assistant.owner == profile?.id) return true
-
-    return assistant.sharing.some((s) => {
-      if (dto.isAllSharingType(s)) return false
-
-      return profile?.workspaces.some((w) => {
-        return (
-          w.id == s.workspaceId &&
-          (w.role == WorkspaceRole.EDITOR ||
-            w.role == WorkspaceRole.OWNER ||
-            w.role == WorkspaceRole.ADMIN)
-        )
-      })
-    })
-  }
 
   const {
     data: assistants,
@@ -205,6 +179,7 @@ const MyAssistantPage = () => {
                         />
                         <Action
                           icon={IconTrash}
+                          visible={canDeleteAssistant(assistant, profile)}
                           onClick={async () => {
                             await onDelete(assistant)
                           }}

--- a/logicle/app/chat/assistants/mine/page.tsx
+++ b/logicle/app/chat/assistants/mine/page.tsx
@@ -136,7 +136,10 @@ const MyAssistantPage = () => {
           <ScrollArea className="flex-1 min-h-0">
             <div className=" gap-4 flex flex-col">
               {(assistants ?? [])
-                .filter((assistant) => canEditAssistant(assistant, profile))
+                .filter(
+                  (assistant) =>
+                    profile && canEditAssistant(assistant, profile.id, profile.workspaces || [])
+                )
                 .filter(filterWithSearch)
                 .slice()
                 .sort((a, b) => -a.updatedAt.localeCompare(b.updatedAt))

--- a/logicle/app/chat/assistants/select/page.tsx
+++ b/logicle/app/chat/assistants/select/page.tsx
@@ -12,12 +12,9 @@ import { SearchBarWithButtonsOnRight } from '@/components/app/SearchBarWithButto
 import * as dto from '@/types/dto'
 import { Badge } from '@/components/ui/badge'
 import { AssistantAvatar } from '@/components/app/Avatars'
+import { isSharedWithAllOrAnyWorkspace } from '@/types/dto'
 
 const EMPTY_ASSISTANT_NAME = ''
-
-const isWorkspaceVisible = (profile: dto.UserProfile, workspaceId: string) => {
-  return profile.workspaces?.find((w) => w.id == workspaceId)
-}
 
 const SelectAssistantPage = () => {
   const { setNewChatAssistantId } = useContext(ChatPageContext)
@@ -35,16 +32,8 @@ const SelectAssistantPage = () => {
   const isAssistantAvailable = (assistant: dto.UserAssistant) => {
     if (assistant.name == EMPTY_ASSISTANT_NAME) return false
     if (assistant.owner == profile?.id) return true
-    for (const sharing of assistant.sharing) {
-      if (sharing.type == 'all') return true
-      if (
-        sharing.type == 'workspace' &&
-        profile &&
-        isWorkspaceVisible(profile, sharing.workspaceId)
-      )
-        return true
-    }
-    return false
+    const workspaceIds = profile?.workspaces?.map((w) => w.id) || []
+    return isSharedWithAllOrAnyWorkspace(assistant.sharing, workspaceIds)
   }
 
   const searchTermLowerCase = searchTerm.toLocaleLowerCase()

--- a/logicle/app/chat/components/Chatbar.tsx
+++ b/logicle/app/chat/components/Chatbar.tsx
@@ -15,6 +15,7 @@ import { AssistantAvatar } from '@/components/app/Avatars'
 import { CreateFolderDialog } from './CreateFolderDialog'
 import { ChatFolder } from './ChatFolder'
 import { useEnvironment } from '@/app/context/environmentProvider'
+import { isSharedWithAllOrAnyWorkspace } from '@/types/dto'
 
 export const Chatbar = () => {
   const { t } = useTranslation()
@@ -31,17 +32,11 @@ export const Chatbar = () => {
   const environment = useEnvironment()
   const userProfile = useUserProfile()
 
-  const isWorkspaceVisible = (workspaceId: string) => {
-    return userProfile?.workspaces?.find((w) => w.id == workspaceId)
-  }
-
+  const userWorkspaceIds = userProfile?.workspaces?.map((w) => w.id) ?? []
   const pinnedAssistants = (userProfile?.pinnedAssistants ?? []).filter((assistant) => {
-    return (
-      assistant.owner == userProfile?.id ||
-      assistant.sharing.find(
-        (s) => s.type == 'all' || (s.type == 'workspace' && isWorkspaceVisible(s.workspaceId))
-      )
-    )
+    // Why am I filtering here? I don't quite remember, but possibly I wanted to
+    // avoid that if an assistant was un-shared, users who had pinned it would not see it
+    return isSharedWithAllOrAnyWorkspace(assistant.sharing, userWorkspaceIds)
   })
 
   let { data: conversations } = useSWRJson<dto.ConversationWithFolder[]>(`/api/conversations`)

--- a/logicle/components/ui/actionlist.tsx
+++ b/logicle/components/ui/actionlist.tsx
@@ -15,11 +15,13 @@ export interface ActionProps {
   text: string
   disabled?: boolean
   destructive?: boolean
+  visible?: boolean
 }
 
 export const Action = (props: ActionProps) => {
   return (
     <DropdownMenuButton
+      visible={props.visible}
       disabled={props.disabled}
       icon={props.icon}
       onClick={props.onClick}
@@ -32,7 +34,7 @@ export const Action = (props: ActionProps) => {
 }
 
 export interface ActionListProps {
-  children?: ReactElement<typeof Action>[] | ReactElement<typeof Action>
+  children?: ReactElement<typeof Action | any>[] | ReactElement<typeof Action | false>
 }
 
 export const ActionList = ({ children }: ActionListProps) => {

--- a/logicle/components/ui/dropdown-menu.tsx
+++ b/logicle/components/ui/dropdown-menu.tsx
@@ -52,12 +52,14 @@ export interface DropdownMenuButtonProps {
   variant?: VariantProps<typeof menuItemVariants>['variant']
   disabled?: boolean
   checked?: boolean
+  visible?: boolean
 }
 
 const DropdownMenuButton = ({
   icon,
   onClick,
   disabled,
+  visible,
   variant,
   checked,
   children,
@@ -66,7 +68,7 @@ const DropdownMenuButton = ({
   return (
     <DropdownMenuPrimitive.Item
       disabled={disabled}
-      className={cn(menuItemVariants({ variant }))}
+      className={`${cn(menuItemVariants({ variant }))} ${visible === false ? 'hidden' : ''}`}
       onClick={onClick}
     >
       {Icon && <Icon />}

--- a/logicle/lib/rbac.ts
+++ b/logicle/lib/rbac.ts
@@ -7,19 +7,20 @@ import * as dto from '@/types/dto'
  * @returns whether the user can edit the assistant
  */
 export const canEditAssistant = (
-  assistant: dto.UserAssistant,
-  profile: dto.UserProfile | undefined
+  assistant: { owner: string; sharing: dto.Sharing[] },
+  userId: string,
+  workspaceMemberships: dto.WorkspaceMembership[]
 ) => {
   // A user can edit the assistant if:
   // - he is the owner
   // - he has the WorkspaceRole Editor role in the same workspace where the assistant has been shared
   //   (if the assistant has been shared to all it is editable only by the owner)
-  if (assistant.owner == profile?.id) return true
+  if (assistant.owner == userId) return true
 
   return assistant.sharing.some((s) => {
     if (dto.isAllSharingType(s)) return false
 
-    return profile?.workspaces.some((w) => {
+    return workspaceMemberships.some((w) => {
       return (
         w.id == s.workspaceId &&
         (w.role == WorkspaceRole.EDITOR ||

--- a/logicle/lib/rbac.ts
+++ b/logicle/lib/rbac.ts
@@ -1,0 +1,41 @@
+import { WorkspaceRole } from '@/types/workspace'
+import * as dto from '@/types/dto'
+
+/**
+ * @param assistant
+ * @param profile the user profile
+ * @returns whether the user can edit the assistant
+ */
+export const canEditAssistant = (
+  assistant: dto.UserAssistant,
+  profile: dto.UserProfile | undefined
+) => {
+  // A user can edit the assistant if:
+  // - he is the owner
+  // - he has the WorkspaceRole Editor role in the same workspace where the assistant has been shared
+  //   (if the assistant has been shared to all it is editable only by the owner)
+  if (assistant.owner == profile?.id) return true
+
+  return assistant.sharing.some((s) => {
+    if (dto.isAllSharingType(s)) return false
+
+    return profile?.workspaces.some((w) => {
+      return (
+        w.id == s.workspaceId &&
+        (w.role == WorkspaceRole.EDITOR ||
+          w.role == WorkspaceRole.OWNER ||
+          w.role == WorkspaceRole.ADMIN)
+      )
+    })
+  })
+}
+
+export const canDeleteAssistant = (
+  assistant: dto.UserAssistant,
+  profile: dto.UserProfile | undefined
+) => {
+  // A user can delete the assistant if:
+  // - he is the owner
+  // - he is an admin
+  return assistant.owner == profile?.id || profile?.role == 'ADMIN'
+}

--- a/logicle/models/assistant.ts
+++ b/logicle/models/assistant.ts
@@ -135,6 +135,7 @@ export const getUserAssistants = async ({
       tags: JSON.parse(assistant.tags),
       prompts: JSON.parse(assistant.prompts),
       ownerName: assistant.ownerName ?? '',
+      cloneable: !assistant.provisioned,
     }
   })
 }

--- a/logicle/types/dto.ts
+++ b/logicle/types/dto.ts
@@ -63,6 +63,7 @@ export interface UserAssistant extends AssistantIdentification {
   sharing: Sharing[]
   createdAt: string
   updatedAt: string
+  cloneable: boolean
 }
 
 export interface UserAssistantWithSupportedMedia extends UserAssistant {

--- a/logicle/types/dto/sharing.ts
+++ b/logicle/types/dto/sharing.ts
@@ -11,6 +11,16 @@ interface WorkspaceSharingType {
 export type Sharing = AllSharingType | WorkspaceSharingType
 export type InsertableSharing = AllSharingType | Omit<WorkspaceSharingType, 'workspaceName'>
 
-export function isAllSharingType(sharing: AllSharingType | WorkspaceSharingType): sharing is AllSharingType {
-  return sharing.type == 'all';
+export function isAllSharingType(
+  sharing: AllSharingType | WorkspaceSharingType
+): sharing is AllSharingType {
+  return sharing.type == 'all'
+}
+
+export function isSharedWithAllOrAnyWorkspace(sharingList: Sharing[], workspaceIds: string[]) {
+  return sharingList.find(
+    (sharing) =>
+      sharing.type == 'all' ||
+      (sharing.type == 'workspace' && workspaceIds.includes(sharing.workspaceId))
+  )
 }


### PR DESCRIPTION
Duplication is available in the assistant context menu:

![image](https://github.com/user-attachments/assets/0511eefa-561e-4292-a439-746f4e5723aa)

or in the "My assistants" page

![image](https://github.com/user-attachments/assets/b9852934-a89b-449e-8db7-ad2d95ef12f6)


In order to be able to clone a (non provisioned) assistant, the user must have access to the assistant under any of these conditions:

* The assistant is owned by the user
* The assistant is shared with all
* The assistant is shared with a workspace of which the user is member (or editor, or admin)