### PR TITLE
Default tool-result files to lazy context with read_file (#852)

### DIFF
--- a/__tests__/conversion.test.ts
+++ b/__tests__/conversion.test.ts
@@ -167,10 +167,12 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    delete process.env.CHAT_TOOL_RESULT_EAGER_FILE_INJECTION
+    delete process.env.CHAT_TOOL_RESULT_EAGER_FILE_INJECTION_RULES
     getFileWithId.mockResolvedValue(pdfFile)
   })
 
-  test('converts tool-result PDF files over the limit to text content', async () => {
+  test('keeps tool-result PDF files as descriptor-only by default', async () => {
     ensureFileAnalysis.mockResolvedValue({
       fileId: pdfFile.id,
       kind: 'pdf',
@@ -251,17 +253,20 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
               },
               {
                 type: 'text',
-                text: `The file "${pdfFile.name}" with id ${pdfFile.id} could not be sent as an attachment: it has too many pages (101 pages, limit is 100). It is possible that some tools can return the content on demand`,
+                text: `File content was not inlined to reduce context bloat. Use read_file with id "${pdfFile.id}" (${pdfFile.name}) for on-demand inspection.`,
               },
             ],
           },
         },
       ],
     })
+    expect(getFileWithId).not.toHaveBeenCalled()
     expect(readBuffer).not.toHaveBeenCalled()
+    expect(ensureFileAnalysis).not.toHaveBeenCalled()
   })
 
-  test('converts tool-result PDF files within the limit to file-data', async () => {
+  test('supports eager file injection override by tool/mime rule', async () => {
+    process.env.CHAT_TOOL_RESULT_EAGER_FILE_INJECTION_RULES = 'fetch=application/pdf'
     ensureFileAnalysis.mockResolvedValue({
       fileId: pdfFile.id,
       kind: 'pdf',
@@ -351,10 +356,11 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
         },
       ],
     })
+    expect(getFileWithId).toHaveBeenCalledWith(pdfFile.id)
     expect(readBuffer).toHaveBeenCalledWith(pdfFile.path, false)
   })
 
-  test('converts tool-result file attachments to text for litellm providers', async () => {
+  test('keeps tool-result file attachments as descriptor-only for litellm by default', async () => {
     ensureFileAnalysis.mockResolvedValue({
       fileId: pdfFile.id,
       kind: 'pdf',
@@ -435,17 +441,19 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
               },
               {
                 type: 'text',
-                text: `The tool returned a file attachment "${pdfFile.name}" (${pdfFile.type}, id ${pdfFile.id}) that is available in the UI, but this provider cannot receive binary tool attachments.`,
+                text: `File content was not inlined to reduce context bloat. Use read_file with id "${pdfFile.id}" (${pdfFile.name}) for on-demand inspection.`,
               },
             ],
           },
         },
       ],
     })
+    expect(getFileWithId).not.toHaveBeenCalled()
     expect(readBuffer).not.toHaveBeenCalled()
+    expect(ensureFileAnalysis).not.toHaveBeenCalled()
   })
 
-  test('converts tool-result PDF files to extracted text when the model has no native PDF support', async () => {
+  test('does not eagerly extract text when the model has no native PDF support', async () => {
     extractFromFile.mockResolvedValue('fallback pdf text')
 
     const { dtoMessageToLlmMessage } = await import('@/backend/lib/chat/conversion')
@@ -506,19 +514,20 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
               },
               {
                 type: 'text',
-                text: `Here is the text content of the file "${pdfFile.name}" with id ${pdfFile.id}\nfallback pdf text`,
+                text: `File content was not inlined to reduce context bloat. Use read_file with id "${pdfFile.id}" (${pdfFile.name}) for on-demand inspection.`,
               },
             ],
           },
         },
       ],
     })
-    expect(extractFromFile).toHaveBeenCalledWith(pdfFile)
+    expect(extractFromFile).not.toHaveBeenCalled()
+    expect(getFileWithId).not.toHaveBeenCalled()
     expect(readBuffer).not.toHaveBeenCalled()
     expect(ensureFileAnalysis).not.toHaveBeenCalled()
   })
 
