### PR TITLE
Add gpt-image-1.5 and gpt-image-2 image model support

### DIFF
--- a/__tests__/imagegenModels.test.ts
+++ b/__tests__/imagegenModels.test.ts
@@ -10,6 +10,8 @@ import {
 describe('image generation model capabilities', () => {
   test('tracks provider-specific model families without central routing', () => {
     expect(isOpenAiImageModel('gpt-image-1')).toBe(true)
+    expect(isOpenAiImageModel('gpt-image-1.5')).toBe(true)
+    expect(isOpenAiImageModel('gpt-image-2')).toBe(true)
     expect(isOpenAiImageModel('dall-e-3')).toBe(true)
     expect(isGeminiImageModel('gemini-2.5-flash-image')).toBe(true)
     expect(isImagenImageModel('imagen-4.0-generate-001')).toBe(true)
@@ -19,6 +21,8 @@ describe('image generation model capabilities', () => {
 
   test('tracks editing-capable models explicitly', () => {
     expect(isImageEditingSupportedModel('gpt-image-1')).toBe(true)
+    expect(isImageEditingSupportedModel('gpt-image-1.5')).toBe(true)
+    expect(isImageEditingSupportedModel('gpt-image-2')).toBe(true)
     expect(isImageEditingSupportedModel('gemini-3-pro-image-preview')).toBe(true)
     expect(isImageEditingSupportedModel('FLUX.1-kontext-pro')).toBe(true)
     expect(isImageEditingSupportedModel('dall-e-3')).toBe(false)

--- a/__tests__/imagegenToolEditing.test.ts
+++ b/__tests__/imagegenToolEditing.test.ts
@@ -14,7 +14,18 @@ describe('image generator editing exposure', () => {
   test('legacy proxy-backed tool enables editing automatically for known supported models', async () => {
     const tool = new ImageGeneratorPlugin(toolParams, {
       apiKey: 'secret',
-      model: 'gpt-image-1',
+      model: 'gpt-image-1.5',
+    })
+
+    const functions = await tool.functions({} as any)
+
+    expect(functions.EditImage).toBeDefined()
+  })
+
+  test('legacy proxy-backed tool also enables editing for the latest OpenAI image model', async () => {
+    const tool = new ImageGeneratorPlugin(toolParams, {
+      apiKey: 'secret',
+      model: 'gpt-image-2',
     })
 
     const functions = await tool.functions({} as any)
@@ -35,6 +46,7 @@ describe('image generator editing exposure', () => {
   })
 
   test('editing exposure is derived from the model capability list', () => {
+    expect(shouldExposeImageEditingTool('gpt-image-2')).toBe(true)
     expect(shouldExposeImageEditingTool('gemini-3-pro-image-preview')).toBe(true)
     expect(shouldExposeImageEditingTool('dall-e-2')).toBe(false)
   })

--- a/apps/backend/lib/imagegen/models.ts
+++ b/apps/backend/lib/imagegen/models.ts
@@ -1,9 +1,12 @@
-export const OPENAI_IMAGE_MODELS = ['dall-e-2', 'dall-e-3', 'gpt-image-1'] as const
-
-export const GEMINI_IMAGE_MODELS = [
-  'gemini-2.5-flash-image',
-  'gemini-3-pro-image-preview',
+export const OPENAI_IMAGE_MODELS = [
+  'dall-e-2',
+  'dall-e-3',
+  'gpt-image-1',
+  'gpt-image-1.5',
+  'gpt-image-2',
 ] as const
+
+export const GEMINI_IMAGE_MODELS = ['gemini-2.5-flash-image', 'gemini-3-pro-image-preview'] as const
 
 export const TOGETHER_IMAGE_MODELS = [
   'FLUX.1-schnell',
@@ -27,6 +30,8 @@ export type ImagenImageModel = (typeof IMAGEN_IMAGE_MODELS)[number]
 
 export const IMAGE_EDITING_MODELS = [
   'gpt-image-1',
+  'gpt-image-1.5',
+  'gpt-image-2',
   'gemini-2.5-flash-image',
   'gemini-3-pro-image-preview',
   'FLUX.1-kontext-pro',

--- a/apps/backend/lib/imagegen/providers/openai.ts
+++ b/apps/backend/lib/imagegen/providers/openai.ts
@@ -3,7 +3,7 @@ import { logger } from '@/lib/logging'
 import { GeneratedImagesResponse, ImageEditRequest, ImageGenerationRequest } from '../types'
 
 const getResponseFormat = (model: string): 'b64_json' | undefined => {
-  if (model === 'gpt-image-1') {
+  if (model === 'gpt-image-1' || model === 'gpt-image-1.5' || model === 'gpt-image-2') {
     return undefined
   }
   return 'b64_json'
@@ -63,9 +63,13 @@ export const editWithOpenAI = async ({
   const client = new OpenAI({ apiKey })
   const uploadImages = images.map(
     (image) =>
-      new File([new Blob([Uint8Array.from(image.data)], { type: image.mimeType })], image.fileName, {
-        type: image.mimeType,
-      })
+      new File(
+        [new Blob([Uint8Array.from(image.data)], { type: image.mimeType })],
+        image.fileName,
+        {
+          type: image.mimeType,
+        }
+      )
   )
   const response = await client.images.edit({
     model,

--- a/apps/backend/lib/tools/imagegenerator/implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/implementation.ts
@@ -24,7 +24,7 @@ import { LlmModel } from '@/lib/chat/models'
 import { shouldExposeImageEditingTool } from '@/backend/lib/imagegen/models'
 
 function get_response_format_parameter(model: string) {
-  if (model === 'gpt-image-1') {
+  if (model === 'gpt-image-1' || model === 'gpt-image-1.5' || model === 'gpt-image-2') {
     return undefined
   } else {
     return 'b64_json'

--- a/apps/frontend/app/admin/tools/components/ImageGeneratorToolFields.tsx
+++ b/apps/frontend/app/admin/tools/components/ImageGeneratorToolFields.tsx
@@ -13,11 +13,19 @@ export const legacyImageGeneratorModels = [
   'dall-e-2',
   'dall-e-3',
   'gpt-image-1',
+  'gpt-image-1.5',
+  'gpt-image-2',
   'gemini-2.5-flash-image',
   'FLUX.1-kontext-max',
 ] as const
 
-export const openAiImageGeneratorModels = ['dall-e-2', 'dall-e-3', 'gpt-image-1'] as const
+export const openAiImageGeneratorModels = [
+  'dall-e-2',
+  'dall-e-3',
+  'gpt-image-1',
+  'gpt-image-1.5',
+  'gpt-image-2',
+] as const
 
 export const googleImageGeneratorModels = [
   'gemini-2.5-flash-image',


### PR DESCRIPTION
## Summary
This adds `gpt-image-1.5` and `gpt-image-2` to Logicle's OpenAI image generation support so they are recognized by the backend, exposed in the admin image generator model picker, and treated as editing-capable models with the correct OpenAI response format handling.

## Details
- add `gpt-image-1.5` and `gpt-image-2` to the OpenAI image model and image editing capability lists
- update both OpenAI image generation code paths to omit `response_format` for the newer GPT image models, matching the existing `gpt-image-1` handling
- expose the new models in the admin image generator configuration UI
- extend tests to cover model recognition and editing exposure for `gpt-image-1.5` and `gpt-image-2`

## Tests
- `npx vitest run __tests__/imagegenModels.test.ts __tests__/imagegenToolEditing.test.ts __tests__/imagegenFiles.test.ts`
