### PR TITLE
Add file authorization service and gate file read paths (#850)

### DIFF
--- a/__tests__/fileAuthorization.test.ts
+++ b/__tests__/fileAuthorization.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+type Row = Record<string, unknown>
+
+const selectFromMock = vi.fn()
+const canUserAccessAssistantMock = vi.fn()
+const getUserWorkspaceMembershipsMock = vi.fn()
+
+const tables: Record<string, Row[]> = {
+  Conversation: [],
+  Tool: [],
+  ToolSharing: [],
+  User: [],
+  FileOwnership: [],
+}
+
+vi.mock('@/db/database', () => ({
+  db: {
+    selectFrom: selectFromMock,
+  },
+}))
+
+vi.mock('@/models/assistant', () => ({
+  canUserAccessAssistant: canUserAccessAssistantMock,
+}))
+
+vi.mock('@/models/user', () => ({
+  getUserWorkspaceMemberships: getUserWorkspaceMembershipsMock,
+}))
+
+function matches(row: Row, whereClauses: Array<{ column: string; op: string; value: unknown }>) {
+  return whereClauses.every(({ column, op, value }) => {
+    if (op === '=') return row[column] === value
+    if (op === 'in') return Array.isArray(value) && value.includes(row[column])
+    throw new Error(`Unsupported operator in test double: ${op}`)
+  })
+}
+
+function mockDbQueries() {
+  selectFromMock.mockImplementation((table: string) => {
+    const whereClauses: Array<{ column: string; op: string; value: unknown }> = []
+    const builder = {
+      select: vi.fn(() => builder),
+      selectAll: vi.fn(() => builder),
+      where: vi.fn((column: string, op: string, value: unknown) => {
+        whereClauses.push({ column, op, value })
+        return builder
+      }),
+      executeTakeFirst: vi.fn(async () => {
+        return tables[table].find((row) => matches(row, whereClauses))
+      }),
+      execute: vi.fn(async () => {
+        return tables[table].filter((row) => matches(row, whereClauses))
+      }),
+    }
+    return builder
+  })
+}
+
+describe('file authorization', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    for (const key of Object.keys(tables)) {
+      tables[key] = []
+    }
+    mockDbQueries()
+    canUserAccessAssistantMock.mockResolvedValue(false)
+    getUserWorkspaceMembershipsMock.mockResolvedValue([])
+  })
+
+  test('canAccess USER owner type (positive and negative)', async () => {
+    const { canAccess } = await import('@/backend/lib/files/authorization')
+    await expect(canAccess({ userId: 'u1' }, 'USER', 'u1')).resolves.toBe(true)
+    await expect(canAccess({ userId: 'u2' }, 'USER', 'u1')).resolves.toBe(false)
+  })
+
+  test('canAccess CHAT owner type (positive and negative)', async () => {
+    tables.Conversation.push({ id: 'c1', ownerId: 'u1' })
+
+    const { canAccess } = await import('@/backend/lib/files/authorization')
+    await expect(canAccess({ userId: 'u1' }, 'CHAT', 'c1')).resolves.toBe(true)
+    await expect(canAccess({ userId: 'u2' }, 'CHAT', 'c1')).resolves.toBe(false)
+  })
+
+  test('canAccess ASSISTANT owner type (positive and negative)', async () => {
+    const { canAccess } = await import('@/backend/lib/files/authorization')
+
+    canUserAccessAssistantMock.mockResolvedValueOnce(true)
+    await expect(canAccess({ userId: 'u1' }, 'ASSISTANT', 'a1')).resolves.toBe(true)
+
+    canUserAccessAssistantMock.mockResolvedValueOnce(false)
+    await expect(canAccess({ userId: 'u1' }, 'ASSISTANT', 'a1')).resolves.toBe(false)
+  })
+
+  test('canAccess TOOL owner type supports public/workspace/private', async () => {
+    tables.Tool.push({ id: 't-public', sharing: 'public' })
+    tables.Tool.push({ id: 't-workspace', sharing: 'workspace' })
+    tables.Tool.push({ id: 't-private', sharing: 'private' })
+    tables.ToolSharing.push({ id: 'ts1', toolId: 't-workspace', workspaceId: 'w1' })
+    tables.User.push({ id: 'u-admin', role: 'ADMIN' })
+    tables.User.push({ id: 'u-user', role: 'USER' })
+
+    getUserWorkspaceMembershipsMock.mockImplementation(async (userId: string) => {
+      if (userId === 'u-workspace') return [{ id: 'w1', name: 'Workspace 1', role: 'MEMBER' }]
+      return []
+    })
+
+    const { canAccess } = await import('@/backend/lib/files/authorization')
+
+    await expect(canAccess({ userId: 'u-any' }, 'TOOL', 't-public')).resolves.toBe(true)
+    await expect(canAccess({ userId: 'u-workspace' }, 'TOOL', 't-workspace')).resolves.toBe(true)
+    await expect(canAccess({ userId: 'u-no-workspace' }, 'TOOL', 't-workspace')).resolves.toBe(false)
+    await expect(canAccess({ userId: 'u-admin' }, 'TOOL', 't-private')).resolves.toBe(true)
+    await expect(canAccess({ userId: 'u-user' }, 'TOOL', 't-private')).resolves.toBe(false)
+  })
+
+  test('canAccessFile keeps legacy unowned files readable', async () => {
+    const { canAccessFile } = await import('@/backend/lib/files/authorization')
+    await expect(canAccessFile({ userId: 'u1' }, 'f-legacy')).resolves.toBe(true)
+  })
+
+  test('canAccessFile enforces ownership and supports shared-access fallback', async () => {
+    tables.Conversation.push({ id: 'c1', ownerId: 'u-chat' })
+    tables.FileOwnership.push({ fileId: 'f1', ownerType: 'USER', ownerId: 'u-owner' })
+    tables.FileOwnership.push({ fileId: 'f2', ownerType: 'USER', ownerId: 'u-other' })
+    tables.FileOwnership.push({ fileId: 'f2', ownerType: 'CHAT', ownerId: 'c1' })
+
+    const { canAccessFile } = await import('@/backend/lib/files/authorization')
+
+    await expect(canAccessFile({ userId: 'u-owner' }, 'f1')).resolves.toBe(true)
+    await expect(canAccessFile({ userId: 'u-nope' }, 'f1')).resolves.toBe(false)
+    await expect(canAccessFile({ userId: 'u-chat' }, 'f2')).resolves.toBe(true)
+  })
+})