-  test('converts tool-result image attachments to text for litellm providers', async () => {
+  test('keeps tool-result image attachments as descriptor-only for litellm by default', async () => {
     const imageFile = {
       ...pdfFile,
       id: 'img-1',
@@ -586,13 +595,14 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
               },
               {
                 type: 'text',
-                text: `The tool returned a file attachment "${imageFile.name}" (${imageFile.type}, id ${imageFile.id}) that is available in the UI, but this provider cannot receive binary tool attachments.`,
+                text: `File content was not inlined to reduce context bloat. Use read_file with id "${imageFile.id}" (${imageFile.name}) for on-demand inspection.`,
               },
             ],
           },
         },
       ],
     })
+    expect(getFileWithId).not.toHaveBeenCalled()
     expect(readBuffer).not.toHaveBeenCalled()
     expect(ensureFileAnalysis).not.toHaveBeenCalled()
   })

--- a/__tests__/promptTokenCounter.test.ts
+++ b/__tests__/promptTokenCounter.test.ts
@@ -109,7 +109,7 @@ describe('countModelMessageTokens', () => {
 
     expect(llmMessage).toBeDefined()
     const tokens = await countModelMessageTokens(fakeModel, llmMessage!)
-    const placeholderText = `The tool returned a file attachment "${imageFile.name}" (${imageFile.type}, id ${imageFile.id}) that is available in the UI, but this provider cannot receive binary tool attachments.`
+    const placeholderText = `File content was not inlined to reduce context bloat. Use read_file with id "${imageFile.id}" (${imageFile.name}) for on-demand inspection.`
 
     expect(tokens).toBe(
       JSON.stringify({ toolCallId: 'call_456', toolName: 'GenerateImage' }).length +

--- a/__tests__/retrieveFileTool.test.ts
+++ b/__tests__/retrieveFileTool.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const executeTakeFirst = vi.fn()
+const extractFromFile = vi.fn()
+const readBuffer = vi.fn()
+
+vi.mock('@/db/database', () => ({
+  db: {
+    selectFrom: vi.fn(() => ({
+      selectAll: vi.fn(() => ({
+        where: vi.fn(() => ({
+          executeTakeFirst,
+        })),
+      })),
+    })),
+  },
+}))
+
+vi.mock('@/lib/textextraction/cache', () => ({
+  cachingExtractor: {
+    extractFromFile,
+  },
+}))
+
+vi.mock('@/lib/storage', () => ({
+  storage: {
+    readBuffer,
+  },
+}))
+
+describe('file-manager read_file', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns extracted text when available', async () => {
+    const fileEntry = {
+      id: 'file-1',
+      name: 'note.txt',
+      type: 'text/plain',
+      path: 'files/note.txt',
+      encrypted: 0,
+      size: 10,
+    }
+    executeTakeFirst.mockResolvedValue(fileEntry)
+    extractFromFile.mockResolvedValue('hello world')
+
+    const { FileManagerPlugin } = await import('@/backend/lib/tools/retrieve-file/implementation')
+    const plugin = new FileManagerPlugin({ id: 't1', name: 'fm', provisioned: false, promptFragment: '' }, {})
+    const readFile = plugin.functions_.read_file as any
+    const result = await readFile.invoke({ params: { id: 'file-1' } } as any)
+
+    expect(result).toEqual({ type: 'text', value: 'hello world' })
+    expect(readBuffer).not.toHaveBeenCalled()
+  })
+
+  test('falls back to base64 bytes when text extraction is unavailable', async () => {
+    const fileEntry = {
+      id: 'file-2',
+      name: 'bin.dat',
+      type: 'application/octet-stream',
+      path: 'files/bin.dat',
+      encrypted: 1,
+      size: 3,
+    }
+    executeTakeFirst.mockResolvedValue(fileEntry)
+    extractFromFile.mockResolvedValue('')
+    readBuffer.mockResolvedValue(Buffer.from([1, 2, 3]))
+
+    const { FileManagerPlugin } = await import('@/backend/lib/tools/retrieve-file/implementation')
+    const plugin = new FileManagerPlugin({ id: 't1', name: 'fm', provisioned: false, promptFragment: '' }, {})
+    const readFile = plugin.functions_.read_file as any
+    const result = await readFile.invoke({ params: { id: 'file-2' } } as any)
+
+    expect(result).toEqual({ type: 'text', value: Buffer.from([1, 2, 3]).toString('base64') })
+    expect(readBuffer).toHaveBeenCalledWith(fileEntry.path, true)
+  })
+})

