### PR TITLE
Normalize MCP/OpenAPI/satellite file-like outputs

### DIFF
--- a/__tests__/toolOutputNormalization.test.ts
+++ b/__tests__/toolOutputNormalization.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { createHash } from 'node:crypto'
+
+const materializedByHash = new Map<string, { id: string; type: string; name: string; size: number }>()
+
+vi.mock('@/backend/lib/files/materialize', () => ({
+  materializeFile: vi.fn(async (params: { content: Buffer; name: string; mimeType: string }) => {
+    const hash = createHash('sha256').update(params.content).digest('hex')
+    const existing = materializedByHash.get(hash)
+    if (existing) return existing
+    const created = {
+      id: `file-${materializedByHash.size + 1}`,
+      type: params.mimeType,
+      name: params.name,
+      size: params.content.byteLength,
+    }
+    materializedByHash.set(hash, created)
+    return created
+  }),
+}))
+
+import {
+  normalizeMcpToolResult,
+  persistFileLikePayload,
+} from '@/backend/lib/tools/file-output-normalization'
+
+describe('tool output normalization', () => {
+  beforeEach(() => {
+    materializedByHash.clear()
+  })
+
+  test('normalizes MCP image/resource file-like outputs into file content items', async () => {
+    const pngData = Buffer.from('fake-png').toString('base64')
+    const res = await normalizeMcpToolResult(
+      {
+        content: [
+          { type: 'image', data: pngData, mimeType: 'image/png' },
+          {
+            type: 'resource',
+            resource: { blob: pngData, mimeType: 'image/png', name: 'resource.png' },
+          },
+        ],
+      },
+      { assistantId: 'a1' }
+    )
+
+    expect(res.type).toBe('content')
+    if (res.type !== 'content') return
+    expect(res.value.every((v) => v.type === 'file')).toBe(true)
+    expect(res.value).toHaveLength(2)
+  })
+
+  test('openapi-like binary payload persists to stable file descriptor', async () => {
+    const payload = Buffer.from('binary-openapi').toString('base64')
+    const persisted = await persistFileLikePayload({
+      assistantId: 'a1',
+      base64Data: payload,
+      mimeType: 'application/pdf',
+      nameHint: 'report.pdf',
+      source: 'OpenAPI',
+    })
+    expect(persisted.kind).toBe('file')
+    expect(persisted.value.type).toBe('file')
+    if (persisted.value.type === 'file') {
+      expect(persisted.value.name).toBe('report.pdf')
+      expect(persisted.value.mimetype).toBe('application/pdf')
+    }
+  })
+
+  test('dedup regression: repeated identical payload resolves to same file id', async () => {
+    const payload = Buffer.from('same-bytes').toString('base64')
+    const first = await persistFileLikePayload({
+      assistantId: 'a1',
+      base64Data: payload,
+      mimeType: 'image/png',
+      source: 'MCP',
+    })
+    const second = await persistFileLikePayload({
+      assistantId: 'a1',
+      base64Data: payload,
+      mimeType: 'image/png',
+      source: 'MCP',
+    })
+    expect(first.value.type).toBe('file')
+    expect(second.value.type).toBe('file')
+    if (first.value.type === 'file' && second.value.type === 'file') {
+      expect(first.value.id).toBe(second.value.id)
+    }
+  })
+
+  test('unsupported mime types degrade to text fallback', async () => {
+    const payload = Buffer.from('fake').toString('base64')
+    const persisted = await persistFileLikePayload({
+      assistantId: 'a1',
+      base64Data: payload,
+      mimeType: 'application/x-msdownload',
+      source: 'MCP',
+      supportedMedia: ['image/png'],
+    })
+    expect(persisted.kind).toBe('text')
+    expect(persisted.value.type).toBe('text')
+  })
+})

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -25,8 +25,11 @@ import { llmModels } from '@/lib/models'
 import { z } from 'zod/v4'
 import { ParameterValueAndDescription } from '@/models/user'
 import { nanoid } from 'nanoid'
-import { extension as mimeExtension } from 'mime-types'
 import { estimateConversationWindowTokens } from '@/backend/lib/chat/token-estimator'
