### PR TITLE
Fix token estimation and add per-component detail breakdown

### DIFF
--- a/__tests__/chatTruncation.test.ts
+++ b/__tests__/chatTruncation.test.ts
@@ -3,11 +3,17 @@ import * as ai from 'ai'
 
 // --- infrastructure mocks (must come before ChatAssistant import) ---
 
-const { mockDtoMessageToLlmMessage, mockSanitizeOrphanToolCalls, mockCountPromptSegmentsTokens } =
+const {
+  mockDtoMessageToLlmMessage,
+  mockSanitizeOrphanToolCalls,
+  mockCountPromptSegmentsTokens,
+  mockEstimateConversationWindowTokens,
+} =
   vi.hoisted(() => ({
     mockDtoMessageToLlmMessage: vi.fn(),
     mockSanitizeOrphanToolCalls: vi.fn((msgs: ai.ModelMessage[]) => msgs),
     mockCountPromptSegmentsTokens: vi.fn(),
+    mockEstimateConversationWindowTokens: vi.fn(),
   }))
 
 vi.mock('@/backend/lib/chat/conversion', () => ({
@@ -17,6 +23,10 @@ vi.mock('@/backend/lib/chat/conversion', () => ({
 
 vi.mock('@/backend/lib/chat/prompt-token-counter', () => ({
   countPromptSegmentsTokens: mockCountPromptSegmentsTokens,
+}))
+
+vi.mock('@/backend/lib/chat/token-estimator', () => ({
+  estimateConversationWindowTokens: mockEstimateConversationWindowTokens,
 }))
 
 vi.mock('@/db/database', () => ({ db: {} }))
@@ -179,6 +189,22 @@ describe('truncateChat', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.spyOn(ChatAssistant, 'buildPreambleSegments')
+    mockEstimateConversationWindowTokens.mockImplementation(async ({ history }: { history: dto.Message[] }) => {
+      const assistant = 10
+      const historyTokens = history.length * 10
+      return {
+        estimate: {
+          assistant,
+          history: historyTokens,
+          draft: 0,
+          total: assistant + historyTokens,
+        },
+        cache: {
+          textTokensCache: { hits: 0, misses: 0 },
+          fileTokenCache: { hits: 0, misses: 0 },
+        },
+      }
+    })
     mockCountPromptSegmentsTokens.mockImplementation(async (_model, segments: PromptSegment[]) => {
       // Each segment counts as 10 tokens in its respective scope
       const counts = { assistant: 0, history: 0, draft: 0 }
@@ -196,7 +222,7 @@ describe('truncateChat', () => {
     const assistant = makeChatAssistant(100)
     const result = await assistant.truncateChat([])
     expect(result).toEqual([])
-    expect(ChatAssistant.buildPreambleSegments).not.toHaveBeenCalled()
+    expect(mockEstimateConversationWindowTokens).not.toHaveBeenCalled()
   })
 
   test('returns all messages when within token limit', async () => {
@@ -222,7 +248,7 @@ describe('truncateChat', () => {
 
     await assistant.truncateChat(messages)
 
-    expect(ChatAssistant.buildPreambleSegments).toHaveBeenCalledTimes(1)
+    expect(mockEstimateConversationWindowTokens).toHaveBeenCalledTimes(3)
   })
 
   test('drops earliest messages when full history exceeds limit', async () => {

--- a/__tests__/conversion.test.ts
+++ b/__tests__/conversion.test.ts
@@ -222,7 +222,7 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
         ],
       },
       pdfCapabilities,
-      openaiLanguageModel
+      openaiLanguageModel.provider
     )
 
     expect(message).toEqual({
@@ -314,7 +314,7 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
         ],
       },
       pdfCapabilities,
-      openaiLanguageModel
+      openaiLanguageModel.provider
     )
 
     expect(message).toEqual({
@@ -406,7 +406,7 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
         ],
       },
       pdfCapabilities,
-      litellmLanguageModel
+      litellmLanguageModel.provider
     )
 
     expect(message).toEqual({
@@ -477,7 +477,7 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
         ],
       },
       { vision: false, function_calling: true, reasoning: false, supportedMedia: [] },
-      openaiLanguageModel
+      openaiLanguageModel.provider
     )
 
     expect(message).toEqual({
@@ -557,7 +557,7 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
         ],
       },
       { ...pdfCapabilities, vision: true, supportedMedia: ['image/png'] },
-      litellmLanguageModel
+      litellmLanguageModel.provider
     )
 
     expect(message).toEqual({

--- a/__tests__/conversion.test.ts
+++ b/__tests__/conversion.test.ts
@@ -444,6 +444,79 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
     expect(readBuffer).not.toHaveBeenCalled()
   })
 
+  test('converts tool-result PDF files to extracted text when the model has no native PDF support', async () => {
+    extractFromFile.mockResolvedValue('fallback pdf text')
+
+    const { dtoMessageToLlmMessage } = await import('@/backend/lib/chat/conversion')
+    const message = await dtoMessageToLlmMessage(
+      {
+        id: 'm3b',
+        conversationId: 'c1',
+        parent: null,
+        sentAt: new Date().toISOString(),
+        citations: [],
+        role: 'tool',
+        parts: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call1',
+            toolName: 'fetch',
+            result: {
+              type: 'content',
+              value: [
+                {
+                  type: 'file',
+                  id: pdfFile.id,
+                  name: pdfFile.name,
+                  size: pdfFile.size,
+                  mimetype: pdfFile.type,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      { vision: false, function_calling: true, reasoning: false, supportedMedia: [] },
+      openaiLanguageModel
+    )
+
+    expect(message).toEqual({
+      role: 'tool',
+      content: [
+        {
+          toolCallId: 'call1',
+          toolName: 'fetch',
+          type: 'tool-result',
+          output: {
+            type: 'content',
+            value: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  attached_files: [
+                    {
+                      id: pdfFile.id,
+                      name: pdfFile.name,
+                      size: pdfFile.size,
+                      mimetype: pdfFile.type,
+                    },
+                  ],
+                }),
+              },
+              {
+                type: 'text',
+                text: `Here is the text content of the file "${pdfFile.name}" with id ${pdfFile.id}\nfallback pdf text`,
+              },
+            ],
+          },
+        },
+      ],
+    })
+    expect(extractFromFile).toHaveBeenCalledWith(pdfFile)
+    expect(readBuffer).not.toHaveBeenCalled()
+    expect(ensureFileAnalysis).not.toHaveBeenCalled()
+  })
+
   test('converts tool-result image attachments to text for litellm providers', async () => {
     const imageFile = {
       ...pdfFile,

--- a/__tests__/promptTokenCounter.test.ts
+++ b/__tests__/promptTokenCounter.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const { mockEstimateNativeImageTokens, mockGetFileWithId } = vi.hoisted(() => ({
+  mockEstimateNativeImageTokens: vi.fn(),
+  mockGetFileWithId: vi.fn(),
+}))
+
+vi.mock('@/backend/lib/chat/image-token-estimator', () => ({
+  estimateNativeImageTokens: mockEstimateNativeImageTokens,
+}))
+
+vi.mock('@/models/file', () => ({
+  getFileWithId: mockGetFileWithId,
+}))
+
+import {
+  countModelMessageTokens,
+  setTokenizerCounter,
+} from '@/backend/lib/chat/prompt-token-counter'
+import { dtoMessageToLlmMessage } from '@/backend/lib/chat/conversion'
+import type { LlmModel } from '@/lib/chat/models'
+
+const fakeModel = {
+  id: 'gpt-5-latest',
+  capabilities: { vision: true, supportedMedia: ['image/png'] },
+} as unknown as LlmModel
+
+describe('countModelMessageTokens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setTokenizerCounter({
+      countText: vi.fn(async (_tokenizer, text: string) => text.length),
+    })
+    mockEstimateNativeImageTokens.mockResolvedValue(321)
+  })
+
+  test('counts tool-result image-data structurally instead of counting base64 payload as text', async () => {
+    const base64Payload = 'a'.repeat(10000)
+    const tokens = await countModelMessageTokens(fakeModel, {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'call_123',
+          toolName: 'GenerateImage',
+          output: {
+            type: 'content',
+            value: [
+              { type: 'text', text: 'The tool displayed 1 images.' },
+              { type: 'image-data', data: base64Payload, mediaType: 'image/png' },
+            ],
+          },
+        },
+      ],
+    })
+
+    expect(tokens).toBe(
+      JSON.stringify({ toolCallId: 'call_123', toolName: 'GenerateImage' }).length +
+        'The tool displayed 1 images.'.length +
+        321
+    )
+    expect(mockEstimateNativeImageTokens).toHaveBeenCalledTimes(1)
+  })
+
+  test('counts LiteLLM tool-result image placeholders as text after conversion', async () => {
+    const imageFile = {
+      id: 'file_123',
+      name: 'generated.png',
+      path: 'files/generated.png',
+      type: 'image/png',
+      size: 456,
+      uploaded: 1,
+      encrypted: 0,
+    }
+    mockGetFileWithId.mockResolvedValue(imageFile)
+
+    const llmMessage = await dtoMessageToLlmMessage(
+      {
+        id: 'tool-msg-1',
+        role: 'tool',
+        conversationId: 'conv-1',
+        parent: 'assistant-msg-1',
+        sentAt: new Date().toISOString(),
+        citations: [],
+        parts: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_456',
+            toolName: 'GenerateImage',
+            result: {
+              type: 'content',
+              value: [
+                { type: 'text', text: 'The tool displayed 1 images.' },
+                {
+                  type: 'file',
+                  id: imageFile.id,
+                  mimetype: imageFile.type,
+                  name: imageFile.name,
+                  size: imageFile.size,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      fakeModel.capabilities,
+      { provider: 'litellm.chat' } as any
+    )
+
+    expect(llmMessage).toBeDefined()
+    const tokens = await countModelMessageTokens(fakeModel, llmMessage!)
+    const placeholderText = `The tool returned a file attachment "${imageFile.name}" (${imageFile.type}, id ${imageFile.id}) that is available in the UI, but this provider cannot receive binary tool attachments.`
+
+    expect(tokens).toBe(
+      JSON.stringify({ toolCallId: 'call_456', toolName: 'GenerateImage' }).length +
+        JSON.stringify({
+          attached_files: [
+            {
+              id: imageFile.id,
+              name: imageFile.name,
+              size: imageFile.size,
+              mimetype: imageFile.type,
+            },
+          ],
+        }).length +
+        'The tool displayed 1 images.'.length +
+        placeholderText.length
+    )
+    expect(mockEstimateNativeImageTokens).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/promptTokenCounter.test.ts
+++ b/__tests__/promptTokenCounter.test.ts
@@ -104,7 +104,7 @@ describe('countModelMessageTokens', () => {
         ],
       },
       fakeModel.capabilities,
-      { provider: 'litellm.chat' } as any
+      'litellm.chat'
     )
 
     expect(llmMessage).toBeDefined()

--- a/__tests__/subassistantTool.test.ts
+++ b/__tests__/subassistantTool.test.ts
@@ -33,6 +33,16 @@ vi.mock('@/backend/lib/chat/prompt-token-counter', () => ({
   countPromptSegmentsTokens: vi.fn().mockResolvedValue({ assistant: 0, history: 0, draft: 0 }),
 }))
 
+vi.mock('@/backend/lib/chat/token-estimator', () => ({
+  estimateConversationWindowTokens: vi.fn().mockResolvedValue({
+    estimate: { assistant: 0, history: 0, draft: 0, total: 0 },
+    cache: {
+      textTokensCache: { hits: 0, misses: 0 },
+      fileTokenCache: { hits: 0, misses: 0 },
+    },
+  }),
+}))
+
 vi.mock('db/database', () => ({
   db: {
     selectFrom: vi.fn().mockReturnValue({

--- a/__tests__/tokenEstimator.test.ts
+++ b/__tests__/tokenEstimator.test.ts
@@ -1456,4 +1456,50 @@ describe('estimateInputTokens', () => {
 
     expect(wrappedResult.estimate).toEqual(directResult.estimate)
   })
+
+  test('estimatePreambleTokens counts prompt segments and analyzed files together', async () => {
+    const fileId = 'preamble-image-1'
+    getFileWithId.mockResolvedValue(makeImageFile(fileId))
+    ensureFileAnalysis.mockResolvedValue({
+      fileId,
+      kind: 'image',
+      status: 'ready',
+      analyzerVersion: 1,
+      payload: {
+        kind: 'image',
+        mimeType: 'image/png',
+        sizeBytes: 456,
+        width: 512,
+        height: 512,
+        frameCount: 1,
+        hasAlpha: false,
+        format: 'png',
+        extractedTextPath: null,
+      },
+      error: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } satisfies dto.FileAnalysis)
+    await mockBuildPreambleSegments([
+      {
+        scope: 'prompt',
+        message: { role: 'system', content: 'system' },
+        analysisFileIds: [fileId],
+      },
+    ])
+
+    const { estimatePreambleTokens } = await import('@/backend/lib/chat/token-estimator')
+    const result = await estimatePreambleTokens({
+      assistantParams: { ...assistantParams, model: gpt41MiniModel.id },
+      model: gpt41MiniModel,
+      tools: [],
+      parameters: {},
+      knowledgeFiles: [],
+    })
+
+    expect(result).toBe(
+      countTextForModel(gpt41MiniModel, 'system') +
+        Math.ceil(estimateNativeImageTokensFromDimensions(gpt41MiniModel, 512, 512))
+    )
+  })
 })

--- a/__tests__/tokenEstimator.test.ts
+++ b/__tests__/tokenEstimator.test.ts
@@ -324,6 +324,157 @@ describe('estimateInputTokens', () => {
     expect(readBuffer).not.toHaveBeenCalled()
   })
 
+  test('counts tool-result image files using native image estimation', async () => {
+    const fileId = 'tool-image-1'
+    getFileWithId.mockResolvedValue(makeImageFile(fileId))
+    ensureFileAnalysis.mockResolvedValue({
+      fileId,
+      kind: 'image',
+      status: 'ready',
+      analyzerVersion: 1,
+      payload: {
+        kind: 'image',
+        mimeType: 'image/png',
+        sizeBytes: 456,
+        width: 1024,
+        height: 1024,
+        frameCount: 1,
+        hasAlpha: false,
+        format: 'png',
+        extractedTextPath: null,
+      },
+      error: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } satisfies dto.FileAnalysis)
+    await mockBuildPreambleSegments([])
+
+    const { estimateInputTokens } = await import('@/backend/lib/chat/token-estimator')
+    const result = await estimateInputTokens({
+      assistantParams: { ...assistantParams, model: gpt41MiniModel.id },
+      model: gpt41MiniModel,
+      tools: [],
+      parameters: {},
+      knowledgeFiles: [],
+      history: [
+        {
+          id: 'tool-msg-1',
+          role: 'tool',
+          conversationId: 'conv-1',
+          parent: 'assistant-msg-1',
+          sentAt: new Date().toISOString(),
+          citations: [],
+          parts: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_1',
+              toolName: 'GenerateImage',
+              result: {
+                type: 'content',
+                value: [
+                  { type: 'text', text: 'The tool displayed 1 images.' },
+                  {
+                    type: 'file',
+                    id: fileId,
+                    mimetype: 'image/png',
+                    name: 'generated.png',
+                    size: 456,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      draftText: '',
+      attachmentFileIds: [],
+    })
+
+    const expectedImageTokens = Math.ceil(
+      estimateNativeImageTokensFromDimensions(gpt41MiniModel, 1024, 1024)
+    )
+    const expectedToolResultPrefix = countTextForModel(
+      gpt41MiniModel,
+      JSON.stringify({ toolCallId: 'call_1', toolName: 'GenerateImage' })
+    )
+    const expectedDescription = countTextForModel(gpt41MiniModel, 'The tool displayed 1 images.')
+
+    expect(result.estimate).toEqual({
+      assistant: 0,
+      history: expectedToolResultPrefix + expectedDescription + expectedImageTokens,
+      draft: 0,
+      total: expectedToolResultPrefix + expectedDescription + expectedImageTokens,
+    })
+    expect(readExtractedTextFromAnalysis).not.toHaveBeenCalled()
+    expect(readBuffer).not.toHaveBeenCalled()
+  })
+
+  test('counts tool-result PDF files as extracted text when the model has no native PDF support', async () => {
+    const fileId = 'tool-pdf-no-native'
+    const file = makePdfFile(fileId)
+    getFileWithId.mockResolvedValue(file)
+    extractFromFile.mockResolvedValue('tool pdf fallback text')
+    await mockBuildPreambleSegments([])
+
+    const { estimateInputTokens } = await import('@/backend/lib/chat/token-estimator')
+    const result = await estimateInputTokens({
+      assistantParams: { ...assistantParams, model: gpt35Model.id },
+      model: gpt35Model,
+      tools: [],
+      parameters: {},
+      knowledgeFiles: [],
+      history: [
+        {
+          id: 'tool-msg-pdf-1',
+          role: 'tool',
+          conversationId: 'conv-1',
+          parent: 'assistant-msg-1',
+          sentAt: new Date().toISOString(),
+          citations: [],
+          parts: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_pdf_1',
+              toolName: 'FetchPdf',
+              result: {
+                type: 'content',
+                value: [
+                  {
+                    type: 'file',
+                    id: fileId,
+                    mimetype: 'application/pdf',
+                    name: file.name,
+                    size: file.size,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      draftText: '',
+      attachmentFileIds: [],
+    })
+
+    const expectedToolCallPrefix = countTextForModel(
+      gpt35Model,
+      JSON.stringify({ toolCallId: 'call_pdf_1', toolName: 'FetchPdf' })
+    )
+    const expectedFallback = countTextForModel(
+      gpt35Model,
+      `Here is the text content of the file "${file.name}" with id ${file.id}\ntool pdf fallback text`
+    )
+
+    expect(result.estimate).toEqual({
+      assistant: 0,
+      history: expectedToolCallPrefix + expectedFallback,
+      draft: 0,
+      total: expectedToolCallPrefix + expectedFallback,
+    })
+    expect(extractFromFile).toHaveBeenCalledWith(file)
+    expect(ensureFileAnalysis).not.toHaveBeenCalled()
+  })
+
   test('counts courtesy text for draft PDF attachments over the native page limit', async () => {
     const fileId = 'pdf-over-limit'
     const file = makePdfFile(fileId)
@@ -1260,5 +1411,49 @@ describe('estimateInputTokens', () => {
     })
 
     expect(result.estimate.assistant).toBe(countTextForModel(claude35SonnetModel, 'system'))
+  })
+
+  test('keeps estimateInputTokens aligned with estimateConversationWindowTokens', async () => {
+    await mockBuildPreambleSegments([
+      {
+        scope: 'prompt',
+        message: { role: 'system', content: 'system' },
+      },
+    ])
+
+    const draft: dto.UserMessage = {
+      id: 'draft-1',
+      role: 'user',
+      content: 'draft text',
+      attachments: [],
+      conversationId: 'conversation-1',
+      parent: null,
+      sentAt: new Date().toISOString(),
+    }
+
+    const { estimateConversationWindowTokens, estimateInputTokens } = await import(
+      '@/backend/lib/chat/token-estimator'
+    )
+    const directResult = await estimateConversationWindowTokens({
+      assistantParams,
+      model: claude35SonnetModel,
+      tools: [],
+      parameters: {},
+      knowledgeFiles: [],
+      history: [],
+      draft,
+    })
+    const wrappedResult = await estimateInputTokens({
+      assistantParams,
+      model: claude35SonnetModel,
+      tools: [],
+      parameters: {},
+      knowledgeFiles: [],
+      history: [],
+      draftText: draft.content,
+      attachmentFileIds: [],
+    })
+
+    expect(wrappedResult.estimate).toEqual(directResult.estimate)
   })
 })

--- a/apps/backend/api/assistants/tokens/estimate/route.ts
+++ b/apps/backend/api/assistants/tokens/estimate/route.ts
@@ -1,21 +1,27 @@
 import { ChatAssistant } from '@/backend/lib/chat'
-import { estimateConversationWindowTokens } from '@/backend/lib/chat/token-estimator'
+import { createTokenDetailCollector, estimateConversationWindowTokens } from '@/backend/lib/chat/token-estimator'
 import { llmModels } from '@/lib/models'
 import { getUserParameters } from '@/lib/parameters'
 import { error, errorSpec, ok, operation, responseSpec } from '@/lib/routes'
 import { availableToolsFiltered } from '@/backend/lib/tools/enumerate'
 import * as dto from '@/types/dto'
 import { tokenizerForModel } from '@/lib/chat/tokenizer'
+import { z } from 'zod'
 
 export const dynamic = 'force-dynamic'
+
+const detailQuerySchema = z.object({
+  detail: z.coerce.boolean().optional(),
+})
 
 export const POST = operation({
   name: 'Estimate assistant draft input tokens',
   description: 'Estimate non-cumulative input tokens for an assistant draft and message list.',
   authentication: 'user',
   requestBodySchema: dto.assistantTokenEstimateRequestSchema,
+  querySchema: detailQuerySchema,
   responses: [responseSpec(200, dto.assistantTokenEstimateResponseSchema), errorSpec(400)] as const,
-  implementation: async ({ session, body }) => {
+  implementation: async ({ session, body, query }) => {
     const { assistant, messages } = body
     const model = llmModels.find((candidate) => candidate.id === assistant.model)
     if (!model) {
@@ -30,14 +36,18 @@ export const POST = operation({
         ? messages
         : messages.map((msg) => (msg.conversationId ? msg : { ...msg, conversationId }))
     const availableTools = await availableToolsFiltered(assistant.tools, assistant.model)
-    const result = await estimateConversationWindowTokens({
-      assistantParams: ChatAssistant.assistantParamsFrom(assistant),
-      model,
-      tools: availableTools,
-      parameters: await getUserParameters(session.userId),
-      knowledgeFiles: assistant.files,
-      history: normalizedMessages,
-    })
+    const collector = query?.detail ? createTokenDetailCollector() : undefined
+    const result = await estimateConversationWindowTokens(
+      {
+        assistantParams: ChatAssistant.assistantParamsFrom(assistant),
+        model,
+        tools: availableTools,
+        parameters: await getUserParameters(session.userId),
+        knowledgeFiles: assistant.files,
+        history: normalizedMessages,
+      },
+      collector
+    )
 
     return ok({
       assistantId: assistant.id,
@@ -48,6 +58,7 @@ export const POST = operation({
         messages: result.estimate.history,
         total: result.estimate.assistant + result.estimate.history,
       },
+      detail: result.detail,
     })
   },
 })

--- a/apps/backend/api/assistants/tokens/estimate/route.ts
+++ b/apps/backend/api/assistants/tokens/estimate/route.ts
@@ -1,5 +1,5 @@
 import { ChatAssistant } from '@/backend/lib/chat'
-import { estimateInputTokens } from '@/backend/lib/chat/token-estimator'
+import { estimateConversationWindowTokens } from '@/backend/lib/chat/token-estimator'
 import { llmModels } from '@/lib/models'
 import { getUserParameters } from '@/lib/parameters'
 import { error, errorSpec, ok, operation, responseSpec } from '@/lib/routes'
@@ -30,15 +30,13 @@ export const POST = operation({
         ? messages
         : messages.map((msg) => (msg.conversationId ? msg : { ...msg, conversationId }))
     const availableTools = await availableToolsFiltered(assistant.tools, assistant.model)
-    const result = await estimateInputTokens({
+    const result = await estimateConversationWindowTokens({
       assistantParams: ChatAssistant.assistantParamsFrom(assistant),
       model,
       tools: availableTools,
       parameters: await getUserParameters(session.userId),
       knowledgeFiles: assistant.files,
       history: normalizedMessages,
-      draftText: '',
-      attachmentFileIds: [],
     })
 
     return ok({

--- a/apps/backend/api/me/assistants/[assistantId]/tokens/estimate/route.ts
+++ b/apps/backend/api/me/assistants/[assistantId]/tokens/estimate/route.ts
@@ -1,6 +1,6 @@
 import { error, errorSpec, notFound, ok, operation, responseSpec } from '@/lib/routes'
 import { ChatAssistant } from '@/backend/lib/chat'
-import { estimateInputTokens } from '@/backend/lib/chat/token-estimator'
+import { createTokenDetailCollector, estimateInputTokens } from '@/backend/lib/chat/token-estimator'
 import { llmModels } from '@/lib/models'
 import { flatten } from '@/lib/chat/conversationUtils'
 import { getUserParameters } from '@/lib/parameters'
@@ -13,8 +13,13 @@ import { getConversation, getConversationMessages } from '@/models/conversation'
 import { tokenEstimateRequestSchema, tokenEstimateResponseSchema } from '@/types/dto'
 import { tokenizerForModel } from '@/lib/chat/tokenizer'
 import { availableToolsForAssistantVersion } from '@/backend/lib/tools/enumerate'
+import { z } from 'zod'
 
 export const dynamic = 'force-dynamic'
+
+const detailQuerySchema = z.object({
+  detail: z.coerce.boolean().optional(),
+})
 
 export const POST = operation({
   name: 'Estimate input tokens',
@@ -22,12 +27,13 @@ export const POST = operation({
     'Estimate non-cumulative input tokens for a message request on a specific assistant/model.',
   authentication: 'user',
   requestBodySchema: tokenEstimateRequestSchema,
+  querySchema: detailQuerySchema,
   responses: [
     responseSpec(200, tokenEstimateResponseSchema),
     errorSpec(400),
     errorSpec(404),
   ] as const,
-  implementation: async ({ params, session, body }) => {
+  implementation: async ({ params, session, body, query }) => {
     const assistantId = params.assistantId
     const assistants = await getUserAssistants(
       {
@@ -76,21 +82,26 @@ export const POST = operation({
       assistantVersion.id,
       assistantVersion.model
     )
-    const result = await estimateInputTokens({
-      assistantParams: ChatAssistant.assistantParamsFrom(assistantVersion),
-      model,
-      tools: availableTools,
-      parameters: await getUserParameters(session.userId),
-      knowledgeFiles: files,
-      history,
-      draftText: body.draftText,
-      attachmentFileIds: body.attachmentFileIds,
-    })
+    const collector = query?.detail ? createTokenDetailCollector() : undefined
+    const result = await estimateInputTokens(
+      {
+        assistantParams: ChatAssistant.assistantParamsFrom(assistantVersion),
+        model,
+        tools: availableTools,
+        parameters: await getUserParameters(session.userId),
+        knowledgeFiles: files,
+        history,
+        draftText: body.draftText,
+        attachmentFileIds: body.attachmentFileIds,
+      },
+      collector
+    )
     return ok({
       assistantId,
       model: model.id,
       tokenizer: tokenizerForModel(model),
       estimate: result.estimate,
+      detail: result.detail,
     })
   },
 })

--- a/apps/backend/lib/chat/conversion.ts
+++ b/apps/backend/lib/chat/conversion.ts
@@ -1,5 +1,4 @@
 import * as ai from 'ai'
-import { LanguageModelV3 } from '@ai-sdk/provider'
 import * as schema from '@/db/schema'
 import { getFileWithId } from '@/models/file'
 import * as dto from '@/types/dto'
@@ -17,8 +16,8 @@ import {
 
 // LiteLLM does not support binary attachments inside tool results. Detect this by inspecting
 // the AI SDK provider string rather than storing the limitation in model capabilities.
-const supportsToolResultAttachments = (languageModel: LanguageModelV3) =>
-  !languageModel.provider.startsWith('litellm')
+const supportsToolResultAttachments = (providerName: string) =>
+  !providerName.startsWith('litellm')
 
 const toolResultAttachmentText = (fileEntry: schema.File) =>
   `The tool returned a file attachment "${fileEntry.name}" (${fileEntry.type}, id ${fileEntry.id}) that is available in the UI, but this provider cannot receive binary tool attachments.`
@@ -118,13 +117,13 @@ export const dtoFileToLlmFilePart = async (
 const dtoFileToToolResultOutputPart = async (
   fileEntry: schema.File,
   capabilities: LlmModelCapabilities,
-  languageModel: LanguageModelV3
+  providerName: string
 ): Promise<
   | { type: 'text'; text: string }
   | { type: 'image-data'; data: string; mediaType: string }
   | { type: 'file-data'; data: string; mediaType: string }
 > => {
-  if (!supportsToolResultAttachments(languageModel)) {
+  if (!supportsToolResultAttachments(providerName)) {
     return {
       type: 'text',
       text: toolResultAttachmentText(fileEntry),
@@ -159,7 +158,7 @@ const dtoFileToToolResultOutputPart = async (
 export const dtoMessageToLlmMessage = async (
   m: dto.Message,
   capabilities: LlmModelCapabilities,
-  languageModel: LanguageModelV3
+  providerName: string
 ): Promise<ai.ModelMessage | undefined> => {
   if (m.role === 'user-request') return undefined
   if (m.role === 'user-response') return undefined
@@ -189,7 +188,7 @@ export const dtoMessageToLlmMessage = async (
                     if (!fileEntry) {
                       throw new Error(`Can't find entry for attachment ${v.id}`)
                     }
-                    return dtoFileToToolResultOutputPart(fileEntry, capabilities, languageModel)
+                    return dtoFileToToolResultOutputPart(fileEntry, capabilities, providerName)
                   }
                 }
               })

--- a/apps/backend/lib/chat/image-token-estimator.ts
+++ b/apps/backend/lib/chat/image-token-estimator.ts
@@ -81,6 +81,21 @@ export const estimateNativeImageTokens = async (model: LlmModel, imageBuffer: Bu
   }
 }
 
+export const nativeImageAlgorithmName = (model: LlmModel): string => {
+  switch (model.owned_by) {
+    case 'openai': {
+      const estimator = getOpenAiEstimator(model)
+      return estimator.mode === 'patch' ? 'openai_patch_image' : 'openai_tile_image'
+    }
+    case 'anthropic':
+      return 'anthropic_native_image'
+    case 'google':
+      return 'gemini_native_image'
+    default:
+      return 'native_image'
+  }
+}
+
 export const estimateNativeImageTokensFromDimensions = (
   model: LlmModel,
   width: number,

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -26,7 +26,7 @@ import { z } from 'zod/v4'
 import { ParameterValueAndDescription } from '@/models/user'
 import { nanoid } from 'nanoid'
 import { extension as mimeExtension } from 'mime-types'
-import { countPromptSegmentsTokens } from '@/backend/lib/chat/prompt-token-counter'
+import { estimateConversationWindowTokens } from '@/backend/lib/chat/token-estimator'
 
 export { fillTemplate } from './preamble'
 export type { PromptSegment } from './preamble'
@@ -437,17 +437,6 @@ export class ChatAssistant {
   async truncateChat(messages: dto.Message[]) {
     if (messages.length === 0) return messages
 
-    const preambleSegments = await ChatAssistant.buildPreambleSegments({
-      assistantParams: this.assistantParams,
-      llmModel: this.llmModel,
-      tools: this.tools,
-      parameters: this.parameters,
-      knowledge: this.knowledge,
-    })
-    const preambleCounts = await countPromptSegmentsTokens(this.llmModel, preambleSegments)
-    const preambleTokens = preambleCounts.assistant + preambleCounts.history + preambleCounts.draft
-
-    const messageCache = new Map<string, ai.ModelMessage>()
     const userTurnStartIndexes = messages.flatMap((message, index) =>
       message.role === 'user' && index > 0 ? [index] : []
     )
@@ -455,16 +444,15 @@ export class ChatAssistant {
 
     for (const startIndex of candidateStartIndexes) {
       const candidateMessages = messages.slice(startIndex)
-      const historySegments = await ChatAssistant.buildHistorySegments(
-        candidateMessages,
-        this.llmModel,
-        this.languageModel,
-        undefined,
-        messageCache
-      )
-      const historyCounts = await countPromptSegmentsTokens(this.llmModel, historySegments)
-      const totalTokens =
-        preambleTokens + historyCounts.assistant + historyCounts.history + historyCounts.draft
+      const { estimate } = await estimateConversationWindowTokens({
+        assistantParams: this.assistantParams,
+        model: this.llmModel,
+        tools: this.tools,
+        parameters: this.parameters,
+        knowledgeFiles: this.knowledge,
+        history: candidateMessages,
+      })
+      const totalTokens = estimate.total
       if (totalTokens <= this.assistantParams.tokenLimit) {
         if (startIndex > 0) {
           logger.info(

--- a/apps/backend/lib/chat/preamble.ts
+++ b/apps/backend/lib/chat/preamble.ts
@@ -1,5 +1,5 @@
 import * as ai from 'ai'
-import { LanguageModelV3 } from '@ai-sdk/provider'
+import type { LanguageModelV3 } from '@ai-sdk/provider'
 import * as dto from '@/types/dto'
 import env from '@/lib/env'
 import { LlmModel } from '@/lib/chat/models'
@@ -163,7 +163,7 @@ export async function buildHistorySegments(
         let converted = cache?.get(message.id)
         if (!converted) {
           converted =
-            (await dtoMessageToLlmMessage(message, llmModel.capabilities, languageModel)) ??
+            (await dtoMessageToLlmMessage(message, llmModel.capabilities, languageModel.provider)) ??
             undefined
           if (converted && cache) cache.set(message.id, converted)
         }

--- a/apps/backend/lib/chat/preamble.ts
+++ b/apps/backend/lib/chat/preamble.ts
@@ -11,10 +11,17 @@ type AssistantParamsLike = {
   systemPrompt: string
 }
 
+export type KnowledgeFileEntry = {
+  fileId: string
+  fileName: string
+  partIndex: number
+}
+
 export type PromptSegment = {
   scope: 'prompt' | 'history' | 'draft'
   message: ai.ModelMessage
   analysisFileIds?: string[]
+  knowledgeFileEntries?: KnowledgeFileEntry[]
 }
 
 export function fillTemplate(
@@ -126,10 +133,16 @@ export async function buildPreambleSegments({
       const analysisFileIds = parts.flatMap((part, index) =>
         part.type === 'file' ? [knowledge[index]?.id ?? ''] : []
       ).filter((id) => id.length > 0)
+      const knowledgeFileEntries: KnowledgeFileEntry[] = knowledge.map((k, index) => ({
+        fileId: k.id,
+        fileName: k.name,
+        partIndex: index,
+      }))
       segments.push({
         scope: 'prompt',
         message: { role: 'user', content: parts },
         analysisFileIds,
+        knowledgeFileEntries,
       })
     }
   }

--- a/apps/backend/lib/chat/prompt-token-counter.ts
+++ b/apps/backend/lib/chat/prompt-token-counter.ts
@@ -110,6 +110,78 @@ export const countDtoToolResultOutputTokens = async (
   }
 }
 
+type ModelToolResultContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'image-data'; data: string; mediaType: string }
+  | { type: 'file-data'; data: string; mediaType: string; filename?: string }
+
+const countModelToolResultContentPartTokens = async (
+  model: LlmModel,
+  item: ModelToolResultContentPart,
+  stats?: TokenCountCacheStats
+): Promise<number> => {
+  switch (item.type) {
+    case 'text':
+      return countTextTokensCached(model, item.text, stats)
+    case 'image-data':
+      if (acceptableImageTypes.includes(item.mediaType)) {
+        return Math.ceil(
+          await estimateNativeImageTokens(model, Buffer.from(item.data, 'base64'))
+        )
+      }
+      return countTextTokensCached(
+        model,
+        JSON.stringify({ mediaType: item.mediaType }),
+        stats
+      )
+    case 'file-data':
+      return countTextTokensCached(
+        model,
+        JSON.stringify({
+          filename: item.filename ?? 'data',
+          mediaType: item.mediaType,
+        }),
+        stats
+      )
+  }
+}
+
+const countModelToolResultOutputTokens = async (
+  model: LlmModel,
+  output: unknown,
+  stats?: TokenCountCacheStats
+): Promise<number> => {
+  if (typeof output === 'string') {
+    return countTextTokensCached(model, output, stats)
+  }
+  if (!output || typeof output !== 'object' || !('type' in output)) {
+    return countTextTokensCached(model, JSON.stringify(output), stats)
+  }
+
+  const typedOutput = output as
+    | { type: 'text' | 'error-text'; value: string }
+    | { type: 'json' | 'error-json'; value: unknown }
+    | { type: 'content'; value: ModelToolResultContentPart[] }
+
+  switch (typedOutput.type) {
+    case 'text':
+    case 'error-text':
+      return countTextTokensCached(model, typedOutput.value, stats)
+    case 'json':
+    case 'error-json':
+      return countTextTokensCached(model, JSON.stringify(typedOutput.value), stats)
+    case 'content': {
+      let tokens = 0
+      for (const item of typedOutput.value) {
+        tokens += await countModelToolResultContentPartTokens(model, item, stats)
+      }
+      return tokens
+    }
+    default:
+      return countTextTokensCached(model, JSON.stringify(output), stats)
+  }
+}
+
 export const countModelMessageTokens = async (
   model: LlmModel,
   message: ai.ModelMessage,
@@ -150,7 +222,7 @@ export const countModelMessageTokens = async (
           }),
           stats
         )
-        tokens += await countTextTokensCached(model, JSON.stringify(part.output), stats)
+        tokens += await countModelToolResultOutputTokens(model, part.output, stats)
         break
       case 'image': {
         if (typeof part.image === 'string') {

--- a/apps/backend/lib/chat/prompt-token-counter.ts
+++ b/apps/backend/lib/chat/prompt-token-counter.ts
@@ -80,36 +80,6 @@ const parseDataUrl = (value: string) => {
   }
 }
 
-export const countDtoToolResultOutputTokens = async (
-  model: LlmModel,
-  output: dto.ToolCallResultOutput,
-  stats?: TokenCountCacheStats
-): Promise<number> => {
-  switch (output.type) {
-    case 'text':
-    case 'error-text':
-      return countTextTokensCached(model, output.value, stats)
-    case 'json':
-    case 'error-json':
-      return countTextTokensCached(model, JSON.stringify(output.value), stats)
-    case 'content': {
-      let tokens = 0
-      for (const item of output.value) {
-        if (item.type === 'text') {
-          tokens += await countTextTokensCached(model, item.text, stats)
-        } else if (item.type === 'file') {
-          tokens += await countTextTokensCached(
-            model,
-            JSON.stringify({ name: item.name, mimetype: item.mimetype }),
-            stats
-          )
-        }
-      }
-      return tokens
-    }
-  }
-}
-
 type ModelToolResultContentPart =
   | { type: 'text'; text: string }
   | { type: 'image-data'; data: string; mediaType: string }

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -21,7 +21,7 @@ import {
   acceptableImageTypes,
   getPdfAttachmentPageLimitText,
 } from '@/backend/lib/chat/file-attachment-policy'
-import { estimateNativeImageTokensFromDimensions } from '@/backend/lib/chat/image-token-estimator'
+import { estimateNativeImageTokensFromDimensions, nativeImageAlgorithmName } from '@/backend/lib/chat/image-token-estimator'
 import { cachingExtractor } from '@/lib/textextraction/cache'
 import {
   countTextTokensCached,
@@ -31,6 +31,7 @@ import {
   createTokenCountCacheStats,
   TokenCountCacheStats,
 } from './prompt-token-counter'
+import type * as ai from 'ai'
 import { buildPreambleSegments } from '@/backend/lib/chat/preamble'
 import { tokenizerForModel } from '@/lib/chat/tokenizer'
 
@@ -205,7 +206,7 @@ const estimateAnalyzedFileTokens = async (
   )
   const entry: FileTokenCacheEntry = {
     tokens,
-    algorithm: 'native_image',
+    algorithm: nativeImageAlgorithmName(model),
     params: { width: analysis.payload.width, height: analysis.payload.height },
   }
   fileTokenCountCache.set(cacheKey, entry)
@@ -455,19 +456,39 @@ export const estimatePreambleTokens = async ({
     // Knowledge segment is optional and always second when present
     if (preambleSegments.length > 1) {
       const knowledgeSegment = preambleSegments[1]
-      const knowledgeTextTokens = await countModelMessageTokens(model, knowledgeSegment.message, stats)
-      collector.addPreamblePart({ type: 'knowledge_text', tokens: knowledgeTextTokens, algorithm })
+      const messageParts = Array.isArray(knowledgeSegment.message.content)
+        ? (knowledgeSegment.message.content as unknown[])
+        : []
 
-      for (const fileId of (knowledgeSegment.analysisFileIds ?? [])) {
-        const file = knowledgeFiles.find((f) => f.id === fileId)
-        const entry = await estimateAnalyzedFileTokens(fileId, model, stats)
+      for (const entry of (knowledgeSegment.knowledgeFileEntries ?? [])) {
+        // Try analysis first (works uniformly for images and PDFs with native support).
+        // Fall back to counting the message part directly for text/unanalyzed files.
+        const analysisEntry = await estimateAnalyzedFileTokens(entry.fileId, model, stats)
+        let fileTokens: number
+        let fileAlgorithm: string
+        let fileParams: Record<string, unknown> | undefined
+        if (analysisEntry.tokens > 0) {
+          fileTokens = analysisEntry.tokens
+          fileAlgorithm = analysisEntry.algorithm
+          fileParams = analysisEntry.params
+        } else {
+          const part = messageParts[entry.partIndex]
+          fileTokens = part
+            ? await countModelMessageTokens(
+                model,
+                { role: 'user', content: [part] } as ai.UserModelMessage,
+                stats
+              )
+            : 0
+          fileAlgorithm = algorithm
+        }
         collector.addPreamblePart({
           type: 'knowledge_file',
-          id: fileId,
-          name: file?.name,
-          tokens: entry.tokens,
-          algorithm: entry.algorithm,
-          params: entry.params,
+          id: entry.fileId,
+          name: entry.fileName,
+          tokens: fileTokens,
+          algorithm: fileAlgorithm,
+          params: fileParams,
         })
       }
     }

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -25,7 +25,6 @@ import { estimateNativeImageTokensFromDimensions, nativeImageAlgorithmName } fro
 import { cachingExtractor } from '@/lib/textextraction/cache'
 import {
   countTextTokensCached,
-  countPromptSegmentsTokens,
   countModelMessageTokens,
   createPendingUserMessage,
   createTokenCountCacheStats,
@@ -229,20 +228,25 @@ const estimateTextFallbackAttachmentTokens = async (
   return countTextTokensCached(model, fallbackText, stats)
 }
 
-const estimatePromptSegmentsTokens = async (
+const estimateKnowledgeFileTokens = async (
+  fileId: string,
+  fileName: string,
+  partIndex: number,
+  messageParts: unknown[],
   model: LlmModel,
-  segments: Awaited<ReturnType<typeof buildPreambleSegments>>,
   stats?: CacheStats
-): Promise<number> => {
-  const { assistant } = await countPromptSegmentsTokens(model, segments, stats)
-  const analysisFileTokens = (
-    await Promise.all(
-      segments.flatMap((segment) =>
-        (segment.analysisFileIds ?? []).map((fileId) => estimateAnalyzedFileTokens(fileId, model, stats))
+): Promise<FileTokenCacheEntry> => {
+  const analysisEntry = await estimateAnalyzedFileTokens(fileId, model, stats)
+  if (analysisEntry.tokens > 0) return analysisEntry
+  const part = messageParts[partIndex]
+  const tokens = part
+    ? await countModelMessageTokens(
+        model,
+        { role: 'user', content: [part] } as ai.UserModelMessage,
+        stats
       )
-    )
-  ).reduce((sum, entry) => sum + entry.tokens, 0)
-  return assistant + analysisFileTokens
+    : 0
+  return { tokens, algorithm: tokenizerForModel(model) }
 }
 
 const estimateToolResultOutputTokens = async (
@@ -444,57 +448,58 @@ export const estimatePreambleTokens = async ({
     parameters,
     knowledge: knowledgeFiles,
   })
-  const total = await estimatePromptSegmentsTokens(model, preambleSegments, stats)
+  if (preambleSegments.length === 0) return 0
 
-  if (collector) {
-    const algorithm = tokenizerForModel(model)
+  const algorithm = tokenizerForModel(model)
 
-    // System prompt segment is always first
-    const systemTokens = await countModelMessageTokens(model, preambleSegments[0].message, stats)
-    collector.addPreamblePart({ type: 'system_prompt', tokens: systemTokens, algorithm })
+  // System prompt is always the first segment
+  const systemTokens = await countModelMessageTokens(model, preambleSegments[0].message, stats)
+  collector?.addPreamblePart({ type: 'system_prompt', tokens: systemTokens, algorithm })
 
-    // Knowledge segment is optional and always second when present
-    if (preambleSegments.length > 1) {
-      const knowledgeSegment = preambleSegments[1]
-      const messageParts = Array.isArray(knowledgeSegment.message.content)
-        ? (knowledgeSegment.message.content as unknown[])
-        : []
-
-      for (const entry of (knowledgeSegment.knowledgeFileEntries ?? [])) {
-        // Try analysis first (works uniformly for images and PDFs with native support).
-        // Fall back to counting the message part directly for text/unanalyzed files.
-        const analysisEntry = await estimateAnalyzedFileTokens(entry.fileId, model, stats)
-        let fileTokens: number
-        let fileAlgorithm: string
-        let fileParams: Record<string, unknown> | undefined
-        if (analysisEntry.tokens > 0) {
-          fileTokens = analysisEntry.tokens
-          fileAlgorithm = analysisEntry.algorithm
-          fileParams = analysisEntry.params
-        } else {
-          const part = messageParts[entry.partIndex]
-          fileTokens = part
-            ? await countModelMessageTokens(
-                model,
-                { role: 'user', content: [part] } as ai.UserModelMessage,
-                stats
-              )
-            : 0
-          fileAlgorithm = algorithm
-        }
-        collector.addPreamblePart({
-          type: 'knowledge_file',
-          id: entry.fileId,
-          name: entry.fileName,
-          tokens: fileTokens,
-          algorithm: fileAlgorithm,
-          params: fileParams,
-        })
-      }
+  // Knowledge segment is optional and always second when present
+  let knowledgeTokens = 0
+  if (preambleSegments.length > 1) {
+    const knowledgeSegment = preambleSegments[1]
+    const messageParts = Array.isArray(knowledgeSegment.message.content)
+      ? (knowledgeSegment.message.content as unknown[])
+      : []
+    for (const entry of (knowledgeSegment.knowledgeFileEntries ?? [])) {
+      const fileEntry = await estimateKnowledgeFileTokens(
+        entry.fileId, entry.fileName, entry.partIndex, messageParts, model, stats
+      )
+      knowledgeTokens += fileEntry.tokens
+      collector?.addPreamblePart({
+        type: 'knowledge_file',
+        id: entry.fileId,
+        name: entry.fileName,
+        tokens: fileEntry.tokens,
+        algorithm: fileEntry.algorithm,
+        params: fileEntry.params,
+      })
     }
   }
 
-  return total
+  // Legacy: count any analysisFileIds not covered by knowledgeFileEntries above
+  // (e.g. segments produced by custom/mocked preamble builders)
+  const coveredFileIds = new Set(
+    preambleSegments.flatMap((seg) => (seg.knowledgeFileEntries ?? []).map((e) => e.fileId))
+  )
+  for (const segment of preambleSegments) {
+    for (const fileId of (segment.analysisFileIds ?? [])) {
+      if (coveredFileIds.has(fileId)) continue
+      const entry = await estimateAnalyzedFileTokens(fileId, model, stats)
+      knowledgeTokens += entry.tokens
+      collector?.addPreamblePart({
+        type: 'knowledge_file',
+        id: fileId,
+        tokens: entry.tokens,
+        algorithm: entry.algorithm,
+        params: entry.params,
+      })
+    }
+  }
+
+  return systemTokens + knowledgeTokens
 }
 
 export const estimateInputTokens = async (

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -25,7 +25,6 @@ import { estimateNativeImageTokensFromDimensions } from '@/backend/lib/chat/imag
 import { cachingExtractor } from '@/lib/textextraction/cache'
 import {
   countTextTokensCached,
-  countDtoToolResultOutputTokens,
   countPromptSegmentsTokens,
   createPendingUserMessage,
   createTokenCountCacheStats,
@@ -78,6 +77,16 @@ type TokenEstimateInput = {
   history: dto.Message[]
   draftText: string
   attachmentFileIds: string[]
+}
+
+export type ConversationWindowEstimateInput = {
+  assistantParams: AssistantParams
+  model: LlmModel
+  tools: ToolImplementation[]
+  parameters: Record<string, ParameterValueAndDescription>
+  knowledgeFiles: dto.AssistantFile[]
+  history: dto.Message[]
+  draft?: dto.UserMessage | null
 }
 
 const estimateTextFallbackAttachmentTokens = async (
@@ -177,6 +186,41 @@ const estimateAttachmentTokens = async (
   )
 }
 
+const estimateToolResultOutputTokens = async (
+  model: LlmModel,
+  output: dto.ToolCallResultOutput,
+  stats?: CacheStats
+): Promise<number> => {
+  switch (output.type) {
+    case 'text':
+    case 'error-text':
+      return countTextTokensCached(model, output.value, stats)
+    case 'json':
+    case 'error-json':
+      return countTextTokensCached(model, JSON.stringify(output.value), stats)
+    case 'content': {
+      let tokens = 0
+      for (const item of output.value) {
+        if (item.type === 'text') {
+          tokens += await countTextTokensCached(model, item.text, stats)
+          continue
+        }
+        tokens += await estimateAttachmentTokens(
+          model,
+          {
+            id: item.id,
+            mimetype: item.mimetype,
+            name: item.name,
+            size: item.size,
+          },
+          stats
+        )
+      }
+      return tokens
+    }
+  }
+}
+
 
 const estimateDtoMessageTokens = async (
   model: LlmModel,
@@ -216,31 +260,40 @@ const estimateDtoMessageTokens = async (
         JSON.stringify({ toolCallId: part.toolCallId, toolName: part.toolName }),
         stats
       )
-      tokens += await countDtoToolResultOutputTokens(model, part.result, stats)
+      tokens += await estimateToolResultOutputTokens(model, part.result, stats)
     }
     return tokens
   }
   return 0
 }
 
-export const estimateInputTokens = async (
-  input: TokenEstimateInput
-): Promise<TokenEstimateResult> => {
-  const stats: CacheStats = createTokenCountCacheStats()
-  const {
-    assistantParams,
-    model,
-    tools,
-    parameters,
-    history,
-    knowledgeFiles,
-    draftText,
-    attachmentFileIds,
-  } = input
+export const estimateHistoryTokens = async (
+  model: LlmModel,
+  history: dto.Message[],
+  stats?: CacheStats
+): Promise<number> => {
+  let historyTokenCount = 0
+  for (const message of history) {
+    historyTokenCount += await estimateDtoMessageTokens(model, message, stats)
+  }
+  return historyTokenCount
+}
 
-  const pendingMessage = await createPendingUserMessage(attachmentFileIds, draftText)
-
-  // Preamble (system prompt, tools, knowledge) — no file bytes loaded
+export const estimatePreambleTokens = async ({
+  assistantParams,
+  model,
+  tools,
+  parameters,
+  knowledgeFiles,
+  stats,
+}: {
+  assistantParams: AssistantParams
+  model: LlmModel
+  tools: ToolImplementation[]
+  parameters: Record<string, ParameterValueAndDescription>
+  knowledgeFiles: dto.AssistantFile[]
+  stats?: CacheStats
+}): Promise<number> => {
   const preambleSegments = await buildPreambleSegments({
     assistantParams,
     llmModel: model,
@@ -256,23 +309,63 @@ export const estimateInputTokens = async (
       )
     )
   ).reduce((sum, value) => sum + value, 0)
+  return assistant + preambleFileTokens
+}
 
-  // History — work directly on dto.Message objects, no file bytes loaded
-  let historyTokenCount = 0
-  for (const message of history) {
-    historyTokenCount += await estimateDtoMessageTokens(model, message, stats)
-  }
+export const estimateInputTokens = async (
+  input: TokenEstimateInput
+): Promise<TokenEstimateResult> => {
+  const {
+    assistantParams,
+    model,
+    tools,
+    parameters,
+    history,
+    knowledgeFiles,
+    draftText,
+    attachmentFileIds,
+  } = input
 
-  // Draft message
-  const draft = pendingMessage ? await estimateDtoMessageTokens(model, pendingMessage, stats) : 0
+  const pendingMessage = await createPendingUserMessage(attachmentFileIds, draftText)
 
-  const total = assistant + preambleFileTokens + historyTokenCount + draft
+  // Backward-compatible wrapper for callers that still provide draft text/file ids
+  // instead of a DTO user message.
+  return estimateConversationWindowTokens({
+    assistantParams,
+    model,
+    tools,
+    parameters,
+    knowledgeFiles,
+    history,
+    draft: pendingMessage,
+  })
+}
+
+export const estimateConversationWindowTokens = async (
+  input: ConversationWindowEstimateInput
+): Promise<TokenEstimateResult> => {
+  const stats: CacheStats = createTokenCountCacheStats()
+  const { assistantParams, model, tools, parameters, knowledgeFiles, history, draft } = input
+
+  const preambleTokenCount = await estimatePreambleTokens({
+    assistantParams,
+    model,
+    tools,
+    parameters,
+    knowledgeFiles,
+    stats,
+  })
+
+  const historyTokenCount = await estimateHistoryTokens(model, history, stats)
+  const draftTokenCount = draft ? await estimateDtoMessageTokens(model, draft, stats) : 0
+
+  const total = preambleTokenCount + historyTokenCount + draftTokenCount
 
   return {
     estimate: {
-      assistant: assistant + preambleFileTokens,
+      assistant: preambleTokenCount,
       history: historyTokenCount,
-      draft,
+      draft: draftTokenCount,
       total,
     },
     cache: stats,

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -26,34 +26,107 @@ import { cachingExtractor } from '@/lib/textextraction/cache'
 import {
   countTextTokensCached,
   countPromptSegmentsTokens,
+  countModelMessageTokens,
   createPendingUserMessage,
   createTokenCountCacheStats,
   TokenCountCacheStats,
 } from './prompt-token-counter'
 import { buildPreambleSegments } from '@/backend/lib/chat/preamble'
+import { tokenizerForModel } from '@/lib/chat/tokenizer'
+
+// --- File token cache -----------------------------------------------------------
+
+type FileTokenCacheEntry = {
+  tokens: number
+  algorithm: string
+  params?: Record<string, unknown>
+}
 
 // Per-model file token count cache, keyed by `${fileId}:${model.id}`
-const fileTokenCountCache = new LRUCache<string, number>({
+const fileTokenCountCache = new LRUCache<string, FileTokenCacheEntry>({
   max: Number.parseInt(process.env.TOKEN_ESTIMATOR_FILE_CACHE_MAX_ENTRIES ?? '1000', 10) || 1000,
 })
 
 type CacheStats = TokenCountCacheStats
+
+// --- Detail collector -----------------------------------------------------------
+
+export interface TokenDetailCollector {
+  addPreamblePart(part: dto.TokenDetailPart): void
+  addHistoryPart(messageId: string, role: string, part: dto.TokenDetailPart): void
+  addDraftPart(part: dto.TokenDetailPart): void
+  build(): dto.TokenEstimateDetail
+}
+
+export const createTokenDetailCollector = (): TokenDetailCollector => {
+  const preamble: dto.TokenDetailPart[] = []
+  const historyMap = new Map<string, { role: string; parts: dto.TokenDetailPart[] }>()
+  const historyOrder: string[] = []
+  const draft: dto.TokenDetailPart[] = []
+
+  return {
+    addPreamblePart(part) {
+      preamble.push(part)
+    },
+    addHistoryPart(messageId, role, part) {
+      if (!historyMap.has(messageId)) {
+        historyMap.set(messageId, { role, parts: [] })
+        historyOrder.push(messageId)
+      }
+      historyMap.get(messageId)!.parts.push(part)
+    },
+    addDraftPart(part) {
+      draft.push(part)
+    },
+    build() {
+      return {
+        preamble,
+        history: historyOrder.map((id) => {
+          const entry = historyMap.get(id)!
+          return {
+            messageId: id,
+            role: entry.role as dto.MessageTokenDetail['role'],
+            parts: entry.parts,
+          }
+        }),
+        draft: draft.length > 0 ? draft : undefined,
+      }
+    },
+  }
+}
+
+// --- Internal helpers -----------------------------------------------------------
+
+type AttachmentDetailCallback = (
+  tokens: number,
+  algorithm: string,
+  params?: Record<string, unknown>
+) => void
 
 const computePdfNativeTokenCount = async (
   model: LlmModel,
   file: NonNullable<Awaited<ReturnType<typeof getFileWithId>>>,
   analysis: dto.FileAnalysis,
   payload: PdfAnalysisPayload
-): Promise<number> => {
+): Promise<FileTokenCacheEntry> => {
   const extractedText = await readExtractedTextFromAnalysis(file, analysis)
   const textTokenCount = await countTextTokensCached(model, normalizeExtractedText(extractedText ?? ''))
-  return Math.ceil(
+  const tokens = Math.ceil(
     predictPdfTokenCount(resolvePdfEstimatorModel(model), {
       pageCount: payload.pageCount,
       visionPageCount: payload.visionPageCount,
       textTokenCount,
     })
   )
+  return {
+    tokens,
+    algorithm: 'pdf_native',
+    params: {
+      pageCount: payload.pageCount,
+      visionPageCount: payload.visionPageCount,
+      textTokenCount,
+    },
+  }
 }
 
 export type TokenEstimateBreakdown = {
@@ -66,6 +139,7 @@ export type TokenEstimateBreakdown = {
 export type TokenEstimateResult = {
   estimate: TokenEstimateBreakdown
   cache: CacheStats
+  detail?: dto.TokenEstimateDetail
 }
 
 type TokenEstimateInput = {
@@ -89,22 +163,6 @@ export type ConversationWindowEstimateInput = {
   draft?: dto.UserMessage | null
 }
 
-const estimateTextFallbackAttachmentTokens = async (
-  model: LlmModel,
-  fileId: string,
-  stats?: CacheStats
-): Promise<number> => {
-  const file = await getFileWithId(fileId)
-  if (!file || file.uploaded !== 1) return 0
-
-  const extractedText = await cachingExtractor.extractFromFile(file)
-  const fallbackText = extractedText
-    ? `Here is the text content of the file "${file.name}" with id ${file.id}\n${extractedText}`
-    : `The content of the file "${file.name}" with id ${file.id} could not be extracted. It is possible that some tools can return the content on demand`
-
-  return countTextTokensCached(model, fallbackText, stats)
-}
-
 const getCachedFileTokenCount = (
   fileId: string,
   model: LlmModel,
@@ -125,65 +183,49 @@ const estimateAnalyzedFileTokens = async (
   fileId: string,
   model: LlmModel,
   stats?: CacheStats
-): Promise<number> => {
+): Promise<FileTokenCacheEntry> => {
   const { cacheKey, cached } = getCachedFileTokenCount(fileId, model, stats)
   if (cached !== undefined) return cached
 
   const file = await getFileWithId(fileId)
-  if (!file || file.uploaded !== 1) return 0
+  if (!file || file.uploaded !== 1) return { tokens: 0, algorithm: 'none' }
   const analysis = await ensureFileAnalysis(file)
-  if (!isReadyFileAnalysis(analysis)) return 0
+  if (!isReadyFileAnalysis(analysis)) return { tokens: 0, algorithm: 'none' }
 
   if (isPdfAnalysisPayload(analysis.payload)) {
-    if (isPdfOverNativePageLimit(analysis.payload, model)) return 0
-    const result = await computePdfNativeTokenCount(model, file, analysis, analysis.payload)
-    fileTokenCountCache.set(cacheKey, result)
-    return result
+    if (isPdfOverNativePageLimit(analysis.payload, model)) return { tokens: 0, algorithm: 'none' }
+    const entry = await computePdfNativeTokenCount(model, file, analysis, analysis.payload)
+    fileTokenCountCache.set(cacheKey, entry)
+    return entry
   }
 
-  if (!isImageAnalysisPayload(analysis.payload)) return 0
-  const result = Math.ceil(
+  if (!isImageAnalysisPayload(analysis.payload)) return { tokens: 0, algorithm: 'none' }
+  const tokens = Math.ceil(
     estimateNativeImageTokensFromDimensions(model, analysis.payload.width, analysis.payload.height)
   )
-  fileTokenCountCache.set(cacheKey, result)
-  return result
+  const entry: FileTokenCacheEntry = {
+    tokens,
+    algorithm: 'native_image',
+    params: { width: analysis.payload.width, height: analysis.payload.height },
+  }
+  fileTokenCountCache.set(cacheKey, entry)
+  return entry
 }
 
-const estimateAttachmentTokens = async (
+const estimateTextFallbackAttachmentTokens = async (
   model: LlmModel,
-  attachment: dto.Attachment,
+  fileId: string,
   stats?: CacheStats
 ): Promise<number> => {
-  if (attachment.mimetype === 'application/pdf') {
-    if (model.capabilities.supportedMedia?.includes('application/pdf')) {
-      const { cacheKey, cached } = getCachedFileTokenCount(attachment.id, model, stats)
-      if (cached !== undefined) return cached
-      const file = await getFileWithId(attachment.id)
-      if (!file || file.uploaded !== 1 || file.type !== 'application/pdf') return 0
-      const analysis = await ensureFileAnalysis(file)
-      if (!isReadyFileAnalysis(analysis) || !isPdfAnalysisPayload(analysis.payload)) return 0
-      if (isPdfOverNativePageLimit(analysis.payload, model)) {
-        const courtesyText = getPdfAttachmentPageLimitText(
-          attachment,
-          analysis.payload.pageCount,
-          model
-        )
-        return courtesyText ? await countTextTokensCached(model, courtesyText, stats) : 0
-      }
-      const result = await computePdfNativeTokenCount(model, file, analysis, analysis.payload)
-      fileTokenCountCache.set(cacheKey, result)
-      return result
-    }
-    return estimateTextFallbackAttachmentTokens(model, attachment.id, stats)
-  }
-  if (model.capabilities.vision && acceptableImageTypes.includes(attachment.mimetype)) {
-    return estimateAnalyzedFileTokens(attachment.id, model, stats)
-  }
-  return countTextTokensCached(
-    model,
-    JSON.stringify({ filename: attachment.name, mediaType: attachment.mimetype }),
-    stats
-  )
+  const file = await getFileWithId(fileId)
+  if (!file || file.uploaded !== 1) return 0
+
+  const extractedText = await cachingExtractor.extractFromFile(file)
+  const fallbackText = extractedText
+    ? `Here is the text content of the file "${file.name}" with id ${file.id}\n${extractedText}`
+    : `The content of the file "${file.name}" with id ${file.id} could not be extracted. It is possible that some tools can return the content on demand`
+
+  return countTextTokensCached(model, fallbackText, stats)
 }
 
 const estimatePromptSegmentsTokens = async (
@@ -198,7 +240,7 @@ const estimatePromptSegmentsTokens = async (
         (segment.analysisFileIds ?? []).map((fileId) => estimateAnalyzedFileTokens(fileId, model, stats))
       )
     )
-  ).reduce((sum, value) => sum + value, 0)
+  ).reduce((sum, entry) => sum + entry.tokens, 0)
   return assistant + analysisFileTokens
 }
 
@@ -223,12 +265,7 @@ const estimateToolResultOutputTokens = async (
         }
         tokens += await estimateAttachmentTokens(
           model,
-          {
-            id: item.id,
-            mimetype: item.mimetype,
-            name: item.name,
-            size: item.size,
-          },
+          { id: item.id, mimetype: item.mimetype, name: item.name, size: item.size },
           stats
         )
       }
@@ -237,16 +274,80 @@ const estimateToolResultOutputTokens = async (
   }
 }
 
+const estimateAttachmentTokens = async (
+  model: LlmModel,
+  attachment: dto.Attachment,
+  stats?: CacheStats,
+  onDetail?: AttachmentDetailCallback
+): Promise<number> => {
+  const algorithm = tokenizerForModel(model)
+  if (attachment.mimetype === 'application/pdf') {
+    if (model.capabilities.supportedMedia?.includes('application/pdf')) {
+      const { cacheKey, cached } = getCachedFileTokenCount(attachment.id, model, stats)
+      if (cached !== undefined) {
+        onDetail?.(cached.tokens, cached.algorithm, cached.params)
+        return cached.tokens
+      }
+      const file = await getFileWithId(attachment.id)
+      if (!file || file.uploaded !== 1 || file.type !== 'application/pdf') return 0
+      const analysis = await ensureFileAnalysis(file)
+      if (!isReadyFileAnalysis(analysis) || !isPdfAnalysisPayload(analysis.payload)) return 0
+      if (isPdfOverNativePageLimit(analysis.payload, model)) {
+        const courtesyText = getPdfAttachmentPageLimitText(
+          attachment,
+          analysis.payload.pageCount,
+          model
+        )
+        const tokens = courtesyText ? await countTextTokensCached(model, courtesyText, stats) : 0
+        onDetail?.(tokens, 'pdf_page_limit_notice', { pageCount: analysis.payload.pageCount })
+        return tokens
+      }
+      const entry = await computePdfNativeTokenCount(model, file, analysis, analysis.payload)
+      fileTokenCountCache.set(cacheKey, entry)
+      onDetail?.(entry.tokens, entry.algorithm, entry.params)
+      return entry.tokens
+    }
+    const tokens = await estimateTextFallbackAttachmentTokens(model, attachment.id, stats)
+    onDetail?.(tokens, 'pdf_text_fallback')
+    return tokens
+  }
+  if (model.capabilities.vision && acceptableImageTypes.includes(attachment.mimetype)) {
+    const entry = await estimateAnalyzedFileTokens(attachment.id, model, stats)
+    onDetail?.(entry.tokens, entry.algorithm, entry.params)
+    return entry.tokens
+  }
+  const tokens = await countTextTokensCached(
+    model,
+    JSON.stringify({ filename: attachment.name, mediaType: attachment.mimetype }),
+    stats
+  )
+  onDetail?.(tokens, algorithm)
+  return tokens
+}
 
 const estimateDtoMessageTokens = async (
   model: LlmModel,
   message: dto.Message,
-  stats?: CacheStats
+  stats?: CacheStats,
+  onDetail?: (part: dto.TokenDetailPart) => void
 ): Promise<number> => {
+  const algorithm = tokenizerForModel(model)
   if (message.role === 'user') {
-    let tokens = await countTextTokensCached(model, message.content, stats)
+    const textTokens = await countTextTokensCached(model, message.content, stats)
+    onDetail?.({ type: 'text', tokens: textTokens, algorithm })
+    let tokens = textTokens
     for (const attachment of message.attachments) {
-      tokens += await estimateAttachmentTokens(model, attachment, stats)
+      tokens += await estimateAttachmentTokens(model, attachment, stats, (aTokens, aAlgorithm, aParams) => {
+        onDetail?.({
+          type: 'attachment',
+          id: attachment.id,
+          name: attachment.name,
+          mimetype: attachment.mimetype,
+          tokens: aTokens,
+          algorithm: aAlgorithm,
+          params: aParams,
+        })
+      })
     }
     return tokens
   }
@@ -254,15 +355,21 @@ const estimateDtoMessageTokens = async (
     let tokens = 0
     for (const part of message.parts) {
       if (part.type === 'text') {
-        tokens += await countTextTokensCached(model, part.text, stats)
+        const t = await countTextTokensCached(model, part.text, stats)
+        onDetail?.({ type: 'text', tokens: t, algorithm })
+        tokens += t
       } else if (part.type === 'reasoning') {
-        tokens += await countTextTokensCached(model, part.reasoning, stats)
+        const t = await countTextTokensCached(model, part.reasoning, stats)
+        onDetail?.({ type: 'reasoning', tokens: t, algorithm })
+        tokens += t
       } else if (part.type === 'tool-call') {
-        tokens += await countTextTokensCached(
+        const t = await countTextTokensCached(
           model,
           JSON.stringify({ toolCallId: part.toolCallId, toolName: part.toolName, input: part.args }),
           stats
         )
+        onDetail?.({ type: 'tool_call', toolCallId: part.toolCallId, toolName: part.toolName, tokens: t, algorithm })
+        tokens += t
       }
     }
     return tokens
@@ -271,12 +378,21 @@ const estimateDtoMessageTokens = async (
     let tokens = 0
     for (const part of message.parts) {
       if (part.type !== 'tool-result') continue
-      tokens += await countTextTokensCached(
+      const metaTokens = await countTextTokensCached(
         model,
         JSON.stringify({ toolCallId: part.toolCallId, toolName: part.toolName }),
         stats
       )
-      tokens += await estimateToolResultOutputTokens(model, part.result, stats)
+      const resultTokens = await estimateToolResultOutputTokens(model, part.result, stats)
+      const partTokens = metaTokens + resultTokens
+      onDetail?.({
+        type: 'tool_result',
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        tokens: partTokens,
+        algorithm,
+      })
+      tokens += partTokens
     }
     return tokens
   }
@@ -286,11 +402,19 @@ const estimateDtoMessageTokens = async (
 export const estimateHistoryTokens = async (
   model: LlmModel,
   history: dto.Message[],
-  stats?: CacheStats
+  stats?: CacheStats,
+  collector?: TokenDetailCollector
 ): Promise<number> => {
   let historyTokenCount = 0
   for (const message of history) {
-    historyTokenCount += await estimateDtoMessageTokens(model, message, stats)
+    historyTokenCount += await estimateDtoMessageTokens(
+      model,
+      message,
+      stats,
+      collector
+        ? (part) => collector.addHistoryPart(message.id, message.role, part)
+        : undefined
+    )
   }
   return historyTokenCount
 }
@@ -302,6 +426,7 @@ export const estimatePreambleTokens = async ({
   parameters,
   knowledgeFiles,
   stats,
+  collector,
 }: {
   assistantParams: AssistantParams
   model: LlmModel
@@ -309,6 +434,7 @@ export const estimatePreambleTokens = async ({
   parameters: Record<string, ParameterValueAndDescription>
   knowledgeFiles: dto.AssistantFile[]
   stats?: CacheStats
+  collector?: TokenDetailCollector
 }): Promise<number> => {
   const preambleSegments = await buildPreambleSegments({
     assistantParams,
@@ -317,11 +443,42 @@ export const estimatePreambleTokens = async ({
     parameters,
     knowledge: knowledgeFiles,
   })
-  return estimatePromptSegmentsTokens(model, preambleSegments, stats)
+  const total = await estimatePromptSegmentsTokens(model, preambleSegments, stats)
+
+  if (collector) {
+    const algorithm = tokenizerForModel(model)
+
+    // System prompt segment is always first
+    const systemTokens = await countModelMessageTokens(model, preambleSegments[0].message, stats)
+    collector.addPreamblePart({ type: 'system_prompt', tokens: systemTokens, algorithm })
+
+    // Knowledge segment is optional and always second when present
+    if (preambleSegments.length > 1) {
+      const knowledgeSegment = preambleSegments[1]
+      const knowledgeTextTokens = await countModelMessageTokens(model, knowledgeSegment.message, stats)
+      collector.addPreamblePart({ type: 'knowledge_text', tokens: knowledgeTextTokens, algorithm })
+
+      for (const fileId of (knowledgeSegment.analysisFileIds ?? [])) {
+        const file = knowledgeFiles.find((f) => f.id === fileId)
+        const entry = await estimateAnalyzedFileTokens(fileId, model, stats)
+        collector.addPreamblePart({
+          type: 'knowledge_file',
+          id: fileId,
+          name: file?.name,
+          tokens: entry.tokens,
+          algorithm: entry.algorithm,
+          params: entry.params,
+        })
+      }
+    }
+  }
+
+  return total
 }
 
 export const estimateInputTokens = async (
-  input: TokenEstimateInput
+  input: TokenEstimateInput,
+  collector?: TokenDetailCollector
 ): Promise<TokenEstimateResult> => {
   const {
     assistantParams,
@@ -336,21 +493,23 @@ export const estimateInputTokens = async (
 
   const pendingMessage = await createPendingUserMessage(attachmentFileIds, draftText)
 
-  // Backward-compatible wrapper for callers that still provide draft text/file ids
-  // instead of a DTO user message.
-  return estimateConversationWindowTokens({
-    assistantParams,
-    model,
-    tools,
-    parameters,
-    knowledgeFiles,
-    history,
-    draft: pendingMessage,
-  })
+  return estimateConversationWindowTokens(
+    {
+      assistantParams,
+      model,
+      tools,
+      parameters,
+      knowledgeFiles,
+      history,
+      draft: pendingMessage,
+    },
+    collector
+  )
 }
 
 export const estimateConversationWindowTokens = async (
-  input: ConversationWindowEstimateInput
+  input: ConversationWindowEstimateInput,
+  collector?: TokenDetailCollector
 ): Promise<TokenEstimateResult> => {
   const stats: CacheStats = createTokenCountCacheStats()
   const { assistantParams, model, tools, parameters, knowledgeFiles, history, draft } = input
@@ -362,10 +521,18 @@ export const estimateConversationWindowTokens = async (
     parameters,
     knowledgeFiles,
     stats,
+    collector,
   })
 
-  const historyTokenCount = await estimateHistoryTokens(model, history, stats)
-  const draftTokenCount = draft ? await estimateDtoMessageTokens(model, draft, stats) : 0
+  const historyTokenCount = await estimateHistoryTokens(model, history, stats, collector)
+  const draftTokenCount = draft
+    ? await estimateDtoMessageTokens(
+        model,
+        draft,
+        stats,
+        collector ? (part) => collector.addDraftPart(part) : undefined
+      )
+    : 0
 
   const total = preambleTokenCount + historyTokenCount + draftTokenCount
 
@@ -377,5 +544,6 @@ export const estimateConversationWindowTokens = async (
       total,
     },
     cache: stats,
+    detail: collector?.build(),
   }
 }

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -186,6 +186,22 @@ const estimateAttachmentTokens = async (
   )
 }
 
+const estimatePromptSegmentsTokens = async (
+  model: LlmModel,
+  segments: Awaited<ReturnType<typeof buildPreambleSegments>>,
+  stats?: CacheStats
+): Promise<number> => {
+  const { assistant } = await countPromptSegmentsTokens(model, segments, stats)
+  const analysisFileTokens = (
+    await Promise.all(
+      segments.flatMap((segment) =>
+        (segment.analysisFileIds ?? []).map((fileId) => estimateAnalyzedFileTokens(fileId, model, stats))
+      )
+    )
+  ).reduce((sum, value) => sum + value, 0)
+  return assistant + analysisFileTokens
+}
+
 const estimateToolResultOutputTokens = async (
   model: LlmModel,
   output: dto.ToolCallResultOutput,
@@ -301,15 +317,7 @@ export const estimatePreambleTokens = async ({
     parameters,
     knowledge: knowledgeFiles,
   })
-  const { assistant } = await countPromptSegmentsTokens(model, preambleSegments, stats)
-  const preambleFileTokens = (
-    await Promise.all(
-      preambleSegments.flatMap((segment) =>
-        (segment.analysisFileIds ?? []).map((fileId) => estimateAnalyzedFileTokens(fileId, model, stats))
-      )
-    )
-  ).reduce((sum, value) => sum + value, 0)
-  return assistant + preambleFileTokens
+  return estimatePromptSegmentsTokens(model, preambleSegments, stats)
 }
 
 export const estimateInputTokens = async (

--- a/apps/backend/lib/models.ts
+++ b/apps/backend/lib/models.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import { stockModels, LlmModel, defaultTokenizerByProvider } from '@/lib/chat/models'
+import { stockModels, LlmModel, defaultTokenizerByOwner } from '@/lib/chat/models'
 import { logger } from './logging'
 
 const loadModels = async (dir: string) => {
@@ -24,7 +24,7 @@ export const llmModels = process.env.PROVISION_MODELS_PATH
   : stockModels
 
 for (const model of llmModels) {
-  model.tokenizer = model.tokenizer ?? defaultTokenizerByProvider(model.provider)
+  model.tokenizer = model.tokenizer ?? defaultTokenizerByOwner(model.owned_by)
   if (model.provider === 'anthropic' && model.capabilities.supportedMedia?.includes('application/pdf')) {
     model.capabilities.nativePdfPageLimit = model.capabilities.nativePdfPageLimit ?? 100
   }

--- a/apps/frontend/app/assistants/components/AssistantForm.tsx
+++ b/apps/frontend/app/assistants/components/AssistantForm.tsx
@@ -192,6 +192,9 @@ export const AssistantForm = ({
   const [assistantContextLength, setAssistantContextLength] = useState<number | undefined>(
     cachedAssistantContextLength
   )
+  const [assistantTokenDetail, setAssistantTokenDetail] = useState<
+    dto.TokenEstimateDetail | undefined
+  >(undefined)
   const shownAssistantContextLength = assistantContextLength ?? cachedAssistantContextLength
   const previousEstimateInputs = useRef<
     | Readonly<{
@@ -230,13 +233,14 @@ export const AssistantForm = ({
         ...assistant,
         ...formValuesToAssistant(form.getValues()),
       }
-      void estimateAssistantDraftTokens({
-        assistant: draftAssistant,
-        messages: [],
-      }).then((result) => {
+      void estimateAssistantDraftTokens(
+        { assistant: draftAssistant, messages: [] },
+        { detail: true }
+      ).then((result) => {
         if (!result.data || latestEstimateRequestSeq.current !== requestSeq) return
         setAssistantContextLength(result.data.estimate.assistant)
         setCachedAssistantContextLength(result.data.estimate.assistant)
+        setAssistantTokenDetail(result.data.detail)
       })
     }, debounceMs)
 
@@ -301,7 +305,9 @@ export const AssistantForm = ({
           <ContextLengthIndicator
             current={shownAssistantContextLength ?? 0}
             limit={tokenLimit}
+            pending={assistantContextLength === undefined}
             details={[t('context_length_tooltip_assistant_form')]}
+            tokenDetail={assistantTokenDetail}
             className="absolute right-0 top-1/2 -translate-y-1/2"
           />
         </div>

--- a/apps/frontend/app/chat/components/ChatInput.tsx
+++ b/apps/frontend/app/chat/components/ChatInput.tsx
@@ -111,6 +111,7 @@ export const ChatInput = ({
     serverPending: false,
   })
   const latestEstimateRequestSeq = useRef(0)
+  const [tokenDetail, setTokenDetail] = useState<dto.TokenEstimateDetail | undefined>(undefined)
 
   const fileInputId = `${useId()}-attach`
 
@@ -197,10 +198,10 @@ export const ChatInput = ({
         serverPending: true,
       }))
       const estimatePromise = draftAssistantForEstimate
-        ? estimateAssistantDraftTokens({
-            assistant: draftAssistantForEstimate,
-            messages: draftEstimateMessages ?? [],
-          })
+        ? estimateAssistantDraftTokens(
+            { assistant: draftAssistantForEstimate, messages: draftEstimateMessages ?? [] },
+            { detail: true }
+          )
         : estimateAssistantTokens(assistantId, {
             conversationId,
             targetMessageId,
@@ -221,6 +222,9 @@ export const ChatInput = ({
                 total: nextTokens,
               },
             }))
+            if (draftAssistantForEstimate) {
+              setTokenDetail(result.data.detail)
+            }
             onServerContextTokensChange?.(nextTokens)
           }
         })
@@ -535,6 +539,7 @@ export const ChatInput = ({
               limit={tokenLimit}
               pending={contextEstimate.serverPending}
               details={contextDetails}
+              tokenDetail={draftAssistantForEstimate ? tokenDetail : undefined}
             />
           }
         />

--- a/apps/frontend/components/app/ContextLengthIndicator.tsx
+++ b/apps/frontend/components/app/ContextLengthIndicator.tsx
@@ -3,13 +3,28 @@
 import { useTranslation } from 'react-i18next'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/frontend/lib/utils'
+import * as dto from '@/types/dto'
 
 type Props = {
   current: number
   limit?: number
   pending?: boolean
   details: string[]
+  tokenDetail?: dto.TokenEstimateDetail
   className?: string
+}
+
+const labelForPart = (part: dto.TokenDetailPart): string => {
+  switch (part.type) {
+    case 'system_prompt':
+      return 'System prompt'
+    case 'knowledge_text':
+      return 'Knowledge (text)'
+    case 'knowledge_file':
+      return part.name ?? part.id ?? 'Knowledge file'
+    default:
+      return part.type
+  }
 }
 
 export const ContextLengthIndicator = ({
@@ -17,6 +32,7 @@ export const ContextLengthIndicator = ({
   limit,
   pending = false,
   details,
+  tokenDetail,
   className,
 }: Props) => {
   const { t } = useTranslation()
@@ -28,6 +44,9 @@ export const ContextLengthIndicator = ({
   const radius = (size - strokeWidth) / 2
   const circumference = 2 * Math.PI * radius
   const dashOffset = circumference * (1 - usageRatio)
+
+  const preambleParts = tokenDetail?.preamble ?? []
+  const preambleTotal = preambleParts.reduce((sum, p) => sum + p.tokens, 0)
 
   return (
     <TooltipProvider delayDuration={150}>
@@ -88,6 +107,29 @@ export const ContextLengthIndicator = ({
           {details.map((detail) => (
             <div key={detail}>{detail}</div>
           ))}
+          {preambleParts.length > 0 && (
+            <div className="mt-2 space-y-1 border-t border-zinc-700 pt-2">
+              {preambleParts.map((part, i) => {
+                const pct = preambleTotal > 0 ? (part.tokens / preambleTotal) * 100 : 0
+                return (
+                  <div key={i} className="flex items-center gap-2">
+                    <span className="min-w-0 flex-1 truncate text-zinc-300">
+                      {labelForPart(part)}
+                    </span>
+                    <div className="w-14 shrink-0 overflow-hidden rounded-full bg-zinc-700">
+                      <div
+                        className="h-1 rounded-full bg-zinc-400 transition-[width] duration-300"
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                    <span className="w-14 shrink-0 text-right tabular-nums text-zinc-400">
+                      {part.tokens.toLocaleString()}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          )}
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/apps/frontend/components/app/ContextLengthIndicator.tsx
+++ b/apps/frontend/components/app/ContextLengthIndicator.tsx
@@ -27,6 +27,49 @@ const labelForPart = (part: dto.TokenDetailPart): string => {
   }
 }
 
+const roleLabel = (role: string): string => {
+  switch (role) {
+    case 'user':
+      return 'User'
+    case 'assistant':
+      return 'Assistant'
+    case 'tool':
+      return 'Tool'
+    default:
+      return role
+  }
+}
+
+const TokenRow = ({
+  label,
+  tokens,
+  grandTotal,
+}: {
+  label: string
+  tokens: number
+  grandTotal: number
+}) => {
+  const pct = grandTotal > 0 ? (tokens / grandTotal) * 100 : 0
+  return (
+    <div className="flex items-center gap-2">
+      <span className="min-w-0 flex-1 truncate text-zinc-300">{label}</span>
+      <div className="w-14 shrink-0 overflow-hidden rounded-full bg-zinc-700">
+        <div
+          className="h-1 rounded-full bg-zinc-400 transition-[width] duration-300"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="w-14 shrink-0 text-right tabular-nums text-zinc-400">
+        {tokens.toLocaleString()}
+      </span>
+    </div>
+  )
+}
+
+const SectionHeader = ({ label }: { label: string }) => (
+  <div className="pb-0.5 pt-2 text-[10px] uppercase tracking-wide text-zinc-500">{label}</div>
+)
+
 export const ContextLengthIndicator = ({
   current,
   limit,
@@ -46,7 +89,18 @@ export const ContextLengthIndicator = ({
   const dashOffset = circumference * (1 - usageRatio)
 
   const preambleParts = tokenDetail?.preamble ?? []
-  const preambleTotal = preambleParts.reduce((sum, p) => sum + p.tokens, 0)
+  const historyMessages = tokenDetail?.history ?? []
+  const draftParts = tokenDetail?.draft ?? []
+
+  const preambleTotal = preambleParts.reduce((s, p) => s + p.tokens, 0)
+  const historyTotal = historyMessages.reduce(
+    (s, m) => s + m.parts.reduce((ms, p) => ms + p.tokens, 0),
+    0
+  )
+  const draftTotal = draftParts.reduce((s, p) => s + p.tokens, 0)
+  const grandTotal = preambleTotal + historyTotal + draftTotal
+
+  const hasDetail = grandTotal > 0
 
   return (
     <TooltipProvider delayDuration={150}>
@@ -107,27 +161,56 @@ export const ContextLengthIndicator = ({
           {details.map((detail) => (
             <div key={detail}>{detail}</div>
           ))}
-          {preambleParts.length > 0 && (
-            <div className="mt-2 space-y-1 border-t border-zinc-700 pt-2">
-              {preambleParts.map((part, i) => {
-                const pct = preambleTotal > 0 ? (part.tokens / preambleTotal) * 100 : 0
-                return (
-                  <div key={i} className="flex items-center gap-2">
-                    <span className="min-w-0 flex-1 truncate text-zinc-300">
-                      {labelForPart(part)}
-                    </span>
-                    <div className="w-14 shrink-0 overflow-hidden rounded-full bg-zinc-700">
-                      <div
-                        className="h-1 rounded-full bg-zinc-400 transition-[width] duration-300"
-                        style={{ width: `${pct}%` }}
+          {hasDetail && (
+            <div className="border-t border-zinc-700">
+              {preambleParts.length > 0 && (
+                <>
+                  <SectionHeader label="Preamble" />
+                  <div className="space-y-1">
+                    {preambleParts.map((part, i) => (
+                      <TokenRow
+                        key={i}
+                        label={labelForPart(part)}
+                        tokens={part.tokens}
+                        grandTotal={grandTotal}
                       />
-                    </div>
-                    <span className="w-14 shrink-0 text-right tabular-nums text-zinc-400">
-                      {part.tokens.toLocaleString()}
-                    </span>
+                    ))}
                   </div>
-                )
-              })}
+                </>
+              )}
+              {historyMessages.length > 0 && (
+                <>
+                  <SectionHeader label="History" />
+                  <div className="max-h-48 space-y-1 overflow-y-auto">
+                    {historyMessages.map((msg, i) => {
+                      const msgTokens = msg.parts.reduce((s, p) => s + p.tokens, 0)
+                      return (
+                        <TokenRow
+                          key={msg.messageId}
+                          label={`${roleLabel(msg.role)} ${i + 1}`}
+                          tokens={msgTokens}
+                          grandTotal={grandTotal}
+                        />
+                      )
+                    })}
+                  </div>
+                </>
+              )}
+              {draftParts.length > 0 && (
+                <>
+                  <SectionHeader label="Draft" />
+                  <div className="space-y-1">
+                    {draftParts.map((part, i) => (
+                      <TokenRow
+                        key={i}
+                        label={labelForPart(part)}
+                        tokens={part.tokens}
+                        grandTotal={grandTotal}
+                      />
+                    ))}
+                  </div>
+                </>
+              )}
             </div>
           )}
         </TooltipContent>

--- a/apps/frontend/next-env.d.ts
+++ b/apps/frontend/next-env.d.ts
@@ -1,4 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -1398,6 +1398,163 @@ paths:
                       - messages
                       - total
                     additionalProperties: false
+                  detail:
+                    description: Detailed per-component token breakdown, present only when
+                      ?detail=true is requested.
+                    type: object
+                    properties:
+                      preamble:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                              description: "Component type: system_prompt, knowledge_text, knowledge_file,
+                                text, attachment, reasoning, tool_call,
+                                tool_result."
+                            tokens:
+                              type: number
+                              description: Token count for this component.
+                            algorithm:
+                              type: string
+                              description: "Algorithm or tokenizer used: cl100k_base, o200k_base,
+                                approx_4chars, native_image, pdf_native,
+                                pdf_text_fallback, pdf_page_limit_notice."
+                            params:
+                              description: Algorithm parameters, e.g. image dimensions or PDF page counts.
+                              type: object
+                              additionalProperties: {}
+                            id:
+                              description: File id or tool call id.
+                              type: string
+                            name:
+                              description: File name.
+                              type: string
+                            mimetype:
+                              description: MIME type for attachment entries.
+                              type: string
+                            toolCallId:
+                              description: Tool call id for tool_call and tool_result entries.
+                              type: string
+                            toolName:
+                              description: Tool name for tool_call and tool_result entries.
+                              type: string
+                          required:
+                            - type
+                            - tokens
+                            - algorithm
+                          additionalProperties: false
+                        description: Per-component breakdown of preamble tokens (system prompt,
+                          knowledge).
+                      history:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            messageId:
+                              type: string
+                            role:
+                              type: string
+                              enum:
+                                - user
+                                - assistant
+                                - tool
+                            parts:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    description: "Component type: system_prompt, knowledge_text, knowledge_file,
+                                      text, attachment, reasoning, tool_call,
+                                      tool_result."
+                                  tokens:
+                                    type: number
+                                    description: Token count for this component.
+                                  algorithm:
+                                    type: string
+                                    description: "Algorithm or tokenizer used: cl100k_base, o200k_base,
+                                      approx_4chars, native_image, pdf_native,
+                                      pdf_text_fallback, pdf_page_limit_notice."
+                                  params:
+                                    description: Algorithm parameters, e.g. image dimensions or PDF page counts.
+                                    type: object
+                                    additionalProperties: {}
+                                  id:
+                                    description: File id or tool call id.
+                                    type: string
+                                  name:
+                                    description: File name.
+                                    type: string
+                                  mimetype:
+                                    description: MIME type for attachment entries.
+                                    type: string
+                                  toolCallId:
+                                    description: Tool call id for tool_call and tool_result entries.
+                                    type: string
+                                  toolName:
+                                    description: Tool name for tool_call and tool_result entries.
+                                    type: string
+                                required:
+                                  - type
+                                  - tokens
+                                  - algorithm
+                                additionalProperties: false
+                          required:
+                            - messageId
+                            - role
+                            - parts
+                          additionalProperties: false
+                        description: Per-message breakdown of history tokens.
+                      draft:
+                        description: Per-component breakdown of draft message tokens.
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                              description: "Component type: system_prompt, knowledge_text, knowledge_file,
+                                text, attachment, reasoning, tool_call,
+                                tool_result."
+                            tokens:
+                              type: number
+                              description: Token count for this component.
+                            algorithm:
+                              type: string
+                              description: "Algorithm or tokenizer used: cl100k_base, o200k_base,
+                                approx_4chars, native_image, pdf_native,
+                                pdf_text_fallback, pdf_page_limit_notice."
+                            params:
+                              description: Algorithm parameters, e.g. image dimensions or PDF page counts.
+                              type: object
+                              additionalProperties: {}
+                            id:
+                              description: File id or tool call id.
+                              type: string
+                            name:
+                              description: File name.
+                              type: string
+                            mimetype:
+                              description: MIME type for attachment entries.
+                              type: string
+                            toolCallId:
+                              description: Tool call id for tool_call and tool_result entries.
+                              type: string
+                            toolName:
+                              description: Tool name for tool_call and tool_result entries.
+                              type: string
+                          required:
+                            - type
+                            - tokens
+                            - algorithm
+                          additionalProperties: false
+                    required:
+                      - preamble
+                      - history
+                    additionalProperties: false
                 required:
                   - assistantId
                   - model
@@ -4380,6 +4537,163 @@ paths:
                       - history
                       - draft
                       - total
+                    additionalProperties: false
+                  detail:
+                    description: Detailed per-component token breakdown, present only when
+                      ?detail=true is requested.
+                    type: object
+                    properties:
+                      preamble:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                              description: "Component type: system_prompt, knowledge_text, knowledge_file,
+                                text, attachment, reasoning, tool_call,
+                                tool_result."
+                            tokens:
+                              type: number
+                              description: Token count for this component.
+                            algorithm:
+                              type: string
+                              description: "Algorithm or tokenizer used: cl100k_base, o200k_base,
+                                approx_4chars, native_image, pdf_native,
+                                pdf_text_fallback, pdf_page_limit_notice."
+                            params:
+                              description: Algorithm parameters, e.g. image dimensions or PDF page counts.
+                              type: object
+                              additionalProperties: {}
+                            id:
+                              description: File id or tool call id.
+                              type: string
+                            name:
+                              description: File name.
+                              type: string
+                            mimetype:
+                              description: MIME type for attachment entries.
+                              type: string
+                            toolCallId:
+                              description: Tool call id for tool_call and tool_result entries.
+                              type: string
+                            toolName:
+                              description: Tool name for tool_call and tool_result entries.
+                              type: string
+                          required:
+                            - type
+                            - tokens
+                            - algorithm
+                          additionalProperties: false
+                        description: Per-component breakdown of preamble tokens (system prompt,
+                          knowledge).
+                      history:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            messageId:
+                              type: string
+                            role:
+                              type: string
+                              enum:
+                                - user
+                                - assistant
+                                - tool
+                            parts:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    description: "Component type: system_prompt, knowledge_text, knowledge_file,
+                                      text, attachment, reasoning, tool_call,
+                                      tool_result."
+                                  tokens:
+                                    type: number
+                                    description: Token count for this component.
+                                  algorithm:
+                                    type: string
+                                    description: "Algorithm or tokenizer used: cl100k_base, o200k_base,
+                                      approx_4chars, native_image, pdf_native,
+                                      pdf_text_fallback, pdf_page_limit_notice."
+                                  params:
+                                    description: Algorithm parameters, e.g. image dimensions or PDF page counts.
+                                    type: object
+                                    additionalProperties: {}
+                                  id:
+                                    description: File id or tool call id.
+                                    type: string
+                                  name:
+                                    description: File name.
+                                    type: string
+                                  mimetype:
+                                    description: MIME type for attachment entries.
+                                    type: string
+                                  toolCallId:
+                                    description: Tool call id for tool_call and tool_result entries.
+                                    type: string
+                                  toolName:
+                                    description: Tool name for tool_call and tool_result entries.
+                                    type: string
+                                required:
+                                  - type
+                                  - tokens
+                                  - algorithm
+                                additionalProperties: false
+                          required:
+                            - messageId
+                            - role
+                            - parts
+                          additionalProperties: false
+                        description: Per-message breakdown of history tokens.
+                      draft:
+                        description: Per-component breakdown of draft message tokens.
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                              description: "Component type: system_prompt, knowledge_text, knowledge_file,
+                                text, attachment, reasoning, tool_call,
+                                tool_result."
+                            tokens:
+                              type: number
+                              description: Token count for this component.
+                            algorithm:
+                              type: string
+                              description: "Algorithm or tokenizer used: cl100k_base, o200k_base,
+                                approx_4chars, native_image, pdf_native,
+                                pdf_text_fallback, pdf_page_limit_notice."
+                            params:
+                              description: Algorithm parameters, e.g. image dimensions or PDF page counts.
+                              type: object
+                              additionalProperties: {}
+                            id:
+                              description: File id or tool call id.
+                              type: string
+                            name:
+                              description: File name.
+                              type: string
+                            mimetype:
+                              description: MIME type for attachment entries.
+                              type: string
+                            toolCallId:
+                              description: Tool call id for tool_call and tool_result entries.
+                              type: string
+                            toolName:
+                              description: Tool name for tool_call and tool_result entries.
+                              type: string
+                          required:
+                            - type
+                            - tokens
+                            - algorithm
+                          additionalProperties: false
+                    required:
+                      - preamble
+                      - history
                     additionalProperties: false
                 required:
                   - assistantId

--- a/apps/frontend/services/tokens.ts
+++ b/apps/frontend/services/tokens.ts
@@ -12,7 +12,11 @@ export const estimateAssistantTokens = async (
 }
 
 export const estimateAssistantDraftTokens = async (
-  payload: dto.AssistantTokenEstimateRequest
+  payload: dto.AssistantTokenEstimateRequest,
+  options?: { detail?: boolean }
 ) => {
-  return await post<dto.AssistantTokenEstimateResponse>(`/api/assistants/tokens/estimate`, payload)
+  const url = options?.detail
+    ? '/api/assistants/tokens/estimate?detail=true'
+    : '/api/assistants/tokens/estimate'
+  return await post<dto.AssistantTokenEstimateResponse>(url, payload)
 }

--- a/packages/core/src/chat/tokenizer.ts
+++ b/packages/core/src/chat/tokenizer.ts
@@ -1,6 +1,6 @@
 import * as dto from '@/types/dto'
 import { getEncoding, Tiktoken } from 'js-tiktoken'
-import { LlmModel, TokenizerStrategy, defaultTokenizerByProvider } from '../models'
+import { LlmModel, TokenizerStrategy, defaultTokenizerByOwner } from '../models'
 
 const encodingCache = new Map<'cl100k_base' | 'o200k_base', Tiktoken>()
 
@@ -20,7 +20,7 @@ export const countTextWithTokenizer = (tokenizer: TokenizerStrategy, text: strin
 }
 
 export const tokenizerForModel = (model: LlmModel): TokenizerStrategy =>
-  model.tokenizer ?? defaultTokenizerByProvider(model.provider)
+  model.tokenizer ?? defaultTokenizerByOwner(model.owned_by)
 
 export const countMessageTokens = (model: LlmModel, message: dto.Message) => {
   const tokenizer = tokenizerForModel(model)

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -64,6 +64,19 @@ export const defaultTokenizerByProvider = (provider: ProviderType): TokenizerStr
   }
 }
 
+export const defaultTokenizerByOwner = (owner: EngineOwner): TokenizerStrategy => {
+  switch (owner) {
+    case 'openai':
+    case 'perplexity':
+      return 'cl100k_base'
+    case 'anthropic':
+    case 'google':
+    case 'gemini':
+    case 'meta':
+      return 'approx_4chars'
+  }
+}
+
 export const stockModels = [
   ...openaiModels,
   ...logicleModels,

--- a/packages/core/src/types/dto/tokenestimate.ts
+++ b/packages/core/src/types/dto/tokenestimate.ts
@@ -32,6 +32,54 @@ const tokenEstimateMetaSchema = z.object({
     .describe('Tokenizer strategy used to compute token estimates.'),
 })
 
+export const tokenDetailPartSchema = z.object({
+  type: z
+    .string()
+    .describe(
+      'Component type: system_prompt, knowledge_text, knowledge_file, text, attachment, reasoning, tool_call, tool_result.'
+    ),
+  tokens: z.number().describe('Token count for this component.'),
+  algorithm: z
+    .string()
+    .describe(
+      'Algorithm or tokenizer used: cl100k_base, o200k_base, approx_4chars, native_image, pdf_native, pdf_text_fallback, pdf_page_limit_notice.'
+    ),
+  params: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Algorithm parameters, e.g. image dimensions or PDF page counts.'),
+  id: z.string().optional().describe('File id or tool call id.'),
+  name: z.string().optional().describe('File name.'),
+  mimetype: z.string().optional().describe('MIME type for attachment entries.'),
+  toolCallId: z.string().optional().describe('Tool call id for tool_call and tool_result entries.'),
+  toolName: z.string().optional().describe('Tool name for tool_call and tool_result entries.'),
+})
+
+export type TokenDetailPart = z.infer<typeof tokenDetailPartSchema>
+
+export const messageTokenDetailSchema = z.object({
+  messageId: z.string(),
+  role: z.enum(['user', 'assistant', 'tool']),
+  parts: z.array(tokenDetailPartSchema),
+})
+
+export type MessageTokenDetail = z.infer<typeof messageTokenDetailSchema>
+
+export const tokenEstimateDetailSchema = z.object({
+  preamble: z
+    .array(tokenDetailPartSchema)
+    .describe('Per-component breakdown of preamble tokens (system prompt, knowledge).'),
+  history: z
+    .array(messageTokenDetailSchema)
+    .describe('Per-message breakdown of history tokens.'),
+  draft: z
+    .array(tokenDetailPartSchema)
+    .optional()
+    .describe('Per-component breakdown of draft message tokens.'),
+})
+
+export type TokenEstimateDetail = z.infer<typeof tokenEstimateDetailSchema>
+
 export const tokenEstimateResponseSchema = tokenEstimateMetaSchema.extend({
   estimate: z.object({
     assistant: z
@@ -51,6 +99,7 @@ export const tokenEstimateResponseSchema = tokenEstimateMetaSchema.extend({
       .number()
       .describe('Final estimate for next request input tokens: assistant + history + draft.'),
   }),
+  detail: tokenEstimateDetailSchema.optional().describe('Detailed per-component token breakdown, present only when ?detail=true is requested.'),
 })
 
 export type TokenEstimateResponse = z.infer<typeof tokenEstimateResponseSchema>
@@ -67,6 +116,7 @@ export const assistantTokenEstimateResponseSchema = tokenEstimateMetaSchema.exte
       .describe('Estimated tokens for the provided message list after ChatAssistant message conversion.'),
     total: z.number().describe('Final estimate for next request input tokens: assistant + messages.'),
   }),
+  detail: tokenEstimateDetailSchema.optional().describe('Detailed per-component token breakdown, present only when ?detail=true is requested.'),
 })
 
 export type AssistantTokenEstimateResponse = z.infer<typeof assistantTokenEstimateResponseSchema>


### PR DESCRIPTION
## Summary

Fixes token estimation accuracy for DTO types and LogicleCloud models, then adds a `?detail=true` query parameter to both token estimate endpoints that returns a full per-component breakdown of the estimated token count. The breakdown is surfaced in the Assistant Edit panel and AssistantPreview ChatInput via an expanded tooltip on the context length indicator.

## Details

- **DTO token estimation fixes**: corrected tokenizer selection for LogicleCloud models; cleaned up preamble estimation to remove a double-counting path where `analysisFileIds` were summed separately on top of `countModelMessageTokens`
- **Unified preamble counting**: preamble total is now computed as the sum of per-file parts using `estimateAnalyzedFileTokens`, guaranteeing `sum(detail.preamble) == estimate.assistant`
- **Token detail API**: `?detail=true` on both `/me/assistants/[id]/tokens/estimate` and `/assistants/tokens/estimate` returns `{ preamble, history, draft }` breakdown; each entry carries `{ tokens, algorithm, params? }` — algorithm names are provider-specific (`anthropic_native_image`, `openai_tile_image`, `openai_patch_image`, `gemini_native_image`, `pdf_native`, `pdf_text_fallback`, `pdf_page_limit_notice`, tokenizer name for text)
- **Knowledge file breakdown**: each knowledge file is reported individually regardless of type (image, PDF, text); image/PDF tokens come from stored analysis metadata — no file bytes are loaded during estimation
- **ContextLengthIndicator**: tooltip expanded with Preamble / History / Draft sections; bars are sized relative to the grand total; History is scrollable for long conversations
- **`dtoMessageToLlmMessage` cleanup**: replaced `LanguageModelV3` parameter with `providerName: string` since only `provider.startsWith('litellm')` was needed

## Tests

- `npm run check-types` — clean
- `npm test` — 571/571 passing