### PR TITLE
Easier native tools

### DIFF
--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -16,7 +16,7 @@ import { ClientSink } from './ClientSink'
 import { ToolUiLinkImpl } from './ToolUiLinkImpl'
 import { ChatState } from './ChatState'
 import { ToolFunction, ToolFunctions, ToolImplementation, ToolUILink } from './tools'
-import { logger, smartStringify } from '@/lib/logging'
+import { logger, loggingFetch } from '@/lib/logging'
 import { expandEnv } from 'templates'
 import { assistantVersionFiles } from '@/models/assistant'
 import { getBackends } from '@/models/backend'
@@ -104,14 +104,6 @@ class ClientSinkImpl implements ClientSink {
       content: attachment,
     })
   }
-}
-
-function loggingFetch(
-  input: string | URL | globalThis.Request,
-  init?: RequestInit
-): Promise<Response> {
-  console.log(`Sending to LLM@${input}: ${smartStringify(JSON.parse(init!.body as string))}`)
-  return fetch(input, init)
 }
 
 function limitMessages(
@@ -624,7 +616,7 @@ export class ChatAssistant {
       let toolCallId = ''
       for await (const chunk of stream.fullStream) {
         if (env.dumpLlmConversation && chunk.type != 'text') {
-          console.log(`Received chunk from LLM ${smartStringify(chunk)}`)
+          console.log('[SDK chunk]', chunk)
         }
 
         if (chunk.type == 'tool-call') {

--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -16,7 +16,7 @@ import { ClientSink } from './ClientSink'
 import { ToolUiLinkImpl } from './ToolUiLinkImpl'
 import { ChatState } from './ChatState'
 import { ToolFunction, ToolFunctions, ToolImplementation, ToolUILink } from './tools'
-import { logger } from '@/lib/logging'
+import { logger, smartStringify } from '@/lib/logging'
 import { expandEnv } from 'templates'
 import { assistantVersionFiles } from '@/models/assistant'
 import { getBackends } from '@/models/backend'
@@ -110,7 +110,7 @@ function loggingFetch(
   input: string | URL | globalThis.Request,
   init?: RequestInit
 ): Promise<Response> {
-  console.log(`Sending to LLM@${input}: ${init?.body}`)
+  console.log(`Sending to LLM@${input}: ${smartStringify(JSON.parse(init!.body as string))}`)
   return fetch(input, init)
 }
 
@@ -624,7 +624,7 @@ export class ChatAssistant {
       let toolCallId = ''
       for await (const chunk of stream.fullStream) {
         if (env.dumpLlmConversation && chunk.type != 'text') {
-          console.log(`Received chunk from LLM ${JSON.stringify(chunk)}`)
+          console.log(`Received chunk from LLM ${smartStringify(chunk)}`)
         }
 
         if (chunk.type == 'tool-call') {

--- a/logicle/lib/logging.ts
+++ b/logicle/lib/logging.ts
@@ -31,3 +31,59 @@ export const logger = winston.createLogger({
   ),
   transports: [new winston.transports.Console()],
 })
+
+export function sanitizeAndTransform(input: unknown, maxStringLength = 50): unknown {
+  const isBinary = (val: any): val is Buffer | ArrayBuffer | Uint8Array =>
+    Buffer.isBuffer(val) || val instanceof ArrayBuffer || ArrayBuffer.isView(val)
+
+  const transformBinary = (val: Buffer | ArrayBuffer | Uint8Array): string => {
+    const buf = Buffer.isBuffer(val)
+      ? val
+      : val instanceof ArrayBuffer
+      ? Buffer.from(val)
+      : Buffer.from(val.buffer, val.byteOffset, val.byteLength)
+    return buf.toString('base64')
+  }
+
+  const recurse = (value: unknown, seen = new WeakSet()): unknown => {
+    if (typeof value === 'string') {
+      return value.length > maxStringLength ? value.slice(0, maxStringLength) : value
+    }
+    if (isBinary(value)) return transformBinary(value)
+    if (Array.isArray(value)) return value.map((v) => recurse(v, seen))
+    if (value && typeof value === 'object') {
+      if (seen.has(value as object)) return undefined
+      seen.add(value as object)
+      const obj = value as Record<string, unknown>
+      return Object.entries(obj).reduce<Record<string, unknown>>((acc, [k, v]) => {
+        acc[k] = recurse(v, seen)
+        return acc
+      }, {})
+    }
+    return value
+  }
+
+  return recurse(input)
+}
+
+export function smartStringify(input: unknown, maxStringLength = 50): string {
+  const cache = new WeakSet<object>()
+
+  const replacer = (_: string, value: unknown): unknown => {
+    if (typeof value === 'string') {
+      return typeof maxStringLength === 'number' && value.length > maxStringLength
+        ? value.slice(0, maxStringLength)
+        : value
+    }
+    if (Buffer.isBuffer(value) || value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+      return sanitizeAndTransform(value, maxStringLength)
+    }
+    if (value && typeof value === 'object') {
+      if (cache.has(value)) return undefined
+      cache.add(value)
+    }
+    return value
+  }
+
+  return JSON.stringify(input, replacer)
+}

--- a/logicle/lib/logging.ts
+++ b/logicle/lib/logging.ts
@@ -193,7 +193,7 @@ function sseLoggingStream(): TransformStream<string, string> {
 
         // Attempt to JSON‑parse data for logging
         try {
-          console.log('[LLM response]', { ...event, parsed: JSON.parse(event.data) })
+          console.log('[LLM response]', JSON.parse(event.data))
         } catch {
           console.log('[LLM response]', event)
         }

--- a/logicle/lib/logging.ts
+++ b/logicle/lib/logging.ts
@@ -193,7 +193,7 @@ function sseLoggingStream(): TransformStream<string, string> {
 
         // Attempt to JSON‑parse data for logging
         try {
-          console.log('[LLM response]', JSON.parse(event.data))
+          console.log('[LLM response]', /*event.event, */ JSON.parse(event.data))
         } catch {
           console.log('[LLM response]', event)
         }

--- a/logicle/lib/tools/anthropic.web_search/implementation.ts
+++ b/logicle/lib/tools/anthropic.web_search/implementation.ts
@@ -1,0 +1,24 @@
+import { ToolBuilder, ToolFunctions, ToolImplementation, ToolParams } from '@/lib/chat/tools'
+import { AnthropicWebSearchInterface, AnthropicWebSearchParams } from './interface'
+
+export class AnthropicWebSearch extends AnthropicWebSearchInterface implements ToolImplementation {
+  static builder: ToolBuilder = (toolParams: ToolParams, params: Record<string, unknown>) =>
+    new AnthropicWebSearch(toolParams, params as unknown as AnthropicWebSearchParams)
+  supportedMedia = []
+  constructor(
+    public toolParams: ToolParams,
+    private params: AnthropicWebSearchParams
+  ) {
+    super()
+  }
+
+  functions(): ToolFunctions {
+    return {
+      web_search: {
+        type: 'provider-defined',
+        id: 'anthropic.web_search_20250305',
+        args: {},
+      },
+    }
+  }
+}

--- a/logicle/lib/tools/anthropic.web_search/interface.ts
+++ b/logicle/lib/tools/anthropic.web_search/interface.ts
@@ -8,5 +8,5 @@ export const NativeToolSchema = z.object({
 })
 
 export class AnthropicWebSearchInterface {
-  static toolName: string = 'anthropic.websearch'
+  static toolName: string = 'anthropic.web_search'
 }

--- a/logicle/lib/tools/anthropic.web_search/interface.ts
+++ b/logicle/lib/tools/anthropic.web_search/interface.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod'
 
-export interface AnthropicWebSearchParams {}
+export type AnthropicWebSearchParams = Record<string, unknown>
 
 export const NativeToolSchema = z.object({
   name: z.string(),

--- a/logicle/lib/tools/anthropic.web_search/interface.ts
+++ b/logicle/lib/tools/anthropic.web_search/interface.ts
@@ -1,0 +1,12 @@
+import * as z from 'zod'
+
+export interface AnthropicWebSearchParams {}
+
+export const NativeToolSchema = z.object({
+  name: z.string(),
+  id: z.string(),
+})
+
+export class AnthropicWebSearchInterface {
+  static toolName: string = 'anthropic.websearch'
+}

--- a/logicle/lib/tools/enumerate.ts
+++ b/logicle/lib/tools/enumerate.ts
@@ -13,6 +13,7 @@ import { ProviderOptionsTool } from './providerOptions/implementation'
 import { AnthropicWebSearch } from './anthropic.web_search/implementation'
 import { OpenaiWebSearch } from './openai.web_search/implementation'
 import { Router } from './router/implementation'
+import { OpenaiCodeInterpreter } from './openai.code_interpreter/implementation'
 
 const builders: Record<string, ToolBuilder> = {
   [Dall_ePlugin.toolName]: Dall_ePlugin.builder,
@@ -28,6 +29,7 @@ const builders: Record<string, ToolBuilder> = {
   // Provider specific tools
   [AnthropicWebSearch.toolName]: AnthropicWebSearch.builder,
   [OpenaiWebSearch.toolName]: OpenaiWebSearch.builder,
+  [OpenaiCodeInterpreter.toolName]: OpenaiCodeInterpreter.builder,
 }
 
 export const buildToolImplementationFromDbInfo = async (

--- a/logicle/lib/tools/enumerate.ts
+++ b/logicle/lib/tools/enumerate.ts
@@ -12,14 +12,16 @@ import { NativeTool } from './nativetool/implementation'
 import { ProviderOptionsTool } from './providerOptions/implementation'
 import { AnthropicWebSearch } from './anthropic.web_search/implementation'
 import { OpenaiWebSearch } from './openai.web_search/implementation'
+import { Router } from './router/implementation'
 
 const builders: Record<string, ToolBuilder> = {
   [Dall_ePlugin.toolName]: Dall_ePlugin.builder,
+  [FileManagerPlugin.toolName]: FileManagerPlugin.builder,
   [OpenApiPlugin.toolName]: OpenApiPlugin.builder,
   [McpPlugin.toolName]: McpPlugin.builder,
   [NativeTool.toolName]: NativeTool.builder,
-  [FileManagerPlugin.toolName]: FileManagerPlugin.builder,
   [ProviderOptionsTool.toolName]: ProviderOptionsTool.builder,
+  [Router.toolName]: Router.builder,
   [TimeOfDay.toolName]: TimeOfDay.builder,
   [WebSearch.toolName]: WebSearch.builder,
 

--- a/logicle/lib/tools/enumerate.ts
+++ b/logicle/lib/tools/enumerate.ts
@@ -1,5 +1,5 @@
 import { assistantVersionTools } from '@/models/assistant'
-import { ToolImplementation } from '@/lib/chat/tools'
+import { ToolBuilder, ToolImplementation } from '@/lib/chat/tools'
 import { TimeOfDay } from './timeofday/implementation'
 import { getTools, getToolsFiltered } from '@/models/tool'
 import * as dto from '@/types/dto'
@@ -9,8 +9,24 @@ import { Dall_ePlugin } from './dall-e/implementation'
 import { McpPlugin } from './mcp/implementation'
 import { WebSearch } from './websearch/implementation'
 import { NativeTool } from './nativetool/implementation'
-import { Router } from './router/implementation'
 import { ProviderOptionsTool } from './providerOptions/implementation'
+import { AnthropicWebSearch } from './anthropic.web_search/implementation'
+import { OpenaiWebSearch } from './openai.web_search/implementation'
+
+const builders: Record<string, ToolBuilder> = {
+  [Dall_ePlugin.toolName]: Dall_ePlugin.builder,
+  [OpenApiPlugin.toolName]: OpenApiPlugin.builder,
+  [McpPlugin.toolName]: McpPlugin.builder,
+  [NativeTool.toolName]: NativeTool.builder,
+  [FileManagerPlugin.toolName]: FileManagerPlugin.builder,
+  [ProviderOptionsTool.toolName]: ProviderOptionsTool.builder,
+  [TimeOfDay.toolName]: TimeOfDay.builder,
+  [WebSearch.toolName]: WebSearch.builder,
+
+  // Provider specific tools
+  [AnthropicWebSearch.toolName]: AnthropicWebSearch.builder,
+  [OpenaiWebSearch.toolName]: OpenaiWebSearch.builder,
+}
 
 export const buildToolImplementationFromDbInfo = async (
   tool: dto.Tool,
@@ -20,27 +36,8 @@ export const buildToolImplementationFromDbInfo = async (
     provisioned: tool.provisioned ? true : false,
     promptFragment: tool.promptFragment,
   }
-  if (tool.type == TimeOfDay.toolName) {
-    return await TimeOfDay.builder(args, tool.configuration, model)
-  } else if (tool.type == OpenApiPlugin.toolName) {
-    return await OpenApiPlugin.builder(args, tool.configuration, model)
-  } else if (tool.type == McpPlugin.toolName) {
-    return await McpPlugin.builder(args, tool.configuration, model)
-  } else if (tool.type == FileManagerPlugin.toolName) {
-    return await FileManagerPlugin.builder(args, tool.configuration, model)
-  } else if (tool.type == Dall_ePlugin.toolName) {
-    return await Dall_ePlugin.builder(args, tool.configuration, model)
-  } else if (tool.type == WebSearch.toolName) {
-    return await WebSearch.builder(args, tool.configuration, model)
-  } else if (tool.type == NativeTool.toolName) {
-    return await NativeTool.builder(args, tool.configuration, model)
-  } else if (tool.type == Router.toolName) {
-    return await Router.builder(args, tool.configuration, model)
-  } else if (tool.type == ProviderOptionsTool.toolName) {
-    return await ProviderOptionsTool.builder(args, tool.configuration, model)
-  } else {
-    return undefined
-  }
+  const builder = builders[tool.type]
+  return await builder?.(args, tool.configuration, model)
 }
 
 export const availableTools = async (model: string) => {

--- a/logicle/lib/tools/openai.code_interpreter/implementation.ts
+++ b/logicle/lib/tools/openai.code_interpreter/implementation.ts
@@ -1,0 +1,31 @@
+import { ToolBuilder, ToolFunctions, ToolImplementation, ToolParams } from '@/lib/chat/tools'
+import { OpenAiCodeInterpreterInterface, OpenAiCodeInterpreterParams } from './interface'
+
+export class OpenaiCodeInterpreter
+  extends OpenAiCodeInterpreterInterface
+  implements ToolImplementation
+{
+  static builder: ToolBuilder = (toolParams: ToolParams, params: Record<string, unknown>) =>
+    new OpenaiCodeInterpreter(toolParams, params as unknown as OpenAiCodeInterpreterParams)
+  supportedMedia = []
+  constructor(
+    public toolParams: ToolParams,
+    private params: OpenAiCodeInterpreterParams
+  ) {
+    super()
+  }
+
+  functions(): ToolFunctions {
+    return {
+      code_interpreter: {
+        type: 'provider-defined',
+        id: 'openai.code_interpreter',
+        args: {
+          container: {
+            type: 'auto',
+          },
+        },
+      },
+    }
+  }
+}

--- a/logicle/lib/tools/openai.code_interpreter/interface.ts
+++ b/logicle/lib/tools/openai.code_interpreter/interface.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod'
 
-export interface OpenAiCodeInterpreterParams {}
+export type OpenAiCodeInterpreterParams = Record<string, unknown>
 
 export const OpenAiCodeInterpreterSchema = z.object({})
 

--- a/logicle/lib/tools/openai.code_interpreter/interface.ts
+++ b/logicle/lib/tools/openai.code_interpreter/interface.ts
@@ -1,0 +1,9 @@
+import * as z from 'zod'
+
+export interface OpenAiCodeInterpreterParams {}
+
+export const OpenAiCodeInterpreterSchema = z.object({})
+
+export class OpenAiCodeInterpreterInterface {
+  static toolName: string = 'openai.code_interpreter'
+}

--- a/logicle/lib/tools/openai.web_search/implementation.ts
+++ b/logicle/lib/tools/openai.web_search/implementation.ts
@@ -1,0 +1,24 @@
+import { ToolBuilder, ToolFunctions, ToolImplementation, ToolParams } from '@/lib/chat/tools'
+import { OpenAiWebSearchInterface, OpenAiWebSearchParams } from './interface'
+
+export class OpenaiWebSearch extends OpenAiWebSearchInterface implements ToolImplementation {
+  static builder: ToolBuilder = (toolParams: ToolParams, params: Record<string, unknown>) =>
+    new OpenaiWebSearch(toolParams, params as unknown as OpenAiWebSearchParams)
+  supportedMedia = []
+  constructor(
+    public toolParams: ToolParams,
+    private params: OpenAiWebSearchParams
+  ) {
+    super()
+  }
+
+  functions(): ToolFunctions {
+    return {
+      web_search_preview: {
+        type: 'provider-defined',
+        id: 'openai.web_search_preview',
+        args: {},
+      },
+    }
+  }
+}

--- a/logicle/lib/tools/openai.web_search/interface.ts
+++ b/logicle/lib/tools/openai.web_search/interface.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod'
 
-export interface OpenAiWebSearchParams {}
+export type OpenAiWebSearchParams = Record<string, unknown>
 
 export const NativeToolSchema = z.object({
   name: z.string(),

--- a/logicle/lib/tools/openai.web_search/interface.ts
+++ b/logicle/lib/tools/openai.web_search/interface.ts
@@ -8,5 +8,5 @@ export const NativeToolSchema = z.object({
 })
 
 export class OpenAiWebSearchInterface {
-  static toolName: string = 'openai.websearch'
+  static toolName: string = 'openai.web_search'
 }

--- a/logicle/lib/tools/openai.web_search/interface.ts
+++ b/logicle/lib/tools/openai.web_search/interface.ts
@@ -1,0 +1,12 @@
+import * as z from 'zod'
+
+export interface OpenAiWebSearchParams {}
+
+export const NativeToolSchema = z.object({
+  name: z.string(),
+  id: z.string(),
+})
+
+export class OpenAiWebSearchInterface {
+  static toolName: string = 'openai.websearch'
+}


### PR DESCRIPTION
This PR introduces logicle tools which map the "native" tools provided by OpenAI and Anthropic
Example configuration:

Code interpreter:
```
  code_interpreter:
    type: openai.code_interpreter
    configuration: {}
    name: Code interpreter (native)
```

Web search (with fallback to HEXA based web search):
```
  websearch:
    type: router
    name: Web search
    capability: true
    icon: ...
    configuration:
      choices:
        - type: openai.web_search
          configuration: {}
          restrictions:
            models:
              - gpt-4o
              - gpt-4.1
        - type: anthropic.web_search
          configuration: {}
          restrictions:
            models:
              - claude-3-7-sonnet-latest
              - claude-3-7-sonnet
        - type: websearch
          name: Web search
          configuration:
            apiKey: ${EXA_API_KEY}
```

