### PR TITLE
Max output tokens per model

### DIFF
--- a/logicle/.env
+++ b/logicle/.env
@@ -16,7 +16,9 @@ ENABLE_SIGNUP=1
 ENABLE_CHAT_AUTOSUMMARY=1
 # Add a button to tool invocation notification to show tool call result in sidebar
 ENABLE_SHOW_TOOL_RESULT=1
-CHAT_MAX_OUTPUT_TOKENS=16384
+# Limit on the output tokens parameter. Models may impose a lower limit
+# CHAT_MAX_OUTPUT_TOKENS=16384
+
 # Use the chat backend/model for autosummary. If set to 0, a reasonable backend/model is found and used
 CHAT_AUTOSUMMARY_USE_CHAT_BACKEND=0
 CHAT_ATTACHMENTS_ALLOWED_FORMATS=image/jpeg,image/png,image/webp,image/gif

--- a/logicle/lib/chat/index.ts
+++ b/logicle/lib/chat/index.ts
@@ -533,7 +533,7 @@ export class ChatAssistant {
     const tools = await this.createAiTools()
     const providerOptions = this.providerOptions(messages)
     return ai.streamText({
-      maxOutputTokens: env.chat.maxOutputTokens,
+      maxOutputTokens: minOptional(this.llmModel.maxOutputTokens, env.chat.maxOutputTokens),
       model: this.languageModel,
       messages,
       tools: this.llmModelCapabilities.function_calling
@@ -992,4 +992,8 @@ export class ChatAssistant {
     }
     return this.computeSafeSummary(summary)
   }
+}
+
+function minOptional(a?: number, b?: number) {
+  return a === undefined ? b : b === undefined ? a : Math.min(a, b)
 }

--- a/logicle/lib/chat/models/anthropic.ts
+++ b/logicle/lib/chat/models/anthropic.ts
@@ -27,7 +27,7 @@ export const claude3HaikuModel: LlmModel = {
     reasoning: false,
   },
   tags: ['obsolete'],
-  maxOutputTokens: 8192,
+  maxOutputTokens: 4096,
 }
 
 export const claude3SonnetModel: LlmModel = {
@@ -44,7 +44,7 @@ export const claude3SonnetModel: LlmModel = {
     reasoning: false,
   },
   tags: ['obsolete'],
-  maxOutputTokens: 8192,
+  maxOutputTokens: 4096,
 }
 
 export const claude3OpusModel: LlmModel = {
@@ -61,7 +61,7 @@ export const claude3OpusModel: LlmModel = {
     reasoning: false,
   },
   tags: ['obsolete'],
-  maxOutputTokens: 8192,
+  maxOutputTokens: 4096,
 }
 
 export const claude35HaikuModel: LlmModel = {
@@ -135,7 +135,7 @@ export const claude4SonnetModel: LlmModel = {
     supportedMedia: ['application/pdf'],
   },
   tags: ['obsolete'],
-  maxOutputTokens: 16384,
+  maxOutputTokens: 64000,
 }
 
 export const claude4OpusModel: LlmModel = {
@@ -153,7 +153,7 @@ export const claude4OpusModel: LlmModel = {
     reasoning: true,
     supportedMedia: ['application/pdf'],
   },
-  maxOutputTokens: 16384,
+  maxOutputTokens: 32000,
 }
 
 export const claude41OpusModel: LlmModel = {
@@ -171,7 +171,7 @@ export const claude41OpusModel: LlmModel = {
     reasoning: true,
     supportedMedia: ['application/pdf'],
   },
-  maxOutputTokens: 16384,
+  maxOutputTokens: 32000,
 }
 
 export const claude45SonnetModel: LlmModel = {
@@ -189,7 +189,7 @@ export const claude45SonnetModel: LlmModel = {
     reasoning: true,
     supportedMedia: ['application/pdf'],
   },
-  maxOutputTokens: 16384,
+  maxOutputTokens: 64000,
 }
 
 export const claudeSonnetLatest: LlmModel = {

--- a/logicle/lib/chat/models/anthropic.ts
+++ b/logicle/lib/chat/models/anthropic.ts
@@ -27,6 +27,7 @@ export const claude3HaikuModel: LlmModel = {
     reasoning: false,
   },
   tags: ['obsolete'],
+  maxOutputTokens: 8192,
 }
 
 export const claude3SonnetModel: LlmModel = {
@@ -43,6 +44,7 @@ export const claude3SonnetModel: LlmModel = {
     reasoning: false,
   },
   tags: ['obsolete'],
+  maxOutputTokens: 8192,
 }
 
 export const claude3OpusModel: LlmModel = {
@@ -59,6 +61,7 @@ export const claude3OpusModel: LlmModel = {
     reasoning: false,
   },
   tags: ['obsolete'],
+  maxOutputTokens: 8192,
 }
 
 export const claude35HaikuModel: LlmModel = {
@@ -76,6 +79,7 @@ export const claude35HaikuModel: LlmModel = {
     supportedMedia: ['application/pdf'],
   },
   tags: ['obsolete'],
+  maxOutputTokens: 8192,
 }
 
 export const claude35SonnetModel: LlmModel = {
@@ -93,6 +97,7 @@ export const claude35SonnetModel: LlmModel = {
     supportedMedia: ['application/pdf'],
   },
   tags: ['obsolete'],
+  maxOutputTokens: 8192,
 }
 
 export const claude37SonnetModel: LlmModel = {
@@ -111,6 +116,7 @@ export const claude37SonnetModel: LlmModel = {
     supportedMedia: ['application/pdf'],
   },
   tags: ['obsolete'],
+  maxOutputTokens: 8192,
 }
 
 export const claude4SonnetModel: LlmModel = {
@@ -129,6 +135,7 @@ export const claude4SonnetModel: LlmModel = {
     supportedMedia: ['application/pdf'],
   },
   tags: ['obsolete'],
+  maxOutputTokens: 16384,
 }
 
 export const claude4OpusModel: LlmModel = {
@@ -146,6 +153,7 @@ export const claude4OpusModel: LlmModel = {
     reasoning: true,
     supportedMedia: ['application/pdf'],
   },
+  maxOutputTokens: 16384,
 }
 
 export const claude41OpusModel: LlmModel = {
@@ -163,6 +171,7 @@ export const claude41OpusModel: LlmModel = {
     reasoning: true,
     supportedMedia: ['application/pdf'],
   },
+  maxOutputTokens: 16384,
 }
 
 export const claude45SonnetModel: LlmModel = {
@@ -180,6 +189,7 @@ export const claude45SonnetModel: LlmModel = {
     reasoning: true,
     supportedMedia: ['application/pdf'],
   },
+  maxOutputTokens: 16384,
 }
 
 export const claudeSonnetLatest: LlmModel = {

--- a/logicle/lib/chat/models/index.ts
+++ b/logicle/lib/chat/models/index.ts
@@ -36,6 +36,7 @@ export interface LlmModel {
   capabilities: LlmModelCapabilities
   defaultReasoning?: ReasoningEffort
   tags?: ModelTags[]
+  maxOutputTokens?: number
 }
 
 export const stockModels = [

--- a/logicle/lib/env.ts
+++ b/logicle/lib/env.ts
@@ -100,7 +100,7 @@ const env = {
       allowedFormats: process.env.CHAT_ATTACHMENTS_ALLOWED_FORMATS ?? '',
       maxImgDimPx: parseInt(process.env.CHAT_ATTACHMENTS_MAX_IMG_DIM_PX ?? '2048', 10),
     },
-    maxOutputTokens: parseInt(process.env.CHAT_MAX_OUTPUT_TOKENS ?? '16384', 10),
+    maxOutputTokens: parseOptionalInt(process.env.CHAT_MAX_OUTPUT_TOKENS),
   },
   provision: {
     config: process.env.PROVISION_PATH,


### PR DESCRIPTION
Anthropic has a maximum number of tokens per model, so....

* Every model has now a maximun number of output tokens (hardwired)
* It is still possible to globally specify a lower number of output tokens (but default is...  undefined)

Currently, the maximum number of output tokens has been given a value only for anthropic