--- a/apps/backend/api/files/[fileId]/analysis/route.ts
+++ b/apps/backend/api/files/[fileId]/analysis/route.ts
@@ -1,8 +1,9 @@
-import { error, errorSpec, notFound, operation, responseSpec } from '@/lib/routes'
+import { error, errorSpec, forbidden, notFound, operation, responseSpec } from '@/lib/routes'
 import { getFileWithId } from '@/models/file'
 import * as dto from '@/types/dto'
 import { getFileAnalysis, inferFileAnalysisKind } from '@/models/fileAnalysis'
 import { ensureFileAnalysisForFile, fileAnalyzerVersion } from '@/lib/file-analysis'
+import { canAccessFile } from '@/backend/lib/files/authorization'
 import { llmModels } from '@/lib/models'
 import env from '@/lib/env'
 import { z } from 'zod'
@@ -23,11 +24,15 @@ export const GET = operation({
   querySchema: z.object({
     modelId: z.string().optional(),
   }),
-  responses: [responseSpec(200, dto.fileAnalysisSchema), errorSpec(404), errorSpec(409)] as const,
-  implementation: async ({ params, query }) => {
+  responses: [responseSpec(200, dto.fileAnalysisSchema), errorSpec(403), errorSpec(404), errorSpec(409)] as const,
+  implementation: async ({ params, query, session }) => {
     const file = await getFileWithId(params.fileId)
     if (!file) {
       return notFound()
+    }
+
+    if (!(await canAccessFile(session, params.fileId))) {
+      return forbidden()
     }
 
     if (file.uploaded !== 1) {

--- a/apps/backend/api/files/[fileId]/content/route.ts
+++ b/apps/backend/api/files/[fileId]/content/route.ts
@@ -1,5 +1,6 @@
 import { db } from '@/db/database'
-import { error, noBody, notFound, operation, responseSpec, errorSpec } from '@/lib/routes'
+import { canAccessFile } from '@/backend/lib/files/authorization'
+import { error, noBody, notFound, forbidden, operation, responseSpec, errorSpec } from '@/lib/routes'
 import { storage } from '@/lib/storage'
 import { logger } from '@/lib/logging'
 import { scheduleFileAnalysisForFile } from '@/lib/file-analysis'
@@ -99,8 +100,8 @@ export const PUT = operation({
 export const GET = operation({
   name: 'Download file content',
   authentication: 'user',
-  responses: [responseSpec(200, z.any()), errorSpec(404)] as const,
-  implementation: async ({ params }) => {
+  responses: [responseSpec(200, z.any()), errorSpec(403), errorSpec(404)] as const,
+  implementation: async ({ params, session }) => {
     const file = await db
       .selectFrom('File')
       .selectAll()
@@ -108,6 +109,9 @@ export const GET = operation({
       .executeTakeFirst()
     if (!file) {
       return notFound()
+    }
+    if (!(await canAccessFile(session, params.fileId))) {
+      return forbidden()
     }
     const fileContent = await storage.readStream(file.path, !!file.encrypted)
     return new Response(fileContent, {

--- a/apps/backend/lib/files/authorization.ts
+++ b/apps/backend/lib/files/authorization.ts
@@ -1,0 +1,115 @@
+import { db } from '@/db/database'
+import type * as schema from '@/db/schema'
+import { canUserAccessAssistant } from '@/models/assistant'
+import { getUserWorkspaceMemberships } from '@/models/user'
+
+type AccessUser =
+  | string
+  | {
+      id?: string
+      role?: string
+      userId?: string
+      userRole?: string
+    }
+  | null
+  | undefined
+
+const normalizeUser = (user: AccessUser): { id: string; role?: string } | null => {
+  if (!user) return null
+  if (typeof user === 'string') {
+    const id = user.trim()
+    return id ? { id } : null
+  }
+
+  const id = (user.userId ?? user.id ?? '').trim()
+  if (!id) return null
+
+  const role = user.userRole ?? user.role
+  return role ? { id, role } : { id }
+}
+
+const isAdminUser = async (userId: string, roleHint?: string): Promise<boolean> => {
+  if (roleHint) {
+    return roleHint === 'ADMIN'
+  }
+
+  const row = await db.selectFrom('User').select('role').where('id', '=', userId).executeTakeFirst()
+  return row?.role === 'ADMIN'
+}
+
+export const canAccess = async (
+  user: AccessUser,
+  ownerType: schema.FileOwnerType,
+  ownerId: string
+): Promise<boolean> => {
+  const normalizedUser = normalizeUser(user)
+  if (!normalizedUser) {
+    return false
+  }
+
+  switch (ownerType) {
+    case 'USER':
+      return normalizedUser.id === ownerId
+    case 'CHAT': {
+      const conversation = await db
+        .selectFrom('Conversation')
+        .select('ownerId')
+        .where('id', '=', ownerId)
+        .executeTakeFirst()
+      return conversation?.ownerId === normalizedUser.id
+    }
+    case 'ASSISTANT':
+      return await canUserAccessAssistant(normalizedUser.id, ownerId)
+    case 'TOOL': {
+      const tool = await db
+        .selectFrom('Tool')
+        .select('sharing')
+        .where('id', '=', ownerId)
+        .executeTakeFirst()
+      if (!tool) {
+        return false
+      }
+
+      if (tool.sharing === 'public') {
+        return true
+      }
+
+      if (tool.sharing === 'workspace') {
+        const memberships = await getUserWorkspaceMemberships(normalizedUser.id)
+        if (memberships.length === 0) {
+          return false
+        }
+        const workspaceIds = memberships.map((m) => m.id)
+        const shared = await db
+          .selectFrom('ToolSharing')
+          .select('id')
+          .where('toolId', '=', ownerId)
+          .where('workspaceId', 'in', workspaceIds)
+          .executeTakeFirst()
+        return !!shared
+      }
+
+      return await isAdminUser(normalizedUser.id, normalizedUser.role)
+    }
+  }
+}
+
+export const canAccessFile = async (user: AccessUser, fileId: string): Promise<boolean> => {
+  const ownershipRows = await db
+    .selectFrom('FileOwnership')
+    .select(['ownerType', 'ownerId'])
+    .where('fileId', '=', fileId)
+    .execute()
+
+  if (ownershipRows.length === 0) {
+    // Legacy migration window behavior: unowned files stay readable.
+    return true
+  }
+
+  for (const row of ownershipRows) {
+    if (await canAccess(user, row.ownerType, row.ownerId)) {
+      return true
+    }
+  }
+  return false
+}

--- a/apps/backend/lib/tools/audio_transcription/implementation.ts
+++ b/apps/backend/lib/tools/audio_transcription/implementation.ts
@@ -15,6 +15,7 @@ import { LlmModel } from '@/lib/chat/models'
 import * as dto from '@/types/dto'
 import { expandToolParameter } from '@/backend/lib/tools/configSecrets'
 import { getFileWithId } from '@/models/file'
+import { canAccessFile } from '@/backend/lib/files/authorization'
 import { storage } from '@/lib/storage'
 import { recordAudioTranscriptionEvent } from './metering'
 import { materializeFile } from '@/backend/lib/files/materialize'
@@ -119,6 +120,10 @@ export class AudioTranscription extends AudioTranscriptionInterface implements T
     const fileId = `${params.fileId ?? ''}`.trim()
     if (!fileId) {
       return { type: 'error-text', value: 'fileId is required' }
+    }
+
+    if (!(await canAccessFile(userId, fileId))) {
+      return { type: 'error-text', value: `You are not authorized to access file: ${fileId}` }
     }
 
     const fileEntry = await getFileWithId(fileId)

--- a/apps/backend/lib/tools/code_interpreter/implementation.ts
+++ b/apps/backend/lib/tools/code_interpreter/implementation.ts
@@ -14,6 +14,7 @@ import { LlmModel } from '@/lib/chat/models'
 import * as dto from '@/types/dto'
 import { expandToolParameter } from '@/backend/lib/tools/configSecrets'
 import { getFileWithId } from '@/models/file'
+import { canAccessFile } from '@/backend/lib/files/authorization'
 import { storage } from '@/lib/storage'
 import { nanoid } from 'nanoid'
 import { logger } from '@/lib/logging'
@@ -111,7 +112,7 @@ export class CodeInterpreter
     }
   }
 
-  private async uploadFiles({ params }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> {
+  private async uploadFiles({ params, userId }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> {
     const containerId = `${params.containerId ?? ''}`
     if (!containerId) {
       return { type: 'error-text', value: 'containerId is required' }
@@ -131,6 +132,9 @@ export class CodeInterpreter
       const fileId = file.fileId
       if (!fileId) {
         return { type: 'error-text', value: 'file_id is required for each file' }
+      }
+      if (!(await canAccessFile(userId, fileId))) {
+        return { type: 'error-text', value: `You are not authorized to access file: ${fileId}` }
       }
       const fileEntry = await getFileWithId(fileId)
       if (!fileEntry) {

--- a/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/chat/tools'
 import * as dto from '@/types/dto'
 import { getFileWithId } from '@/models/file'
+import { canAccessFile } from '@/backend/lib/files/authorization'
 import { nanoid } from 'nanoid'
 import { expandToolParameter } from '@/backend/lib/tools/configSecrets'
 import { storage } from '@/lib/storage'
@@ -163,7 +164,10 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
     })
   }
 
-  private async loadImage(fileId: string) {
+  private async loadImage(fileId: string, userId?: string) {
+    if (!(await canAccessFile(userId, fileId))) {
+      throw new Error(`Tool invocation unauthorized for file: ${fileId}`)
+    }
     const fileEntry = await getFileWithId(fileId)
     if (!fileEntry) {
       throw new Error(`Tool invocation required non existing file: ${fileId}`)
@@ -188,7 +192,7 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
     }
     const apiKey = await expandToolParameter(this.toolParams, this.params.apiKey)
     const fileIds = invocationParams.fileId as string[]
-    const files = await Promise.all(fileIds.map((fileId) => this.loadImage(fileId)))
+    const files = await Promise.all(fileIds.map((fileId) => this.loadImage(fileId, userId)))
     const aiResponse = this.assertImageResponse(
       await this.editDirect({
         apiKey,

--- a/apps/backend/lib/tools/imagegenerator/implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/implementation.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/tools/schemas'
 import OpenAI from 'openai'
 import { getFileWithId } from '@/models/file'
+import { canAccessFile } from '@/backend/lib/files/authorization'
 import { nanoid } from 'nanoid'
 import env from '@/lib/env'
 import { expandToolParameter } from '@/backend/lib/tools/configSecrets'
@@ -124,7 +125,10 @@ export class ImageGeneratorPlugin
     })
   }
 
-  private async loadImageAsWebFile(fileId: string) {
+  private async loadImageAsWebFile(fileId: string, userId?: string) {
+    if (!(await canAccessFile(userId, fileId))) {
+      throw new Error(`Tool invocation unauthorized for file: ${fileId}`)
+    }
     const fileEntry = await getFileWithId(fileId)
     if (!fileEntry) {
       throw new Error(`Tool invocation required non existing file: ${fileId}`)
@@ -150,7 +154,7 @@ export class ImageGeneratorPlugin
     const fileIds = invocationParams.fileId as string[]
     const files = await Promise.all(
       fileIds.map((fileId) => {
-        return this.loadImageAsWebFile(fileId)
+        return this.loadImageAsWebFile(fileId, userId)
       })
     )
     const aiResponse = await openai.images.edit({

--- a/apps/backend/lib/tools/openapi/body.ts
+++ b/apps/backend/lib/tools/openapi/body.ts
@@ -3,6 +3,7 @@ import FormData from 'form-data'
 import { PassThrough } from 'node:stream'
 import { ToolFunctionSchemaParams } from '@/lib/tools/openapi-types'
 import { getFileWithId } from '@/models/file'
+import { canAccessFile } from '@/backend/lib/files/authorization'
 import { storage } from '@/lib/storage'
 import { ensureABView } from '@/backend/lib/utils'
 import { JSONSchema7 } from 'json-schema'
@@ -16,11 +17,12 @@ interface BodyAndHeader {
 
 type BodyCreator = (
   invocationParams: Record<string, unknown>,
-  schema: OpenAPIV3.SchemaObject
+  schema: OpenAPIV3.SchemaObject,
+  userId?: string
 ) => Promise<BodyAndHeader>
 
 export interface BodyHandler {
-  createBody: (invocationParams: Record<string, unknown>) => Promise<BodyAndHeader>
+  createBody: (invocationParams: Record<string, unknown>, userId?: string) => Promise<BodyAndHeader>
   mergeParamsIntoToolFunctionSchema: (toolParams: ToolFunctionSchemaParams) => void
 }
 
@@ -64,7 +66,8 @@ async function formDataToBuffer(form: FormData): Promise<Uint8Array<ArrayBuffer>
 
 async function createFormBody(
   invocationParams: Record<string, unknown>,
-  schema: OpenAPIV3.SchemaObject
+  schema: OpenAPIV3.SchemaObject,
+  userId?: string
 ): Promise<BodyAndHeader> {
   const bodyParamInstances = invocationParams.body as Record<string, any>
   const form = new FormData()
@@ -91,6 +94,9 @@ async function createFormBody(
         throw new Error(
           `Tool invocation requires a body, but param ${definedPropertyName} is missing`
         )
+      }
+      if (!(await canAccessFile(userId, `${propInvocationValue}`))) {
+        throw new Error(`Tool invocation unauthorized for file: ${propInvocationValue}`)
       }
       const fileEntry = await getFileWithId(`${propInvocationValue}`)
       if (!fileEntry) {
@@ -177,8 +183,8 @@ export function findBodyHandler(spec: OpenAPIV3.RequestBodyObject): BodyHandler 
         if (mediaObject?.schema) {
           const schema = mediaObject.schema as OpenAPIV3.SchemaObject
           return {
-            createBody: (invocationParams: Record<string, unknown>) => {
-              return bodyHandler[1](invocationParams, schema)
+            createBody: (invocationParams: Record<string, unknown>, userId?: string) => {
+              return bodyHandler[1](invocationParams, schema, userId)
             },
             mergeParamsIntoToolFunctionSchema: (toolParams: ToolFunctionSchemaParams) => {
               mergeRequestBodyDefIntoToolFunctionSchema(toolParams, schema)

--- a/apps/backend/lib/tools/openapi/implementation.ts
+++ b/apps/backend/lib/tools/openapi/implementation.ts
@@ -178,7 +178,7 @@ function convertOpenAPIOperationToToolFunction(
     let body: Body
     let headers: Record<string, string> = {}
     if (bodyHandler) {
-      const res = await bodyHandler.createBody(invocationParams)
+      const res = await bodyHandler.createBody(invocationParams, userId)
       body = res.body
       headers = { ...headers, ...res.headers }
     }


### PR DESCRIPTION
## Summary
Add ownership-based file authorization for file reads by introducing a centralized authorization service and enforcing it across API file-read endpoints and internal tool file-by-id readers. Unauthorized file reads now return access-denied behavior, while legacy unowned files remain readable during the migration window.

## Details
- Add `canAccess(user, ownerType, ownerId)` and `canAccessFile(user, fileId)` in backend file authorization service.
- Gate `GET /api/files/{fileId}/content` and `GET /api/files/{fileId}/analysis` with `403` on unauthorized access.
- Gate internal tool file read paths that consume file IDs (`audio_transcription`, image generation/editing, code interpreter uploads, OpenAPI multipart binary request-body handling).
- Preserve legacy coexistence behavior: files with zero ownership rows are readable.
- Add focused tests for positive/negative owner-type access, shared-access behavior, and legacy unowned-file behavior.

## Tests
- `npm run check-types` (pass)
- `npx vitest run` (pass)
