### PR TITLE
Reduce audio transcriber memory usage for large files

### DIFF
--- a/__tests__/storageCoverage.test.ts
+++ b/__tests__/storageCoverage.test.ts
@@ -1,0 +1,375 @@
+import { Readable } from 'node:stream'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { AesEncryptingStorage } from '@/ee/AesEncryptingStorage'
+import { MemoryStorage } from '@/lib/storage/MemoryStorage'
+import {
+  bufferToReadableStream,
+  collectStreamToBuffer,
+  nodeStreamToReadableStream,
+} from '@/lib/storage/utils'
+
+const password = 'my_key'
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+})
+
+describe('apps/backend/lib/storage/MemoryStorage', () => {
+  test('removes stored buffers', async () => {
+    const storage = new MemoryStorage()
+    await storage.writeBuffer('test', Buffer.from('value'), false)
+
+    await storage.rm('test')
+
+    expect(storage.map.test).toBeUndefined()
+  })
+})
+
+describe('apps/backend/lib/storage/utils', () => {
+  test('destroy node streams when web stream is cancelled', async () => {
+    const nodeStream = new Readable({ read() {} })
+    const destroySpy = vi.spyOn(nodeStream, 'destroy')
+    const webStream = nodeStreamToReadableStream(nodeStream)
+
+    await webStream.cancel()
+
+    expect(destroySpy).toHaveBeenCalled()
+  })
+})
+
+describe('apps/backend/lib/storage/FsStorage constructor and logging', () => {
+  test('creates a missing root directory', async () => {
+    const rootDir = path.join(os.tmpdir(), `logicle-storage-create-${Date.now()}`)
+    await fs.promises.rm(rootDir, { recursive: true, force: true })
+    const { FsStorage } = await import('@/backend/lib/storage/FsStorage')
+
+    const storage = new FsStorage(rootDir)
+
+    await expect(fs.promises.stat(rootDir)).resolves.toBeTruthy()
+    expect(storage.rootPath).toBe(rootDir)
+    await fs.promises.rm(rootDir, { recursive: true, force: true })
+  })
+
+  test('logs and rethrows when root directory creation fails', async () => {
+    const infoSpy = vi.spyOn((await import('@/lib/logging')).logger, 'info').mockImplementation(() => {})
+    const { FsStorage } = await import('@/backend/lib/storage/FsStorage')
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false)
+    vi.spyOn(fs, 'mkdirSync').mockImplementation(() => {
+      throw new Error('mkdir failed')
+    })
+
+    expect(() => new FsStorage('/tmp/fail')).toThrow('mkdir failed')
+    expect(infoSpy).toHaveBeenCalledWith('Failed creating file storage directory')
+  })
+
+  test('logs progress for files larger than one megabyte', async () => {
+    const debugSpy = vi.spyOn((await import('@/lib/logging')).logger, 'debug').mockImplementation(() => {})
+    const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logicle-fs-storage-large-'))
+    const { FsStorage } = await import('@/backend/lib/storage/FsStorage')
+    const storage = new FsStorage(tempDir)
+    const payload = Buffer.alloc(1024 * 1024 + 5, 8)
+
+    await storage.writeStream('large.bin', bufferToReadableStream(payload))
+
+    expect(debugSpy).toHaveBeenCalledWith(`Read ${1024 * 1024}`)
+    expect(debugSpy).toHaveBeenCalledWith(`Total read = ${payload.length}`)
+    await fs.promises.rm(tempDir, { recursive: true, force: true })
+  })
+})
+
+describe('apps/backend/ee/AesEncryptingStorage', () => {
+  test('delegates rm to inner storage', async () => {
+    const inner = new MemoryStorage()
+    const rmSpy = vi.spyOn(inner, 'rm')
+    const storage = await AesEncryptingStorage.create(inner, password)
+
+    await storage.rm('path-to-remove')
+
+    expect(rmSpy).toHaveBeenCalledWith('path-to-remove')
+  })
+
+  test('surfaces stream failures from encrypted processing', async () => {
+    const storage = await AesEncryptingStorage.create(new MemoryStorage(), password)
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]))
+        controller.error(new Error('boom'))
+      },
+    })
+
+    await expect(storage.writeStream('boom', stream, true)).rejects.toThrow('boom')
+  })
+})
+
+describe('apps/backend/ee/PgpEncryptingStorage', () => {
+  test('delegates rm to inner storage', async () => {
+    const inner = new MemoryStorage()
+    const rmSpy = vi.spyOn(inner, 'rm')
+    const storage = await (await import('@/ee/PgpEncryptingStorage')).PgpEncryptingStorage.create(
+      inner,
+      password
+    )
+
+    await storage.rm('path-to-remove')
+
+    expect(rmSpy).toHaveBeenCalledWith('path-to-remove')
+  })
+})
+
+describe('apps/backend/lib/storage/S3Storage', () => {
+  test('covers constructor, reads, writes, and error handling', async () => {
+    process.env.AWS_DEFAULT_REGION = 'eu-west-1'
+    process.env.AWS_ACCESS_KEY_ID = 'key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret'
+
+    const send = vi.fn()
+    const done = vi.fn()
+    const info = vi.fn()
+    const error = vi.fn()
+    const uploadCalls: any[] = []
+    const clientConfigs: any[] = []
+
+    vi.doMock('@/lib/logging', () => ({
+      logger: { info, error },
+    }))
+    vi.doMock('@aws-sdk/client-s3', () => ({
+      S3Client: vi.fn().mockImplementation((config) => {
+        clientConfigs.push(config)
+        return { send }
+      }),
+      GetObjectCommand: vi.fn().mockImplementation((params) => ({ params })),
+    }))
+    vi.doMock('@aws-sdk/lib-storage', () => ({
+      Upload: vi.fn().mockImplementation((config) => {
+        uploadCalls.push(config)
+        return { done }
+      }),
+    }))
+
+    const { S3Storage } = await import('@/backend/lib/storage/S3Storage')
+
+    const storage = new S3Storage('bucket-name')
+    expect(storage.bucketName).toBe('bucket-name')
+    expect(storage.region).toBe('eu-west-1')
+    expect(storage.hostName).toBe('bucket-name.s3.eu-west-1.amazonaws.com')
+    expect(clientConfigs[0]).toEqual({
+      region: 'eu-west-1',
+      credentials: {
+        accessKeyId: 'key',
+        secretAccessKey: 'secret',
+      },
+    })
+
+    await storage.writeStream('file.bin', bufferToReadableStream(Buffer.from('data')))
+    expect(uploadCalls[0]).toMatchObject({
+      client: { send },
+      params: {
+        Bucket: 'bucket-name',
+        Key: 'file.bin',
+      },
+      queueSize: 4,
+      partSize: 5 * 1024 * 1024,
+    })
+    expect(info).toHaveBeenCalledWith('Successfully uploaded file.bin to bucket bucket-name')
+
+    done.mockRejectedValueOnce(new Error('upload failed'))
+    await expect(storage.writeStream('broken.bin', bufferToReadableStream(Buffer.from('x')))).rejects.toThrow(
+      'upload failed'
+    )
+    expect(info).toHaveBeenCalledWith(
+      'Failed to upload broken.bin to bucket bucket-name. Forwarding exception'
+    )
+
+    const transformToByteArray = vi.fn().mockResolvedValue(new Uint8Array([1]))
+    send.mockResolvedValueOnce({ Body: { transformToByteArray } })
+    await storage.rm('exists.bin')
+    expect(transformToByteArray).toHaveBeenCalled()
+
+    send.mockResolvedValueOnce({ Body: undefined })
+    await expect(storage.rm('empty.bin')).resolves.toBeUndefined()
+
+    const noSuchKey = new Error('missing')
+    noSuchKey.name = 'NoSuchKey'
+    send.mockRejectedValueOnce(noSuchKey)
+    await expect(storage.rm('missing.bin')).resolves.toBeUndefined()
+    expect(info).toHaveBeenCalledWith("Can't delete non existing object at missing.bin")
+
+    const processError = new Error('process failed')
+    send.mockRejectedValueOnce(processError)
+    await expect(storage.rm('error.bin')).rejects.toThrow('process failed')
+    expect(error).toHaveBeenCalledWith('Failed to process the S3 object at error.bin', processError)
+
+    send.mockRejectedValueOnce('not-an-error')
+    await expect(storage.rm('weird.bin')).rejects.toBe('not-an-error')
+
+    const webStream = bufferToReadableStream(Buffer.from('downloaded'))
+    send.mockResolvedValueOnce({
+      Body: {
+        transformToWebStream: vi.fn().mockReturnValue(webStream),
+      },
+    })
+    await expect(collectStreamToBuffer(await storage.readStream('read.bin'))).resolves.toEqual(
+      Buffer.from('downloaded')
+    )
+
+    send.mockResolvedValueOnce({ Body: undefined })
+    await expect(storage.readStream('nobody.bin')).rejects.toThrow('Failed reading S3 object nobody.bin: No body')
+    expect(error).toHaveBeenCalledWith('Failed reading S3 object', expect.any(Error))
+
+    const readError = new Error('read failed')
+    send.mockRejectedValueOnce(readError)
+    await expect(storage.readStream('broken-read.bin')).rejects.toThrow('read failed')
+    expect(error).toHaveBeenCalledWith('Failed reading S3 object', readError)
+  })
+})
+
+describe('apps/backend/lib/storage/index', () => {
+  test('builds fs+aes+caching storage from env', async () => {
+    vi.doMock('@/lib/env', () => ({
+      default: {
+        fileStorage: {
+          location: '/tmp/storage',
+          cacheSizeInMb: 4,
+          encryptionProvider: 'aes',
+          encryptionKey: 'secret',
+        },
+      },
+    }))
+
+    const cachingInstances: any[] = []
+    const fsInstances: any[] = []
+    const aesInstances: any[] = []
+    const fakeFsStorage = { kind: 'fs' }
+    const fakeAesStorage = { kind: 'aes' }
+
+    vi.doMock('@/lib/storage/FsStorage', () => ({
+      FsStorage: vi.fn().mockImplementation((location) => {
+        fsInstances.push(location)
+        return fakeFsStorage
+      }),
+    }))
+    vi.doMock('@/ee/AesEncryptingStorage', () => ({
+      AesEncryptingStorage: {
+        create: vi.fn().mockImplementation(async (storage, key) => {
+          aesInstances.push({ storage, key })
+          return fakeAesStorage
+        }),
+      },
+    }))
+    vi.doMock('@/ee/PgpEncryptingStorage', () => ({
+      PgpEncryptingStorage: {
+        create: vi.fn(),
+      },
+    }))
+    vi.doMock('@/lib/storage/CachingStorage', () => ({
+      CachingStorage: vi.fn().mockImplementation((storage, size) => {
+        const wrapped = { kind: 'cache', storage, size }
+        cachingInstances.push(wrapped)
+        return wrapped
+      }),
+    }))
+    vi.doMock('@/lib/storage/S3Storage', () => ({
+      S3Storage: vi.fn(),
+    }))
+
+    const module = await import('@/backend/lib/storage')
+
+    expect(fsInstances).toEqual(['/tmp/storage'])
+    expect(aesInstances).toEqual([{ storage: fakeFsStorage, key: 'secret' }])
+    expect(cachingInstances).toEqual([{ kind: 'cache', storage: fakeAesStorage, size: 4 }])
+    expect(module.storage).toEqual(cachingInstances[0])
+  })
+
+  test('builds s3+pgp storage without cache from env', async () => {
+    vi.doMock('@/lib/env', () => ({
+      default: {
+        fileStorage: {
+          location: 's3://bucket-name',
+          cacheSizeInMb: 0,
+          encryptionProvider: 'pgp',
+          encryptionKey: 'secret',
+        },
+      },
+    }))
+
+    const s3Instances: any[] = []
+    const pgpInstances: any[] = []
+    const fakeS3Storage = { kind: 's3' }
+    const fakePgpStorage = { kind: 'pgp' }
+
+    vi.doMock('@/lib/storage/S3Storage', () => ({
+      S3Storage: vi.fn().mockImplementation((bucket) => {
+        s3Instances.push(bucket)
+        return fakeS3Storage
+      }),
+    }))
+    vi.doMock('@/ee/PgpEncryptingStorage', () => ({
+      PgpEncryptingStorage: {
+        create: vi.fn().mockImplementation(async (storage, key) => {
+          pgpInstances.push({ storage, key })
+          return fakePgpStorage
+        }),
+      },
+    }))
+    vi.doMock('@/ee/AesEncryptingStorage', () => ({
+      AesEncryptingStorage: {
+        create: vi.fn(),
+      },
+    }))
+    vi.doMock('@/lib/storage/CachingStorage', () => ({
+      CachingStorage: vi.fn(),
+    }))
+    vi.doMock('@/lib/storage/FsStorage', () => ({
+      FsStorage: vi.fn(),
+    }))
+
+    const module = await import('@/backend/lib/storage')
+
+    expect(s3Instances).toEqual(['bucket-name'])
+    expect(pgpInstances).toEqual([{ storage: fakeS3Storage, key: 'secret' }])
+    expect(module.storage).toEqual(fakePgpStorage)
+  })
+
+  test('throws for missing storage location', async () => {
+    vi.doMock('@/lib/env', () => ({
+      default: {
+        fileStorage: {
+          location: '',
+          cacheSizeInMb: 0,
+          encryptionProvider: 'aes',
+          encryptionKey: 'secret',
+        },
+      },
+    }))
+
+    await expect(import('@/backend/lib/storage')).rejects.toThrow(
+      'FILE_STORAGE_LOCATION not defined. Upload failing'
+    )
+  })
+
+  test('throws for invalid s3 url', async () => {
+    vi.doMock('@/lib/env', () => ({
+      default: {
+        fileStorage: {
+          location: 's3://',
+          cacheSizeInMb: 0,
+          encryptionProvider: 'pgp',
+          encryptionKey: 'secret',
+        },
+      },
+    }))
+
+    await expect(import('@/backend/lib/storage')).rejects.toThrow(
+      'Invalid S3 URL. Must be in the format s3://bucket'
+    )
+  })
+})

