### PR TITLE
Branding

### DIFF
--- a/logicle/app/context/client-i18n-provider.tsx
+++ b/logicle/app/context/client-i18n-provider.tsx
@@ -5,15 +5,24 @@ import { useTranslation } from 'react-i18next'
 import { useEffect, useState } from 'react'
 import { useUserProfile } from '@/components/providers/userProfileContext'
 
-initi18n()
+let inited = false
 
 export default function ClientI18nProvider({
   children,
+  brand,
 }: {
   children: React.ReactNode
+  brand: Record<string, string>
 }): React.ReactNode {
+  if (!inited) {
+    initi18n(brand)
+    inited = true
+  }
+
   const userProfile = useUserProfile()
   const { i18n } = useTranslation()
+
+  console.log('ClientI18nProvider')
   // We don't want to wait for language load (i.e. show nothing) when
   // the user has changed the language
   const [waitForLanguageLoad, setWaitForLanguageLoad] = useState<boolean>(true)

--- a/logicle/app/context/client.ts
+++ b/logicle/app/context/client.ts
@@ -4,19 +4,23 @@ import i18next from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import resourcesToBackend from 'i18next-resources-to-backend'
 
-export function initi18n() {
+export function initi18n(brand?: Record<string, string>) {
   void i18next
     .use(initReactI18next)
     .use(
-      resourcesToBackend((language: string, namespace: string) => {
+      resourcesToBackend(async (language: string, namespace: string) => {
         if (namespace == 'all') {
-          return Promise.all([
-            import(`../../locales/${language}/logicle.json`),
-            import(`../../locales/${language}/tools.json`),
-          ]).then(([logicleModule, toolsModule]) => ({
-            ...logicleModule.default,
-            ...toolsModule.default,
-          }))
+          const logicle = (await import(`../../locales/${language}/logicle.json`))
+            .default as Record<string, string>
+          const tools = (await import(`../../locales/${language}/tools.json`)).default as Record<
+            string,
+            string
+          >
+          return {
+            ...logicle,
+            ...tools,
+            ...(brand || {}),
+          }
         } else {
           return import(`../../locales/${language}/${namespace}.json`)
         }

--- a/logicle/app/layout.tsx
+++ b/logicle/app/layout.tsx
@@ -29,18 +29,17 @@ export const metadata: Metadata = {
 
 const loadProvisionedStyles = async (dir: string) => {
   const children = fs.readdirSync(dir).sort()
-  return Promise.all(
-    children.map((child) => {
-      const childPath = path.resolve(dir, child)
-      return fs.promises.readFile(childPath, 'utf-8')
-    })
-  )
+  const readFile = async (name: string) => {
+    const childPath = path.resolve(dir, name)
+    return { name, content: await fs.promises.readFile(childPath, 'utf-8') }
+  }
+  return Promise.all(children.map((child) => readFile(child)))
 }
 
 const loadBrandI18n = async (dir: string) => {
   const childPath = path.resolve(dir, 'brand.json')
   try {
-    fs.promises.access(childPath)
+    await fs.promises.access(childPath)
   } catch {
     return {}
   }
@@ -77,8 +76,8 @@ export default async function RootLayout({
     <html className={openSans.className} translate="no">
       <head>
         <meta name="google" content="notranslate" />
-        {styles.map((css) => {
-          return <style dangerouslySetInnerHTML={{ __html: css }}></style>
+        {styles.map((s) => {
+          return <style key={s.name} dangerouslySetInnerHTML={{ __html: s.content }}></style>
         })}
       </head>
       <body className="overflow-hidden h-full">

--- a/logicle/app/layout.tsx
+++ b/logicle/app/layout.tsx
@@ -37,6 +37,16 @@ const loadProvisionedStyles = async (dir: string) => {
   )
 }
 
+const loadBrandI18n = async (dir: string) => {
+  const childPath = path.resolve(dir, 'brand.json')
+  try {
+    fs.promises.access(childPath)
+  } catch {
+    return {}
+  }
+  return JSON.parse(await fs.promises.readFile(childPath, 'utf-8'))
+}
+
 export default async function RootLayout({
   // Layouts must accept a children prop.
   // This will be populated with nested layouts or pages
@@ -62,7 +72,7 @@ export default async function RootLayout({
 
   console.log('Loading css')
   const styles = env.provision.brand ? await loadProvisionedStyles(env.provision.brand) : []
-
+  const brand = env.provision.brand ? await loadBrandI18n(env.provision.brand) : {}
   return (
     <html className={openSans.className} translate="no">
       <head>
@@ -76,7 +86,7 @@ export default async function RootLayout({
           <ConfirmationModalContextProvider>
             <Toaster toastOptions={{ duration: 4000 }} />
             <UserProfileProvider>
-              <ClientI18nProvider>
+              <ClientI18nProvider brand={brand}>
                 <EnvironmentProvider value={environment}>
                   <ClientSessionProvider session={session}>
                     <ActiveWorkspaceProvider>

--- a/logicle/app/layout.tsx
+++ b/logicle/app/layout.tsx
@@ -11,8 +11,9 @@ import { Environment, EnvironmentProvider } from './context/environmentProvider'
 import env from '@/lib/env'
 import UserProfileProvider from '@/components/providers/userProfileContext'
 import { ActiveWorkspaceProvider } from '@/components/providers/activeWorkspaceContext'
-import { ChatPageState, defaultChatPageState } from './chat/components/state'
 import { ChatPageContextProvider } from './chat/components/ChatPageContextProvider'
+import * as fs from 'fs'
+import * as path from 'path'
 
 const openSans = Red_Hat_Display({
   subsets: ['latin'],
@@ -24,6 +25,16 @@ export const metadata: Metadata = {
     template: '%s • Logicle',
     default: 'Logicle',
   },
+}
+
+const loadProvisionedStyles = async (dir: string) => {
+  const children = fs.readdirSync(dir).sort()
+  return Promise.all(
+    children.map((child) => {
+      const childPath = path.resolve(dir, child)
+      return fs.promises.readFile(childPath, 'utf-8')
+    })
+  )
 }
 
 export default async function RootLayout({
@@ -49,10 +60,16 @@ export default async function RootLayout({
     appUrl: env.appUrl,
   }
 
+  console.log('Loading css')
+  const styles = env.provision.brand ? await loadProvisionedStyles(env.provision.brand) : []
+
   return (
     <html className={openSans.className} translate="no">
       <head>
         <meta name="google" content="notranslate" />
+        {styles.map((css) => {
+          return <style dangerouslySetInnerHTML={{ __html: css }}></style>
+        })}
       </head>
       <body className="overflow-hidden h-full">
         <ThemeProvider>

--- a/logicle/lib/env.ts
+++ b/logicle/lib/env.ts
@@ -97,6 +97,7 @@ const env = {
   },
   provision: {
     source: process.env.PROVISION_PATH,
+    brand: process.env.PROVISION_BRAND_PATH,
   },
   fileStorage: {
     location: process.env.FILE_STORAGE_LOCATION,

--- a/logicle/lib/env.ts
+++ b/logicle/lib/env.ts
@@ -96,7 +96,7 @@ const env = {
     },
   },
   provision: {
-    source: process.env.PROVISION_PATH,
+    config: process.env.PROVISION_PATH,
     brand: process.env.PROVISION_BRAND_PATH,
   },
   fileStorage: {

--- a/logicle/lib/provision.ts
+++ b/logicle/lib/provision.ts
@@ -43,7 +43,7 @@ interface Provision {
 }
 
 export async function provision() {
-  const provisionPath = env.provision.source
+  const provisionPath = env.provision.config
   if (!provisionPath) return
   if (!fs.existsSync(provisionPath)) {
     throw new Error(`No provisioning file at ${provisionPath}`)

--- a/logicle/models/images.ts
+++ b/logicle/models/images.ts
@@ -12,13 +12,12 @@ export const getImage = async (imageId: string): Promise<schema.Image> => {
 }
 
 export const existsImage = async (imageId: string): Promise<Boolean> => {
-  const result = await db
+  const aa = await db
     .selectFrom('Image')
-    .select((eb) =>
-      eb.exists(db.selectFrom('Image').select('id').where('Image.id', '=', imageId)).as('exists')
-    )
-    .executeTakeFirstOrThrow()
-  return !!result.exists
+    .select('Image.id')
+    .where('Image.id', '=', imageId)
+    .executeTakeFirst()
+  return aa != undefined
 }
 
 async function nanoIdFromHash(input: string, size = 21) {


### PR DESCRIPTION
This PR adds support for externally provided branding files, say... css / i18n

Define a provision brand path in environment (or .env). For example...

`PROVISION_BRAND_PATH=/home/luca/logicle-provision/brand`

And in the branding directori:

.css files will be injected in the resulting html
brand.json will be injected in i18n

