### PR TITLE
Let users be able to set "null" for model in image generation

### DIFF
--- a/logicle/app/admin/tools/components/ToolForm.tsx
+++ b/logicle/app/admin/tools/components/ToolForm.tsx
@@ -81,6 +81,9 @@ const ToolForm: FC<Props> = ({ type, tool, onSubmit }) => {
     for (const key of Object.keys(v)) {
       if (!form.formState.dirtyFields[key]) delete v[key]
     }
+    if (type == 'dall-e' && values.configuration['model'] === '') {
+      values.configuration['model'] = null
+    }
     onSubmit(v)
   }
 
@@ -202,12 +205,18 @@ const ToolForm: FC<Props> = ({ type, tool, onSubmit }) => {
             control={form.control}
             name="configuration.model"
             render={({ field }) => (
-              <FormItem label={t('model')}>
-                <Select onValueChange={(value) => field.onChange(value)} value={field.value}>
+              <FormItem label={t('default_model')}>
+                <Select
+                  onValueChange={(value) => field.onChange(value === '<null>' ? null : value)}
+                  value={field.value}
+                >
                   <SelectTrigger>
-                    <SelectValue />
+                    <SelectValue placeholder={t('default_')} />
                   </SelectTrigger>
                   <SelectContent>
+                    <SelectItem key={''} value={'<null>'}>
+                      {t('default_')}
+                    </SelectItem>
                     {Dall_eModels.map((m) => {
                       return (
                         <SelectItem key={m} value={m}>

--- a/logicle/lib/tools/dall-e/implementation.ts
+++ b/logicle/lib/tools/dall-e/implementation.ts
@@ -26,7 +26,7 @@ function get_response_format_parameter(model: Model | string) {
 export class Dall_ePlugin extends Dall_ePluginInterface implements ToolImplementation {
   static builder: ToolBuilder = (params: Record<string, unknown>, provisioned: boolean) =>
     new Dall_ePlugin(params as unknown as Dall_ePluginParams, provisioned) // TODO: need a better validation
-  defaultModel: Model
+  defaultModel: Model | string
   supportedMedia = []
   functions: Record<string, ToolFunction>
   constructor(

--- a/logicle/lib/tools/dall-e/interface.ts
+++ b/logicle/lib/tools/dall-e/interface.ts
@@ -6,12 +6,12 @@ export type Model = (typeof Dall_eModels)[number]
 
 export interface Dall_ePluginParams {
   apiKey: string
-  model?: Model
+  model?: Model | string
 }
 
 export const Dall_eSchema = z.object({
   apiKey: z.string(),
-  model: z.enum(Dall_eModels),
+  model: z.string().nullish(),
 })
 
 export class Dall_ePluginInterface {

--- a/logicle/locales/en/logicle.json
+++ b/logicle/locales/en/logicle.json
@@ -133,6 +133,7 @@
   "daily-usage": "Daily Usage",
   "dashboard": "Dashboard",
   "default_": "Default",
+  "default_model": "Default model",
   "default-redirect-url": "Default redirect URL",
   "delete-member-warning": "Deleting a member will delete all activites related to that member. This action cannot be undone.",
   "delete-sso-connection-confirmation": "Are you sure you want to delete this SSO Connection? This action can not be undone.",

--- a/logicle/locales/it/logicle.json
+++ b/logicle/locales/it/logicle.json
@@ -133,6 +133,7 @@
   "daily-usage": "Utilizzo Giornaliero",
   "dashboard": "Dashboard",
   "default_": "Predefinito",
+  "default_model": "Modello predefinito",
   "default-redirect-url": "URL di reindirizzamento predefinito",
   "delete-member-warning": "Eliminare un membro comporterà la cancellazione di tutte le attività correlate. Questa azione non può essere annullata.",
   "delete-sso-connection-confirmation": "Sei sicuro di voler eliminare questa connessione SSO? Questa azione non può essere annullata.",


### PR DESCRIPTION
Image generation tool is multi model. 
It must be like this, because we have assistants which take advantage of the "model".
But letting the AI decide introduces confusion and errors, so... having a default still makes sense.
The user can customize the default model, and also accept the system provided one.
The UX is not the best, especially when an "unknown" model is specified by the user (for example flux-x.y.z), but... we'll take care of this later.
