### PR TITLE
Improve error chunk handling

### DIFF
--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -657,8 +657,11 @@ export class ChatAssistant {
         } else if (chunk.type == 'error') {
           // Let's throw an error, it will be handled by the same code
           // which handles errors thrown when sending a message
-          if (chunk.error) throw chunk.error
-          else throw new ai.AISDKError({ name: 'blabla', message: 'LLM sent a error' })
+          throw new ai.AISDKError({
+            name: 'error_chunk',
+            message: 'LLM sent an error chunk',
+            cause: chunk.error,
+          })
         } else if (chunk.type == 'source') {
           const citation: dto.Citation = {
             title: chunk.title ?? '',


### PR DESCRIPTION
I'm really not clear if we should handle an error chunk as an exception, or... simply continue streaming the result.
I'll carry on with an exception, but... I'm not sure.
We currently serialize an error flag on each LLM response, not an error chunk.