--- a/apps/backend/lib/chat/conversion.ts
+++ b/apps/backend/lib/chat/conversion.ts
@@ -7,6 +7,7 @@ import { logger } from '@/lib/logging'
 import { storage } from '@/lib/storage'
 import { LlmModelCapabilities } from '@/lib/chat/models'
 import { cachingExtractor } from '@/lib/textextraction/cache'
+import env from '@/lib/env'
 import {
   acceptableImageTypes,
   canSendAsNativeFile,
@@ -23,6 +24,9 @@ const toolResultAttachmentText = (fileEntry: schema.File) =>
   `The tool returned a file attachment "${fileEntry.name}" (${fileEntry.type}, id ${fileEntry.id}) that is available in the UI, but this provider cannot receive binary tool attachments.`
 type ToolCallResultOutput = ai.ToolResultPart['output']
 
+const toolResultReadFileHint = (file: { id: string; name: string }) =>
+  `File content was not inlined to reduce context bloat. Use read_file with id "${file.id}" (${file.name}) for on-demand inspection.`
+
 const describeAttachedFiles = (
   files: Array<{ id: string; name: string; size: number; mimetype: string }>
 ) => ({
@@ -33,6 +37,43 @@ const describeAttachedFiles = (
     mimetype: f.mimetype,
   })),
 })
