### PR TITLE
Introduce shared file materialization service

### DIFF
--- a/apps/backend/lib/files/materialize.ts
+++ b/apps/backend/lib/files/materialize.ts
@@ -1,0 +1,114 @@
+import { db } from '@/db/database'
+import type * as schema from '@/db/schema'
+import env from '@/lib/env'
+import { storage } from '@/lib/storage'
+import { nanoid } from 'nanoid'
+import { createHash } from 'node:crypto'
+
+export interface FileOwnerRef {
+  ownerType: schema.FileOwnerType
+  ownerId: string
+  displayName?: string | null
+}
+
+export interface MaterializeFileParams {
+  content: Buffer | Uint8Array
+  name: string
+  mimeType: string
+  owner: FileOwnerRef
+}
+
+const sanitizePathSegment = (value: string): string => {
+  return value.replace(/(\W+)/gi, '-')
+}
+
+const hashContent = (content: Buffer | Uint8Array): string => {
+  return createHash('sha256').update(content).digest('hex')
+}
+
+const getFileWithId = async (id: string): Promise<schema.File | undefined> => {
+  return await db.selectFrom('File').selectAll().where('id', '=', id).executeTakeFirst()
+}
+
+const upsertOwnership = async (
+  fileId: string,
+  owner: FileOwnerRef,
+  timestamp: string
+): Promise<void> => {
+  await db
+    .insertInto('FileOwnership')
+    .values({
+      id: nanoid(),
+      fileId,
+      ownerType: owner.ownerType,
+      ownerId: owner.ownerId,
+      displayName: owner.displayName ?? null,
+      createdAt: timestamp,
+    })
+    .onConflict((oc) =>
+      oc.columns(['fileId', 'ownerType', 'ownerId']).doUpdateSet({
+        displayName: owner.displayName ?? null,
+      })
+    )
+    .execute()
+}
+
+/**
+ * Persist file content and logical ownership with deduplication.
+ * The same bytes map to one File row (by contentHash), while ownership rows may differ.
+ */
+export const materializeFile = async (params: MaterializeFileParams): Promise<schema.File> => {
+  const contentHash = hashContent(params.content)
+  const existing = await db
+    .selectFrom('File')
+    .selectAll()
+    .where('contentHash', '=', contentHash)
+    .where('uploaded', '=', 1)
+    .executeTakeFirst()
+
+  const timestamp = new Date().toISOString()
+  if (existing) {
+    await upsertOwnership(existing.id, params.owner, timestamp)
+    return existing
+  }
+
+  const fileId = nanoid()
+  const storagePath = `${fileId}-${sanitizePathSegment(params.name)}`
+  await storage.writeBuffer(storagePath, Buffer.from(params.content), env.fileStorage.encryptFiles)
+
+  await db.transaction().execute(async (trx) => {
+    await trx
+      .insertInto('File')
+      .values({
+        id: fileId,
+        name: params.name,
+        path: storagePath,
+        type: params.mimeType,
+        size: params.content.byteLength,
+        uploaded: 1,
+        createdAt: timestamp,
+        encrypted: env.fileStorage.encryptFiles ? 1 : 0,
+        contentHash,
+      })
+      .execute()
+
+    await trx
+      .insertInto('FileOwnership')
+      .values({
+        id: nanoid(),
+        fileId,
+        ownerType: params.owner.ownerType,
+        ownerId: params.owner.ownerId,
+        displayName: params.owner.displayName ?? null,
+        createdAt: timestamp,
+      })
+      .execute()
+  })
+
+  const created = await getFileWithId(fileId)
+  if (!created) {
+    throw new Error('Materialization failed')
+  }
+  return created
+}
+


### PR DESCRIPTION
## Summary
Adds a shared backend file materialization service that computes content hashes, deduplicates persisted files, and maintains relational ownership links via `FileOwnership`.

## Details
- add `materializeFile(...)` in `apps/backend/lib/files/materialize.ts`
- compute `SHA-256` hash from content and use it to detect already-uploaded files
- on dedup hit, reuse the existing `File` row and upsert `(fileId, ownerType, ownerId)` ownership
- on dedup miss, write blob content to storage, create `File`, and create `FileOwnership`
- support optional per-owner `displayName` updates during ownership upsert

## Tests
- `npm run check-types` (pass)
