### PR TITLE
Max output tokens is now configurable (default 16384)

### DIFF
--- a/logicle/.env
+++ b/logicle/.env
@@ -16,6 +16,7 @@ ENABLE_SIGNUP=1
 ENABLE_CHAT_AUTOSUMMARY=1
 # Add a button to tool invocation notification to show tool call result in sidebar
 ENABLE_SHOW_TOOL_RESULT=1
+CHAT_MAX_OUTPUT_TOKENS=16384
 # Use the chat backend/model for autosummary. If set to 0, a reasonable backend/model is found and used
 CHAT_AUTOSUMMARY_USE_CHAT_BACKEND=0
 CHAT_ATTACHMENTS_ALLOWED_FORMATS=image/jpeg,image/png,image/webp,image/gif

--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -533,6 +533,7 @@ export class ChatAssistant {
     const tools = await this.createAiTools()
     const providerOptions = this.providerOptions(messages)
     return ai.streamText({
+      maxOutputTokens: env.chat.maxOutputTokens,
       model: this.languageModel,
       messages,
       tools: this.llmModelCapabilities.function_calling

--- a/logicle/lib/env.ts
+++ b/logicle/lib/env.ts
@@ -100,6 +100,7 @@ const env = {
       allowedFormats: process.env.CHAT_ATTACHMENTS_ALLOWED_FORMATS ?? '',
       maxImgDimPx: parseInt(process.env.CHAT_ATTACHMENTS_MAX_IMG_DIM_PX ?? '2048', 10),
     },
+    maxOutputTokens: parseInt(process.env.CHAT_MAX_OUTPUT_TOKENS ?? '16384', 10),
   },
   provision: {
     config: process.env.PROVISION_PATH,


### PR DESCRIPTION
Anthropic APIs need a max output tokens param, which is too low by default (4096)
To make it simple, we now pass output tokens to all LLMs, default is 16384 and is configurable with the env var CHAT_MAX_OUTPUT_TOKENS
