### PR TITLE
Dont log legal AI SDK messages as unsupported

### DIFF
--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -619,13 +619,23 @@ export class ChatAssistant {
           console.log('[SDK chunk]', chunk)
         }
 
-        if (chunk.type == 'tool-call') {
+        if (chunk.type == 'start') {
+          // do nothing
+        } else if (chunk.type == 'start-step') {
+          // do nothing
+        } else if (chunk.type == 'finish-step') {
+          // do nothing
+        } else if (chunk.type == 'tool-call') {
           if (!chunk.providerExecuted) {
             // TODO: send something to the interface
             toolName = chunk.toolName
             toolArgs = chunk.input as Record<string, unknown>
             toolCallId = chunk.toolCallId
           }
+        } else if (chunk.type == 'text-start') {
+          // do nothing
+        } else if (chunk.type == 'text-end') {
+          // do nothing
         } else if (chunk.type == 'text') {
           const delta = chunk.text
           msg.content = msg.content + delta


### PR DESCRIPTION
New AI SDK messages were logged as "unknown". Replaced with no-op 