### PR TITLE
Avoid using builtin tool calls (e.g. web search) for context

### DIFF
--- a/logicle/lib/chat/ClientSink.ts
+++ b/logicle/lib/chat/ClientSink.ts
@@ -3,7 +3,7 @@ import * as dto from '@/types/dto'
 export interface ClientSink {
   enqueue(streamPart: dto.TextStreamPart): void
   enqueueNewMessage(msg: dto.Message): void
-  enqueueNewPart(part: dto.AssistantMessagePart): void
+  enqueueNewPart(part: dto.MessagePart): void
   enqueueSummary(summary: string): void
   enqueueTextDelta(delta: string): void
   enqueueReasoningDelta(delta: string): void

--- a/logicle/lib/chat/conversationUtils.ts
+++ b/logicle/lib/chat/conversationUtils.ts
@@ -95,6 +95,12 @@ const makeAssistantGroup = (
               ...b,
               status: 'running',
             } satisfies ToolCallPartEx
+          } else if (b.type === 'builtin-tool-call') {
+            return {
+              ...b,
+              status: 'running',
+              type: 'tool-call',
+            } satisfies ToolCallPartEx
           } else {
             return b
           }
@@ -106,7 +112,7 @@ const makeAssistantGroup = (
       })
       msgExt = assistantMessageExt
       for (const part of msg.parts) {
-        if (part.type === 'tool-result') {
+        if (part.type === 'builtin-tool-result') {
           const related = pendingToolCalls.get(part.toolCallId)
           if (related) {
             related.status = 'completed'

--- a/logicle/lib/chat/conversion.ts
+++ b/logicle/lib/chat/conversion.ts
@@ -70,13 +70,8 @@ export const dtoMessageToLlmMessage = async (
           type: 'text',
           text: part.text,
         })
-      } else if (part.type === 'tool-result') {
-        parts.push({
-          type: 'tool-result',
-          toolCallId: part.toolCallId,
-          toolName: part.toolName,
-          output: part.result,
-        })
+      } else if (part.type === 'builtin-tool-result') {
+        // builtin tools are just... notifications
       } else if (part.type === 'reasoning' && part.reasoning_signature) {
         parts.push({
           type: 'reasoning',

--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -63,7 +63,7 @@ class ClientSinkImpl implements ClientSink {
     }
   }
 
-  enqueueNewPart(part: dto.AssistantMessagePart) {
+  enqueueNewPart(part: dto.MessagePart) {
     this.enqueue({
       type: 'part',
       part,
@@ -653,8 +653,8 @@ export class ChatAssistant {
         ) {
           // do nothing
         } else if (chunk.type === 'tool-call') {
-          const toolCall: dto.ToolCallPart = {
-            type: 'tool-call',
+          const toolCall: dto.ToolCallPart | dto.BuiltinToolCallPart = {
+            type: chunk.providerExecuted ? 'builtin-tool-call' : 'tool-call',
             toolName: chunk.toolName,
             args: chunk.input,
             toolCallId: chunk.toolCallId,
@@ -662,8 +662,8 @@ export class ChatAssistant {
           msg.parts.push(toolCall)
           clientSink.enqueueNewPart(toolCall)
         } else if (chunk.type === 'tool-result') {
-          const toolCall: dto.ToolCallResultPart = {
-            type: 'tool-result',
+          const toolCall: dto.BuiltinToolCallResultPart = {
+            type: 'builtin-tool-result',
             toolName: chunk.toolName,
             toolCallId: chunk.toolCallId,
             result: chunk.output,

--- a/logicle/lib/chat/types.ts
+++ b/logicle/lib/chat/types.ts
@@ -20,7 +20,7 @@ export type AssistantMessagePartEx =
   | dto.ErrorPart
   | dto.DebugPart
   | ToolCallPartEx
-  | dto.ToolCallResultPart
+  | dto.BuiltinToolCallResultPart
 
 export type AssistantMessageEx = Omit<dto.AssistantMessage, 'parts'> & {
   parts: AssistantMessagePartEx[]

--- a/logicle/types/dto/chat.ts
+++ b/logicle/types/dto/chat.ts
@@ -61,16 +61,31 @@ export type ToolCallPart = ToolCall & { type: 'tool-call' }
 
 export type ToolCallResultPart = ToolCallResult & { type: 'tool-result' }
 
+export type BuiltinToolCallPart = ToolCall & { type: 'builtin-tool-call' }
+
+export type BuiltinToolCallResultPart = ToolCallResult & { type: 'builtin-tool-result' }
+
 export type ErrorPart = {
   type: 'error'
   error: string
 }
 
+export type MessagePart =
+  | TextPart
+  | ReasoningPart
+  | BuiltinToolCallPart
+  | BuiltinToolCallResultPart
+  | ToolCallPart
+  | ToolCallResultPart
+  | ErrorPart
+  | DebugPart
+
 export type AssistantMessagePart =
   | TextPart
   | ReasoningPart
   | ToolCallPart
-  | ToolCallResultPart
+  | BuiltinToolCallPart
+  | BuiltinToolCallResultPart
   | ErrorPart
   | DebugPart
 
@@ -137,7 +152,7 @@ interface TextStreamPartNewMessage extends TextStreamPartGeneric {
 
 interface TextStreamPartNewPart extends TextStreamPartGeneric {
   type: 'part'
-  part: dto.AssistantMessagePart
+  part: dto.MessagePart
 }
 
 interface TextStreamPartText extends TextStreamPartGeneric {


### PR DESCRIPTION
Even though Vercel's AI SDK makes tool calls for builtin and functions very similar.. they're not the same thing:  builtins are more like... a notification, and do not enter into context