### PR TITLE
Router tool

### DIFF
--- a/logicle/app/api/assistants/evaluate/route.ts
+++ b/logicle/app/api/assistants/evaluate/route.ts
@@ -20,7 +20,7 @@ export const POST = requireSession(async (session: SimpleSession, req: Request) 
     return ApiResponses.invalidParameter('No backend')
   }
 
-  const availableTools = await availableToolsFiltered(assistant.tools)
+  const availableTools = await availableToolsFiltered(assistant.tools, assistant.model)
 
   const provider = await ChatAssistant.build(
     backend,

--- a/logicle/app/api/chat/route.ts
+++ b/logicle/app/api/chat/route.ts
@@ -95,7 +95,10 @@ export const POST = requireSession(async (session, req) => {
 
   const dbMessages = await getMessages(userMessage.conversationId)
   const linearThread = extractLinearConversation(dbMessages, userMessage)
-  const availableTools = await availableToolsForAssistantVersion(assistant.assistantVersionId)
+  const availableTools = await availableToolsForAssistantVersion(
+    assistant.assistantVersionId,
+    assistant.model
+  )
 
   const updateChatTitle = async (conversationId: string, title: string) => {
     await db

--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -245,7 +245,9 @@ export class ChatAssistant {
     if (files.length == 0) {
       files = undefined
     }
-    const functions = Object.fromEntries(tools.flatMap((tool) => Object.entries(tool.functions)))
+    const functions = Object.fromEntries(
+      tools.flatMap((tool) => Object.entries(tool.functions(assistantParams.model)))
+    )
     const promptFragments = [
       assistantParams.systemPrompt,
       ...tools.map((t) => t.toolParams.promptFragment),

--- a/logicle/lib/chat/tools.ts
+++ b/logicle/lib/chat/tools.ts
@@ -55,10 +55,11 @@ export interface ToolParams {
 export interface ToolImplementation {
   supportedMedia: string[]
   toolParams: ToolParams
-  functions: ToolFunctions
+  functions: (model: string) => ToolFunctions
 }
 
 export type ToolBuilder = (
   tool: ToolParams,
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
+  model: string
 ) => Promise<ToolImplementation> | ToolImplementation

--- a/logicle/lib/tools/dall-e/implementation.ts
+++ b/logicle/lib/tools/dall-e/implementation.ts
@@ -29,14 +29,14 @@ export class Dall_ePlugin extends Dall_ePluginInterface implements ToolImplement
     new Dall_ePlugin(toolParams, params as unknown as Dall_ePluginParams)
   forcedModel: Model | string | undefined
   supportedMedia = []
-  functions: ToolFunctions
+  functions_: ToolFunctions
   constructor(
     public toolParams: ToolParams,
     private params: Dall_ePluginParams
   ) {
     super()
     this.forcedModel = params.model
-    this.functions = {
+    this.functions_ = {
       GenerateImage: {
         description: 'Generate one or more images from a textual description',
         parameters: {
@@ -64,7 +64,7 @@ export class Dall_ePlugin extends Dall_ePluginInterface implements ToolImplement
       },
     }
     if (!this.forcedModel || this.forcedModel == 'gpt-image-1') {
-      this.functions['EditImage'] = {
+      this.functions_['EditImage'] = {
         description:
           'Modify user provided images using instruction provided by the user. Look in chat context to find uploaded or generated images',
         parameters: {
@@ -101,6 +101,8 @@ export class Dall_ePlugin extends Dall_ePluginInterface implements ToolImplement
       }
     }
   }
+
+  functions = () => this.functions_
 
   private async invokeGenerate({ params: invocationParams, uiLink }: ToolInvokeParams) {
     const openai = new OpenAI({

--- a/logicle/lib/tools/enumerate.ts
+++ b/logicle/lib/tools/enumerate.ts
@@ -9,62 +9,69 @@ import { Dall_ePlugin } from './dall-e/implementation'
 import { McpPlugin } from './mcp/implementation'
 import { WebSearch } from './websearch/implementation'
 import { NativeTool } from './nativetool/implementation'
+import { Router } from './router/implementation'
 
 export const buildToolImplementationFromDbInfo = async (
-  tool: dto.Tool
+  tool: dto.Tool,
+  model: string
 ): Promise<ToolImplementation | undefined> => {
   const args = {
     provisioned: tool.provisioned ? true : false,
     promptFragment: tool.promptFragment,
   }
   if (tool.type == TimeOfDay.toolName) {
-    return await TimeOfDay.builder(args, tool.configuration)
+    return await TimeOfDay.builder(args, tool.configuration, model)
   } else if (tool.type == OpenApiPlugin.toolName) {
-    return await OpenApiPlugin.builder(args, tool.configuration)
+    return await OpenApiPlugin.builder(args, tool.configuration, model)
   } else if (tool.type == McpPlugin.toolName) {
-    return await McpPlugin.builder(args, tool.configuration)
+    return await McpPlugin.builder(args, tool.configuration, model)
   } else if (tool.type == FileManagerPlugin.toolName) {
-    return await FileManagerPlugin.builder(args, tool.configuration)
+    return await FileManagerPlugin.builder(args, tool.configuration, model)
   } else if (tool.type == Dall_ePlugin.toolName) {
-    return await Dall_ePlugin.builder(args, tool.configuration)
+    return await Dall_ePlugin.builder(args, tool.configuration, model)
   } else if (tool.type == WebSearch.toolName) {
-    return await WebSearch.builder(args, tool.configuration)
+    return await WebSearch.builder(args, tool.configuration, model)
   } else if (tool.type == NativeTool.toolName) {
-    return await NativeTool.builder(args, tool.configuration)
+    return await NativeTool.builder(args, tool.configuration, model)
+  } else if (tool.type == Router.toolName) {
+    return await Router.builder(args, tool.configuration, model)
   } else {
     return undefined
   }
 }
 
-export const availableTools = async () => {
+export const availableTools = async (model: string) => {
   const tools = await getTools()
   return (
     await Promise.all(
       tools.map((t) => {
-        return buildToolImplementationFromDbInfo(t)
+        return buildToolImplementationFromDbInfo(t, model)
       })
     )
   ).filter((t) => !(t == undefined)) as ToolImplementation[]
 }
 
-export const availableToolsForAssistantVersion = async (assistantVersionId: string) => {
+export const availableToolsForAssistantVersion = async (
+  assistantVersionId: string,
+  model: string
+) => {
   const tools = await assistantVersionTools(assistantVersionId)
   const implementations = (
     await Promise.all(
       tools.map((t) => {
-        return buildToolImplementationFromDbInfo(t)
+        return buildToolImplementationFromDbInfo(t, model)
       })
     )
   ).filter((t) => !(t == undefined)) as ToolImplementation[]
   return implementations
 }
 
-export const availableToolsFiltered = async (ids: string[]) => {
+export const availableToolsFiltered = async (ids: string[], model: string) => {
   const tools = await getToolsFiltered(ids)
   const implementations = (
     await Promise.all(
       tools.map((t) => {
-        return buildToolImplementationFromDbInfo(t)
+        return buildToolImplementationFromDbInfo(t, model)
       })
     )
   ).filter((t) => t !== undefined) as ToolImplementation[]

--- a/logicle/lib/tools/mcp/implementation.ts
+++ b/logicle/lib/tools/mcp/implementation.ts
@@ -49,14 +49,14 @@ export class McpPlugin extends McpInterface implements ToolImplementation {
     return new McpPlugin(toolParams, functions) // TODO: need a better validation
   }
 
-  functions: ToolFunctions
   supportedMedia = []
 
   constructor(
     public toolParams: ToolParams,
-    functions: ToolFunctions
+    private functions_: ToolFunctions
   ) {
     super()
-    this.functions = functions
   }
+
+  functions = () => this.functions_
 }

--- a/logicle/lib/tools/nativetool/implementation.ts
+++ b/logicle/lib/tools/nativetool/implementation.ts
@@ -11,11 +11,14 @@ export class NativeTool extends NativeToolInterface implements ToolImplementatio
   ) {
     super()
   }
-  functions: ToolFunctions = {
-    WebSearch: {
-      type: 'provider-defined',
-      id: this.params.name as `${string}.${string}`,
-      args: {},
-    },
+
+  functions(): ToolFunctions {
+    return {
+      WebSearch: {
+        type: 'provider-defined',
+        id: this.params.name as `${string}.${string}`,
+        args: {},
+      },
+    }
   }
 }

--- a/logicle/lib/tools/openapi/implementation.ts
+++ b/logicle/lib/tools/openapi/implementation.ts
@@ -358,9 +358,10 @@ export class OpenApiPlugin extends OpenApiInterface implements ToolImplementatio
 
   constructor(
     public toolParams: ToolParams,
-    public functions: ToolFunctions,
+    private functions_: ToolFunctions,
     public supportedMedia: string[]
   ) {
     super()
   }
+  functions = () => this.functions_
 }

--- a/logicle/lib/tools/retrieve-file/implementation.ts
+++ b/logicle/lib/tools/retrieve-file/implementation.ts
@@ -14,7 +14,9 @@ export class FileManagerPlugin extends FileManagerPluginInterface implements Too
     super()
   }
 
-  functions: ToolFunctions = {
+  functions = () => this.functions_
+
+  functions_: ToolFunctions = {
     GetFile: {
       description: 'Get the content of an uploaded file in base64 format',
       parameters: {

--- a/logicle/lib/tools/router/implementation.ts
+++ b/logicle/lib/tools/router/implementation.ts
@@ -1,0 +1,70 @@
+import { ToolBuilder, ToolFunctions, ToolImplementation, ToolParams } from '@/lib/chat/tools'
+import { Restrictions, RouterInterface, RouterParams } from './interface'
+import { buildToolImplementationFromDbInfo } from '../enumerate'
+
+interface ImplementationChoice {
+  implementation: ToolImplementation
+  restrictions?: Restrictions
+}
+
+export class Router extends RouterInterface implements ToolImplementation {
+  supportedMedia = []
+  constructor(
+    public toolParams: ToolParams,
+    private params: RouterParams,
+    private choices: ImplementationChoice[]
+  ) {
+    super()
+  }
+
+  static builder: ToolBuilder = async (
+    toolParams: ToolParams,
+    params_: Record<string, unknown>,
+    model: string
+  ) => {
+    const params = params_ as unknown as RouterParams
+    const choices: ImplementationChoice[] = []
+    for (const choice of params.choices) {
+      const implementation = await buildToolImplementationFromDbInfo(
+        {
+          id: '',
+          type: choice.type,
+          name: '',
+          description: '',
+          promptFragment: '',
+          provisioned: toolParams.provisioned ? 1 : 0,
+          capability: 0,
+          createdAt: '',
+          updatedAt: '',
+          configuration: choice.configuration,
+          tags: [],
+          icon: null,
+        },
+        model
+      )
+      if (implementation) {
+        choices.push({
+          implementation,
+          restrictions: choice.restrictions,
+        })
+      }
+    }
+    return new Router(toolParams, params, choices)
+  }
+
+  functions(model: string): ToolFunctions {
+    for (const choice of this.choices) {
+      const restrictions = choice.restrictions
+      if (restrictions) {
+        const models = restrictions.models
+        if (models) {
+          if (!models.includes(model)) {
+            continue
+          }
+        }
+      }
+      return choice.implementation.functions(model)
+    }
+    return {}
+  }
+}

--- a/logicle/lib/tools/router/interface.ts
+++ b/logicle/lib/tools/router/interface.ts
@@ -1,0 +1,20 @@
+import * as z from 'zod'
+
+export interface Restrictions {
+  models?: string[]
+}
+
+interface Choice {
+  type: string
+  configuration: Record<string, any>
+  restrictions?: Restrictions
+}
+export interface RouterParams {
+  choices: Choice[]
+}
+
+export const RouterSchema = z.object({ choices: z.any() })
+
+export class RouterInterface {
+  static toolName: string = 'router'
+}

--- a/logicle/lib/tools/timeofday/implementation.ts
+++ b/logicle/lib/tools/timeofday/implementation.ts
@@ -7,7 +7,10 @@ export class TimeOfDay extends TimeOfDayInterface implements ToolImplementation 
     super()
   }
   supportedMedia = []
-  functions: ToolFunctions = {
+
+  functions = () => this.functions_
+
+  private functions_: ToolFunctions = {
     timeOfDay: {
       description: 'Retrieve the current time',
       parameters: {

--- a/logicle/lib/tools/websearch/implementation.ts
+++ b/logicle/lib/tools/websearch/implementation.ts
@@ -39,7 +39,10 @@ export class WebSearch extends WebSearchInterface implements ToolImplementation 
   ) {
     super()
   }
-  functions: ToolFunctions = {
+
+  functions = () => this.functions_
+
+  functions_: ToolFunctions = {
     WebSearch: {
       description:
         "Search on the internet. Quando utilizzi l'informazione presente in una delle risposte contenute nel risultato, includi riferimenti a questa, utilizzando una sintassi markdown [x](http://blabla), dove x è l'indice della risposta",

--- a/logicle/models/assistant.ts
+++ b/logicle/models/assistant.ts
@@ -374,9 +374,9 @@ export const updateAssistantVersion = async (
   if (assistant.tools) {
     // TODO: delete all and insert all might be replaced by differential logic
     await deleteAssistantVersionToolAssociations(assistantVersionId)
-    const files = toAssistantToolAssociation(assistantVersionId, assistant.tools)
-    if (files.length != 0) {
-      await db.insertInto('AssistantVersionToolAssociation').values(files).execute()
+    const tools = toAssistantToolAssociation(assistantVersionId, assistant.tools)
+    if (tools.length != 0) {
+      await db.insertInto('AssistantVersionToolAssociation').values(tools).execute()
     }
   }
   const imageId =

--- a/logicle/package.json
+++ b/logicle/package.json
@@ -63,7 +63,7 @@
     "@tailwindcss/typography": "0.5.9",
     "@tanstack/react-table": "^8.21.2",
     "@uiw/react-codemirror": "^4.23.6",
-    "ai": "^4.3.15",
+    "ai": "^4.3.16",
     "ajv": "^8.17.1",
     "ajv-draft-04": "^1.0.0",
     "autoprefixer": "^10.4.16",

--- a/logicle/pnpm-lock.yaml
+++ b/logicle/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
         specifier: ^4.23.6
         version: 4.23.10(@babel/runtime@7.26.10)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.11.0)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.4)(codemirror@6.0.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       ai:
-        specifier: ^4.3.15
-        version: 4.3.15(react@19.1.0)(zod@3.24.2)
+        specifier: ^4.3.16
+        version: 4.3.16(react@19.1.0)(zod@3.24.2)
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -3214,8 +3214,8 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ai@4.3.15:
-    resolution: {integrity: sha512-TYKRzbWg6mx/pmTadlAEIhuQtzfHUV0BbLY72+zkovXwq/9xhcH24IlQmkyBpElK6/4ArS0dHdOOtR1jOPVwtg==}
+  ai@4.3.16:
+    resolution: {integrity: sha512-KUDwlThJ5tr2Vw0A1ZkbDKNME3wzWhuVfAOwIvFUzl1TPVDFAXDFTXio3p+jaKneB+dKNCvFFlolYmmgHttG1g==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -11908,7 +11908,7 @@ snapshots:
       indent-string: 4.0.0
     optional: true
 
-  ai@4.3.15(react@19.1.0)(zod@3.24.2):
+  ai@4.3.16(react@19.1.0)(zod@3.24.2):
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@3.24.2)
@@ -15969,7 +15969,7 @@ snapshots:
 
   postcss@8.5.3:
     dependencies:
-      nanoid: 3.3.10
+      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
This PR introduce, tool router, i.e. a tool which can route to different tool implementations depending on model capabilities

Here an example which uses OpenAI's search for gpt-4o and gpt-4.1 model, and EXA for other models

tools:
  websearch:
    type: router
    name: Web search
    capability: true
    configuration:
      choices:
        - type: native
          configuration:
            name: openai.web_search_preview
          restrictions:
            models:
              - gpt-4o
              - gpt-4.1
        - type: websearch
          name: Web search
          capability: false
          configuration:
            apiKey: ${EXA_API_KEY}
