### PR TITLE
Generate summaries in the language set in User preferences

### DIFF
--- a/logicle/app/api/chat/route.ts
+++ b/logicle/app/api/chat/route.ts
@@ -74,6 +74,7 @@ class MessageAuditor {
 
 export const POST = requireSession(async (session, req) => {
   const userMessage = (await req.json()) as dto.Message
+  const acceptLanguageHeader = req.headers.get('Accept-Language')
 
   const conversationWithBackendAssistant = await getConversationWithBackendAssistant(
     userMessage.conversationId
@@ -128,6 +129,7 @@ export const POST = requireSession(async (session, req) => {
       saveMessage: saveAndAuditMessage,
       updateChatTitle,
       user: session.userId,
+      userLanguage: acceptLanguageHeader ?? undefined,
     }
   )
 

--- a/logicle/app/assistants/components/AssistantPreview.tsx
+++ b/logicle/app/assistants/components/AssistantPreview.tsx
@@ -76,6 +76,7 @@ export const AssistantPreview = ({ assistant, className, sendDisabled }: Props) 
 
     await fetchChatResponse(
       '/api/assistants/evaluate',
+      {},
       JSON.stringify({
         assistant: assistant,
         messages: flatten([...conversation.messages, userMessage]),

--- a/logicle/app/chat/components/ChatPageContextProvider.tsx
+++ b/logicle/app/chat/components/ChatPageContextProvider.tsx
@@ -32,7 +32,7 @@ export const ChatPageContextProvider: FC<Props> = ({ initialState, children }) =
 
   const nonStateSelectedConversation = useRef<string | undefined>()
   const runningChats = useRef<Map<string, RunningChatState>>(new Map<string, RunningChatState>())
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   // Memoized function to prevent re-renders
   const setNewChatAssistantId = useCallback(
@@ -118,6 +118,7 @@ export const ChatPageContextProvider: FC<Props> = ({ initialState, children }) =
       })
       await fetchChatResponse(
         '/api/chat',
+        { 'Accept-Language': `${i18n.language};q=1.0, en;q=0.8, *;q=0.5` },
         JSON.stringify(userMessage),
         conversation,
         userMessage,

--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -157,6 +157,7 @@ interface AssistantParams {
 interface Options {
   saveMessage?: (message: dto.Message, usage?: Usage) => Promise<void>
   updateChatTitle?: (conversationId: string, title: string) => Promise<void>
+  userLanguage?: string
   user?: string
   debug?: boolean
 }
@@ -722,8 +723,7 @@ export class ChatAssistant {
     const messages: ai.CoreMessage[] = [
       {
         role: 'system',
-        content:
-          'The user will provide a chat in JSON format. Reply with a title, at most three words, in the same language of the conversation. Be very concise: no apices, nor preamble',
+        content: `The user will provide a chat in JSON format. Reply with a title, at most three words. The user preferred language for the title is "${this.options.userLanguage}". If this preference is not valid, you may use the same language of the messages of the conversion. Be very concise: no apices, nor preamble`,
       },
       {
         role: 'user',

--- a/logicle/services/chat.ts
+++ b/logicle/services/chat.ts
@@ -18,6 +18,7 @@ class BackendError extends Error {}
 
 export const fetchChatResponse = async (
   location: string,
+  headers: Record<string, string>,
   body: string,
   conversation: ConversationWithMessages,
   userMsg: dto.Message,
@@ -37,6 +38,7 @@ export const fetchChatResponse = async (
     await fetchEventSource(location, {
       method: 'POST',
       headers: {
+        ...headers,
         'Content-Type': 'application/json',
       },
       signal: abortController.signal,


### PR DESCRIPTION
This PR:
* Derive the language for summary generation from Accept-Language header, if available
* Derive Accept-Language header from User preferences