### PR TITLE
Fix #849: thread root owner through execution context

### DIFF
--- a/__tests__/chatAssistant.test.ts
+++ b/__tests__/chatAssistant.test.ts
@@ -597,6 +597,7 @@ describe('ChatAssistant.invokeFunction', () => {
     const invokeResult: dto.ToolCallResultOutput = { type: 'content', value: [] }
     const fn: ToolFunction = { description: 'Test', invoke: vi.fn().mockResolvedValue(invokeResult) }
     const assistant = makeChatAssistant()
+    ;(assistant as any).options = { user: 'u1', conversationId: 'c1' }
     const chatState = { chatHistory: [makeUserMsg()], conversationId: 'c1' } as any
     const toolUILink = { attachments: [] } as any
 
@@ -604,7 +605,12 @@ describe('ChatAssistant.invokeFunction', () => {
 
     expect(result).toEqual(invokeResult)
     expect(fn.invoke).toHaveBeenCalledWith(
-      expect.objectContaining({ params: { x: 1 }, toolName: 'myTool', toolCallId: 'tc1' })
+      expect.objectContaining({
+        params: { x: 1 },
+        toolName: 'myTool',
+        toolCallId: 'tc1',
+        rootOwner: { type: 'CHAT', id: 'c1' },
+      })
     )
   })
 

--- a/__tests__/subassistantTool.test.ts
+++ b/__tests__/subassistantTool.test.ts
@@ -285,4 +285,30 @@ describe('SubAssistantTool.invoke_assistant', () => {
       value: 'Sub-assistant "Sub Bot" backend not found',
     })
   })
+
+  test('propagates rootOwner to nested chat assistant build', async () => {
+    mockStreamText.mockReturnValue(makeStreamResult('done'))
+    const buildSpy = vi.spyOn(ChatAssistant, 'build')
+
+    await invoke({
+      llmModel: fakeLlmModel,
+      messages: [],
+      assistantId: 'parent',
+      userId: 'user-1',
+      rootOwner: { type: 'CHAT', id: 'root-conversation' },
+      params: { assistantId: 'asst-1', input: 'hello' },
+      uiLink: fakeUiLink,
+    })
+
+    expect(buildSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        rootOwner: { type: 'CHAT', id: 'root-conversation' },
+      })
+    )
+  })
 })

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -91,6 +91,10 @@ interface Options {
   userLanguage?: string
   user?: string
   conversationId?: string
+  rootOwner?: {
+    type: 'CHAT' | 'USER' | 'ASSISTANT'
+    id: string
+  }
   debug?: boolean
   abortSignal?: AbortSignal
 }
