### PR TITLE
Raise default token limit to 128000

### DIFF
--- a/logicle/app/chat/assistants/mine/page.tsx
+++ b/logicle/app/chat/assistants/mine/page.tsx
@@ -75,7 +75,7 @@ const MyAssistantPage = () => {
       backendId: backends[0].backendId,
       model: (latest ?? defaultBackend.models[0]).id,
       systemPrompt: '',
-      tokenLimit: 16000,
+      tokenLimit: 128000,
       temperature: DEFAULT_TEMPERATURE,
       tools: [],
       files: [],


### PR DESCRIPTION
The previous default is... obsolete.
As we badly need to improve token limit enforcement, I'll keep the ugly hardwired logic
 