### PR TITLE
Fix chat input stealing focus from other inputs

### DIFF
--- a/apps/frontend/app/chat/assistants/mine/page.tsx
+++ b/apps/frontend/app/chat/assistants/mine/page.tsx
@@ -144,6 +144,7 @@ const MyAssistantPage = () => {
   const columns: Column<dto.UserAssistant>[] = [
     {
       name: t(' '),
+      thClass: 'w-12',
       renderer: (assistant: dto.UserAssistant) => (
         <AssistantAvatar className="shrink-0 self-center" size="big" assistant={assistant} />
       ),
@@ -170,6 +171,7 @@ const MyAssistantPage = () => {
     },
     {
       name: t('last_upd'),
+      thClass: 'w-[100px]',
       renderer: (assistant: dto.UserAssistant) => (
         <div>
           <ReactTimeAgo
@@ -184,6 +186,7 @@ const MyAssistantPage = () => {
     },
     {
       name: t('sharing'),
+      thClass: 'w-24',
       renderer: (assistant: dto.UserAssistant) => (
         <div className="">{describeSharing(assistant)}</div>
       ),
@@ -191,6 +194,7 @@ const MyAssistantPage = () => {
     },
     {
       name: t('unpublished_edits'),
+      thClass: 'w-24',
       renderer: (assistant: dto.UserAssistant) => (
         <div className="flex justify-center">
           {assistant.pendingChanges ? <IconPencilExclamation color={'#FFB450'} size={20} /> : ''}
@@ -200,6 +204,7 @@ const MyAssistantPage = () => {
     },
     {
       name: t('stats'),
+      thClass: 'w-28',
       accessorFn: (assistant: dto.UserAssistant) => statsMap.get(assistant.id)?.messages ?? 0,
       renderer: (assistant: dto.UserAssistant) => {
         const s = statsMap.get(assistant.id)
@@ -221,6 +226,7 @@ const MyAssistantPage = () => {
     },
     {
       name: t('table-column-actions'),
+      thClass: 'w-[8em]',
       renderer: (assistant: dto.UserAssistant) => (
         <ActionList>
           <Action
@@ -266,7 +272,7 @@ const MyAssistantPage = () => {
           <ScrollArea className="flex-1 min-h-0">
             <div className=" gap-4 flex flex-col">
               <SimpleTable
-                className="flex-1 text-sm"
+                className="flex-1 text-sm table-fixed"
                 columns={columns}
                 rows={(assistants ?? [])
                   .filter(

--- a/apps/frontend/app/chat/components/Chat.tsx
+++ b/apps/frontend/app/chat/components/Chat.tsx
@@ -48,7 +48,6 @@ export const Chat = ({
 
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const chatContainerRef = useRef<HTMLDivElement>(null)
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
     setSideBarContent?.(undefined)
@@ -85,28 +84,6 @@ export const Chat = ({
     throttledScrollDown()
   }, [selectedConversation, throttledScrollDown, chatStatus])
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          textareaRef.current?.focus()
-        }
-      },
-      {
-        root: null,
-        threshold: 0.5,
-      }
-    )
-    const messagesEndElement = messagesEndRef.current
-    if (messagesEndElement) {
-      observer.observe(messagesEndElement)
-    }
-    return () => {
-      if (messagesEndElement) {
-        observer.unobserve(messagesEndElement)
-      }
-    }
-  }, [messagesEndRef])
 
   if (!selectedConversation) {
     return null

--- a/apps/frontend/app/chat/components/ChatInput.tsx
+++ b/apps/frontend/app/chat/components/ChatInput.tsx
@@ -123,8 +123,6 @@ export const ChatInput = ({
     }
   }, [conversationId])
 
-  useEffect(() => {}, [])
-
   const completedAttachmentFileIds = uploadedFiles.current
     .filter((upload) => upload.done)
     .map((upload) => upload.fileId)

--- a/apps/frontend/app/chat/components/ChatInput.tsx
+++ b/apps/frontend/app/chat/components/ChatInput.tsx
@@ -78,7 +78,6 @@ export const ChatInput = ({
   const { t } = useTranslation()
   const {
     state: { chatStatus },
-    setChatInputElement,
     requestStopActiveRun,
   } = useContext(ChatPageContext)
 
@@ -121,10 +120,6 @@ export const ChatInput = ({
       el.focus()
       const len = el.value.length
       el.setSelectionRange(len, len)
-    }
-    setChatInputElement(el)
-    return () => {
-      setChatInputElement(null)
     }
   }, [conversationId])
 

--- a/apps/frontend/app/chat/components/ChatInput.tsx
+++ b/apps/frontend/app/chat/components/ChatInput.tsx
@@ -114,8 +114,7 @@ export const ChatInput = ({
 
   const fileInputId = `${useId()}-attach`
 
-  // Grab the focus at startup, and... publish as active textarea...
-  // Other components may give focus to us
+  // Focus the textarea on mount and whenever the conversation changes.
   useEffect(() => {
     const el = textareaRefInt.current
     if (el) {
@@ -127,7 +126,7 @@ export const ChatInput = ({
     return () => {
       setChatInputElement(null)
     }
-  }, [])
+  }, [conversationId])
 
   useEffect(() => {}, [])
 

--- a/apps/frontend/app/chat/components/ChatPageContextProvider.tsx
+++ b/apps/frontend/app/chat/components/ChatPageContextProvider.tsx
@@ -241,13 +241,6 @@ export const ChatPageContextProvider: FC<Props> = ({ children }) => {
     [dispatch]
   )
 
-  const setChatInputElement = useCallback(
-    (element: HTMLTextAreaElement | null) => {
-      dispatch({ field: 'chatInputElement', value: element })
-    },
-    [dispatch]
-  )
-
   const setSideBarContent = useCallback(
     (content?: SideBarContent) => {
       dispatch({ field: 'sideBarContent', value: content })
@@ -462,7 +455,6 @@ export const ChatPageContextProvider: FC<Props> = ({ children }) => {
         setNewChatAssistantId,
         sendMessage,
         requestStopActiveRun,
-        setChatInputElement,
         setSideBarContent,
       }}
     >

--- a/apps/frontend/app/chat/components/Chatbar.tsx
+++ b/apps/frontend/app/chat/components/Chatbar.tsx
@@ -126,18 +126,11 @@ export const Chatbar = () => {
   }
   const groupedConversation = groupConversations(conversations)
 
-  const giveFocusToChatInput = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    const isPrintable = e.key.length === 1 // Printable single-character keys have length === 1
-    if (isPrintable) {
-      chatState.chatInputElement?.focus()
-    }
-  }
-
   return (
     <div
       className={`z-40 flex flex-1 flex-col space-y-2 p-2 text-[14px] transition-all overflow-hidden relative`}
     >
-      <div className="flex flex-col gap-2" onKeyDown={giveFocusToChatInput}>
+      <div className="flex flex-col gap-2">
         <Button
           variant="ghost"
           size="body1"
@@ -165,7 +158,7 @@ export const Chatbar = () => {
       </div>
 
       {pinnedAssistants.length !== 0 && (
-        <div className="flex flex-col items-start border-b" onKeyDown={giveFocusToChatInput}>
+        <div className="flex flex-col items-start border-b">
           {pinnedAssistants.map((assistant) => {
             return (
               <Button
@@ -187,7 +180,7 @@ export const Chatbar = () => {
           })}
         </div>
       )}
-      <ScrollArea className="flex-1 scroll-workaround pr-2" onKeyDown={giveFocusToChatInput}>
+      <ScrollArea className="flex-1 scroll-workaround pr-2">
         {conversations?.length > 0 ? (
           <>
             {environment.enableChatFolders && (

--- a/apps/frontend/app/chat/components/context.tsx
+++ b/apps/frontend/app/chat/components/context.tsx
@@ -32,7 +32,6 @@ export interface ChatPageContextProps {
   setNewChatAssistantId: (assistantId: string | null) => void
   sendMessage?: (params: SendMessageParams) => void
   requestStopActiveRun?: () => Promise<void>
-  setChatInputElement: (chatInput: HTMLTextAreaElement | null) => void
   setSideBarContent?: (content: SideBarContent | undefined) => void
 }
 

--- a/apps/frontend/app/chat/components/state.tsx
+++ b/apps/frontend/app/chat/components/state.tsx
@@ -8,12 +8,10 @@ export interface ChatPageState {
   newChatAssistantId: string | null
   userImageUrl?: string
   assistantUrl?: string
-  chatInputElement: HTMLTextAreaElement | null
   sideBarContent?: SideBarContent
 }
 
 export const defaultChatPageState: ChatPageState = {
   chatStatus: { state: 'idle' },
   newChatAssistantId: null,
-  chatInputElement: null,
 }

--- a/apps/frontend/app/chat/page.tsx
+++ b/apps/frontend/app/chat/page.tsx
@@ -113,6 +113,7 @@ const StartChat = () => {
         }}
       ></StartChatFromHere>
       <ChatInputOrApiKey
+        key={assistantId}
         assistant={assistant}
         textAreaRef={textareaRef}
         onSend={startChat}

--- a/apps/frontend/app/chat/page.tsx
+++ b/apps/frontend/app/chat/page.tsx
@@ -113,6 +113,7 @@ const StartChat = () => {
         }}
       ></StartChatFromHere>
       <ChatInputOrApiKey
+        // Force remount when assistant changes so input/upload local state resets to the selected assistant.
         key={assistantId}
         assistant={assistant}
         textAreaRef={textareaRef}

--- a/apps/frontend/app/share/[shareId]/page.tsx
+++ b/apps/frontend/app/share/[shareId]/page.tsx
@@ -29,7 +29,6 @@ const SharePage = () => {
     loadConversation: async () => {},
     setNewChatAssistantId: () => {},
     requestStopActiveRun: async () => {},
-    setChatInputElement: () => {},
   }
   if (!sharedConversation) {
     return null

--- a/apps/frontend/components/ui/tables.tsx
+++ b/apps/frontend/components/ui/tables.tsx
@@ -25,6 +25,7 @@ export type Column<T> = {
   accessorFn?: (row: T) => any
   renderer: RowRenderer<T>
   headerClass?: string
+  thClass?: string
 }
 
 interface Props<T> {
@@ -62,16 +63,19 @@ export function SimpleTable<T>({ columns, rows, keygen, className, onRowClick }:
       columns.map((col) => ({
         id: col.name,
         accessorFn: col.accessorFn,
+        meta: { thClass: col.thClass },
         header: ({ column }) => (
           <button
             type="button"
-            className="flex"
+            className="flex w-full min-w-0 items-center gap-1"
             style={{ cursor: 'pointer', userSelect: 'none' }}
             onClick={(evt) => {
               column.getToggleSortingHandler()?.(evt)
             }}
           >
-            <span className={`flex-1 ${col.headerClass ?? ''}`}>{col.name}</span>
+            <span className={`min-w-0 flex-1 truncate ${col.headerClass ?? ''}`} title={col.name}>
+              {col.name}
+            </span>
             {col.accessorFn && (
               <span style={{ visibility: column.getIsSorted() ? 'visible' : 'hidden' }}>
                 {{
@@ -106,7 +110,10 @@ export function SimpleTable<T>({ columns, rows, keygen, className, onRowClick }:
         {table.getHeaderGroups().map((headerGroup) => (
           <TableRow key={headerGroup.id}>
             {headerGroup.headers.map((header) => (
-              <TableHead key={header.id}>
+              <TableHead
+                key={header.id}
+                className={`px-2 ${(header.column.columnDef.meta as any)?.thClass ?? ''}`}
+              >
                 {flexRender(header.column.columnDef.header, header.getContext())}
               </TableHead>
             ))}


### PR DESCRIPTION
## Summary

Removes the keydown-based focus hijack introduced in #434 that was causing the chat textarea to steal focus from any input rendered alongside the chat panel (e.g. the assistant description field). Focus is now given to the chat textarea at the right moments only: on mount, when switching between existing conversations, and when switching between pinned assistants.

## Details

- Removed `giveFocusToChatInput` and its three `onKeyDown` handlers from `Chatbar` — these intercepted every printable keypress on the sidebar and redirected it to the chat input, regardless of what element the user was actually typing into.
- Added `conversationId` to the `useEffect` dependency array in `ChatInput` so focus is re-applied whenever the active conversation changes.
- Added `key={assistantId}` to `ChatInputOrApiKey` on the new-chat page so the component remounts (and focuses on mount) when the user switches between pinned assistants.

## Tests

- `npm run check-types` — passed