@@ -148,6 +152,7 @@ export class ChatAssistant {
     this.functions = ChatAssistant.computeFunctions(tools, llmModel, {
       userId: options.user,
       assistantId: assistantParams.assistantId,
+      rootOwner: options.rootOwner ?? (options.conversationId ? { type: 'CHAT', id: options.conversationId } : undefined),
     })
     this.llmModel = llmModel
     this.llmModelCapabilities = this.llmModel.capabilities
@@ -212,7 +217,14 @@ export class ChatAssistant {
   static async computeFunctions(
     tools: ToolImplementation[],
     llmModel: LlmModel,
-    context?: { userId?: string; assistantId?: string }
+    context?: {
+      userId?: string
+      assistantId?: string
+      rootOwner?: {
+        type: 'CHAT' | 'USER' | 'ASSISTANT'
+        id: string
+      }
+    }
   ): Promise<ToolFunctions> {
     const functions = (
       await Promise.all(
@@ -256,20 +268,22 @@ export class ChatAssistant {
                   const ext = mimeExtension(r.mimeType ?? '') || 'bin'
                   const name = `${id}.${ext}`
                   const assistantOwnerId = context?.assistantId
-                  if (!context?.userId && !assistantOwnerId) {
+                  if (!context?.rootOwner && !context?.userId && !assistantOwnerId) {
                     throw new Error('Missing owner context for satellite-generated file')
                   }
                   const dbFile = await materializeFile({
                     content: imgBinaryData,
                     name,
                     mimeType: r.mimeType ?? 'application/octet-stream',
-                    owner: context?.userId
-                      ? { ownerType: 'USER', ownerId: context.userId, displayName: name }
-                      : {
-                          ownerType: 'ASSISTANT',
-                          ownerId: assistantOwnerId!,
-                          displayName: name,
-                        },
+                    owner: context?.rootOwner
+                      ? { ownerType: context.rootOwner.type, ownerId: context.rootOwner.id, displayName: name }
+                      : context?.userId
+                        ? { ownerType: 'USER', ownerId: context.userId, displayName: name }
+                        : {
+                            ownerType: 'ASSISTANT',
+                            ownerId: assistantOwnerId!,
+                            displayName: name,
+                          },
                   })
                   toolResult.value.push({
                     type: 'file',
@@ -284,20 +298,22 @@ export class ChatAssistant {
                   const ext = mimeExtension(r.resource.mimeType ?? '') || 'bin'
                   const name = `${id}.${ext}`
                   const assistantOwnerId = context?.assistantId
-                  if (!context?.userId && !assistantOwnerId) {
+                  if (!context?.rootOwner && !context?.userId && !assistantOwnerId) {
                     throw new Error('Missing owner context for satellite-generated file')
                   }
                   const dbFile = await materializeFile({
                     content: imgBinaryData,
                     name,
                     mimeType: r.resource.mimeType ?? 'application/octet-stream',
-                    owner: context?.userId
-                      ? { ownerType: 'USER', ownerId: context.userId, displayName: name }
-                      : {
-                          ownerType: 'ASSISTANT',
-                          ownerId: assistantOwnerId!,
-                          displayName: name,
-                        },
+                    owner: context?.rootOwner
+                      ? { ownerType: context.rootOwner.type, ownerId: context.rootOwner.id, displayName: name }
+                      : context?.userId
+                        ? { ownerType: 'USER', ownerId: context.userId, displayName: name }
+                        : {
+                            ownerType: 'ASSISTANT',
+                            ownerId: assistantOwnerId!,
+                            displayName: name,
+                          },
                   })
                   toolResult.value.push({
                     type: 'file',
@@ -720,6 +736,9 @@ export class ChatAssistant {
         assistantId: this.assistantParams.assistantId,
         userId: this.options.user,
         conversationId: this.options.conversationId,
+        rootOwner:
+          this.options.rootOwner ??
+          (this.options.conversationId ? { type: 'CHAT', id: this.options.conversationId } : undefined),
         toolCallId: toolCall.toolCallId,
         toolName: toolCall.toolName,
         params: args,
@@ -997,6 +1016,9 @@ export class ChatAssistant {
             messages: chatState.chatHistory,
             assistantId: this.assistantParams.assistantId,
             userId: this.options.user,
+            rootOwner:
+              this.options.rootOwner ??
+              (this.options.conversationId ? { type: 'CHAT', id: this.options.conversationId } : undefined),
             toolCallId: toolCall.toolCallId,
             toolName: toolCall.toolName,
             params: toolCall.args,

--- a/apps/backend/lib/tools/audio_transcription/implementation.ts
+++ b/apps/backend/lib/tools/audio_transcription/implementation.ts
@@ -18,6 +18,7 @@ import { getFileWithId } from '@/models/file'
 import { storage } from '@/lib/storage'
 import { recordAudioTranscriptionEvent } from './metering'
 import { materializeFile } from '@/backend/lib/files/materialize'
+import { resolveFileOwner } from '@/backend/lib/tools/ownership'
 
 type AssemblyAiUploadResponse = {
   upload_url: string
@@ -113,6 +114,7 @@ export class AudioTranscription extends AudioTranscriptionInterface implements T
     userId,
     conversationId,
     assistantId,
+    rootOwner,
   }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> {
     const fileId = `${params.fileId ?? ''}`.trim()
     if (!fileId) {
@@ -211,11 +213,7 @@ export class AudioTranscription extends AudioTranscriptionInterface implements T
         content: transcriptBuffer,
         name: transcriptFileName,
         mimeType: 'text/plain',
-        owner: conversationId
-          ? { ownerType: 'CHAT', ownerId: conversationId, displayName: transcriptFileName }
-          : userId
-            ? { ownerType: 'USER', ownerId: userId, displayName: transcriptFileName }
-            : { ownerType: 'ASSISTANT', ownerId: assistantId, displayName: transcriptFileName },
+        owner: resolveFileOwner({ rootOwner, conversationId, userId, assistantId }, transcriptFileName),
       })
 
       return {

--- a/apps/backend/lib/tools/code_interpreter/implementation.ts
+++ b/apps/backend/lib/tools/code_interpreter/implementation.ts
@@ -22,6 +22,7 @@ import { mimeTypeOfFile } from '@/lib/mimeTypes'
 import OpenAI, { toFile } from 'openai'
 import { FileListResponse } from 'openai/resources/containers/files/files'
 import { materializeFile } from '@/backend/lib/files/materialize'
+import { resolveFileOwner } from '@/backend/lib/tools/ownership'
 
 type UploadedFile = {
   fileId: string
@@ -232,6 +233,7 @@ export class CodeInterpreter
     conversationId,
     userId,
     assistantId,
+    rootOwner,
   }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> {
     const containerId = `${params.containerId ?? ''}`
     if (!containerId) {
@@ -266,11 +268,7 @@ export class CodeInterpreter
           response.headers.get('content-type') ??
           mimeTypeOfFile(fileName) ??
           'application/octet-stream',
-        owner: conversationId
-          ? { ownerType: 'CHAT', ownerId: conversationId, displayName: fileName }
-          : userId
-            ? { ownerType: 'USER', ownerId: userId, displayName: fileName }
-            : { ownerType: 'ASSISTANT', ownerId: assistantId, displayName: fileName },
+        owner: resolveFileOwner({ rootOwner, conversationId, userId, assistantId }, fileName),
       })
       storedMetadata.push({ file_id: file.fileId, stored_id: dbFile.id })
       storedFiles.value.push({

--- a/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
@@ -37,6 +37,7 @@ import {
   ImageGenerationRequest,
 } from '@/backend/lib/imagegen/types'
 import { materializeFile } from '@/backend/lib/files/materialize'
+import { resolveFileOwner } from '@/backend/lib/tools/ownership'
 import {
   DirectImageGeneratorPluginParams,
   ReplicateImageGeneratorPluginParams,
@@ -134,6 +135,7 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
     conversationId,
     userId,
     assistantId,
+    rootOwner,
   }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> {
     const apiKey = await expandToolParameter(this.toolParams, this.params.apiKey)
     const aiResponse = this.assertImageResponse(
@@ -157,6 +159,7 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
       conversationId,
       userId,
       assistantId,
+      rootOwner,
     })
   }
 
@@ -173,7 +176,13 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
     }
   }
 
-  private async invokeEdit({ params: invocationParams, conversationId, userId, assistantId }: ToolInvokeParams) {
+  private async invokeEdit({
+    params: invocationParams,
+    conversationId,
+    userId,
+    assistantId,
+    rootOwner,
+  }: ToolInvokeParams) {
     if (!isImageEditingSupportedModel(this.model)) {
       throw new Error(`Image editing is not supported for model: ${this.model}`)
     }
@@ -202,12 +211,18 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
       conversationId,
       userId,
       assistantId,
+      rootOwner,
     })
   }
 
   protected async handleResponse(
     aiResponse: GeneratedImagesResponse,
-    ownerContext: { conversationId?: string; userId?: string; assistantId: string }
+    ownerContext: {
+      conversationId?: string
+      userId?: string
+      assistantId: string
+      rootOwner?: { type: 'CHAT' | 'USER' | 'ASSISTANT'; id: string }
+    }
   ) {
     const responseData = aiResponse.data ?? []
     if (responseData.length === 0) {
@@ -230,11 +245,7 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
         content: imgBinaryData,
         name,
         mimeType,
-        owner: ownerContext.conversationId
-          ? { ownerType: 'CHAT', ownerId: ownerContext.conversationId, displayName: name }
-          : ownerContext.userId
-            ? { ownerType: 'USER', ownerId: ownerContext.userId, displayName: name }
-            : { ownerType: 'ASSISTANT', ownerId: ownerContext.assistantId, displayName: name },
+        owner: resolveFileOwner(ownerContext, name),
       })
       result.value.push({
         type: 'file',

--- a/apps/backend/lib/tools/imagegenerator/implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/implementation.ts
@@ -22,6 +22,7 @@ import { ensureABView } from '@/backend/lib/utils'
 import { LlmModel } from '@/lib/chat/models'
 import { shouldExposeImageEditingTool } from '@/backend/lib/imagegen/models'
 import { materializeFile } from '@/backend/lib/files/materialize'
+import { resolveFileOwner } from '@/backend/lib/tools/ownership'
 
 function get_response_format_parameter(model: string) {
   if (model === 'gpt-image-1' || model === 'gpt-image-1.5' || model === 'gpt-image-2') {
@@ -99,6 +100,7 @@ export class ImageGeneratorPlugin
     conversationId,
     userId,
     assistantId,
+    rootOwner,
   }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> {
     const apiKey = await expandToolParameter(this.toolParams, this.params.apiKey)
     const openai = new OpenAI({
@@ -118,6 +120,7 @@ export class ImageGeneratorPlugin
       conversationId,
       userId,
       assistantId,
+      rootOwner,
     })
   }
 
@@ -132,7 +135,13 @@ export class ImageGeneratorPlugin
     return new File([blob], 'upload.png', { type: fileEntry.type })
   }
 
-  private async invokeEdit({ params: invocationParams, conversationId, userId, assistantId }: ToolInvokeParams) {
+  private async invokeEdit({
+    params: invocationParams,
+    conversationId,
+    userId,
+    assistantId,
+    rootOwner,
+  }: ToolInvokeParams) {
     const apiKey = await expandToolParameter(this.toolParams, this.params.apiKey)
     const openai = new OpenAI({
       apiKey,
@@ -157,12 +166,18 @@ export class ImageGeneratorPlugin
       conversationId,
       userId,
       assistantId,
+      rootOwner,
     })
   }
 
   async handleResponse(
     aiResponse: ImagesResponse,
-    ownerContext: { conversationId?: string; userId?: string; assistantId: string }
+    ownerContext: {
+      conversationId?: string
+      userId?: string
+      assistantId: string
+      rootOwner?: { type: 'CHAT' | 'USER' | 'ASSISTANT'; id: string }
+    }
   ) {
     const responseData = aiResponse.data ?? []
     if (responseData.length === 0) {
@@ -187,11 +202,7 @@ export class ImageGeneratorPlugin
         content: imgBinaryData,
         name,
         mimeType: 'image/png',
-        owner: ownerContext.conversationId
-          ? { ownerType: 'CHAT', ownerId: ownerContext.conversationId, displayName: name }
-          : ownerContext.userId
-            ? { ownerType: 'USER', ownerId: ownerContext.userId, displayName: name }
-            : { ownerType: 'ASSISTANT', ownerId: ownerContext.assistantId, displayName: name },
+        owner: resolveFileOwner(ownerContext, name),
       })
       result.value.push({
         type: 'file' as const,

--- a/apps/backend/lib/tools/openapi/implementation.ts
+++ b/apps/backend/lib/tools/openapi/implementation.ts
@@ -27,6 +27,7 @@ import { JSONValue } from 'ai'
 import * as dto from '@/types/dto'
 import { LlmModel } from '@/lib/chat/models'
 import { materializeFile } from '@/backend/lib/files/materialize'
+import { resolveFileOwner } from '@/backend/lib/tools/ownership'
 
 export interface OpenApiPluginParams extends Record<string, unknown> {
   spec: string
@@ -143,17 +144,14 @@ function convertOpenAPIOperationToToolFunction(
     conversationId,
     userId,
     assistantId,
+    rootOwner,
   }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> => {
     const storeFile = async (data: Uint8Array, fileName: string, contentType: string) => {
       return await materializeFile({
         content: Buffer.from(data),
         name: fileName,
         mimeType: contentType,
-        owner: conversationId
-          ? { ownerType: 'CHAT', ownerId: conversationId, displayName: fileName }
-          : userId
-            ? { ownerType: 'USER', ownerId: userId, displayName: fileName }
-            : { ownerType: 'ASSISTANT', ownerId: assistantId, displayName: fileName },
+        owner: resolveFileOwner({ rootOwner, conversationId, userId, assistantId }, fileName),
       })
     }
 

--- a/apps/backend/lib/tools/ownership.ts
+++ b/apps/backend/lib/tools/ownership.ts
@@ -1,0 +1,35 @@
+import type { FileOwnerRef } from '@/backend/lib/files/materialize'
+import type { ToolInvokeParams } from '@/lib/chat/tools'
+
+export const resolveFileOwner = (
+  params: Pick<ToolInvokeParams, 'rootOwner' | 'conversationId' | 'userId' | 'assistantId'>,
+  displayName: string
+): FileOwnerRef => {
+  const rootOwner = params.rootOwner
+  if (rootOwner) {
+    return {
+      ownerType: rootOwner.type,
+      ownerId: rootOwner.id,
+      displayName,
+    }
+  }
+  if (params.conversationId) {
+    return {
+      ownerType: 'CHAT',
+      ownerId: params.conversationId,
+      displayName,
+    }
+  }
+  if (params.userId) {
+    return {
+      ownerType: 'USER',
+      ownerId: params.userId,
+      displayName,
+    }
+  }
+  return {
+    ownerType: 'ASSISTANT',
+    ownerId: params.assistantId,
+    displayName,
+  }
+}

--- a/apps/backend/lib/tools/subassistant/implementation.ts
+++ b/apps/backend/lib/tools/subassistant/implementation.ts
@@ -58,7 +58,7 @@ export class SubAssistantTool implements ToolImplementation {
           additionalProperties: false,
         },
         requireConfirm: false,
-        invoke: async ({ params, userId, conversationId }) => {
+        invoke: async ({ params, userId, conversationId, rootOwner }) => {
           const assistantId = params.assistantId as string
           const input = params.input as string
           const entry = assistants.find((a) => a.id === assistantId)
@@ -111,6 +111,7 @@ export class SubAssistantTool implements ToolImplementation {
             const assistant = await ChatAssistant.build(providerConfig, assistantParams, parameters, tools, files, {
               user: userId,
               conversationId,
+              rootOwner,
             })
 
             const subConversationId = nanoid()

--- a/packages/core/src/chat/tools.ts
+++ b/packages/core/src/chat/tools.ts
@@ -15,6 +15,10 @@ export interface ToolInvokeParams {
   assistantId: string
   userId?: string
   conversationId?: string
+  rootOwner?: {
+    type: 'CHAT' | 'USER' | 'ASSISTANT'
+    id: string
+  }
   toolCallId?: string
   toolName?: string
   params: Record<string, unknown>
@@ -24,6 +28,10 @@ export interface ToolInvokeParams {
 
 export interface ToolFunctionContext {
   userId?: string
+  rootOwner?: {
+    type: 'CHAT' | 'USER' | 'ASSISTANT'
+    id: string
+  }
 }
 
 export interface ToolAuthParams {
@@ -31,6 +39,10 @@ export interface ToolAuthParams {
   messages: dto.Message[]
   assistantId: string
   userId?: string
+  rootOwner?: {
+    type: 'CHAT' | 'USER' | 'ASSISTANT'
+    id: string
+  }
   toolCallId: string
   toolName: string
   params: Record<string, unknown>


### PR DESCRIPTION
## Summary
Ensure nested tool and sub-assistant execution preserves and uses the root execution owner for file ownership.

## Details
- Add `rootOwner` to tool function context/invoke/auth params.
- Seed `rootOwner` from active chat run context (`{ type: 'CHAT', id: conversationId }`).
- Propagate `rootOwner` through nested tool/sub-assistant chains unchanged.
- Introduce shared owner resolver and use it across file-producing tools.
- Update satellite-generated file ownership to prefer `rootOwner`.
- Add tests for invoke context and sub-assistant root owner propagation.

## Tests
- `npm run check-types`
- `npm run test -- __tests__/chatAssistant.test.ts __tests__/subassistantTool.test.ts`