### PR TITLE
Fix assistant prompt syntax highlighting

### DIFF
--- a/apps/frontend/app/assistants/components/AdvancedInstructionsEditor.tsx
+++ b/apps/frontend/app/assistants/components/AdvancedInstructionsEditor.tsx
@@ -72,7 +72,11 @@ const AdvancedInstructionsEditor = forwardRef<HTMLDivElement, Props>(function In
       value={value ?? defaultValue ?? ''}
       onChange={onChange}
       editable={!disabled}
-      basicSetup={false}
+      basicSetup={{
+        lineNumbers: false,
+        foldGutter: false,
+        highlightActiveLineGutter: false,
+      }}
       placeholder={placeholder}
       extensions={[markdown({ base: markdownLanguage, codeLanguages: languages }), ...wrapping]}
     />


### PR DESCRIPTION
## Summary
Restore syntax highlighting in the advanced assistant instructions editor by re-enabling the minimal CodeMirror setup needed for fallback highlighting while keeping the custom wrapping and editor styling.

## Details
- switch the advanced instructions editor from `basicSetup={false}` to a trimmed `basicSetup` configuration
- preserve the existing custom wrapping theme and hide the extra gutter features that are not needed in this editor
- fix the regression where Markdown content rendered as plain monospace text with no syntax highlighting

## Risks
- this slightly expands the CodeMirror baseline behavior in the advanced editor, though the added setup is limited to the built-in defaults minus the disabled gutter features

## Tests
- `npm run check-types`
