### PR TITLE
Fix assistant table header clipping and spacing

### DIFF
--- a/apps/frontend/app/chat/assistants/mine/page.tsx
+++ b/apps/frontend/app/chat/assistants/mine/page.tsx
@@ -144,6 +144,7 @@ const MyAssistantPage = () => {
   const columns: Column<dto.UserAssistant>[] = [
     {
       name: t(' '),
+      thClass: 'w-12',
       renderer: (assistant: dto.UserAssistant) => (
         <AssistantAvatar className="shrink-0 self-center" size="big" assistant={assistant} />
       ),
@@ -170,6 +171,7 @@ const MyAssistantPage = () => {
     },
     {
       name: t('last_upd'),
+      thClass: 'w-[100px]',
       renderer: (assistant: dto.UserAssistant) => (
         <div>
           <ReactTimeAgo
@@ -184,6 +186,7 @@ const MyAssistantPage = () => {
     },
     {
       name: t('sharing'),
+      thClass: 'w-24',
       renderer: (assistant: dto.UserAssistant) => (
         <div className="">{describeSharing(assistant)}</div>
       ),
@@ -191,6 +194,7 @@ const MyAssistantPage = () => {
     },
     {
       name: t('unpublished_edits'),
+      thClass: 'w-24',
       renderer: (assistant: dto.UserAssistant) => (
         <div className="flex justify-center">
           {assistant.pendingChanges ? <IconPencilExclamation color={'#FFB450'} size={20} /> : ''}
@@ -200,6 +204,7 @@ const MyAssistantPage = () => {
     },
     {
       name: t('stats'),
+      thClass: 'w-28',
       accessorFn: (assistant: dto.UserAssistant) => statsMap.get(assistant.id)?.messages ?? 0,
       renderer: (assistant: dto.UserAssistant) => {
         const s = statsMap.get(assistant.id)
@@ -221,6 +226,7 @@ const MyAssistantPage = () => {
     },
     {
       name: t('table-column-actions'),
+      thClass: 'w-[8em]',
       renderer: (assistant: dto.UserAssistant) => (
         <ActionList>
           <Action
@@ -266,7 +272,7 @@ const MyAssistantPage = () => {
           <ScrollArea className="flex-1 min-h-0">
             <div className=" gap-4 flex flex-col">
               <SimpleTable
-                className="flex-1 text-sm"
+                className="flex-1 text-sm table-fixed"
                 columns={columns}
                 rows={(assistants ?? [])
                   .filter(

--- a/apps/frontend/components/ui/tables.tsx
+++ b/apps/frontend/components/ui/tables.tsx
@@ -25,6 +25,7 @@ export type Column<T> = {
   accessorFn?: (row: T) => any
   renderer: RowRenderer<T>
   headerClass?: string
+  thClass?: string
 }
 
 interface Props<T> {
@@ -62,16 +63,19 @@ export function SimpleTable<T>({ columns, rows, keygen, className, onRowClick }:
       columns.map((col) => ({
         id: col.name,
         accessorFn: col.accessorFn,
+        meta: { thClass: col.thClass },
         header: ({ column }) => (
           <button
             type="button"
-            className="flex"
+            className="flex w-full min-w-0 items-center gap-1"
             style={{ cursor: 'pointer', userSelect: 'none' }}
             onClick={(evt) => {
               column.getToggleSortingHandler()?.(evt)
             }}
           >
-            <span className={`flex-1 ${col.headerClass ?? ''}`}>{col.name}</span>
+            <span className={`min-w-0 flex-1 truncate ${col.headerClass ?? ''}`} title={col.name}>
+              {col.name}
+            </span>
             {col.accessorFn && (
               <span style={{ visibility: column.getIsSorted() ? 'visible' : 'hidden' }}>
                 {{
@@ -106,7 +110,10 @@ export function SimpleTable<T>({ columns, rows, keygen, className, onRowClick }:
         {table.getHeaderGroups().map((headerGroup) => (
           <TableRow key={headerGroup.id}>
             {headerGroup.headers.map((header) => (
-              <TableHead key={header.id}>
+              <TableHead
+                key={header.id}
+                className={`px-2 ${(header.column.columnDef.meta as any)?.thClass ?? ''}`}
+              >
                 {flexRender(header.column.columnDef.header, header.getContext())}
               </TableHead>
             ))}


### PR DESCRIPTION
## Summary
This updates assistant table header rendering so long titles truncate correctly in narrow columns and header cells use tighter horizontal spacing.

## Details
- updated shared table header layout to allow shrink/truncation (`w-full`, `min-w-0`, `truncate`) and added native hover title for full header text
- reduced header horizontal padding in the shared table wrapper from the primitive default to a tighter override
- included assistant-list page adjustments in the same change set

## Tests
- `npm run check-types` (pass)
