### PR TITLE
Improve "new chat" ux

### DIFF
--- a/logicle/app/chat/layout.tsx
+++ b/logicle/app/chat/layout.tsx
@@ -1,15 +1,6 @@
-import { ChatPageContextProvider } from '@/app/chat/components/ChatPageContextProvider'
-import { ChatPageState, defaultChatPageState } from '@/app/chat/components/state'
 import { MainLayout } from '../layouts/MainLayout'
 import { Chatbar } from './components/Chatbar'
 
 export default function ChatLayout({ children }) {
-  const initialState: ChatPageState = {
-    ...defaultChatPageState,
-  }
-  return (
-    <ChatPageContextProvider initialState={initialState}>
-      <MainLayout leftBar={<Chatbar />}>{children}</MainLayout>
-    </ChatPageContextProvider>
-  )
+  return <MainLayout leftBar={<Chatbar />}>{children}</MainLayout>
 }

--- a/logicle/app/layout.tsx
+++ b/logicle/app/layout.tsx
@@ -11,6 +11,8 @@ import { Environment, EnvironmentProvider } from './context/environmentProvider'
 import env from '@/lib/env'
 import UserProfileProvider from '@/components/providers/userProfileContext'
 import { ActiveWorkspaceProvider } from '@/components/providers/activeWorkspaceContext'
+import { ChatPageState, defaultChatPageState } from './chat/components/state'
+import { ChatPageContextProvider } from './chat/components/ChatPageContextProvider'
 
 const openSans = Red_Hat_Display({
   subsets: ['latin'],
@@ -46,6 +48,10 @@ export default async function RootLayout({
     enableApiKeys: env.apiKeys.enable,
     appUrl: env.appUrl,
   }
+  const initialState: ChatPageState = {
+    ...defaultChatPageState,
+  }
+
   return (
     <html className={openSans.className} translate="no">
       <head>
@@ -59,7 +65,11 @@ export default async function RootLayout({
               <ClientI18nProvider>
                 <EnvironmentProvider value={environment}>
                   <ClientSessionProvider session={session}>
-                    <ActiveWorkspaceProvider>{children}</ActiveWorkspaceProvider>
+                    <ActiveWorkspaceProvider>
+                      <ChatPageContextProvider initialState={initialState}>
+                        {children}
+                      </ChatPageContextProvider>
+                    </ActiveWorkspaceProvider>
                   </ClientSessionProvider>
                 </EnvironmentProvider>
               </ClientI18nProvider>


### PR DESCRIPTION
Trying to improve the app usability.
The chat state has been moved to app level, in order to avoid to end up in assistant "explore" every time the user navigates to administration (the state contains the id of the assistant for the new chat, and the default is null!)
Moreover, the Chat state is initialized with the most recently used assistant

 