### PR TITLE
Derive package version from github release version 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            APP_VERSION=${{ github.event.release.tag_name }}


### PR DESCRIPTION
package.json is patched at CI build time using the release tag.
There are definitely other ways of doing the job... this one was the easiest!
