### PR TITLE
Add file ownership schema foundation

### DIFF
--- a/__tests__/conversion.test.ts
+++ b/__tests__/conversion.test.ts
@@ -50,6 +50,7 @@ const openaiLanguageModel = { provider: 'openai.responses' } as any
 const litellmLanguageModel = { provider: 'litellm.chat' } as any
 
 const pdfFile = {
+  contentHash: null,
   id: 'pdf-1',
   name: 'example.pdf',
   path: 'files/example.pdf',

--- a/__tests__/textExtractionCache.test.ts
+++ b/__tests__/textExtractionCache.test.ts
@@ -28,6 +28,7 @@ describe('cachingExtractor', () => {
 
   test('prefers analysis-backed extracted text over direct extraction', async () => {
     const fileEntry = {
+      contentHash: null,
       id: 'file-1',
       name: 'example.pdf',
       path: 'files/example.pdf',
@@ -75,6 +76,7 @@ describe('cachingExtractor', () => {
 
   test('falls back to direct extraction when analysis text is unavailable', async () => {
     const fileEntry = {
+      contentHash: null,
       id: 'file-2',
       name: 'example.txt',
       path: 'files/example.txt',
@@ -102,6 +104,7 @@ describe('cachingExtractor', () => {
 
   test('falls back to direct extraction when analysis sidecar read fails', async () => {
     const fileEntry = {
+      contentHash: null,
       id: 'file-3',
       name: 'example.txt',
       path: 'files/example.txt',

--- a/apps/backend/db/migrations.generated.ts
+++ b/apps/backend/db/migrations.generated.ts
@@ -36,6 +36,7 @@ import * as m20260312FileAnalysis from './migrations/20260312-file_analysis'
 import * as m20260319MessageFeedback from './migrations/20260319-message_feedback'
 import * as m20260320AssistantSubAssistants from './migrations/20260320-assistant_sub_assistants'
 import * as m20260330UserEnabled from './migrations/20260330-user_enabled'
+import * as m20260502FileOwnership from './migrations/20260502-file_ownership'
 
 import type { MigrationWithDialect } from './migrations'
 
@@ -76,4 +77,5 @@ export const migrationModules: Record<string, MigrationWithDialect> = {
   '20260319-message_feedback': m20260319MessageFeedback,
   '20260320-assistant_sub_assistants': m20260320AssistantSubAssistants,
   '20260330-user_enabled': m20260330UserEnabled,
+  '20260502-file_ownership': m20260502FileOwnership,
 }

--- a/apps/backend/db/migrations/20260502-file_ownership.ts
+++ b/apps/backend/db/migrations/20260502-file_ownership.ts
@@ -16,6 +16,7 @@ export async function up(db: Kysely<any>, dialect: 'sqlite' | 'postgresql'): Pro
       .addColumn('fileId', 'text', (col) => col.notNull())
       .addColumn('ownerType', sql`"FileOwnerType"`, (col) => col.notNull())
       .addColumn('ownerId', 'text', (col) => col.notNull())
+      .addColumn('displayName', 'text')
       .addColumn('createdAt', 'text', (col) => col.notNull())
       .addForeignKeyConstraint('fk_FileOwnership_File', ['fileId'], 'File', ['id'], (cb) =>
         cb.onDelete('cascade')
@@ -33,6 +34,7 @@ export async function up(db: Kysely<any>, dialect: 'sqlite' | 'postgresql'): Pro
       .addColumn('fileId', 'text', (col) => col.notNull())
       .addColumn('ownerType', 'text', (col) => col.notNull())
       .addColumn('ownerId', 'text', (col) => col.notNull())
+      .addColumn('displayName', 'text')
       .addColumn('createdAt', 'text', (col) => col.notNull())
       .addForeignKeyConstraint('fk_FileOwnership_File', ['fileId'], 'File', ['id'], (cb) =>
         cb.onDelete('cascade')

--- a/apps/backend/db/migrations/20260502-file_ownership.ts
+++ b/apps/backend/db/migrations/20260502-file_ownership.ts
@@ -1,0 +1,55 @@
+import { Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<any>, dialect: 'sqlite' | 'postgresql'): Promise<void> {
+  await db.schema.alterTable('File').addColumn('contentHash', 'text').execute()
+
+  await db.schema.createIndex('idx_File_contentHash').on('File').column('contentHash').execute()
+
+  if (dialect === 'postgresql') {
+    await db.schema
+      .createType('FileOwnerType')
+      .asEnum(['USER', 'CHAT', 'ASSISTANT', 'TOOL'])
+      .execute()
+    await db.schema
+      .createTable('FileOwnership')
+      .addColumn('id', 'text', (col) => col.notNull().primaryKey())
+      .addColumn('fileId', 'text', (col) => col.notNull())
+      .addColumn('ownerType', sql`"FileOwnerType"`, (col) => col.notNull())
+      .addColumn('ownerId', 'text', (col) => col.notNull())
+      .addColumn('createdAt', 'text', (col) => col.notNull())
+      .addForeignKeyConstraint('fk_FileOwnership_File', ['fileId'], 'File', ['id'], (cb) =>
+        cb.onDelete('cascade')
+      )
+      .addUniqueConstraint('uq_FileOwnership_fileId_ownerType_ownerId', [
+        'fileId',
+        'ownerType',
+        'ownerId',
+      ])
+      .execute()
+  } else {
+    await db.schema
+      .createTable('FileOwnership')
+      .addColumn('id', 'text', (col) => col.notNull().primaryKey())
+      .addColumn('fileId', 'text', (col) => col.notNull())
+      .addColumn('ownerType', 'text', (col) => col.notNull())
+      .addColumn('ownerId', 'text', (col) => col.notNull())
+      .addColumn('createdAt', 'text', (col) => col.notNull())
+      .addForeignKeyConstraint('fk_FileOwnership_File', ['fileId'], 'File', ['id'], (cb) =>
+        cb.onDelete('cascade')
+      )
+      .addUniqueConstraint('uq_FileOwnership_fileId_ownerType_ownerId', [
+        'fileId',
+        'ownerType',
+        'ownerId',
+      ])
+      .execute()
+  }
+
+  await db.schema
+    .createIndex('idx_FileOwnership_ownerType_ownerId')
+    .on('FileOwnership')
+    .columns(['ownerType', 'ownerId'])
+    .execute()
+
+  await db.schema.createIndex('idx_FileOwnership_fileId').on('FileOwnership').column('fileId').execute()
+}

--- a/apps/backend/db/schema.ts
+++ b/apps/backend/db/schema.ts
@@ -107,6 +107,7 @@ export interface ConversationFolderMembership {
 }
 
 export interface File {
+  contentHash: string | null
   id: string
   name: string
   path: string
@@ -126,6 +127,16 @@ export interface FileAnalysis {
   error: string | null
   createdAt: string
   updatedAt: string
+}
+
+export type FileOwnerType = 'USER' | 'CHAT' | 'ASSISTANT' | 'TOOL'
+
+export interface FileOwnership {
+  id: string
+  fileId: string
+  ownerType: FileOwnerType
+  ownerId: string
+  createdAt: string
 }
 
 export interface Image {
@@ -362,6 +373,7 @@ export interface DB {
   ConversationSharing: ConversationSharing
   File: File
   FileAnalysis: FileAnalysis
+  FileOwnership: FileOwnership
   IdpConnection: IdpConnection
   Image: Image
   Message: Message

--- a/apps/backend/db/schema.ts
+++ b/apps/backend/db/schema.ts
@@ -136,6 +136,7 @@ export interface FileOwnership {
   fileId: string
   ownerType: FileOwnerType
   ownerId: string
+  displayName: string | null
   createdAt: string
 }
 


### PR DESCRIPTION
## Summary

Adds the database foundation for relational file ownership and future content-based deduplication. This introduces a nullable `contentHash` on `File` and a new `FileOwnership` table, without changing runtime file creation or authorization behavior yet.

## Details

- add `contentHash` to `File`
- add `FileOwnership` with owner type, owner id, optional `displayName`, and uniqueness on `(fileId, ownerType, ownerId)`
- use a PostgreSQL enum for `ownerType` and `text` in SQLite
- add supporting indexes for `contentHash`, `fileId`, and `(ownerType, ownerId)`
- regenerate `apps/backend/db/migrations.generated.ts`
- update test fixtures to include the new nullable `contentHash` field

## Risks

- this is schema-only groundwork and does not yet enforce ownership on existing file access paths
- existing files are not backfilled in this change; `contentHash` remains nullable for now

## Tests

- `npm run generate:migration-manifest`
- `npm run check-types`