+
+type EagerFileRule = {
+  toolPattern: string
+  mimePattern: string
+}
+
+const parseEagerFileRules = (rawRules: string): EagerFileRule[] => {
+  return rawRules
+    .split(';')
+    .map((rule) => rule.trim())
+    .filter((rule) => rule.length > 0)
+    .flatMap((rule) => {
+      const [toolRaw, mimeRaw] = rule.split('=').map((s) => s?.trim() ?? '')
+      if (!toolRaw || !mimeRaw) return []
+      return mimeRaw
+        .split('|')
+        .map((mimePattern) => mimePattern.trim().toLowerCase())
+        .filter((mimePattern) => mimePattern.length > 0)
+        .map((mimePattern) => ({ toolPattern: toolRaw, mimePattern }))
+    })
+}
+
+const patternMatches = (value: string, pattern: string): boolean => {
+  if (pattern === '*') return true
+  if (pattern.endsWith('/*')) return value.startsWith(pattern.slice(0, -1))
+  return value === pattern
+}
+
+const shouldEagerInjectToolFile = (toolName: string, mimeType: string): boolean => {
+  if (env.chat.toolResults.eagerFileInjectionDefault) return true
+  const normalizedMime = mimeType.toLowerCase()
+  const rules = parseEagerFileRules(env.chat.toolResults.eagerFileInjectionRules)
+  return rules.some(
+    (rule) =>
+      patternMatches(toolName, rule.toolPattern) && patternMatches(normalizedMime, rule.mimePattern)
+  )
+}
 
 export const loadImagePartFromFileEntry = async (fileEntry: schema.File): Promise<ai.ImagePart> => {
   const fileContent = await storage.readBuffer(fileEntry.path, !!fileEntry.encrypted)
@@ -166,7 +207,8 @@ export const dtoMessageToLlmMessage = async (
     const results = m.parts.filter((m) => m.type === 'tool-result')
     if (results.length === 0) return undefined
     const convertOutput = async (
-      output: dto.ToolCallResultOutput
+      output: dto.ToolCallResultOutput,
+      toolName: string
     ): Promise<ToolCallResultOutput> => {
       if ((output as dto.ToolCallResultOutput).type) {
         switch (output.type) {
@@ -184,6 +226,12 @@ export const dtoMessageToLlmMessage = async (
                   case 'text':
                     return v
                   case 'file': {
+                    if (!shouldEagerInjectToolFile(toolName, v.mimetype)) {
+                      return {
+                        type: 'text' as const,
+                        text: toolResultReadFileHint(v),
+                      }
+                    }
                     const fileEntry = await getFileWithId(v.id)
                     if (!fileEntry) {
                       throw new Error(`Can't find entry for attachment ${v.id}`)
@@ -223,7 +271,7 @@ export const dtoMessageToLlmMessage = async (
           return {
             toolCallId: result.toolCallId,
             toolName: result.toolName,
-            output: await convertOutput(result.result),
+            output: await convertOutput(result.result, result.toolName),
             type: 'tool-result',
           }
         })

--- a/apps/backend/lib/tools/retrieve-file/implementation.ts
+++ b/apps/backend/lib/tools/retrieve-file/implementation.ts
@@ -12,6 +12,8 @@ import {
 import { db } from '@/db/database'
 import * as dto from '@/types/dto'
 import { LlmModel } from '@/lib/chat/models'
+import { cachingExtractor } from '@/lib/textextraction/cache'
+import { storage } from '@/lib/storage'
 
 export class FileManagerPlugin extends FileManagerPluginInterface implements ToolImplementation {
   static builder: ToolBuilder = (toolParams: ToolParams, params: Record<string, unknown>) =>
@@ -63,6 +65,42 @@ export class FileManagerPlugin extends FileManagerPluginInterface implements Too
               mimetype: fileEntry.type,
             },
           ],
+        }
+      },
+    },
+    read_file: {
+      description:
+        'Read file content on-demand by file id. Returns extracted text when available, otherwise base64 bytes.',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            description: 'file id',
+          },
+        },
+        additionalProperties: false,
+        required: ['id'],
+      },
+      invoke: async ({ params }): Promise<dto.ToolCallResultOutput> => {
+        const fileEntry = await db.selectFrom('File').selectAll().where('id', '=', `${params.id}`).executeTakeFirst()
+        if (!fileEntry) {
+          return {
+            type: 'error-text',
+            value: 'File not found',
+          }
+        }
+        const extractedText = await cachingExtractor.extractFromFile(fileEntry)
+        if (typeof extractedText === 'string' && extractedText.length > 0) {
+          return {
+            type: 'text',
+            value: extractedText,
+          }
+        }
+        const bytes = await storage.readBuffer(fileEntry.path, !!fileEntry.encrypted)
+        return {
+          type: 'text',
+          value: bytes.toString('base64'),
         }
       },
     },

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -124,6 +124,10 @@ const env = {
       maxImgDimPx: parseInt(process.env.CHAT_ATTACHMENTS_MAX_IMG_DIM_PX ?? '2048', 10),
       maxSize: parseInt(process.env.CHAT_ATTACHMENTS_MAX_SIZE ?? '50000000', 10),
     },
+    toolResults: {
+      eagerFileInjectionDefault: process.env.CHAT_TOOL_RESULT_EAGER_FILE_INJECTION === '1',
+      eagerFileInjectionRules: process.env.CHAT_TOOL_RESULT_EAGER_FILE_INJECTION_RULES ?? '',
+    },
     maxOutputTokens: parseOptionalInt(process.env.CHAT_MAX_OUTPUT_TOKENS),
   },
   assistants: {


### PR DESCRIPTION
## Summary
Default tool-result file handling to lazy descriptor-only context to prevent repeated content inlining, and add on-demand file reads via `read_file(id)`.

## Details
- Update tool-result conversion to keep file descriptors in context by default and avoid eager binary/text injection.
- Add configurable eager override controls via `CHAT_TOOL_RESULT_EAGER_FILE_INJECTION` and `CHAT_TOOL_RESULT_EAGER_FILE_INJECTION_RULES` (per tool/mime).
- Add `read_file` to the file-manager tool for ID-based on-demand file inspection (extracted text when available, base64 fallback).
- Update conversion tests for lazy-default behavior and eager-rule override.
- Add `read_file` integration tests.

## Risks
- Existing flows that implicitly relied on eager tool-result file payloads now require a follow-up `read_file` call unless eager override is configured.

## Tests
- `npm run check-types`
- `npx vitest run __tests__/conversion.test.ts __tests__/toolOutputNormalization.test.ts __tests__/retrieveFileTool.test.ts`