+import {
+  normalizeMcpToolResult,
+  persistFileLikePayload,
+} from '@/backend/lib/tools/file-output-normalization'
 
 export { fillTemplate } from './preamble'
 export type { PromptSegment } from './preamble'
@@ -241,7 +244,6 @@ export class ChatAssistant {
     const functions_ = Object.fromEntries(functions)
     const satelliteHub = await import('@/lib/satellite/hub')
     const { callSatelliteMethod } = satelliteHub
-    const { materializeFile } = await import('@/backend/lib/files/materialize')
     const connections = satelliteHub.connections
     connections.forEach((conn) => {
       if (conn.userId !== context?.userId) return
@@ -263,65 +265,31 @@ export class ChatAssistant {
               }
               for (const r of content) {
                 if (r.type === 'image' && typeof r.data === 'string') {
-                  const imgBinaryData = Buffer.from(r.data, 'base64')
-                  const id = nanoid()
-                  const ext = mimeExtension(r.mimeType ?? '') || 'bin'
-                  const name = `${id}.${ext}`
-                  const assistantOwnerId = context?.assistantId
-                  if (!context?.rootOwner && !context?.userId && !assistantOwnerId) {
-                    throw new Error('Missing owner context for satellite-generated file')
-                  }
-                  const dbFile = await materializeFile({
-                    content: imgBinaryData,
-                    name,
+                  const persisted = await persistFileLikePayload({
+                    rootOwner: context?.rootOwner,
+                    conversationId: undefined,
+                    userId: context?.userId,
+                    assistantId: context?.assistantId ?? '',
+                    base64Data: r.data,
                     mimeType: r.mimeType ?? 'application/octet-stream',
-                    owner: context?.rootOwner
-                      ? { ownerType: context.rootOwner.type, ownerId: context.rootOwner.id, displayName: name }
-                      : context?.userId
-                        ? { ownerType: 'USER', ownerId: context.userId, displayName: name }
-                        : {
-                            ownerType: 'ASSISTANT',
-                            ownerId: assistantOwnerId!,
-                            displayName: name,
-                          },
+                    source: 'Satellite',
                   })
-                  toolResult.value.push({
-                    type: 'file',
-                    id: dbFile.id,
-                    mimetype: dbFile.type,
-                    name: dbFile.name,
-                    size: dbFile.size,
-                  })
+                  toolResult.value.push(persisted.value)
                 } else if (r.type === 'resource') {
-                  const imgBinaryData = Buffer.from(r.resource.blob as string, 'base64')
-                  const id = nanoid()
-                  const ext = mimeExtension(r.resource.mimeType ?? '') || 'bin'
-                  const name = `${id}.${ext}`
-                  const assistantOwnerId = context?.assistantId
-                  if (!context?.rootOwner && !context?.userId && !assistantOwnerId) {
-                    throw new Error('Missing owner context for satellite-generated file')
+                  const normalized = await normalizeMcpToolResult(
+                    { content: [r] },
+                    {
+                      rootOwner: context?.rootOwner,
+                      conversationId: undefined,
+                      userId: context?.userId,
+                      assistantId: context?.assistantId ?? '',
+                    }
+                  )
+                  if (normalized.type === 'content') {
+                    toolResult.value.push(...normalized.value)
+                  } else {
+                    toolResult.value.push({ type: 'text', text: JSON.stringify(normalized.value) })
                   }
-                  const dbFile = await materializeFile({
-                    content: imgBinaryData,
-                    name,
-                    mimeType: r.resource.mimeType ?? 'application/octet-stream',
-                    owner: context?.rootOwner
-                      ? { ownerType: context.rootOwner.type, ownerId: context.rootOwner.id, displayName: name }
-                      : context?.userId
-                        ? { ownerType: 'USER', ownerId: context.userId, displayName: name }
-                        : {
-                            ownerType: 'ASSISTANT',
-                            ownerId: assistantOwnerId!,
-                            displayName: name,
-                          },
-                  })
-                  toolResult.value.push({
-                    type: 'file',
-                    id: dbFile.id,
-                    mimetype: dbFile.type,
-                    name: dbFile.name,
-                    size: dbFile.size,
-                  })
                 } else if (r.type === 'text' && typeof r.text === 'string') {
                   toolResult.value.push({
                     type: 'text',

--- a/apps/backend/lib/tools/file-output-normalization.ts
+++ b/apps/backend/lib/tools/file-output-normalization.ts
@@ -1,0 +1,170 @@
+import { resolveFileOwner } from '@/backend/lib/tools/ownership'
+import env from '@/lib/env'
+import { logger } from '@/lib/logging'
+import type { ToolInvokeParams } from '@/lib/chat/tools'
+import * as dto from '@/types/dto'
+import { extension as mimeExtension } from 'mime-types'
+import { JSONValue } from 'ai'
+
+interface PersistFileLikeParams
+  extends Pick<ToolInvokeParams, 'rootOwner' | 'conversationId' | 'userId' | 'assistantId'> {
+  base64Data: string
+  mimeType: string
+  nameHint?: string
+  source: string
+  supportedMedia?: string[]
+}
+
+const defaultMimeType = 'application/octet-stream'
+
+const parseAllowedFromEnv = (): string[] => {
+  const raw = env.chat.attachments.allowedFormats
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map((v) => v.trim().toLowerCase())
+    .filter(Boolean)
+}
+
+const mimeAllowed = (mimeType: string, allowlist: string[]): boolean => {
+  if (allowlist.length === 0) return true
+  const normalized = mimeType.toLowerCase()
+  return allowlist.some((allowed) => {
+    if (allowed.endsWith('/*')) {
+      const prefix = allowed.slice(0, allowed.length - 1)
+      return normalized.startsWith(prefix)
+    }
+    return normalized === allowed
+  })
+}
+
+const makeFileName = (mimeType: string, nameHint?: string): string => {
+  if (nameHint && nameHint.length > 0) return nameHint
+  const ext = mimeExtension(mimeType) || 'bin'
+  return `tool-output.${ext}`
+}
+
+const toFilePart = (fileEntry: {
+  id: string
+  type: string
+  name: string
+  size: number
+}): Extract<dto.ToolCallResultOutput, { type: 'content' }>['value'][number] => ({
+  type: 'file',
+  id: fileEntry.id,
+  mimetype: fileEntry.type,
+  name: fileEntry.name,
+  size: fileEntry.size,
+})
+
+export const persistFileLikePayload = async (
+  params: PersistFileLikeParams
+): Promise<
+  | { kind: 'file'; value: Extract<dto.ToolCallResultOutput, { type: 'content' }>['value'][number] }
+  | { kind: 'text'; value: Extract<dto.ToolCallResultOutput, { type: 'content' }>['value'][number] }
+> => {
+  const mimeType = (params.mimeType || defaultMimeType).toLowerCase()
+  const allowlist = [
+    ...new Set([...(params.supportedMedia ?? []).map((m) => m.toLowerCase()), ...parseAllowedFromEnv()]),
+  ]
+  if (!mimeAllowed(mimeType, allowlist)) {
+    logger.warn(`[${params.source}] File-like output rejected by mime allowlist`, {
+      mimeType,
+      allowlist,
+    })
+    return {
+      kind: 'text',
+      value: {
+        type: 'text',
+        text: `Tool returned unsupported file payload (${mimeType}); keeping a text fallback instead.`,
+      },
+    }
+  }
+
+  const bytes = Buffer.from(params.base64Data, 'base64')
+  if (!bytes.length && params.base64Data.length > 0) {
+    logger.warn(`[${params.source}] File-like payload is not valid base64`, { mimeType })
+    return {
+      kind: 'text',
+      value: {
+        type: 'text',
+        text: `Tool returned an invalid base64 file payload (${mimeType}); keeping a text fallback instead.`,
+      },
+    }
+  }
+  if (bytes.byteLength > env.chat.attachments.maxSize) {
+    logger.warn(`[${params.source}] File-like payload exceeds max size`, {
+      mimeType,
+      size: bytes.byteLength,
+      maxSize: env.chat.attachments.maxSize,
+    })
+    return {
+      kind: 'text',
+      value: {
+        type: 'text',
+        text: `Tool returned a file payload too large to store (${bytes.byteLength} bytes, max ${env.chat.attachments.maxSize}).`,
+      },
+    }
+  }
+
+  const fileName = makeFileName(mimeType, params.nameHint)
+  const { materializeFile } = await import('@/backend/lib/files/materialize')
+  const dbFile = await materializeFile({
+    content: bytes,
+    name: fileName,
+    mimeType,
+    owner: resolveFileOwner(params, fileName),
+  })
+  return { kind: 'file', value: toFilePart(dbFile) }
+}
+
+export const normalizeMcpToolResult = async (
+  result: any,
+  params: Pick<ToolInvokeParams, 'rootOwner' | 'conversationId' | 'userId' | 'assistantId'>
+): Promise<dto.ToolCallResultOutput> => {
+  const contentParts: Extract<dto.ToolCallResultOutput, { type: 'content' }>['value'] = []
+  for (const item of Array.isArray(result?.content) ? result.content : []) {
+    if (item?.type === 'text' && typeof item.text === 'string') {
+      contentParts.push({ type: 'text', text: item.text })
+      continue
+    }
+    if (item?.type === 'image' && typeof item.data === 'string') {
+      const persisted = await persistFileLikePayload({
+        ...params,
+        base64Data: item.data,
+        mimeType: item.mimeType ?? defaultMimeType,
+        source: 'MCP',
+      })
+      contentParts.push(persisted.value)
+      continue
+    }
+    if (item?.type === 'resource' && typeof item.resource?.blob === 'string') {
+      const persisted = await persistFileLikePayload({
+        ...params,
+        base64Data: item.resource.blob,
+        mimeType: item.resource.mimeType ?? defaultMimeType,
+        nameHint: item.resource.name,
+        source: 'MCP',
+      })
+      contentParts.push(persisted.value)
+      continue
+    }
+    if (item?.type === 'resource' && typeof item.resource?.text === 'string') {
+      contentParts.push({ type: 'text', text: item.resource.text })
+      continue
+    }
+    contentParts.push({ type: 'text', text: JSON.stringify(item) })
+  }
+
+  if (result?.structuredContent !== undefined) {
+    contentParts.push({
+      type: 'text',
+      text: JSON.stringify(result.structuredContent),
+    })
+  }
+
+  if (contentParts.length === 0) {
+    return { type: 'json', value: result as JSONValue }
+  }
+  return { type: 'content', value: contentParts }
+}

--- a/apps/backend/lib/tools/mcp/implementation.ts
+++ b/apps/backend/lib/tools/mcp/implementation.ts
@@ -18,13 +18,13 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { nanoid } from 'nanoid'
-import { JSONValue } from 'ai'
 import env from '@/lib/env'
 import { resolveMcpOAuthToken } from './oauth'
 import type { ToolAuthParams } from '@/lib/chat/tools'
 import { LlmModel } from '@/lib/chat/models'
 import { LRUCache } from 'lru-cache'
 import * as dto from '@/types/dto'
+import { normalizeMcpToolResult } from '@/backend/lib/tools/file-output-normalization'
 
 interface CacheItem {
   id: string
@@ -190,10 +190,7 @@ async function convertMcpSpecToToolFunctions(
           name: tool.name,
           arguments: params,
         })
-        return {
-          type: 'json',
-          value: result as JSONValue,
-        }
+        return await normalizeMcpToolResult(result, invokeParams)
       },
     }
   }

--- a/apps/backend/lib/tools/openapi/implementation.ts
+++ b/apps/backend/lib/tools/openapi/implementation.ts
@@ -26,8 +26,7 @@ import { JSONSchema7 } from 'json-schema'
 import { JSONValue } from 'ai'
 import * as dto from '@/types/dto'
 import { LlmModel } from '@/lib/chat/models'
-import { materializeFile } from '@/backend/lib/files/materialize'
-import { resolveFileOwner } from '@/backend/lib/tools/ownership'
+import { persistFileLikePayload } from '@/backend/lib/tools/file-output-normalization'
 
 export interface OpenApiPluginParams extends Record<string, unknown> {
   spec: string
@@ -146,14 +145,17 @@ function convertOpenAPIOperationToToolFunction(
     assistantId,
     rootOwner,
   }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> => {
-    const storeFile = async (data: Uint8Array, fileName: string, contentType: string) => {
-      return await materializeFile({
-        content: Buffer.from(data),
-        name: fileName,
+    const storeFile = async (data: Uint8Array, fileName: string, contentType: string) =>
+      await persistFileLikePayload({
+        rootOwner,
+        conversationId,
+        userId,
+        assistantId,
+        base64Data: Buffer.from(data).toString('base64'),
         mimeType: contentType,
-        owner: resolveFileOwner({ rootOwner, conversationId, userId, assistantId }, fileName),
+        nameHint: fileName,
+        source: 'OpenAPI',
       })
-    }
 
     const opParameters = operation.parameters as OpenAPIV3.ParameterObject[]
     let builtPath = pathKey
@@ -234,14 +236,8 @@ function convertOpenAPIOperationToToolFunction(
               text: await part.text(),
             })
           } else {
-            const dbFile = await storeFile(await part.bytes(), fileName, mediaType)
-            result.value.push({
-              type: 'file',
-              id: dbFile.id,
-              mimetype: dbFile.type,
-              name: dbFile.name,
-              size: dbFile.size,
-            })
+            const persisted = await storeFile(await part.bytes(), fileName, mediaType)
+            result.value.push(persisted.value)
           }
         }
         return result
@@ -255,7 +251,7 @@ function convertOpenAPIOperationToToolFunction(
         const contentTypeOrDefault = contentType ?? 'application/binary'
         const fileName = contentDisposition.preferredFilename ?? 'fileName'
         const body = await response.blob()
-        const dbFile = await storeFile(await body.bytes(), fileName, contentTypeOrDefault)
+        const persisted = await storeFile(await body.bytes(), fileName, contentTypeOrDefault)
         return {
           type: 'content',
           value: [
@@ -263,17 +259,18 @@ function convertOpenAPIOperationToToolFunction(
               type: 'text',
               text: `File ${fileName} has been sent to the user and is plainly visible, so don't repeat the descriptions in detail. Do not list download links as they are available in the ChatGPT UI already. Do not mention anything about visualizing / downloading to the user`,
             },
-            {
-              type: 'file',
-              id: dbFile.id,
-              mimetype: dbFile.type,
-              name: dbFile.name,
-              size: dbFile.size,
-            },
+            persisted.value,
           ],
         }
       } else if (contentType && contentType === 'application/json') {
         return { type: 'json', value: (await response.json()) as JSONValue }
+      } else if (contentType && !contentType.startsWith('text/')) {
+        const body = await response.blob()
+        const persisted = await storeFile(await body.bytes(), 'response.bin', contentType)
+        return {
+          type: 'content',
+          value: [persisted.value],
+        }
       } else {
         return { type: 'text', value: await response.text() }
       }


### PR DESCRIPTION
## Summary
Normalize MCP, OpenAPI, and satellite file-like tool outputs through a shared post-processing layer so binary payloads are persisted as first-class files and surfaced as stable file descriptors instead of inline base64.

## Details
- Added a shared normalizer for file-like tool outputs that detects MCP image/resource blobs and base64+mime payloads, applies mime/size policy checks, and persists accepted payloads via `materializeFile`.
- Wired MCP tool execution to normalize returned `content` blocks into `content` parts with `{ type: 'file', id, name, mimetype, size }` descriptors.
- Updated OpenAPI tool response handling so multipart attachments and binary responses use the same normalization path and policy behavior.
- Refactored satellite tool-result conversion to reuse the shared file normalization logic instead of duplicating file persistence handling.
- Added integration-style tests for MCP image/resource normalization, OpenAPI binary persistence behavior, unsupported mime fallback, and dedup regression on repeated identical payloads.

## Risks
- Behavior for unsupported or oversized binary payloads now explicitly degrades to text fallback instead of leaving raw payloads inline.

## Tests
- `npm run check-types`
- `npx vitest run __tests__/toolOutputNormalization.test.ts`
- `npx vitest run`