### PR TITLE
More robust handling of HTML <pre> blocks

### DIFF
--- a/logicle/app/chat/components/AssistantMessageMarkdown.tsx
+++ b/logicle/app/chat/components/AssistantMessageMarkdown.tsx
@@ -60,12 +60,16 @@ export const AssistantMessageMarkdown: React.FC<{
   const components: Components = React.useMemo(
     () => ({
       pre({ children, ...props }) {
-        const onlyChild = React.Children.only(children)
+        if (!children) {
+          return <pre></pre>
+        }
+        const arr = React.Children.toArray(children)
         if (
-          React.isValidElement(onlyChild) &&
-          (onlyChild as any).props.className === 'language-mermaid'
+          arr.length == 1 &&
+          React.isValidElement(arr[0]) &&
+          arr[0].props.className === 'language-mermaid'
         ) {
-          return onlyChild
+          return arr[0]
         }
         return <pre {...props}>{children}</pre>
       },


### PR DESCRIPTION
<pre> blocks have a special handling, as... they might contain mermaid code.
But... <pre> blocks coming from HTML-in-markdown were simply failing.
Fixed
