### PR TITLE
Fix huge regression with logicle provider

### DIFF
--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -828,7 +828,7 @@ export class ChatAssistant {
     const bestModel = models.reduce((maxItem, currentItem) =>
       modelScore(currentItem.id) > modelScore(maxItem.id) ? currentItem : maxItem
     )
-    return ChatAssistant.createLanguageModel(bestBackend, bestModel.id)
+    return ChatAssistant.createLanguageModel(bestBackend, bestModel)
   }
 
   computeSafeSummary = async (text: string) => {


### PR DESCRIPTION
OpenAI responses API were buing used almost always with logicle provider.
Litellm Responses API endpoint conversion to other models is simply not a supported feature.
