### PR TITLE
Send reasoning and signature back to LLM in tool response

### DIFF
--- a/logicle/lib/chat/conversion.ts
+++ b/logicle/lib/chat/conversion.ts
@@ -55,7 +55,7 @@ export const dtoMessageToLlmMessage = async (
     }
   }
   if (m.role == 'tool-call') {
-    let reasoningParts: ReasoningPart[] =
+    const reasoningParts: ReasoningPart[] =
       m.reasoning && m.reasoning_signature
         ? [
             {

--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -613,6 +613,8 @@ export class ChatAssistant {
           const delta = chunk.textDelta
           msg.reasoning = (msg.reasoning ?? '') + delta
           clientSink.enqueueReasoningDelta(delta)
+        } else if (chunk.type == 'reasoning-signature') {
+          msg.reasoning_signature = chunk.signature
         } else if (chunk.type == 'finish') {
           usage = chunk.usage
           // In some cases, at least when getting weird payload responses, vercel SDK returns NANs.

--- a/logicle/types/dto/chat.ts
+++ b/logicle/types/dto/chat.ts
@@ -40,6 +40,7 @@ export interface ToolCallAuthResponse {
 export type BaseMessage = Omit<schema.Message, 'role'> & {
   attachments: Attachment[]
   reasoning?: string
+  reasoning_signature?: string
   citations?: dto.Citation[]
 }
 


### PR DESCRIPTION
This is required by Anthropic models.
Unfortunately, reasoning_signature is not available in Logicle, so...

**Anthropic reasoning models with logicle provider will fail if tools are enabled**