### PR TITLE
Fix DOCX export for shared chats

### DIFF
--- a/apps/backend/api/share/[shareId]/export/docx/route.ts
+++ b/apps/backend/api/share/[shareId]/export/docx/route.ts
@@ -1,0 +1,33 @@
+import { db } from '@/db/database'
+import { renderDocxFromMarkdown } from '@/backend/lib/docx/export'
+import { notFound, operation, responseSpec, errorSpec } from '@/lib/routes'
+import * as dto from '@/types/dto'
+import { z } from 'zod'
+
+export const POST = operation({
+  name: 'Export shared conversation markdown to DOCX',
+  description: 'Render markdown into a DOCX document for a shared conversation preview.',
+  authentication: 'user',
+  requestBodySchema: dto.conversationDocxExportRequestSchema,
+  responses: [responseSpec(200, z.any()), errorSpec(404)] as const,
+  implementation: async ({ params, body }) => {
+    const sharedConversation = await db
+      .selectFrom('ConversationSharing')
+      .select('id')
+      .where('ConversationSharing.id', '=', params.shareId)
+      .executeTakeFirst()
+
+    if (!sharedConversation) {
+      return notFound(`No shared conversation with id ${params.shareId}`)
+    }
+
+    const doc = await renderDocxFromMarkdown(body.markdown)
+    return new Response(Buffer.from(doc), {
+      status: 200,
+      headers: {
+        'content-type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'content-disposition': 'attachment; filename="message.docx"',
+      },
+    })
+  },
+})

--- a/apps/backend/lib/router/routes.generated.ts
+++ b/apps/backend/lib/router/routes.generated.ts
@@ -79,6 +79,7 @@ export const backendRouteModules = [
   { pathname: '/api/satellites', load: () => import('@/backend/api/satellites/route') },
   { pathname: '/api/settings', load: () => import('@/backend/api/settings/route') },
   { pathname: '/api/share/[shareId]/clone', load: () => import('@/backend/api/share/[shareId]/clone/route') },
+  { pathname: '/api/share/[shareId]/export/docx', load: () => import('@/backend/api/share/[shareId]/export/docx/route') },
   { pathname: '/api/share/[shareId]/messages', load: () => import('@/backend/api/share/[shareId]/messages/route') },
   { pathname: '/api/share/[shareId]', load: () => import('@/backend/api/share/[shareId]/route') },
   { pathname: '/api/sso/[id]', load: () => import('@/backend/api/sso/[id]/route') },

--- a/apps/frontend/app/chat/components/AssistantMessageGroup.tsx
+++ b/apps/frontend/app/chat/components/AssistantMessageGroup.tsx
@@ -39,7 +39,7 @@ import { Upload } from '@/components/app/upload'
 import { useSWRJson } from '@/hooks/swr'
 import { mutate } from 'swr'
 import { delete_, put } from '@/lib/fetch'
-import { exportConversationDocx } from '@/services/docx'
+import { exportConversationDocx, exportSharedConversationDocx } from '@/services/docx'
 import toast from 'react-hot-toast'
 import {
   Dialog,
@@ -54,6 +54,7 @@ interface Props {
   assistant: dto.AssistantIdentification & { tools?: dto.UserAssistant['tools'] }
   group: IAssistantMessageGroup
   isLast: boolean
+  shareId?: string
 }
 
 const findAncestorUserMessage = (
@@ -125,7 +126,7 @@ interface FeedbackItem {
   comment: string | null
 }
 
-export const AssistantMessageGroup: FC<Props> = ({ assistant, group, isLast }) => {
+export const AssistantMessageGroup: FC<Props> = ({ assistant, group, isLast, shareId }) => {
   const { t } = useTranslation()
   const avatarUrl = assistant.iconUri
   const avatarFallback = assistant.name
@@ -340,9 +341,9 @@ export const AssistantMessageGroup: FC<Props> = ({ assistant, group, isLast }) =
 
   const onSaveDocx = async () => {
     const extractedMarkdown = await convertToMarkdown(false)
-    const blob = await exportConversationDocx(conversationId, {
-      markdown: extractedMarkdown,
-    })
+    const blob = shareId
+      ? await exportSharedConversationDocx(shareId, { markdown: extractedMarkdown })
+      : await exportConversationDocx(conversationId, { markdown: extractedMarkdown })
     downloadAsFile(blob, 'message.docx')
   }
 

--- a/apps/frontend/app/chat/components/MessageGroup.tsx
+++ b/apps/frontend/app/chat/components/MessageGroup.tsx
@@ -9,11 +9,14 @@ interface Props {
   assistant: dto.AssistantIdentification & { tools?: dto.UserAssistant['tools'] }
   group: IMessageGroup
   isLast: boolean
+  shareId?: string
 }
 
-export const MessageGroup: FC<Props> = ({ assistant, group, isLast }) => {
+export const MessageGroup: FC<Props> = ({ assistant, group, isLast, shareId }) => {
   if (group.actor === 'assistant') {
-    return <AssistantMessageGroup assistant={assistant} group={group} isLast={isLast} />
+    return (
+      <AssistantMessageGroup assistant={assistant} group={group} isLast={isLast} shareId={shareId} />
+    )
   } else {
     return <UserMessageGroup group={group} />
   }

--- a/apps/frontend/app/share/[shareId]/page.tsx
+++ b/apps/frontend/app/share/[shareId]/page.tsx
@@ -73,6 +73,7 @@ const SharePage = () => {
                 assistant={sharedConversation.assistant}
                 group={group}
                 isLast={index + 1 === groupList.length}
+                shareId={shareId}
               />
             ))}
           </div>

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -6330,6 +6330,39 @@ paths:
             type: string
       security:
         - bearerAuth: []
+  /api/share/{shareId}/export/docx:
+    post:
+      summary: Export shared conversation markdown to DOCX
+      description: Render markdown into a DOCX document for a shared conversation preview.
+      responses:
+        "200":
+          description: Response
+          content:
+            application/json:
+              schema: {}
+        "404":
+          $ref: "#/components/responses/Error"
+      parameters:
+        - name: shareId
+          in: path
+          required: true
+          schema:
+            type: string
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                markdown:
+                  type: string
+                  description: Markdown content to render into a DOCX document.
+              required:
+                - markdown
+              additionalProperties: false
   /api/share/{shareId}/messages:
     get:
       summary: Get shared conversation messages

--- a/apps/frontend/services/docx.ts
+++ b/apps/frontend/services/docx.ts
@@ -7,3 +7,10 @@ export const exportConversationDocx = async (
 ) => {
   return await postBlob(`/api/conversations/${conversationId}/export/docx`, payload)
 }
+
+export const exportSharedConversationDocx = async (
+  shareId: string,
+  payload: dto.ConversationDocxExportRequest
+) => {
+  return await postBlob(`/api/share/${shareId}/export/docx`, payload)
+}


### PR DESCRIPTION
## Summary
This fixes chat DOCX export from shared conversation pages by adding a shared-chat export endpoint and routing the existing export button to the correct backend API depending on context.

## Details
- add a shared conversation DOCX export endpoint under `/api/share/{shareId}/export/docx`
- update the shared conversation page to pass `shareId` through the message group components
- teach the assistant message export action to call the shared export API when rendering a shared chat
- regenerate the backend route manifest and OpenAPI spec for the new route

## Tests
- `npm run check-types`
- `npm run generate:backend-route-manifest`
- `npm run generate:openapi`