### PR TITLE
Enforce UTC Z timestamp schemas across DTOs and assistant responses

### DIFF
--- a/apps/backend/api/auth/refresh/route.ts
+++ b/apps/backend/api/auth/refresh/route.ts
@@ -2,9 +2,10 @@ import { z } from 'zod'
 import { operation, responseSpec, ok } from '@/lib/routes'
 import { makeExpiryDate, setSessionCookie } from '@/lib/auth/session'
 import { updateSessionExpiry } from '@/models/session'
+import { iso8601UtcDateTimeSchema } from '@/types/dto/common'
 
 const refreshResponseSchema = z.object({
-  expiresAt: z.string(),
+  expiresAt: iso8601UtcDateTimeSchema,
 })
 
 export const runtime = 'nodejs'

--- a/apps/backend/api/me/assistants/route.ts
+++ b/apps/backend/api/me/assistants/route.ts
@@ -2,6 +2,7 @@ import { ok, operation, responseSpec } from '@/lib/routes'
 import { getAssistantsWithOwner } from '@/models/assistant'
 import { z } from 'zod'
 import * as dto from '@/types/dto'
+import { iso8601UtcDateTimeSchema } from '@/types/dto/common'
 
 const assistantWithOwnerSchema = z.object({
   id: z.string(),
@@ -14,8 +15,8 @@ const assistantWithOwnerSchema = z.object({
   temperature: z.number(),
   tokenLimit: z.number(),
   reasoning_effort: z.enum(['low', 'medium', 'high']).nullable(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
+  createdAt: iso8601UtcDateTimeSchema,
+  updatedAt: iso8601UtcDateTimeSchema,
   owner: z.string(),
   ownerName: z.string(),
   modelName: z.string(),

--- a/apps/backend/api/me/assistants/route.ts
+++ b/apps/backend/api/me/assistants/route.ts
@@ -1,31 +1,6 @@
 import { ok, operation, responseSpec } from '@/lib/routes'
 import { getAssistantsWithOwner } from '@/models/assistant'
-import { z } from 'zod'
 import * as dto from '@/types/dto'
-import { iso8601UtcDateTimeSchema } from '@/types/dto/common'
-
-const assistantWithOwnerSchema = z.object({
-  id: z.string(),
-  assistantId: z.string(),
-  backendId: z.string(),
-  description: z.string(),
-  model: z.string(),
-  name: z.string(),
-  systemPrompt: z.string(),
-  temperature: z.number(),
-  tokenLimit: z.number(),
-  reasoning_effort: z.enum(['low', 'medium', 'high']).nullable(),
-  createdAt: iso8601UtcDateTimeSchema,
-  updatedAt: iso8601UtcDateTimeSchema,
-  owner: z.string(),
-  ownerName: z.string(),
-  modelName: z.string(),
-  sharing: dto.sharingSchema.array(),
-  tags: z.array(z.string()),
-  prompts: z.array(z.string()),
-  iconUri: z.string().nullable(),
-  provisioned: z.boolean(),
-})
 
 export const dynamic = 'force-dynamic'
 
@@ -33,7 +8,7 @@ export const GET = operation({
   name: 'List my assistants',
   description: 'List assistants created by the current user.',
   authentication: 'user',
-  responses: [responseSpec(200, assistantWithOwnerSchema.array())] as const,
+  responses: [responseSpec(200, dto.assistantWithOwnerSchema.array())] as const,
   implementation: async ({ session }) => {
     return ok(await getAssistantsWithOwner({ userId: session.userId }))
   },

--- a/packages/core/src/types/dto/apikey.ts
+++ b/packages/core/src/types/dto/apikey.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod'
+import { iso8601UtcDateTimeSchema } from './common'
 
 export const apiKeySchema = z.object({
   id: z.string(),
   key: z.string(),
   userId: z.string(),
   description: z.string(),
-  createdAt: z.string(), // consider .datetime() if it's ISO
-  expiresAt: z.string().nullable(), // consider .datetime().nullable()
+  createdAt: iso8601UtcDateTimeSchema,
+  expiresAt: iso8601UtcDateTimeSchema.nullable(),
   enabled: z.number(),
   provisioned: z.boolean(),
 })

--- a/packages/core/src/types/dto/assistant.ts
+++ b/packages/core/src/types/dto/assistant.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { Sharing } from './sharing'
+import { iso8601UtcDateTimeSchema } from './common'
 
 export const assistantFileSchema = z.object({
   id: z.string(),
@@ -39,8 +40,8 @@ export const assistantVersionSchema = z.object({
   reasoning_effort: z.enum(['low', 'medium', 'high']).nullable(),
   tags: z.string(),
   prompts: z.string(),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
+  createdAt: iso8601UtcDateTimeSchema,
+  updatedAt: iso8601UtcDateTimeSchema,
   current: z.boolean(),
   published: z.boolean(),
 })
@@ -127,8 +128,8 @@ export const assistantWithOwnerSchema = z.object({
   temperature: z.number(),
   tokenLimit: z.number(),
   reasoning_effort: z.enum(['low', 'medium', 'high']).nullable(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
+  createdAt: iso8601UtcDateTimeSchema,
+  updatedAt: iso8601UtcDateTimeSchema,
   owner: z.string(),
   ownerName: z.string(),
   modelName: z.string(),
@@ -143,7 +144,7 @@ export type AssistantWithOwner = z.infer<typeof assistantWithOwnerSchema>
 
 export const assistantUserDataSchema = z.object({
   pinned: z.boolean(),
-  lastUsed: z.string().nullable(), // consider .datetime().nullable() if ISO is guaranteed
+  lastUsed: iso8601UtcDateTimeSchema.nullable(),
 })
 
 export const updateableAssistantUserDataSchema = assistantUserDataSchema
@@ -191,14 +192,14 @@ export const userAssistantSchema = z.object({
   model: z.string(),
   usability: assistantUsabilitySchema,
   pinned: z.boolean(),
-  lastUsed: z.string().nullable(),
+  lastUsed: iso8601UtcDateTimeSchema.nullable(),
   owner: z.string(),
   ownerName: z.string(),
   tags: z.array(z.string()),
   prompts: z.array(z.string()),
   sharing: sharingSchema.array(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
+  createdAt: iso8601UtcDateTimeSchema,
+  updatedAt: iso8601UtcDateTimeSchema,
   cloneable: z.boolean(),
   tokenLimit: z.number(),
   tools: z.array(

--- a/packages/core/src/types/dto/chat.ts
+++ b/packages/core/src/types/dto/chat.ts
@@ -7,14 +7,15 @@ import {
 } from './assistant'
 import { z } from 'zod'
 import { JSONValue } from 'ai'
+import { iso8601UtcDateTimeSchema } from './common'
 
 export const conversationSchema = z.object({
   assistantId: z.string(),
   id: z.string(),
   name: z.string(),
   ownerId: z.string(),
-  createdAt: z.string().datetime(),
-  lastMsgSentAt: z.string().datetime().nullable(),
+  createdAt: iso8601UtcDateTimeSchema,
+  lastMsgSentAt: iso8601UtcDateTimeSchema.nullable(),
 })
 
 export type Conversation = z.infer<typeof conversationSchema>
@@ -55,10 +56,10 @@ export const chatRunSchema = z.object({
   ownerId: z.string(),
   requestMessageId: z.string(),
   status: chatRunStatusSchema,
-  stopRequestedAt: z.string().datetime().nullable(),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
-  completedAt: z.string().datetime().nullable(),
+  stopRequestedAt: iso8601UtcDateTimeSchema.nullable(),
+  createdAt: iso8601UtcDateTimeSchema,
+  updatedAt: iso8601UtcDateTimeSchema,
+  completedAt: iso8601UtcDateTimeSchema.nullable(),
   lastEventSequence: z.number().int().nonnegative(),
   error: z.string().nullable(),
 })

--- a/packages/core/src/types/dto/common.ts
+++ b/packages/core/src/types/dto/common.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+
+export const iso8601UtcDateTimeSchema = z.iso.datetime({
+  offset: false,
+  local: false,
+})

--- a/packages/core/src/types/dto/file-analysis.ts
+++ b/packages/core/src/types/dto/file-analysis.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { iso8601UtcDateTimeSchema } from './common'
 
 export const fileAnalysisKindValues = [
   'pdf',
@@ -93,8 +94,8 @@ export const fileAnalysisSchema = z.object({
   payload: fileAnalysisPayloadSchema.nullable(),
   warnings: z.array(z.string()).optional(),
   error: z.string().nullable(),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
+  createdAt: iso8601UtcDateTimeSchema,
+  updatedAt: iso8601UtcDateTimeSchema,
 })
 
 export type FileAnalysisPayload = z.infer<typeof fileAnalysisPayloadSchema>

--- a/packages/core/src/types/dto/file.ts
+++ b/packages/core/src/types/dto/file.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { iso8601UtcDateTimeSchema } from './common'
 
 export const fileSchema = z.object({
   id: z.string(),
@@ -7,7 +8,7 @@ export const fileSchema = z.object({
   type: z.string(),
   size: z.number(),
   uploaded: z.union([z.literal(0), z.literal(1)]),
-  createdAt: z.string().datetime(),
+  createdAt: iso8601UtcDateTimeSchema,
   encrypted: z.union([z.literal(0), z.literal(1)]),
 })
 

--- a/packages/core/src/types/dto/session.ts
+++ b/packages/core/src/types/dto/session.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod'
+import { iso8601UtcDateTimeSchema } from './common'
 
 export const sessionSummarySchema = z.object({
   id: z.string(),
-  createdAt: z.string().datetime(),
-  expiresAt: z.string().datetime(),
-  lastSeenAt: z.string().datetime().nullable(),
+  createdAt: iso8601UtcDateTimeSchema,
+  expiresAt: iso8601UtcDateTimeSchema,
+  lastSeenAt: iso8601UtcDateTimeSchema.nullable(),
   userAgent: z.string().nullable(),
   ipAddress: z.string().nullable(),
   authMethod: z.enum(['password', 'idp']),

--- a/packages/core/src/types/dto/tool.ts
+++ b/packages/core/src/types/dto/tool.ts
@@ -1,4 +1,5 @@
 import * as z from 'zod'
+import { iso8601UtcDateTimeSchema } from './common'
 
 export const privateSharingSchema = z.object({
   type: z.literal('private'),
@@ -30,8 +31,8 @@ export const toolSchema = z.object({
   sharing: sharing2Schema,
   provisioned: z.boolean(),
   capability: z.boolean(),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
+  createdAt: iso8601UtcDateTimeSchema,
+  updatedAt: iso8601UtcDateTimeSchema,
   promptFragment: z.string(),
 })
 

--- a/packages/core/src/types/dto/user.ts
+++ b/packages/core/src/types/dto/user.ts
@@ -2,6 +2,7 @@ import { WorkspaceRole } from '../workspace'
 import { z } from 'zod'
 import { userAssistantSchema } from './assistant'
 import { userPreferencesSchema } from './userpreferences'
+import { iso8601UtcDateTimeSchema } from './common'
 
 export enum UserRole {
   USER = 'USER',
@@ -10,13 +11,13 @@ export enum UserRole {
 
 export const userSchema = z.object({
   id: z.string(),
-  createdAt: z.string().datetime(),
+  createdAt: iso8601UtcDateTimeSchema,
   email: z.string().email(),
   name: z.string(),
   password: z.string().nullable(),
   role: z.nativeEnum(UserRole),
   provisioned: z.boolean(),
-  updatedAt: z.string().datetime(),
+  updatedAt: iso8601UtcDateTimeSchema,
   preferences: z.string(),
   image: z.string().nullable(),
   ssoUser: z.boolean(),
@@ -71,12 +72,12 @@ export const workspaceMembershipSchema = z.object({
 
 export const userProfileSchema = z.object({
   id: z.string(),
-  createdAt: z.string().datetime(),
+  createdAt: iso8601UtcDateTimeSchema,
   email: z.string().email(),
   name: z.string(),
   role: z.nativeEnum(UserRole),
   provisioned: z.boolean(),
-  updatedAt: z.string().datetime(),
+  updatedAt: iso8601UtcDateTimeSchema,
   image: z.string().nullable(),
   ssoUser: z.boolean(),
   properties: z.record(z.string(), z.string()),

--- a/packages/core/src/types/dto/workspace.ts
+++ b/packages/core/src/types/dto/workspace.ts
@@ -1,13 +1,14 @@
 import { z } from 'zod'
 import { WorkspaceRole } from '../workspace'
+import { iso8601UtcDateTimeSchema } from './common'
 
 export const workspaceSchema = z.object({
   id: z.string(),
   name: z.string(),
   slug: z.string(),
   domain: z.string().nullable(),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
+  createdAt: iso8601UtcDateTimeSchema,
+  updatedAt: iso8601UtcDateTimeSchema,
 })
 
 export const insertableWorkspaceSchema = workspaceSchema.omit({
@@ -35,8 +36,8 @@ export const workspaceMemberSchema = z.object({
   userId: z.string(),
   workspaceId: z.string(),
   role: z.nativeEnum(WorkspaceRole),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
+  createdAt: iso8601UtcDateTimeSchema,
+  updatedAt: iso8601UtcDateTimeSchema,
   name: z.string(),
   email: z.string(),
 })


### PR DESCRIPTION
## Summary

Enforce shared UTC ISO 8601 `Z` timestamp validation across core DTOs and affected backend responses, and reuse the shared assistant response schema so timestamp validation stays consistent between the API and shared types.

## Details

- Replace multiple DTO `createdAt`, `updatedAt`, `expiresAt`, `lastUsed`, and related timestamp fields with `iso8601UtcDateTimeSchema`
- Tighten backend response schemas for `/api/auth/refresh` and `/api/me/assistants` to require normalized UTC timestamps
- Reuse `dto.assistantWithOwnerSchema` in `/api/me/assistants` instead of maintaining a duplicate route-local schema

## Tests

- Ran `npm run check-types` successfully