### PR TITLE
Store assistant ordering in assistant select in browser state

### DIFF
--- a/logicle/app/chat/assistants/select/page.tsx
+++ b/logicle/app/chat/assistants/select/page.tsx
@@ -20,6 +20,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { IconArrowNarrowDown, IconCalendar, IconClock, IconSortAZ } from '@tabler/icons-react'
+import { useUiState } from '@/components/providers/uistate'
 
 const EMPTY_ASSISTANT_NAME = ''
 
@@ -33,7 +34,7 @@ const SelectAssistantPage = () => {
   const profile = useUserProfile()
   const [searchTerm, setSearchTerm] = useState<string>('')
   const [tagsFilter, setTagsFilter] = useState<string | null>(null)
-  const [ordering, setOrdering] = useState<Ordering>('lastused')
+  const [ordering, setOrdering] = useUiState<Ordering>('assistants_select_ordering', 'lastused')
 
   const {
     data: assistants,

--- a/logicle/components/providers/uistate.tsx
+++ b/logicle/components/providers/uistate.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import { useUserProfile } from './userProfileContext'
+
+type UIProps = Record<string, unknown>
+
+const parseUIState = (key: string): UIProps => {
+  const data = localStorage.getItem(key)
+  try {
+    if (data) {
+      return JSON.parse(data)
+    }
+  } catch {
+    console.log('Failed parsing cache storage')
+  }
+  return {}
+}
+
+export function useUiState<T = string>(propName: string, defaultValue: T): [T, (input: T) => void] {
+  const profile = useUserProfile()
+  const key = `ui/${profile?.id || ''}`
+  const [uiProps, setUiProps] = useState<UIProps>(() => parseUIState(key))
+  const propValue = (uiProps[propName] ?? defaultValue) as T
+  const setPropValue = (value: T) => {
+    const uiState = parseUIState(key)
+    uiState[propName] = value
+    localStorage.setItem(key, JSON.stringify(uiState))
+    setUiProps(uiState)
+  }
+  return [propValue, setPropValue]
+}


### PR DESCRIPTION
Assistant orderingm, in assistant select page, is now stored in browser state.

The feature is based on useUiState, a super simple drop-in replacement for useState which stores status in browser local storage
