### PR TITLE
Route tool file creation paths through materializeFile

### DIFF
--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -145,7 +145,10 @@ export class ChatAssistant {
     private parameters: Record<string, ParameterValueAndDescription>,
     private knowledge: dto.AssistantFile[]
   ) {
-    this.functions = ChatAssistant.computeFunctions(tools, llmModel, { userId: options.user })
+    this.functions = ChatAssistant.computeFunctions(tools, llmModel, {
+      userId: options.user,
+      assistantId: assistantParams.assistantId,
+    })
     this.llmModel = llmModel
     this.llmModelCapabilities = this.llmModel.capabilities
     this.saveMessage = options.saveMessage || (async () => {})
@@ -209,7 +212,7 @@ export class ChatAssistant {
   static async computeFunctions(
     tools: ToolImplementation[],
     llmModel: LlmModel,
-    context?: { userId?: string }
+    context?: { userId?: string; assistantId?: string }
   ): Promise<ToolFunctions> {
     const functions = (
       await Promise.all(
@@ -226,8 +229,7 @@ export class ChatAssistant {
     const functions_ = Object.fromEntries(functions)
     const satelliteHub = await import('@/lib/satellite/hub')
     const { callSatelliteMethod } = satelliteHub
-    const { storage } = await import('@/lib/storage')
-    const { addFile } = await import('@/models/file')
+    const { materializeFile } = await import('@/backend/lib/files/materialize')
     const connections = satelliteHub.connections
     connections.forEach((conn) => {
       if (conn.userId !== context?.userId) return
@@ -253,13 +255,22 @@ export class ChatAssistant {
                   const id = nanoid()
                   const ext = mimeExtension(r.mimeType ?? '') || 'bin'
                   const name = `${id}.${ext}`
-                  await storage.writeBuffer(name, imgBinaryData, env.fileStorage.encryptFiles)
-                  const dbEntry: dto.InsertableFile = {
-                    name,
-                    type: r.mimeType ?? 'application/octet-stream',
-                    size: imgBinaryData.byteLength,
+                  const assistantOwnerId = context?.assistantId
+                  if (!context?.userId && !assistantOwnerId) {
+                    throw new Error('Missing owner context for satellite-generated file')
                   }
-                  const dbFile = await addFile(dbEntry, name, env.fileStorage.encryptFiles)
+                  const dbFile = await materializeFile({
+                    content: imgBinaryData,
+                    name,
+                    mimeType: r.mimeType ?? 'application/octet-stream',
+                    owner: context?.userId
+                      ? { ownerType: 'USER', ownerId: context.userId, displayName: name }
+                      : {
+                          ownerType: 'ASSISTANT',
+                          ownerId: assistantOwnerId!,
+                          displayName: name,
+                        },
+                  })
                   toolResult.value.push({
                     type: 'file',
                     id: dbFile.id,
@@ -272,14 +283,22 @@ export class ChatAssistant {
                   const id = nanoid()
                   const ext = mimeExtension(r.resource.mimeType ?? '') || 'bin'
                   const name = `${id}.${ext}`
-                  const path = name
-                  await storage.writeBuffer(name, imgBinaryData, env.fileStorage.encryptFiles)
-                  const dbEntry: dto.InsertableFile = {
-                    name,
-                    type: r.resource.mimeType ?? 'application/octet-stream',
-                    size: imgBinaryData.byteLength,
+                  const assistantOwnerId = context?.assistantId
+                  if (!context?.userId && !assistantOwnerId) {
+                    throw new Error('Missing owner context for satellite-generated file')
                   }
-                  const dbFile = await addFile(dbEntry, path, env.fileStorage.encryptFiles)
+                  const dbFile = await materializeFile({
+                    content: imgBinaryData,
+                    name,
+                    mimeType: r.resource.mimeType ?? 'application/octet-stream',
+                    owner: context?.userId
+                      ? { ownerType: 'USER', ownerId: context.userId, displayName: name }
+                      : {
+                          ownerType: 'ASSISTANT',
+                          ownerId: assistantOwnerId!,
+                          displayName: name,
+                        },
+                  })
                   toolResult.value.push({
                     type: 'file',
                     id: dbFile.id,

--- a/apps/backend/lib/tools/audio_transcription/implementation.ts
+++ b/apps/backend/lib/tools/audio_transcription/implementation.ts
@@ -14,12 +14,10 @@ import {
 import { LlmModel } from '@/lib/chat/models'
 import * as dto from '@/types/dto'
 import { expandToolParameter } from '@/backend/lib/tools/configSecrets'
-import { addFile, getFileWithId } from '@/models/file'
+import { getFileWithId } from '@/models/file'
 import { storage } from '@/lib/storage'
 import { recordAudioTranscriptionEvent } from './metering'
-import { nanoid } from 'nanoid'
-import { InsertableFile } from '@/types/dto/file'
-import env from '@/lib/env'
+import { materializeFile } from '@/backend/lib/files/materialize'
 
 type AssemblyAiUploadResponse = {
   upload_url: string
@@ -113,6 +111,8 @@ export class AudioTranscription extends AudioTranscriptionInterface implements T
   private async invokeTranscription({
     params,
     userId,
+    conversationId,
+    assistantId,
   }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> {
     const fileId = `${params.fileId ?? ''}`.trim()
     if (!fileId) {
@@ -207,14 +207,16 @@ export class AudioTranscription extends AudioTranscriptionInterface implements T
       const transcriptText = this.formatTranscript(fileEntry.name, transcript)
       const transcriptBuffer = Buffer.from(transcriptText, 'utf-8')
       const transcriptFileName = `${fileEntry.name}.transcript.txt`
-      const storagePath = nanoid()
-      await storage.writeBuffer(storagePath, transcriptBuffer, env.fileStorage.encryptFiles)
-      const dbEntry: InsertableFile = {
+      const dbFile = await materializeFile({
+        content: transcriptBuffer,
         name: transcriptFileName,
-        type: 'text/plain',
-        size: transcriptBuffer.byteLength,
-      }
-      const dbFile = await addFile(dbEntry, storagePath, env.fileStorage.encryptFiles)
+        mimeType: 'text/plain',
+        owner: conversationId
+          ? { ownerType: 'CHAT', ownerId: conversationId, displayName: transcriptFileName }
+          : userId
+            ? { ownerType: 'USER', ownerId: userId, displayName: transcriptFileName }
+            : { ownerType: 'ASSISTANT', ownerId: assistantId, displayName: transcriptFileName },
+      })
 
       return {
         type: 'content',

--- a/apps/backend/lib/tools/code_interpreter/implementation.ts
+++ b/apps/backend/lib/tools/code_interpreter/implementation.ts
@@ -13,15 +13,15 @@ import {
 import { LlmModel } from '@/lib/chat/models'
 import * as dto from '@/types/dto'
 import { expandToolParameter } from '@/backend/lib/tools/configSecrets'
-import { getFileWithId, addFile } from '@/models/file'
+import { getFileWithId } from '@/models/file'
 import { storage } from '@/lib/storage'
 import { nanoid } from 'nanoid'
-import env from '@/lib/env'
 import { logger } from '@/lib/logging'
 import path from 'node:path'
 import { mimeTypeOfFile } from '@/lib/mimeTypes'
 import OpenAI, { toFile } from 'openai'
 import { FileListResponse } from 'openai/resources/containers/files/files'
+import { materializeFile } from '@/backend/lib/files/materialize'
 
 type UploadedFile = {
   fileId: string
@@ -227,7 +227,12 @@ export class CodeInterpreter
     }
   }
 
-  private async downloadFiles({ params }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> {
+  private async downloadFiles({
+    params,
+    conversationId,
+    userId,
+    assistantId,
+  }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> {
     const containerId = `${params.containerId ?? ''}`
     if (!containerId) {
       return { type: 'error-text', value: 'containerId is required' }
@@ -254,20 +259,19 @@ export class CodeInterpreter
       })
       const buffer = Buffer.from(await response.arrayBuffer())
       const fileName = path.basename(file.path)
-      const storagePath = `${nanoid()}-${fileName}`
-      await storage.writeBuffer(storagePath, buffer, env.fileStorage.encryptFiles)
-      const dbFile = await addFile(
-        {
-          name: storagePath,
-          type:
-            response.headers.get('content-type') ??
-            mimeTypeOfFile(fileName) ??
-            'application/octet-stream',
-          size: buffer.byteLength,
-        },
-        storagePath,
-        env.fileStorage.encryptFiles
-      )
+      const dbFile = await materializeFile({
+        content: buffer,
+        name: fileName,
+        mimeType:
+          response.headers.get('content-type') ??
+          mimeTypeOfFile(fileName) ??
+          'application/octet-stream',
+        owner: conversationId
+          ? { ownerType: 'CHAT', ownerId: conversationId, displayName: fileName }
+          : userId
+            ? { ownerType: 'USER', ownerId: userId, displayName: fileName }
+            : { ownerType: 'ASSISTANT', ownerId: assistantId, displayName: fileName },
+      })
       storedMetadata.push({ file_id: file.fileId, stored_id: dbFile.id })
       storedFiles.value.push({
         type: 'file',

--- a/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
@@ -7,10 +7,8 @@ import {
   ToolParams,
 } from '@/lib/chat/tools'
 import * as dto from '@/types/dto'
-import { addFile, getFileWithId } from '@/models/file'
+import { getFileWithId } from '@/models/file'
 import { nanoid } from 'nanoid'
-import { InsertableFile } from '@/types/dto/file'
-import env from '@/lib/env'
 import { expandToolParameter } from '@/backend/lib/tools/configSecrets'
 import { storage } from '@/lib/storage'
 import { ensureABView } from '@/backend/lib/utils'
@@ -38,6 +36,7 @@ import {
   ImageEditRequest,
   ImageGenerationRequest,
 } from '@/backend/lib/imagegen/types'
+import { materializeFile } from '@/backend/lib/files/materialize'
 import {
   DirectImageGeneratorPluginParams,
   ReplicateImageGeneratorPluginParams,
@@ -132,6 +131,9 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
 
   private async invokeGenerate({
     params: invocationParams,
+    conversationId,
+    userId,
+    assistantId,
   }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> {
     const apiKey = await expandToolParameter(this.toolParams, this.params.apiKey)
     const aiResponse = this.assertImageResponse(
@@ -151,7 +153,11 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
       toolName: this.toolParams.name,
       userId: typeof invocationParams.userId === 'string' ? invocationParams.userId : undefined,
     })
-    return await this.handleResponse(aiResponse)
+    return await this.handleResponse(aiResponse, {
+      conversationId,
+      userId,
+      assistantId,
+    })
   }
 
   private async loadImage(fileId: string) {
@@ -167,7 +173,7 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
     }
   }
 
-  private async invokeEdit({ params: invocationParams }: ToolInvokeParams) {
+  private async invokeEdit({ params: invocationParams, conversationId, userId, assistantId }: ToolInvokeParams) {
     if (!isImageEditingSupportedModel(this.model)) {
       throw new Error(`Image editing is not supported for model: ${this.model}`)
     }
@@ -192,10 +198,17 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
       toolName: this.toolParams.name,
       userId: typeof invocationParams.userId === 'string' ? invocationParams.userId : undefined,
     })
-    return await this.handleResponse(aiResponse)
+    return await this.handleResponse(aiResponse, {
+      conversationId,
+      userId,
+      assistantId,
+    })
   }
 
-  protected async handleResponse(aiResponse: GeneratedImagesResponse) {
+  protected async handleResponse(
+    aiResponse: GeneratedImagesResponse,
+    ownerContext: { conversationId?: string; userId?: string; assistantId: string }
+  ) {
     const responseData = aiResponse.data ?? []
     if (responseData.length === 0) {
       throw new Error('Image provider returned no images')
@@ -213,13 +226,16 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
       const imgBinaryData = Buffer.from(img.b64_json, 'base64')
       const mimeType = normalizeGeneratedImageMimeType(img.mimeType)
       const name = `${nanoid()}.${generatedImageExtensionForMimeType(mimeType)}`
-      await storage.writeBuffer(name, imgBinaryData, env.fileStorage.encryptFiles)
-      const dbEntry: InsertableFile = {
+      const dbFile = await materializeFile({
+        content: imgBinaryData,
         name,
-        type: mimeType,
-        size: imgBinaryData.byteLength,
-      }
-      const dbFile = await addFile(dbEntry, name, env.fileStorage.encryptFiles)
+        mimeType,
+        owner: ownerContext.conversationId
+          ? { ownerType: 'CHAT', ownerId: ownerContext.conversationId, displayName: name }
+          : ownerContext.userId
+            ? { ownerType: 'USER', ownerId: ownerContext.userId, displayName: name }
+            : { ownerType: 'ASSISTANT', ownerId: ownerContext.assistantId, displayName: name },
+      })
       result.value.push({
         type: 'file',
         id: dbFile.id,

--- a/apps/backend/lib/tools/imagegenerator/implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/implementation.ts
@@ -12,9 +12,8 @@ import {
   ImageGeneratorPluginParams,
 } from '@/lib/tools/schemas'
 import OpenAI from 'openai'
-import { addFile, getFileWithId } from '@/models/file'
+import { getFileWithId } from '@/models/file'
 import { nanoid } from 'nanoid'
-import { InsertableFile } from '@/types/dto/file'
 import env from '@/lib/env'
 import { expandToolParameter } from '@/backend/lib/tools/configSecrets'
 import { storage } from '@/lib/storage'
@@ -22,6 +21,7 @@ import { ImagesResponse } from 'openai/resources/images'
 import { ensureABView } from '@/backend/lib/utils'
 import { LlmModel } from '@/lib/chat/models'
 import { shouldExposeImageEditingTool } from '@/backend/lib/imagegen/models'
+import { materializeFile } from '@/backend/lib/files/materialize'
 
 function get_response_format_parameter(model: string) {
   if (model === 'gpt-image-1' || model === 'gpt-image-1.5' || model === 'gpt-image-2') {
@@ -96,6 +96,9 @@ export class ImageGeneratorPlugin
 
   private async invokeGenerate({
     params: invocationParams,
+    conversationId,
+    userId,
+    assistantId,
   }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> {
     const apiKey = await expandToolParameter(this.toolParams, this.params.apiKey)
     const openai = new OpenAI({
@@ -111,7 +114,11 @@ export class ImageGeneratorPlugin
       //quality: 'standard',
       response_format: get_response_format_parameter(model),
     })
-    return await this.handleResponse(aiResponse)
+    return await this.handleResponse(aiResponse, {
+      conversationId,
+      userId,
+      assistantId,
+    })
   }
 
   private async loadImageAsWebFile(fileId: string) {
@@ -125,7 +132,7 @@ export class ImageGeneratorPlugin
     return new File([blob], 'upload.png', { type: fileEntry.type })
   }
 
-  private async invokeEdit({ params: invocationParams }: ToolInvokeParams) {
+  private async invokeEdit({ params: invocationParams, conversationId, userId, assistantId }: ToolInvokeParams) {
     const apiKey = await expandToolParameter(this.toolParams, this.params.apiKey)
     const openai = new OpenAI({
       apiKey,
@@ -146,10 +153,17 @@ export class ImageGeneratorPlugin
       //quality: 'standard',
       response_format: get_response_format_parameter(this.model),
     })
-    return await this.handleResponse(aiResponse)
+    return await this.handleResponse(aiResponse, {
+      conversationId,
+      userId,
+      assistantId,
+    })
   }
 
-  async handleResponse(aiResponse: ImagesResponse) {
+  async handleResponse(
+    aiResponse: ImagesResponse,
+    ownerContext: { conversationId?: string; userId?: string; assistantId: string }
+  ) {
     const responseData = aiResponse.data ?? []
     if (responseData.length === 0) {
       throw new Error('Unexpected response from OpenAI')
@@ -169,15 +183,16 @@ export class ImageGeneratorPlugin
       }
       const imgBinaryData = Buffer.from(img.b64_json, 'base64')
       const name = `${nanoid()}.png`
-      const path = name
-      await storage.writeBuffer(name, imgBinaryData, env.fileStorage.encryptFiles)
-      const mimeType = 'image/png'
-      const dbEntry: InsertableFile = {
+      const dbFile = await materializeFile({
+        content: imgBinaryData,
         name,
-        type: mimeType,
-        size: imgBinaryData.byteLength,
-      }
-      const dbFile = await addFile(dbEntry, path, env.fileStorage.encryptFiles)
+        mimeType: 'image/png',
+        owner: ownerContext.conversationId
+          ? { ownerType: 'CHAT', ownerId: ownerContext.conversationId, displayName: name }
+          : ownerContext.userId
+            ? { ownerType: 'USER', ownerId: ownerContext.userId, displayName: name }
+            : { ownerType: 'ASSISTANT', ownerId: ownerContext.assistantId, displayName: name },
+      })
       result.value.push({
         type: 'file' as const,
         id: dbFile.id,

--- a/apps/backend/lib/tools/openapi/implementation.ts
+++ b/apps/backend/lib/tools/openapi/implementation.ts
@@ -11,13 +11,11 @@ import { OpenApiInterface } from '@/lib/tools/schemas'
 import OpenAPIParser from '@readme/openapi-parser'
 import { OpenAPIV3 } from 'openapi-types'
 import env from '@/lib/env'
-import { addFile } from '@/models/file'
 import { logger } from '@/lib/logging'
 import { parseDocument } from 'yaml'
 import { expandEnv } from 'templates'
 import { parseMultipart } from '@mjackson/multipart-parser'
 import JacksonHeaders from '@mjackson/headers'
-import { InsertableFile } from '@/types/dto/file'
 import { nanoid } from 'nanoid'
 import winston from 'winston'
 import { ToolFunctionSchemaParams } from '@/lib/tools/openapi-types'
@@ -28,6 +26,7 @@ import { JSONSchema7 } from 'json-schema'
 import { JSONValue } from 'ai'
 import * as dto from '@/types/dto'
 import { LlmModel } from '@/lib/chat/models'
+import { materializeFile } from '@/backend/lib/files/materialize'
 
 export interface OpenApiPluginParams extends Record<string, unknown> {
   spec: string
@@ -141,18 +140,21 @@ function convertOpenAPIOperationToToolFunction(
     params: invocationParams,
     uiLink,
     debug,
+    conversationId,
+    userId,
+    assistantId,
   }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> => {
     const storeFile = async (data: Uint8Array, fileName: string, contentType: string) => {
-      const path = `${fileName}-${nanoid()}`
-      await storage.writeBuffer(path, data, env.fileStorage.encryptFiles)
-
-      const dbEntry: InsertableFile = {
+      return await materializeFile({
+        content: Buffer.from(data),
         name: fileName,
-        type: contentType,
-        size: data.byteLength,
-      }
-
-      return await addFile(dbEntry, path, env.fileStorage.encryptFiles)
+        mimeType: contentType,
+        owner: conversationId
+          ? { ownerType: 'CHAT', ownerId: conversationId, displayName: fileName }
+          : userId
+            ? { ownerType: 'USER', ownerId: userId, displayName: fileName }
+            : { ownerType: 'ASSISTANT', ownerId: assistantId, displayName: fileName },
+      })
     }
 
     const opParameters = operation.parameters as OpenAPIV3.ParameterObject[]


### PR DESCRIPTION
## Summary
Routes major tool-driven file creation paths through the shared `materializeFile(...)` service so file persistence consistently applies hashing/dedup and ownership upsert behavior.

## Details
- replace direct `storage.writeBuffer(...) + addFile(...)` in OpenAPI attachment/multipart handling with `materializeFile(...)`
- replace direct file writes in image generation tool outputs (direct and non-direct implementations) with `materializeFile(...)`
- replace code interpreter downloaded-file persistence with `materializeFile(...)`
- replace audio transcription output file persistence with `materializeFile(...)`
- replace satellite MCP `image` and `resource` save paths in chat runtime with `materializeFile(...)`
- propagate `assistantId` in chat tool setup context to support ownership fallback when `conversationId` is unavailable

## Tests
- `npm run check-types` (pass)
- `npx vitest run __tests__/chatAssistant.test.ts __tests__/parallelToolCalls.test.ts __tests__/conversion.test.ts` (pass)