--- a/__tests__/storages.ts
+++ b/__tests__/storages.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'vitest'
+import { test, expect, vi } from 'vitest'
 import { MemoryStorage } from '@/lib/storage/MemoryStorage'
 import { CachingStorage } from '@/lib/storage/CachingStorage'
 import { AesEncryptingStorage } from '@/ee/AesEncryptingStorage'
@@ -15,6 +15,20 @@ function makeFailingReadableStream(): ReadableStream<Uint8Array> {
     start(controller) {
       controller.enqueue(new Uint8Array([1, 2, 3]))
       controller.error(new Error('boom: upload reader failed'))
+    },
+  })
+}
+
+function makeChunkedReadableStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  let chunkIndex = 0
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      const chunk = chunks[chunkIndex++]
+      if (!chunk) {
+        controller.close()
+        return
+      }
+      controller.enqueue(chunk)
     },
   })
 }
@@ -125,6 +139,38 @@ test('CachingStorage does not cache large streams discovered at runtime', async 
   expect(inner.readCalls).toBe(2)
 })
 
+test('CachingStorage does not cache unknown-size streams that grow past the limit mid-read', async () => {
+  const payloadChunks = [
+    Buffer.alloc(400_000, 1),
+    Buffer.alloc(400_000, 2),
+    Buffer.alloc(400_000, 3),
+  ]
+  const payload = Buffer.concat(payloadChunks)
+  const inner = new (class extends InstrumentedStorage {
+    override async readStream(
+      path: string,
+      _encrypted?: boolean,
+      options?: StorageReadOptions
+    ): Promise<ReadableStream<Uint8Array>> {
+      this.readCalls += 1
+      this.readOptionsLog.push(options)
+      return makeChunkedReadableStream(
+        this.map[path] ? payloadChunks.map((chunk) => new Uint8Array(chunk)) : []
+      )
+    }
+  })()
+  const storage = new CachingStorage(inner, 1)
+  inner.map[fileName] = payload
+
+  const firstStream = await storage.readStream(fileName, false)
+  const firstRead = await collectStreamToBuffer(firstStream)
+  const secondRead = await storage.readBuffer(fileName, false)
+
+  expect(firstRead.equals(payload)).toBe(true)
+  expect(secondRead.equals(payload)).toBe(true)
+  expect(inner.readCalls).toBe(2)
+})
+
 test('CachingStorage caches writes when payload fits cache size', async () => {
   const inner = new InstrumentedStorage()
   const storage = new CachingStorage(inner, 1)
@@ -152,6 +198,53 @@ test('CachingStorage does not cache oversized writes', async () => {
   expect(inner.readCalls).toBe(2)
 })
 
+test('CachingStorage delegates removals to inner storage', async () => {
+  const inner = new InstrumentedStorage()
+  const storage = new CachingStorage(inner, 1)
+  inner.map[fileName] = Buffer.from('exists')
+
+  await storage.rm(fileName)
+
+  expect(inner.map[fileName]).toBeUndefined()
+})
+
+test('CachingStorage does not cache unknown-size streamed writes that grow past the limit', async () => {
+  const inner = new InstrumentedStorage()
+  const storage = new CachingStorage(inner, 1)
+  const chunks = [
+    Buffer.alloc(400_000, 5),
+    Buffer.alloc(400_000, 6),
+    Buffer.alloc(400_000, 7),
+  ]
+  const payload = Buffer.concat(chunks)
+
+  await storage.writeStream(
+    fileName,
+    makeChunkedReadableStream(chunks.map((chunk) => new Uint8Array(chunk))),
+    false
+  )
+  const firstRead = await storage.readBuffer(fileName, false)
+  const secondRead = await storage.readBuffer(fileName, false)
+
+  expect(firstRead.equals(payload)).toBe(true)
+  expect(secondRead.equals(payload)).toBe(true)
+  expect(inner.readCalls).toBe(2)
+})
+
+test('CachingStorage propagates read failures from the inner stream', async () => {
+  const inner = new (class extends InstrumentedStorage {
+    override async readStream(): Promise<ReadableStream<Uint8Array>> {
+      this.readCalls += 1
+      return makeFailingReadableStream()
+    }
+  })()
+  const storage = new CachingStorage(inner, 1)
+
+  await expect(collectStreamToBuffer(await storage.readStream(fileName, false))).rejects.toThrow(
+    'boom: upload reader failed'
+  )
+})
+
 test('TestAesEncryptingStorageShortString', async () => {
   const storage = await AesEncryptingStorage.create(new MemoryStorage(), password)
   const text = 'just testing'
@@ -173,6 +266,52 @@ test('TestAesEncryptingStorageNotSoShortString', async () => {
   await storage.writeBuffer(fileName, Buffer.from(text), true)
   const buf = await storage.readBuffer(fileName, true)
   expect(buf.toString()).toBe(text)
+})
+
+test('TestAesEncryptingStorageLargeChunkedStream', async () => {
+  const storage = await AesEncryptingStorage.create(new MemoryStorage(), password)
+  const chunks = [
+    Buffer.alloc(7, 1),
+    Buffer.alloc(31, 2),
+    Buffer.alloc(800_000, 3),
+    Buffer.alloc(400_003, 4),
+  ]
+  const payload = Buffer.concat(chunks)
+
+  await storage.writeStream(
+    fileName,
+    makeChunkedReadableStream(chunks.map((chunk) => new Uint8Array(chunk))),
+    true
+  )
+  const buf = await storage.readBuffer(fileName, true)
+
+  expect(buf.equals(payload)).toBe(true)
+})
+
+test('TestAesEncryptingStorageRejectsNegativeCounterIncrement', async () => {
+  const storage = await AesEncryptingStorage.create(new MemoryStorage(), password)
+  const encryptSpy = vi
+    .spyOn(crypto.subtle, 'encrypt')
+    .mockResolvedValue({ byteLength: -16 } as ArrayBuffer)
+
+  await expect(storage.writeBuffer(fileName, Buffer.from('x'), true)).rejects.toThrow(
+    'Increment must be non-negative'
+  )
+
+  encryptSpy.mockRestore()
+})
+
+test('TestAesEncryptingStorageRejectsCounterOverflow', async () => {
+  const storage = await AesEncryptingStorage.create(new MemoryStorage(), password)
+  const encryptSpy = vi
+    .spyOn(crypto.subtle, 'encrypt')
+    .mockResolvedValue({ byteLength: Number.POSITIVE_INFINITY } as ArrayBuffer)
+
+  await expect(storage.writeBuffer(fileName, Buffer.from('x'), true)).rejects.toThrow(
+    'IV overflowed beyond its length'
+  )
+
+  encryptSpy.mockRestore()
 })
 
 test('TestPgpEncryptingStorageShortString', async () => {

--- a/__tests__/storages.ts
+++ b/__tests__/storages.ts
@@ -4,6 +4,8 @@ import { CachingStorage } from '@/lib/storage/CachingStorage'
 import { AesEncryptingStorage } from '@/ee/AesEncryptingStorage'
 import { PgpEncryptingStorage } from '@/ee/PgpEncryptingStorage'
 import { FsStorage } from '@/lib/storage/FsStorage'
+import { BaseStorage, StorageReadOptions } from '@/lib/storage/api'
+import { collectStreamToBuffer, bufferToReadableStream } from '@/lib/storage/utils'
 
 const fileName = 'test'
 const password = 'my_key'
@@ -15,6 +17,33 @@ function makeFailingReadableStream(): ReadableStream<Uint8Array> {
       controller.error(new Error('boom: upload reader failed'))
     },
   })
+}
+
+class InstrumentedStorage extends BaseStorage {
+  map: Record<string, Uint8Array> = {}
+  readCalls = 0
+  writeCalls = 0
+  readOptionsLog: Array<StorageReadOptions | undefined> = []
+
+  async rm(path: string) {
+    delete this.map[path]
+  }
+
+  async readStream(
+    path: string,
+    _encrypted?: boolean,
+    options?: StorageReadOptions
+  ): Promise<ReadableStream<Uint8Array>> {
+    this.readCalls += 1
+    this.readOptionsLog.push(options)
+    return bufferToReadableStream(this.map[path])
+  }
+
+  async writeStream(path: string, stream: ReadableStream<Uint8Array>) {
+    this.writeCalls += 1
+    const buffer = await collectStreamToBuffer(stream)
+    this.map[path] = buffer
+  }
 }
 
 test('TestFsStorageWriteFailingReadableStream', async () => {
@@ -36,6 +65,91 @@ test('TestCachingStorage', async () => {
   await storage.writeBuffer(fileName, Buffer.from('just testing'), false)
   const aaaa = await storage.readBuffer(fileName, false)
   expect(aaaa.toString()).toBe('just testing')
+})
+
+test('CachingStorage serves repeated small reads from cache', async () => {
+  const inner = new InstrumentedStorage()
+  const storage = new CachingStorage(inner, 1)
+  await inner.writeBuffer(fileName, Buffer.from('small payload'), false)
+
+  const firstRead = await storage.readBuffer(fileName, false)
+  const secondRead = await storage.readBuffer(fileName, false)
+
+  expect(firstRead.toString()).toBe('small payload')
+  expect(secondRead.toString()).toBe('small payload')
+  expect(inner.readCalls).toBe(1)
+})
+
+test('CachingStorage proactively bypasses cache for oversized expected size', async () => {
+  const inner = new InstrumentedStorage()
+  const storage = new CachingStorage(inner, 1)
+  await inner.writeBuffer(fileName, Buffer.from('small payload'), false)
+
+  const firstRead = await storage.readBuffer(fileName, false)
+  const secondStream = await storage.readStream(fileName, false, { expectedSizeBytes: 2 * 1048576 })
+  const secondRead = await collectStreamToBuffer(secondStream)
+  const thirdRead = await storage.readBuffer(fileName, false)
+
+  expect(firstRead.toString()).toBe('small payload')
+  expect(secondRead.toString()).toBe('small payload')
+  expect(thirdRead.toString()).toBe('small payload')
+  expect(inner.readCalls).toBe(2)
+})
+
+test('CachingStorage bypassCache option skips cache and does not evict cached value', async () => {
+  const inner = new InstrumentedStorage()
+  const storage = new CachingStorage(inner, 1)
+  await inner.writeBuffer(fileName, Buffer.from('small payload'), false)
+
+  await storage.readBuffer(fileName, false)
+  const bypassedStream = await storage.readStream(fileName, false, { bypassCache: true })
+  const bypassedRead = await collectStreamToBuffer(bypassedStream)
+  const cachedRead = await storage.readBuffer(fileName, false)
+
+  expect(bypassedRead.toString()).toBe('small payload')
+  expect(cachedRead.toString()).toBe('small payload')
+  expect(inner.readCalls).toBe(2)
+})
+
+test('CachingStorage does not cache large streams discovered at runtime', async () => {
+  const inner = new InstrumentedStorage()
+  const storage = new CachingStorage(inner, 1)
+  const payload = Buffer.alloc(2 * 1048576, 7)
+  await inner.writeBuffer(fileName, payload, false)
+
+  const firstRead = await storage.readBuffer(fileName, false)
+  const secondRead = await storage.readBuffer(fileName, false)
+
+  expect(firstRead.equals(payload)).toBe(true)
+  expect(secondRead.equals(payload)).toBe(true)
+  expect(inner.readCalls).toBe(2)
+})
+
+test('CachingStorage caches writes when payload fits cache size', async () => {
+  const inner = new InstrumentedStorage()
+  const storage = new CachingStorage(inner, 1)
+
+  await storage.writeBuffer(fileName, Buffer.from('write cached'), false)
+  const firstRead = await storage.readBuffer(fileName, false)
+  const secondRead = await storage.readBuffer(fileName, false)
+
+  expect(firstRead.toString()).toBe('write cached')
+  expect(secondRead.toString()).toBe('write cached')
+  expect(inner.readCalls).toBe(0)
+})
+
+test('CachingStorage does not cache oversized writes', async () => {
+  const inner = new InstrumentedStorage()
+  const storage = new CachingStorage(inner, 1)
+  const payload = Buffer.alloc(2 * 1048576, 4)
+
+  await storage.writeBuffer(fileName, payload, false)
+  const firstRead = await storage.readBuffer(fileName, false)
+  const secondRead = await storage.readBuffer(fileName, false)
+
+  expect(firstRead.equals(payload)).toBe(true)
+  expect(secondRead.equals(payload)).toBe(true)
+  expect(inner.readCalls).toBe(2)
 })
 
 test('TestAesEncryptingStorageShortString', async () => {

--- a/apps/backend/ee/AesEncryptingStorage.ts
+++ b/apps/backend/ee/AesEncryptingStorage.ts
@@ -1,5 +1,5 @@
 import { logger } from '@/lib/logging'
-import { Storage, BaseStorage } from '@/lib/storage/api'
+import { Storage, BaseStorage, StorageReadOptions } from '@/lib/storage/api'
 import { ensureABView } from '@/backend/lib/utils'
 
 const concatenate = (chunks: Uint8Array[]) => {
@@ -78,8 +78,12 @@ export class AesEncryptingStorage extends BaseStorage {
     return new AesEncryptingStorage(innerStorage, cryptoKey)
   }
 
-  async readStream(path: string, encrypted: boolean): Promise<ReadableStream<Uint8Array>> {
-    const innerStream = await this.innerStorage.readStream(path, encrypted)
+  async readStream(
+    path: string,
+    encrypted: boolean,
+    options?: StorageReadOptions
+  ): Promise<ReadableStream<Uint8Array>> {
+    const innerStream = await this.innerStorage.readStream(path, encrypted, options)
     return encrypted ? await this.createProcessingStream(path, innerStream) : innerStream
   }
 

--- a/apps/backend/ee/PgpEncryptingStorage.ts
+++ b/apps/backend/ee/PgpEncryptingStorage.ts
@@ -1,4 +1,4 @@
-import { Storage, BaseStorage } from '@/lib/storage/api'
+import { Storage, BaseStorage, StorageReadOptions } from '@/lib/storage/api'
 import * as openpgp from 'openpgp'
 
 export class PgpEncryptingStorage extends BaseStorage {
@@ -14,8 +14,12 @@ export class PgpEncryptingStorage extends BaseStorage {
     return new PgpEncryptingStorage(innerStorage, passPhrase)
   }
 
-  async readStream(path: string, encrypted: boolean): Promise<ReadableStream<Uint8Array>> {
-    const innerStream = await this.innerStorage.readStream(path, encrypted)
+  async readStream(
+    path: string,
+    encrypted: boolean,
+    options?: StorageReadOptions
+  ): Promise<ReadableStream<Uint8Array>> {
+    const innerStream = await this.innerStorage.readStream(path, encrypted, options)
     if (!encrypted) return innerStream
     const { data: clearStream } = await openpgp.decrypt({
       message: await openpgp.readMessage({ binaryMessage: innerStream }),

--- a/apps/backend/lib/storage/CachingStorage.ts
+++ b/apps/backend/lib/storage/CachingStorage.ts
@@ -6,6 +6,7 @@ import { logger } from '@/lib/logging'
 export class CachingStorage extends BaseStorage {
   cache: LRUCache<string, Uint8Array>
   innerStorage: Storage
+  private readonly maxCacheableItemSizeBytes: number
   constructor(innerStorage: Storage, cacheSizeMb: number) {
     super()
     this.innerStorage = innerStorage
@@ -15,6 +16,7 @@ export class CachingStorage extends BaseStorage {
         return value.length
       },
     })
+    this.maxCacheableItemSizeBytes = Math.round(cacheSizeMb * 1048576)
   }
 
   async readStream(path: string, encrypted: boolean): Promise<ReadableStream<Uint8Array>> {
@@ -37,7 +39,10 @@ export class CachingStorage extends BaseStorage {
 
   private sendToCacheStream(path: string, stream: ReadableStream<Uint8Array>) {
     const cache = this.cache
+    const maxCacheableItemSizeBytes = this.maxCacheableItemSizeBytes
     const chunks: Buffer[] = []
+    let totalBytes = 0
+    let shouldCache = true
     return new ReadableStream({
       start(controller) {
         const reader = stream.getReader()
@@ -47,11 +52,21 @@ export class CachingStorage extends BaseStorage {
             const { done, value } = await reader.read()
             if (done) {
               controller.close()
-              cache.set(path, Buffer.concat(chunks))
-              logger.debug(`cache size is ${cache.calculatedSize}`)
+              if (shouldCache) {
+                cache.set(path, Buffer.concat(chunks))
+                logger.debug(`cache size is ${cache.calculatedSize}`)
+              }
               return
             }
-            chunks.push(Buffer.from(value)) // Collect data for Buffer
+            if (shouldCache) {
+              totalBytes += value.byteLength
+              if (totalBytes > maxCacheableItemSizeBytes) {
+                shouldCache = false
+                chunks.length = 0
+              } else {
+                chunks.push(Buffer.from(value))
+              }
+            }
             controller.enqueue(value) // Pass data downstream
             await push() // Read the next chunk
           } catch (e) {

--- a/apps/backend/lib/storage/CachingStorage.ts
+++ b/apps/backend/lib/storage/CachingStorage.ts
@@ -1,5 +1,5 @@
 import { LRUCache } from 'lru-cache'
-import { Storage, BaseStorage } from './api'
+import { Storage, BaseStorage, StorageReadOptions } from './api'
 import { bufferToReadableStream } from './utils'
 import { logger } from '@/lib/logging'
 
@@ -19,12 +19,24 @@ export class CachingStorage extends BaseStorage {
     this.maxCacheableItemSizeBytes = Math.round(cacheSizeMb * 1048576)
   }
 
-  async readStream(path: string, encrypted: boolean): Promise<ReadableStream<Uint8Array>> {
+  async readStream(
+    path: string,
+    encrypted: boolean,
+    options?: StorageReadOptions
+  ): Promise<ReadableStream<Uint8Array>> {
+    const shouldBypassCache =
+      options?.bypassCache === true ||
+      (typeof options?.expectedSizeBytes === 'number' &&
+        options.expectedSizeBytes > this.maxCacheableItemSizeBytes)
+    if (shouldBypassCache) {
+      return this.innerStorage.readStream(path, encrypted, options)
+    }
+
     const cachedValue = this.cache.get(path)
     if (cachedValue) {
       return bufferToReadableStream(cachedValue)
     }
-    const innerStream = await this.innerStorage.readStream(path, encrypted)
+    const innerStream = await this.innerStorage.readStream(path, encrypted, options)
     return this.sendToCacheStream(path, innerStream)
   }
 

--- a/apps/backend/lib/storage/FsStorage.ts
+++ b/apps/backend/lib/storage/FsStorage.ts
@@ -29,7 +29,11 @@ export class FsStorage extends BaseStorage {
     return await fs.promises.readFile(fsPath)
   }
 
-  async readStream(path: string): Promise<ReadableStream<Uint8Array>> {
+  async readStream(
+    path: string,
+    _encrypted?: boolean,
+    _options?: { expectedSizeBytes?: number; bypassCache?: boolean }
+  ): Promise<ReadableStream<Uint8Array>> {
     const fsPath = `${this.rootPath}/${path}`
     const nodeStream = createReadStream(fsPath)
     return nodeStreamToReadableStream(nodeStream)

--- a/apps/backend/lib/storage/MemoryStorage.ts
+++ b/apps/backend/lib/storage/MemoryStorage.ts
@@ -8,7 +8,11 @@ export class MemoryStorage extends BaseStorage {
     delete this.map[path]
   }
 
-  async readStream(path: string): Promise<ReadableStream<Uint8Array>> {
+  async readStream(
+    path: string,
+    _encrypted?: boolean,
+    _options?: { expectedSizeBytes?: number; bypassCache?: boolean }
+  ): Promise<ReadableStream<Uint8Array>> {
     return bufferToReadableStream(this.map[path])
   }
 

--- a/apps/backend/lib/storage/S3Storage.ts
+++ b/apps/backend/lib/storage/S3Storage.ts
@@ -68,7 +68,11 @@ export class S3Storage extends BaseStorage {
     }
   }
 
-  async readStream(path: string): Promise<ReadableStream<Uint8Array>> {
+  async readStream(
+    path: string,
+    _encrypted?: boolean,
+    _options?: { expectedSizeBytes?: number; bypassCache?: boolean }
+  ): Promise<ReadableStream<Uint8Array>> {
     try {
       const params = {
         Bucket: this.bucketName, // Replace with your bucket name

--- a/apps/backend/lib/storage/api.ts
+++ b/apps/backend/lib/storage/api.ts
@@ -1,15 +1,28 @@
 import { bufferToReadableStream, collectStreamToBuffer } from './utils'
 
+export interface StorageReadOptions {
+  expectedSizeBytes?: number
+  bypassCache?: boolean
+}
+
 export interface Storage {
   writeStream(path: string, stream: ReadableStream<Uint8Array>, encrypted: boolean): Promise<void>
   writeBuffer(path: string, buffer: Uint8Array, encrypted: boolean): Promise<void>
   rm(path: string): Promise<void>
-  readStream(path: string, encrypted: boolean): Promise<ReadableStream<Uint8Array>>
+  readStream(
+    path: string,
+    encrypted: boolean,
+    options?: StorageReadOptions
+  ): Promise<ReadableStream<Uint8Array>>
   readBuffer(path: string, encrypted: boolean): Promise<Buffer>
 }
 
 export abstract class BaseStorage implements Storage {
-  abstract readStream(path: string, encrypted: boolean): Promise<ReadableStream<Uint8Array>>
+  abstract readStream(
+    path: string,
+    encrypted: boolean,
+    options?: StorageReadOptions
+  ): Promise<ReadableStream<Uint8Array>>
   abstract writeStream(
     path: string,
     stream: ReadableStream<Uint8Array>,

--- a/apps/backend/lib/tools/audio_transcription/implementation.ts
+++ b/apps/backend/lib/tools/audio_transcription/implementation.ts
@@ -124,22 +124,20 @@ export class AudioTranscription extends AudioTranscriptionInterface implements T
       return { type: 'error-text', value: `File not found: ${fileId}` }
     }
 
-    const fileContent = await storage.readBuffer(fileEntry.path, !!fileEntry.encrypted)
+    const fileContent = await storage.readStream(fileEntry.path, !!fileEntry.encrypted)
     const headers = await this.getHeaders()
 
     try {
-      const uploadResponse = await fetch(`${this.getApiUrl()}/v2/upload`, {
+      const uploadRequest: RequestInit & { duplex: 'half' } = {
         method: 'POST',
         headers: {
           ...headers,
           'content-type': fileEntry.type || 'application/octet-stream',
         },
-        body: new Uint8Array(
-          fileContent.buffer as ArrayBuffer,
-          fileContent.byteOffset,
-          fileContent.byteLength
-        ),
-      })
+        body: fileContent,
+        duplex: 'half',
+      }
+      const uploadResponse = await fetch(`${this.getApiUrl()}/v2/upload`, uploadRequest)
       if (!uploadResponse.ok) {
         return {
           type: 'error-text',

--- a/apps/backend/lib/tools/audio_transcription/implementation.ts
+++ b/apps/backend/lib/tools/audio_transcription/implementation.ts
@@ -124,7 +124,11 @@ export class AudioTranscription extends AudioTranscriptionInterface implements T
       return { type: 'error-text', value: `File not found: ${fileId}` }
     }
 
-    const fileContent = await storage.readStream(fileEntry.path, !!fileEntry.encrypted)
+    const expectedSizeBytes =
+      typeof fileEntry.size === 'number' && Number.isFinite(fileEntry.size) ? fileEntry.size : undefined
+    const fileContent = await storage.readStream(fileEntry.path, !!fileEntry.encrypted, {
+      expectedSizeBytes,
+    })
     const headers = await this.getHeaders()
 
     try {


### PR DESCRIPTION
## Summary
This reduces peak memory usage during audio transcription by streaming file uploads to AssemblyAI and preventing oversized storage reads from being accumulated into the in-memory cache.

## Details
- switched audio transcription upload to use `storage.readStream(...)` and stream the request body to AssemblyAI instead of materializing a full buffer first
- kept Node fetch streaming compatibility by using a typed request object with `duplex: 'half'`
- updated caching storage stream handling to skip cache population when a stream exceeds the configured cache capacity, avoiding large `Buffer.concat(...)` allocations for big files

## Risks
- streaming upload behavior depends on the runtime fetch implementation supporting streamed request bodies (current Node runtime supports this)

## Tests
- `npm run check-types` (pass)