### PR TITLE
Fix image tool schema declaration

### DIFF
--- a/logicle/lib/tools/dall-e/implementation.ts
+++ b/logicle/lib/tools/dall-e/implementation.ts
@@ -73,7 +73,7 @@ export class Dall_ePlugin extends Dall_ePluginInterface implements ToolImplement
             },
           },
           additionalProperties: false,
-          required: ['prompt', 'imageId'],
+          required: ['prompt', 'fileId'],
         },
         invoke: this.invokeEdit.bind(this),
       }


### PR DESCRIPTION
The schema declaration was wrong! the property was 'fileId', but the required field indicated 'imageId'

Weirdly enough, only gemini was noticing it
