### PR TITLE
feat: thread conversationId through tool invocation chain

### DIFF
--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -90,6 +90,7 @@ interface Options {
   updateChatTitle?: (title: string) => Promise<void>
   userLanguage?: string
   user?: string
+  conversationId?: string
   debug?: boolean
   abortSignal?: AbortSignal
 }
@@ -699,6 +700,7 @@ export class ChatAssistant {
         messages: chatState.chatHistory,
         assistantId: this.assistantParams.assistantId,
         userId: this.options.user,
+        conversationId: this.options.conversationId,
         toolCallId: toolCall.toolCallId,
         toolName: toolCall.toolName,
         params: args,

--- a/apps/backend/lib/chat/startServerChatRun.ts
+++ b/apps/backend/lib/chat/startServerChatRun.ts
@@ -200,6 +200,7 @@ export const startServerChatRun = async ({
           saveMessage: saveAndAuditMessage,
           updateChatTitle,
           user: session.userId,
+          conversationId: userMessage.conversationId,
           userLanguage: acceptLanguageHeader ?? undefined,
           abortSignal: abortController.signal,
         }

--- a/apps/backend/lib/tools/subassistant/implementation.ts
+++ b/apps/backend/lib/tools/subassistant/implementation.ts
@@ -58,7 +58,7 @@ export class SubAssistantTool implements ToolImplementation {
           additionalProperties: false,
         },
         requireConfirm: false,
-        invoke: async ({ params, userId }) => {
+        invoke: async ({ params, userId, conversationId }) => {
           const assistantId = params.assistantId as string
           const input = params.input as string
           const entry = assistants.find((a) => a.id === assistantId)
@@ -110,12 +110,13 @@ export class SubAssistantTool implements ToolImplementation {
 
             const assistant = await ChatAssistant.build(providerConfig, assistantParams, parameters, tools, files, {
               user: userId,
+              conversationId,
             })
 
-            const conversationId = nanoid()
+            const subConversationId = nanoid()
             const userMsg: dto.UserMessage = {
               id: nanoid(),
-              conversationId,
+              conversationId: subConversationId,
               parent: null,
               sentAt: new Date().toISOString(),
               role: 'user',

--- a/packages/core/src/chat/tools.ts
+++ b/packages/core/src/chat/tools.ts
@@ -14,6 +14,7 @@ export interface ToolInvokeParams {
   messages: dto.Message[]
   assistantId: string
   userId?: string
+  conversationId?: string
   toolCallId?: string
   toolName?: string
   params: Record<string, unknown>


### PR DESCRIPTION
## Summary

Passes the parent conversation ID from the chat run options through to `ToolInvokeParams`, making it available to all tool implementations. The `SubAssistantTool` now receives the originating conversation ID so it can associate sub-assistant calls with their parent conversation. A variable shadowing issue in the sub-assistant implementation is also fixed by renaming the local sub-conversation ID variable to `subConversationId`.

## Details

- Added `conversationId?: string` to `Options` in `apps/backend/lib/chat/index.ts` and forwarded it to tool invocations
- Added `conversationId?: string` to `ToolInvokeParams` in `packages/core/src/chat/tools.ts`
- `startServerChatRun` now populates `conversationId` from `userMessage.conversationId`
- `SubAssistantTool` destructures `conversationId` from invoke params and passes it to `ChatAssistant.build`; renamed local `conversationId → subConversationId` to eliminate shadowing

## Tests

- `npm run check-types` — passed with no errors