### PR TITLE
Derive open telemetry attributes from environment

### DIFF
--- a/logicle/.env
+++ b/logicle/.env
@@ -31,4 +31,7 @@ OPENAPI_FETCH_TIMEOUT_SECS=3600
 
 NEXT_TELEMETRY_DISABLED=1
 # This endpoint must be... a json endpoint, not grpc!!!!
-#OTEL_EXPORTER_OTLP_ENDPOINT=http://telemetry.example.com:4318
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://telemetry.example.com:4318
+
+# Use this to specify a host.name or other attributes. host name in containers won't make much sense!
+# OTEL_RESOURCE_ATTRIBUTES=host.name=portatile-di-luca


### PR DESCRIPTION
It is now possible to specify additional resources in environment

Example:
```
OTEL_RESOURCE_ATTRIBUTES=host.name=my-laptop
```
