### PR TITLE
Save chat input in local storage

### DIFF
--- a/logicle/app/chat/components/Chat.tsx
+++ b/logicle/app/chat/components/Chat.tsx
@@ -8,6 +8,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { IconArrowDown } from '@tabler/icons-react'
 import * as dto from '@/types/dto'
 import { ChatMessage } from './ChatMessage'
+import { useChatInput } from '@/components/providers/localstoragechatstate'
 
 export interface ChatProps {
   assistant: dto.AssistantIdentification
@@ -21,7 +22,7 @@ export const Chat = ({ assistant, className, supportedMedia }: ChatProps) => {
     sendMessage,
   } = useContext(ChatPageContext)
 
-  const [chatInput, setChatInput] = useState<string>('')
+  const [chatInput, setChatInput] = useChatInput(selectedConversation?.id ?? '')
   const [autoScrollEnabled, setAutoScrollEnabled] = useState<boolean>(true)
   const [showScrollDownButton, setShowScrollDownButton] = useState<boolean>(false)
 

--- a/logicle/app/chat/page.tsx
+++ b/logicle/app/chat/page.tsx
@@ -14,6 +14,7 @@ import { StartChatFromHere } from './components/StartChatFromHere'
 import * as dto from '@/types/dto'
 import { useEnvironment } from '../context/environmentProvider'
 import { useTranslation } from 'react-i18next'
+import { useChatInput } from '@/components/providers/localstoragechatstate'
 
 const deriveChatTitle = (msg: string) => {
   return msg.length > 30 ? msg.substring(0, 30) + '...' : msg
@@ -27,7 +28,8 @@ const StartChat = () => {
     setSelectedConversation,
   } = useContext(ChatPageContext)
 
-  const [chatInput, setChatInput] = useState<string>('')
+  const [chatInput, setChatInput] = useChatInput('new-chat')
+
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 
   // In order to start the chat faster, and avoid race conditions, we set the
@@ -44,6 +46,8 @@ const StartChat = () => {
       setSelectedConversation(undefined)
     }
   }, [started, selectedConversation, setSelectedConversation])
+
+  useEffect(() => {})
 
   const { data: session } = useSession()
 

--- a/logicle/components/providers/localstoragechatstate.tsx
+++ b/logicle/components/providers/localstoragechatstate.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+
+interface ChatState {
+  version: number
+  input: string
+}
+
+type ChatsState = Record<string, ChatState>
+
+export const useChatInput = (id: string): [string, (input: string) => void] => {
+  const [chatState, setChatState] = useState<ChatsState>(() => {
+    return JSON.parse(localStorage.getItem(`chats`) || '{}')
+  })
+  const chatInput = chatState[id]?.input || ''
+  const setChatInput = (input: string) => {
+    // reparse, just in case... other contexts have updated localstorage
+    const chats = JSON.parse(localStorage.getItem(`chats`) || '{}')
+    chats[id] = {
+      ...chats[id],
+      input,
+    }
+    localStorage.setItem('chats', JSON.stringify(chats))
+    setChatState(chats)
+  }
+  return [chatInput, setChatInput]
+}


### PR DESCRIPTION
In a previous PR we moved chat input from the global chat state to lower level components, in order to avoid re-rendering more than needed.
This is defintely too much, as losing input text is very annoying.
So...  chat input, and possibly other stuff, is now stored in localstorage *per conversation*
One possible drawback, is that the same state is consumed in different places, modification won't be reflected everywhere.
But.. for the moment... the solution is simply... good enough

