### PR TITLE
Fix pinned assistant visibility

### DIFF
--- a/logicle/app/chat/components/Chatbar.tsx
+++ b/logicle/app/chat/components/Chatbar.tsx
@@ -36,7 +36,10 @@ export const Chatbar = () => {
   const pinnedAssistants = (userProfile?.pinnedAssistants ?? []).filter((assistant) => {
     // Why am I filtering here? I don't quite remember, but possibly I wanted to
     // avoid that if an assistant was un-shared, users who had pinned it would not see it
-    return isSharedWithAllOrAnyWorkspace(assistant.sharing, userWorkspaceIds)
+    return (
+      assistant.owner == userProfile?.id ||
+      isSharedWithAllOrAnyWorkspace(assistant.sharing, userWorkspaceIds)
+    )
   })
 
   let { data: conversations } = useSWRJson<dto.ConversationWithFolder[]>(`/api/conversations`)


### PR DESCRIPTION
The super-zealuous check "is this pinned assistant assistant really available" was badly broken, and owner assistants (!) were not taken into account
