### PR TITLE
Cleaner assistant tools editing APIs

### DIFF
--- a/logicle/app/api/assistants/[assistantId]/clone/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/clone/route.ts
@@ -1,7 +1,7 @@
 import {
   assistantVersionFiles,
   assistantSharingData,
-  assistantVersionToolsEnablement,
+  assistantVersionEnabledTools,
   createAssistant,
   getAssistant,
   getAssistantVersion,
@@ -44,7 +44,7 @@ export const POST = requireSession(
       ...assistantVersion,
       name: 'Copy of' + ' ' + assistantVersion.name,
       iconUri: assistantVersion.imageId ? await getImageAsDataUri(assistantVersion.imageId) : null,
-      tools: await assistantVersionToolsEnablement(assistantVersion.id),
+      tools: await assistantVersionEnabledTools(assistantVersion.id),
       files: await assistantVersionFiles(assistantVersion.id),
       prompts: JSON.parse(assistantVersion.prompts),
       tags: JSON.parse(assistantVersion.tags),

--- a/logicle/app/api/assistants/[assistantId]/route.ts
+++ b/logicle/app/api/assistants/[assistantId]/route.ts
@@ -1,7 +1,7 @@
 import {
   assistantVersionFiles,
   assistantSharingData,
-  assistantVersionToolsEnablement,
+  assistantVersionEnabledTools,
   deleteAssistant,
   getAssistant,
   getAssistantVersion,
@@ -49,7 +49,7 @@ export const GET = requireSession(
       owner: assistant.owner,
       provisioned: assistant.provisioned,
       iconUri: assistantVersion.imageId ? `/api/images/${assistantVersion.imageId}` : null,
-      tools: await assistantVersionToolsEnablement(assistantVersion.id),
+      tools: await assistantVersionEnabledTools(assistantVersion.id),
       files: await assistantVersionFiles(assistantVersion.id),
       sharing: sharingData,
       tags: JSON.parse(assistantVersion.tags),

--- a/logicle/app/api/assistants/evaluate/route.ts
+++ b/logicle/app/api/assistants/evaluate/route.ts
@@ -20,8 +20,7 @@ export const POST = requireSession(async (session: SimpleSession, req: Request) 
     return ApiResponses.invalidParameter('No backend')
   }
 
-  const enabledToolIds = assistant.tools.filter((a) => a.enabled).map((a) => a.id)
-  const availableTools = await availableToolsFiltered(enabledToolIds)
+  const availableTools = await availableToolsFiltered(assistant.tools)
 
   const provider = await ChatAssistant.build(
     backend,

--- a/logicle/app/api/user/tools/route.ts
+++ b/logicle/app/api/user/tools/route.ts
@@ -1,0 +1,20 @@
+import { createPrompt, getPrompts } from '@/models/prompt'
+import ApiResponses from '@/api/utils/ApiResponses'
+import * as dto from '@/types/dto'
+import { requireSession } from '../../utils/auth'
+import { getTools } from '@/models/tool'
+
+export const dynamic = 'force-dynamic'
+
+// Fetch prompts
+export const GET = requireSession(async (session) => {
+  const tools = (await getTools()).map((t) => {
+    return {
+      id: t.id,
+      name: t.name,
+      provisioned: t.provisioned,
+      capability: t.capability,
+    }
+  })
+  return ApiResponses.json(tools)
+})

--- a/logicle/app/assistants/[id]/page.tsx
+++ b/logicle/app/assistants/[id]/page.tsx
@@ -15,6 +15,7 @@ import { IconArrowLeft } from '@tabler/icons-react'
 import { AssistantPublishDialog } from '../components/AssistantPublishDialog'
 import { useUserProfile } from '@/components/providers/userProfileContext'
 import { RotatingLines } from 'react-loader-spinner'
+import { useSWRJson } from '@/hooks/swr'
 
 interface State {
   assistant?: dto.AssistantDraft
@@ -42,7 +43,7 @@ const AssistantPage = () => {
   const userProfile = useUserProfile()
   const saveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [saving, setSaving] = useState(false)
-
+  const { data: tools } = useSWRJson('/api/user/tools')
   useEffect(() => {
     const doLoad = async () => {
       const response = await get<dto.AssistantDraft>(assistantUrl)

--- a/logicle/app/assistants/components/AssistantForm.tsx
+++ b/logicle/app/assistants/components/AssistantForm.tsx
@@ -84,9 +84,9 @@ interface ToolsTabPanelProps {
 export const ToolsTabPanel = ({ form, visible, className }: ToolsTabPanelProps) => {
   const { t } = useTranslation()
   const [isAddToolsDialogVisible, setAddToolsDialogVisible] = useState(false)
-  const { data: tools_ } = useSWRJson<dto.AssistantTool[]>('/api/user/tools')
-  const capabilities = tools_?.filter((t) => t.capability) || []
-  const tools = tools_?.filter((t) => !t.capability) || []
+  const { data: allTools } = useSWRJson<dto.AssistantTool[]>('/api/user/tools')
+  const allCapabilities = allTools?.filter((t) => t.capability) || []
+  const allNonCapabilities = allTools?.filter((t) => !t.capability) || []
   return (
     <>
       <ScrollArea className={`${className}`} style={{ display: visible ? undefined : 'none' }}>
@@ -96,13 +96,13 @@ export const ToolsTabPanel = ({ form, visible, className }: ToolsTabPanelProps) 
             name="tools"
             render={({ field }) => (
               <>
-                <Card style={{ display: capabilities.length != 0 ? undefined : 'none' }}>
+                <Card style={{ display: allCapabilities.length != 0 ? undefined : 'none' }}>
                   <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
                     <CardTitle>{t('capabilities')}</CardTitle>
                   </CardHeader>
                   <CardContent>
                     <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-4">
-                      {capabilities.map((capability) => {
+                      {allCapabilities.map((capability) => {
                         return (
                           <div
                             key={capability.id}
@@ -142,7 +142,7 @@ export const ToolsTabPanel = ({ form, visible, className }: ToolsTabPanelProps) 
                   <CardContent>
                     <div className="flex"></div>
                     <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-4">
-                      {tools
+                      {allNonCapabilities
                         .filter((t) => field.value.includes(t.id))
                         .map((p) => {
                           return (
@@ -177,9 +177,7 @@ export const ToolsTabPanel = ({ form, visible, className }: ToolsTabPanelProps) 
       </ScrollArea>
       {isAddToolsDialogVisible && (
         <AddToolsDialog
-          members={tools.filter(
-            (tool) => !tool.capability && !form.getValues().tools.includes(tool.id)
-          )}
+          members={allNonCapabilities.filter((tool) => !form.getValues().tools.includes(tool.id))}
           onClose={() => setAddToolsDialogVisible(false)}
           onAddTools={(tools: dto.AssistantTool[]) => {
             const idsToEnable = tools.map((t) => t.id)

--- a/logicle/app/assistants/components/AssistantForm.tsx
+++ b/logicle/app/assistants/components/AssistantForm.tsx
@@ -30,6 +30,8 @@ import { StringList } from '@/components/ui/stringlist'
 import { IconUpload } from '@tabler/icons-react'
 import { AddToolsDialog } from './AddToolsDialog'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useSWRJson } from '@/hooks/swr'
+import { filterFns } from '@tanstack/react-table'
 
 const DEFAULT = '__DEFAULT__'
 const fileSchema = z.object({
@@ -42,7 +44,6 @@ const fileSchema = z.object({
 const toolSchema = z.object({
   id: z.string(),
   name: z.string(),
-  enabled: z.boolean(),
   capability: z.number(),
   provisioned: z.number(),
 })
@@ -56,7 +57,7 @@ const formSchema = z.object({
   reasoning_effort: z.enum(['low', 'medium', 'high', DEFAULT]),
   tokenLimit: z.coerce.number().min(256),
   temperature: z.coerce.number().min(0).max(1),
-  tools: toolSchema.array(),
+  tools: z.string().array(),
   files: fileSchema.array(),
   tags: z.string().array(),
   prompts: z.string().array(),
@@ -83,9 +84,9 @@ interface ToolsTabPanelProps {
 export const ToolsTabPanel = ({ form, visible, className }: ToolsTabPanelProps) => {
   const { t } = useTranslation()
   const [isAddToolsDialogVisible, setAddToolsDialogVisible] = useState(false)
-  const anyCapability = (tools: dto.AssistantTool[]) => {
-    return tools.some((tool) => tool.capability)
-  }
+  const { data: tools_ } = useSWRJson<dto.AssistantTool[]>('/api/user/tools')
+  const capabilities = tools_?.filter((t) => t.capability) || []
+  const tools = tools_?.filter((t) => !t.capability) || []
   return (
     <>
       <ScrollArea className={`${className}`} style={{ display: visible ? undefined : 'none' }}>
@@ -95,35 +96,33 @@ export const ToolsTabPanel = ({ form, visible, className }: ToolsTabPanelProps) 
             name="tools"
             render={({ field }) => (
               <>
-                <Card style={{ display: anyCapability(field.value) ? undefined : 'none' }}>
+                <Card style={{ display: capabilities.length != 0 ? undefined : 'none' }}>
                   <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
                     <CardTitle>{t('capabilities')}</CardTitle>
                   </CardHeader>
                   <CardContent>
                     <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-4">
-                      {field.value
-                        .filter((tool) => tool.capability)
-                        .map((p) => {
-                          return (
-                            <div
-                              key={p.id}
-                              className="flex flex-row items-center space-y-0 border p-3"
-                            >
-                              <div className="flex-1">
-                                <div className="flex-1">{p.name}</div>
-                              </div>
-                              <Switch
-                                onCheckedChange={(value) => {
-                                  form.setValue(
-                                    'tools',
-                                    withEnablePatched(field.value, p.id, value)
-                                  )
-                                }}
-                                checked={p.enabled}
-                              ></Switch>
+                      {capabilities.map((capability) => {
+                        return (
+                          <div
+                            key={capability.id}
+                            className="flex flex-row items-center space-y-0 border p-3"
+                          >
+                            <div className="flex-1">
+                              <div className="flex-1">{capability.name}</div>
                             </div>
-                          )
-                        })}
+                            <Switch
+                              onCheckedChange={(value) => {
+                                form.setValue(
+                                  'tools',
+                                  withEnablePatched(field.value, capability.id, value)
+                                )
+                              }}
+                              checked={field.value.includes(capability.id)}
+                            ></Switch>
+                          </div>
+                        )
+                      })}
                     </div>
                   </CardContent>
                 </Card>
@@ -143,8 +142,8 @@ export const ToolsTabPanel = ({ form, visible, className }: ToolsTabPanelProps) 
                   <CardContent>
                     <div className="flex"></div>
                     <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-4">
-                      {field.value
-                        .filter((tool) => !tool.capability && tool.enabled)
+                      {tools
+                        .filter((t) => field.value.includes(t.id))
                         .map((p) => {
                           return (
                             <div
@@ -178,16 +177,13 @@ export const ToolsTabPanel = ({ form, visible, className }: ToolsTabPanelProps) 
       </ScrollArea>
       {isAddToolsDialogVisible && (
         <AddToolsDialog
-          members={form.getValues().tools.filter((tool) => !tool.capability && !tool.enabled)}
+          members={tools.filter(
+            (tool) => !tool.capability && !form.getValues().tools.includes(tool.id)
+          )}
           onClose={() => setAddToolsDialogVisible(false)}
           onAddTools={(tools: dto.AssistantTool[]) => {
             const idsToEnable = tools.map((t) => t.id)
-            const patched = form.getValues().tools.map((p) => {
-              return {
-                ...p,
-                enabled: p.enabled || idsToEnable.includes(p.id),
-              }
-            })
+            const patched = [...form.getValues().tools, ...idsToEnable]
             form.setValue('tools', patched)
           }}
         />
@@ -785,11 +781,10 @@ export const AssistantForm = ({ assistant, onSubmit, onChange, onValidate, fireS
     </FormProvider>
   )
 }
-function withEnablePatched(tools: dto.AssistantTool[], id: string, enabled: boolean) {
-  return tools.map((p) => {
-    return {
-      ...p,
-      enabled: p.id == id ? enabled : p.enabled,
-    }
-  })
+function withEnablePatched(tools: string[], id: string, enabled: boolean) {
+  const patched = tools.slice().filter((t) => t != id)
+  if (enabled) {
+    patched.push(id)
+  }
+  return patched
 }

--- a/logicle/app/assistants/components/AssistantPreview.tsx
+++ b/logicle/app/assistants/components/AssistantPreview.tsx
@@ -36,6 +36,7 @@ export const AssistantPreview = ({ assistant, className, sendDisabled }: Props) 
     ownerName: '',
     cloneable: false,
     versionId: '',
+    tools: [],
   }
 
   const [conversation, setConversation] = useState<ConversationWithMessages>({

--- a/logicle/lib/provision.ts
+++ b/logicle/lib/provision.ts
@@ -136,15 +136,6 @@ const provisionAssistants = async (assistants: Record<string, ProvisionableAssis
     const insertableAssistant = {
       ...assistant,
       files: [] as dto.AssistantFile[],
-      tools: assistant.tools.map((tool) => {
-        return {
-          id: tool,
-          name: '',
-          enabled: true,
-          capability: 0,
-          provisioned: 1,
-        }
-      }),
       reasoning_effort: assistant.reasoning_effort ?? null,
       iconUri: icon ?? null,
     }

--- a/logicle/models/assistant.ts
+++ b/logicle/models/assistant.ts
@@ -21,16 +21,14 @@ function toAssistantFileAssociation(
 
 function toAssistantToolAssociation(
   assistantVersionId: string,
-  tools: dto.AssistantTool[]
+  toolIds: string[]
 ): schema.AssistantVersionToolAssociation[] {
-  return tools
-    .filter((p) => p.enabled)
-    .map((p) => {
-      return {
-        assistantVersionId,
-        toolId: p.id,
-      }
-    })
+  return toolIds.map((t) => {
+    return {
+      assistantVersionId,
+      toolId: t,
+    }
+  })
 }
 
 export const getAssistantVersion = async (
@@ -506,24 +504,13 @@ export const setAssistantDeleted = async (assistantId: string) => {
 }
 
 // list all tools with enable flag for a given assistant
-export const assistantVersionToolsEnablement = async (assistantVersionId: string) => {
+export const assistantVersionEnabledTools = async (assistantVersionId: string) => {
   const tools = await db
-    .selectFrom('Tool')
-    .leftJoin('AssistantVersionToolAssociation', (join) =>
-      join
-        .onRef('Tool.id', '=', 'AssistantVersionToolAssociation.toolId')
-        .on('AssistantVersionToolAssociation.assistantVersionId', '=', assistantVersionId)
-    )
-    .select(['Tool.id', 'Tool.name', 'Tool.provisioned', 'Tool.capability'])
-    .select('AssistantVersionToolAssociation.toolId as enabled')
+    .selectFrom('AssistantVersionToolAssociation')
+    .select('AssistantVersionToolAssociation.toolId')
+    .where('AssistantVersionToolAssociation.assistantVersionId', '=', assistantVersionId)
     .execute()
-  return tools.map((tool) => ({
-    id: tool.id,
-    capability: tool.capability,
-    provisioned: tool.provisioned,
-    name: tool.name,
-    enabled: tool.enabled != undefined,
-  }))
+  return tools.map((t) => t.toolId)
 }
 
 // list all associated files

--- a/logicle/models/tool.ts
+++ b/logicle/models/tool.ts
@@ -41,9 +41,10 @@ export const createToolWithId = async (
   capability?: boolean,
   provisioned?: boolean
 ): Promise<dto.Tool> => {
+  const { icon, ...toolWithoutIcon } = tool
   const dbTool: schema.Tool = {
-    ...tool,
-    imageId: tool.icon == null ? null : await getOrCreateImageFromDataUri(tool.icon),
+    ...toolWithoutIcon,
+    imageId: icon == null ? null : await getOrCreateImageFromDataUri(icon),
     configuration: JSON.stringify(tool.configuration),
     tags: JSON.stringify(tool.tags),
     id: id,

--- a/logicle/types/dto/assistants.ts
+++ b/logicle/types/dto/assistants.ts
@@ -4,7 +4,6 @@ import { Sharing } from './sharing'
 export interface AssistantTool {
   id: string
   name: string
-  enabled: boolean
   capability: number
   provisioned: number
 }
@@ -18,7 +17,7 @@ export interface AssistantFile {
 
 export type AssistantDraft = Omit<schema.AssistantVersion, 'imageId' | 'tags' | 'prompts'> & {
   owner: string
-  tools: AssistantTool[]
+  tools: string[]
   files: AssistantFile[]
   sharing: Sharing[]
   tags: string[]


### PR DESCRIPTION
The AssistantDraft DTO... had a weird structure, where all tools were present, but flagged with an enable flag.
This choice was particularly awkward for PATCH apis.
Moreover, changes in tool list were not reflected in Assistant Form
