### PR TITLE
Reasonable fallbacks for "last used assistant"

### DIFF
--- a/logicle/models/conversation.ts
+++ b/logicle/models/conversation.ts
@@ -120,6 +120,18 @@ export const getConversations = async (ownerId: string) => {
     .execute()
 }
 
+export const getMostRecentConversation = async (ownerId: string) => {
+  return await db
+    .selectFrom('Conversation')
+    .selectAll()
+    .where('lastMsgSentAt', 'is not', null)
+    .where('ownerId', '=', ownerId)
+    .orderBy('lastMsgSentAt', 'desc')
+    .limit(1)
+    .select('assistantId')
+    .executeTakeFirst()
+}
+
 export const getConversationsWithFolder = async (ownerId: string, limit?: number) => {
   let query = db
     .selectFrom('Conversation')


### PR DESCRIPTION
When there's no assistant with lastUsed data (we started saving this info only recently) going to the homepage, or /chat, causes a transition to assistant selection page, quite annoying...

So... I implemented a few ways of getting this info (first match win):

* Assistant of the conversation most recently updated
* First pinned assistant
* First assistant
