### PR TITLE
Openai response summaries

### DIFF
--- a/logicle/.env
+++ b/logicle/.env
@@ -25,5 +25,10 @@ ENABLE_LOGICLE_CLOUD_IMAGE_PROXY=0
 FILE_STORAGE_ENCRYPTION_KEY=CHANGEIT
 OPENAPI_TOOL_REQUIRE_CONFIRM=0
 OPENAPI_FETCH_TIMEOUT_SECS=3600
+# Response APIs support native tools and reasoning summaries. 
+# But... tool validation is stricter
+# To avoid breaking, we leave the default to completion APIs
+# Note that response APIs are used anyway when native tools like web search are enabled
+OPENAI_USE_RESPONSE_APIS=0
 # Limit the number of conversations returned by conversion list API
 # MAX_CONVERSATION_RESULTS=1000

--- a/logicle/lib/env.ts
+++ b/logicle/lib/env.ts
@@ -68,6 +68,7 @@ const env = {
   tools: {
     openApi: {
       requireConfirmation: process.env.OPENAPI_TOOL_REQUIRE_CONFIRM == '1',
+      timeoutSecs: parseFloat(process.env.OPENAPI_FETCH_TIMEOUT_SECS ?? '3600'),
     },
     websearch: {
       defaultApiUrl: process.env.WEBSEARCH_TOOL_DEFAULT_API_URL ?? 'https://api.exa.ai/search',
@@ -80,8 +81,11 @@ const env = {
     },
   },
   providers: {
-    logicleCloud: {
-      enable: process.env.ENABLE_LOGICLE_CLOUD_IMAGE_PROXY == '1',
+    openai: {
+      useResponseApis: process.env.OPENAI_USE_RESPONSE_APIS == '1',
+    },
+    logicle: {
+      useResponseApisForOpenAi: process.env.OPENAI_USE_RESPONSE_APIS == '1',
     },
   },
   signup: {
@@ -117,9 +121,6 @@ const env = {
   },
   apiKeys: {
     enable: process.env.ENABLE_APIKEYS == '1',
-  },
-  openapi: {
-    timeoutSecs: parseFloat(process.env.OPENAPI_FETCH_TIMEOUT_SECS ?? '3600'),
   },
   dumpLlmConversation: process.env.DUMP_LLM_CONVERSATION == '1',
   conversationLimit: parseOptionalInt(process.env.MAX_CONVERSATION_RESULTS),

--- a/logicle/lib/tools/openapi/implementation.ts
+++ b/logicle/lib/tools/openapi/implementation.ts
@@ -281,7 +281,7 @@ async function customFetch(
   // TODO: verify that creating an agent for each and every request
   // is perhaps not a good idea
   const agent = new Agent({
-    headersTimeout: env.openapi.timeoutSecs * 1000,
+    headersTimeout: env.tools.openApi.timeoutSecs * 1000,
   })
   try {
     return await fetch(url, {

--- a/logicle/package.json
+++ b/logicle/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.12",
     "@ai-sdk/google-vertex": "^2.2.1",
-    "@ai-sdk/openai": "^1.3.16",
+    "@ai-sdk/openai": "^1.3.22",
     "@ai-sdk/openai-compatible": "^0.2.0",
     "@ai-sdk/perplexity": "^1.1.0",
     "@ai-sdk/provider": "^1.1.0",

--- a/logicle/pnpm-lock.yaml
+++ b/logicle/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^2.2.1
         version: 2.2.1(encoding@0.1.13)(zod@3.24.2)
       '@ai-sdk/openai':
-        specifier: ^1.3.16
-        version: 1.3.16(zod@3.24.2)
+        specifier: ^1.3.22
+        version: 1.3.22(zod@3.24.2)
       '@ai-sdk/openai-compatible':
         specifier: ^0.2.0
         version: 0.2.0(zod@3.24.2)
@@ -480,8 +480,8 @@ packages:
     peerDependencies:
       zod: ^3.0.0
 
-  '@ai-sdk/openai@1.3.16':
-    resolution: {integrity: sha512-pjtiBKt1GgaSKZryTbM3tqgoegJwgAUlp1+X5uN6T+VPnI4FLSymV65tyloWzDlyqZmi9HXnnSRPu76VoL5D5g==}
+  '@ai-sdk/openai@1.3.22':
+    resolution: {integrity: sha512-QwA+2EkG0QyjVR+7h6FE7iOu2ivNqAVMm9UJZkVxxTk5OIq5fFJDTEI/zICEMuHImTTXR2JjsL6EirJ28Jc4cw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
@@ -503,12 +503,6 @@ packages:
 
   '@ai-sdk/provider-utils@2.2.0':
     resolution: {integrity: sha512-RX5BnDSqudjvZjwwpROcxVQElyX7rUn/xImBgaZLXekSGqq8f7/tefqDcQiRbDZjuCd4CVIfhrK8y/Pta8cPfQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.23.8
-
-  '@ai-sdk/provider-utils@2.2.7':
-    resolution: {integrity: sha512-kM0xS3GWg3aMChh9zfeM+80vEZfXzR3JEUBdycZLtbRZ2TRT8xOj3WodGHPb06sUK5yD7pAXC/P7ctsi2fvUGQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.23.8
@@ -7960,10 +7954,10 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.0(zod@3.24.2)
       zod: 3.24.2
 
-  '@ai-sdk/openai@1.3.16(zod@3.24.2)':
+  '@ai-sdk/openai@1.3.22(zod@3.24.2)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.2)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.24.2)
       zod: 3.24.2
 
   '@ai-sdk/perplexity@1.1.0(zod@3.24.2)':
@@ -7986,13 +7980,6 @@ snapshots:
       '@ai-sdk/provider': 1.1.0
       eventsource-parser: 3.0.0
       nanoid: 3.3.10
-      secure-json-parse: 2.7.0
-      zod: 3.24.2
-
-  '@ai-sdk/provider-utils@2.2.7(zod@3.24.2)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.11
       secure-json-parse: 2.7.0
       zod: 3.24.2
 


### PR DESCRIPTION
Finally... we have reasoning for OpenAI reasoning models
But... reasoning requires responses API and responses API enforce stricter requirements on function calling.... (optional parameters are not allowed).
While there are workaround, it is probably a better idea to modify all the openapi tools in order to comply to this requirement.

This is the env flag to enable Responses API:

`OPENAI_USE_RESPONSE_APIS=1`


