### PR TITLE
fix: limit concurrent knowledge file reads to prevent server stall

### DIFF
--- a/apps/backend/lib/chat/preamble.ts
+++ b/apps/backend/lib/chat/preamble.ts
@@ -7,6 +7,23 @@ import { ToolImplementation } from '@/lib/chat/tools'
 import type { ParameterValueAndDescription } from '@/models/user'
 import { dtoMessageToLlmMessage, sanitizeOrphanToolCalls } from '@/backend/lib/chat/conversion'
 
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  fn: (item: T) => Promise<R>,
+  concurrency: number
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let nextIndex = 0
+  async function worker() {
+    while (nextIndex < items.length) {
+      const i = nextIndex++
+      results[i] = await fn(items[i]!)
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker))
+  return results
+}
+
 type AssistantParamsLike = {
   systemPrompt: string
 }
@@ -125,10 +142,10 @@ export async function buildPreambleSegments({
     }
     const knowledgePlugin = resolvedTools.find((t) => t instanceof KnowledgePlugin)
     if (knowledgePlugin) {
-      const parts = await Promise.all(
-        knowledge.map((k) =>
-          (knowledgePlugin as InstanceType<typeof KnowledgePlugin>).knowledgeToInputPart(k, llmModel)
-        )
+      const parts = await mapWithConcurrency(
+        knowledge,
+        (k) => (knowledgePlugin as InstanceType<typeof KnowledgePlugin>).knowledgeToInputPart(k, llmModel),
+        8
       )
       const analysisFileIds = parts.flatMap((part, index) =>
         part.type === 'file' ? [knowledge[index]?.id ?? ''] : []

--- a/apps/backend/lib/chat/preamble.ts
+++ b/apps/backend/lib/chat/preamble.ts
@@ -142,6 +142,10 @@ export async function buildPreambleSegments({
     }
     const knowledgePlugin = resolvedTools.find((t) => t instanceof KnowledgePlugin)
     if (knowledgePlugin) {
+      // Limit concurrency to avoid saturating the libuv thread pool and
+      // the Node.js microtask queue when an assistant has many knowledge files.
+      // Unbounded Promise.all over hundreds of files causes multi-second
+      // health-check stalls and S3 socket pool exhaustion.
       const parts = await mapWithConcurrency(
         knowledge,
         (k) => (knowledgePlugin as InstanceType<typeof KnowledgePlugin>).knowledgeToInputPart(k, llmModel),


### PR DESCRIPTION
## Summary

`buildPreambleSegments` was launching an unbounded `Promise.all` over every knowledge file attached to an assistant. With hundreds of files, this saturated the libuv thread pool and the Node.js microtask queue, causing all I/O — including unrelated requests such as the health endpoint — to stall for minutes at a time. On the forel instance (514–599 PDFs), this triggered 2–5 minute gaps where the health check was completely unresponsive and `@smithy/node-http-handler` reported its S3 socket pool (50 connections) with 136–288 requests queued.

## Details

- Root cause: `Promise.all(knowledge.map(k => knowledgeToInputPart(k, llmModel)))` in [preamble.ts](apps/backend/lib/chat/preamble.ts) fired all file reads concurrently with no bound.
- Fix: replace with a `mapWithConcurrency(items, fn, 8)` helper (16 lines, no new dependency) that runs at most 8 concurrent reads at a time.
- The number 8 was chosen to stay within 2× the default libuv thread pool size (4), leaving headroom for other I/O.

## Tests

Local reproduction with 191 PDF knowledge files (local FS + PGP encryption):

| Metric | Before | After |
|--------|--------|-------|
| Token estimation request | ~76s | ~9s |
| Health check p99 during load | ~15 000ms | ~939ms |
| Health check typical | 3 000–5 000ms | 10–50ms |

- `npm run check-types` passes.