### PR TITLE
Prevent mysterious activity in Assistant form

### DIFF
--- a/logicle/app/assistants/components/AssistantForm.tsx
+++ b/logicle/app/assistants/components/AssistantForm.tsx
@@ -132,6 +132,7 @@ export const ToolsTabPanel = ({ form, visible, className }: ToolsTabPanelProps) 
                   <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
                     <CardTitle>{t('tools')}</CardTitle>
                     <Button
+                      type="button"
                       onClick={(evt) => {
                         setAddToolsDialogVisible(true)
                         evt.preventDefault()
@@ -656,6 +657,9 @@ export const AssistantForm = ({ assistant, onSubmit, onChange, onValidate, fireS
                             form.setValue('tags', [...field.value, value])
                             element.value = ''
                           }
+                          // If we don't invoke preventDefault() upstream components
+                          // may do weird things (like submitting forms...)
+                          e.preventDefault()
                         }
                       }}
                     ></Input>

--- a/logicle/components/ui/ImageUpload.tsx
+++ b/logicle/components/ui/ImageUpload.tsx
@@ -68,6 +68,7 @@ const ImageUpload = (props: Props) => {
           onChange={(e) => handleImageChange(e)}
         />
         <Button
+          type="button"
           variant="destructive_link"
           size="link"
           className={`uppercase ${(image ?? '') != '' ? 'visible' : 'invisible'}`}

--- a/logicle/components/ui/stringlist.tsx
+++ b/logicle/components/ui/stringlist.tsx
@@ -36,8 +36,14 @@ export const StringList = ({ value, onChange, addNewPlaceHolder, maxItems }: Str
                 copy[index] = element.value
                 onChange(copy)
               }}
+              onKeyDown={(evt) => {
+                if (evt.key === 'Enter') {
+                  evt.preventDefault()
+                }
+              }}
             ></Input>
             <Button
+              type="button"
               variant="secondary"
               onClick={(evt) => {
                 evt.preventDefault()


### PR DESCRIPTION
Not that mysterious, as a matter of fact...
Forms love submitting the form when user hits enter, unless... the default is not prevented.
Even worse, if there is no submit button... any simple innocent button is a candidate for "click on enter".
Recipe for disaster.
This PR tries to reduce