### PR TITLE
Compatibility with older native tool spec

### DIFF
--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -189,11 +189,7 @@ export class ChatAssistant {
     this.llmModelCapabilities = this.llmModel.capabilities
     this.saveMessage = options.saveMessage || (async () => {})
     this.updateChatTitle = options.updateChatTitle || (async () => {})
-    this.languageModel = ChatAssistant.createLanguageModel(
-      providerConfig,
-      llmModel,
-      Object.entries(this.functions).some(([, value]) => value.type == 'provider-defined')
-    )
+    this.languageModel = ChatAssistant.createLanguageModel(providerConfig, llmModel)
     let systemPrompt = assistantParams.systemPrompt
     if (knowledge) {
       systemPrompt = `${systemPrompt ?? ''}\nAvailable files:\n${JSON.stringify(knowledge)}`
@@ -234,8 +230,8 @@ export class ChatAssistant {
     )
   }
 
-  static createLanguageModel(params: ProviderConfig, model: LlmModel, haveNativeTools?: boolean) {
-    let languageModel = this.createLanguageModelBasic(params, model, haveNativeTools)
+  static createLanguageModel(params: ProviderConfig, model: LlmModel) {
+    let languageModel = this.createLanguageModelBasic(params, model)
     if (model.owned_by == 'perplexity') {
       languageModel = ai.wrapLanguageModel({
         model: languageModel as LanguageModelV2,
@@ -245,11 +241,7 @@ export class ChatAssistant {
     return languageModel
   }
 
-  static createLanguageModelBasic(
-    params: ProviderConfig,
-    model: LlmModel,
-    haveNativeTools?: boolean
-  ): LanguageModelV2 {
+  static createLanguageModelBasic(params: ProviderConfig, model: LlmModel): LanguageModelV2 {
     const fetch = env.dumpLlmConversation ? loggingFetch : undefined
     switch (params.providerType) {
       case 'openai':

--- a/logicle/lib/tools/nativetool/implementation.ts
+++ b/logicle/lib/tools/nativetool/implementation.ts
@@ -13,10 +13,17 @@ export class NativeTool extends NativeToolInterface implements ToolImplementatio
   }
 
   functions(): ToolFunctions {
+    let name = this.params.name
+    let type = this.params.type
+    if (name == 'openai.web_search_preview') {
+      // Hack for legacy configuration syntax
+      type = 'openai.web_search_preview'
+      name = 'web_search_preview'
+    }
     return {
-      [this.params.name]: {
+      [name]: {
         type: 'provider-defined',
-        id: this.params.id as `${string}.${string}`,
+        id: type as `${string}.${string}`,
         args: this.params.args || {},
       },
     }

--- a/logicle/lib/tools/nativetool/interface.ts
+++ b/logicle/lib/tools/nativetool/interface.ts
@@ -3,7 +3,7 @@ import * as z from 'zod'
 export interface NativeToolParams {
   // if not defined... the
   name: string
-  id: string
+  type?: string
   args?: Record<string, any>
 }
 


### PR DESCRIPTION
The new spec for native tool is kind of

```
        - type: native
          configuration:
            type: openai.web_search_preview
            name: web_search_preview
          restrictions:
            models:
              - gpt-4o
              - gpt-4.1
        - type: native
          configuration:
            type: anthropic.web_search_20250305
            name: web_search
          restrictions:
            models:
              - claude-3-7-sonnet-latest
              - claude-3-7-sonnet
```

Where type and name are both needed to match with vercel (weird) implementation.

As a hack...
older syntax with only name = "openai.web_search_preview" is still supported
