### PR TITLE
Faster initial response

### DIFF
--- a/logicle/lib/chat/ChatState.ts
+++ b/logicle/lib/chat/ChatState.ts
@@ -1,8 +1,5 @@
 import * as dto from '@/types/dto'
 import { nanoid } from 'nanoid'
-import * as ai from 'ai'
-import { dtoMessageToLlmMessage } from './conversion'
-import { LlmModelCapabilities } from './models'
 
 export class ChatState {
   chatHistory: dto.Message[]

--- a/logicle/lib/chat/ChatState.ts
+++ b/logicle/lib/chat/ChatState.ts
@@ -5,25 +5,15 @@ import { dtoMessageToLlmMessage } from './conversion'
 import { LlmModelCapabilities } from './models'
 
 export class ChatState {
-  llmMessages: ai.ModelMessage[]
   chatHistory: dto.Message[]
   conversationId: string
-  constructor(
-    chatHistory: dto.Message[],
-    llmMessages: ai.ModelMessage[],
-    private llmModelCapabilities: LlmModelCapabilities
-  ) {
-    this.llmMessages = llmMessages
+  constructor(chatHistory: dto.Message[]) {
     this.chatHistory = chatHistory
     this.conversationId = chatHistory[0].conversationId
   }
 
   async push(msg: dto.Message): Promise<dto.Message> {
     this.chatHistory = [...this.chatHistory, msg]
-    const llmMsg = await dtoMessageToLlmMessage(msg, this.llmModelCapabilities)
-    if (llmMsg) {
-      this.llmMessages = [...this.llmMessages, llmMsg]
-    }
     return msg
   }
 

--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -515,14 +515,6 @@ export class ChatAssistant {
   async sendUserMessageAndStreamResponse(
     chatHistory: dto.Message[]
   ): Promise<ReadableStream<string>> {
-    const encoding = getEncoding('cl100k_base')
-    const { limitedMessages } = limitMessages(
-      encoding,
-      this.systemPromptMessage?.content ?? '',
-      chatHistory.filter((m) => m.role !== 'tool-auth-request' && m.role !== 'tool-auth-response'),
-      this.assistantParams.tokenLimit
-    )
-
     const chatState = new ChatState(chatHistory)
     return new ReadableStream<string>({
       start: async (streamController) => {

--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -461,7 +461,27 @@ export class ChatAssistant {
     }
     return undefined
   }
-  async invokeLlm(llmMessages: ai.ModelMessage[]) {
+
+  async computeLlmMessages(chatHistory: dto.Message[]) {
+    const encoding = getEncoding('cl100k_base')
+    const { limitedMessages } = limitMessages(
+      encoding,
+      this.systemPromptMessage?.content ?? '',
+      chatHistory.filter((m) => m.role !== 'tool-auth-request' && m.role !== 'tool-auth-response'),
+      this.assistantParams.tokenLimit
+    )
+    const llmMessages = (
+      await Promise.all(
+        limitedMessages
+          .filter((m) => m.role !== 'tool-auth-request' && m.role !== 'tool-auth-response')
+          .map((m) => dtoMessageToLlmMessage(m, this.llmModelCapabilities))
+      )
+    ).filter((l) => l !== undefined)
+    return sanitizeOrphanToolCalls(llmMessages)
+  }
+
+  async invokeLlm(chatState: ChatState) {
+    const llmMessages = await this.computeLlmMessages(chatState.chatHistory)
     let messages = llmMessages
     if (this.systemPromptMessage) {
       messages = [this.systemPromptMessage, ...messages]
@@ -503,15 +523,7 @@ export class ChatAssistant {
       this.assistantParams.tokenLimit
     )
 
-    const llmMessages = (
-      await Promise.all(
-        limitedMessages
-          .filter((m) => m.role !== 'tool-auth-request' && m.role !== 'tool-auth-response')
-          .map((m) => dtoMessageToLlmMessage(m, this.llmModelCapabilities))
-      )
-    ).filter((l) => l !== undefined)
-    const llmMessagesSanitized = sanitizeOrphanToolCalls(llmMessages)
-    const chatState = new ChatState(chatHistory, llmMessagesSanitized, this.llmModelCapabilities)
+    const chatState = new ChatState(chatHistory)
     return new ReadableStream<string>({
       start: async (streamController) => {
         const clientSink = new ClientSinkImpl(streamController, chatState.conversationId)
@@ -769,7 +781,7 @@ export class ChatAssistant {
       clientSink.enqueueNewMessage(assistantResponse)
       let usage: Usage | undefined
       try {
-        const responseStream = await this.invokeLlm(chatState.llmMessages)
+        const responseStream = await this.invokeLlm(chatState)
         usage = await receiveStreamIntoMessage(responseStream, assistantResponse)
       } catch (e) {
         if (e instanceof ToolSetupError) {


### PR DESCRIPTION
The conversion of message dtos to LLM is now deferred to after the initial (empty) response is sent.
This should make the UI feel a bit snappier.
And the code is simpler....
 