### PR TITLE
Opentelemetry host name attrubute

### DIFF
--- a/logicle/instrumentation.ts
+++ b/logicle/instrumentation.ts
@@ -4,6 +4,7 @@ import { LoggerProvider, BatchLogRecordProcessor } from '@opentelemetry/sdk-logs
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
 import { resourceFromAttributes } from '@opentelemetry/resources'
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
+import os from 'node:os'
 
 const initOpenTelemetry = async (endPoint: string) => {
   registerOTel({
@@ -21,6 +22,7 @@ const initOpenTelemetry = async (endPoint: string) => {
   const loggerProvider = new LoggerProvider({
     resource: resourceFromAttributes({
       [ATTR_SERVICE_NAME]: 'logicle-app',
+      'host.name': os.hostname(),
     }),
     processors: [
       new BatchLogRecordProcessor(


### PR DESCRIPTION
Vercel's opentelemetry... does not add it by default, it does not make much sense in their environment.
Let's add it by ourselves.

It would be a bit cleaner to use environment variables, but we have no expansion, so... let's do it simple.
