### PR TITLE
Add orphan cleanup job for unowned files

### DIFF
--- a/__tests__/fileOrphanCleanup.test.ts
+++ b/__tests__/fileOrphanCleanup.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const selectFromMock = vi.fn()
+const deleteFromMock = vi.fn()
+const storageRmMock = vi.fn()
+const infoMock = vi.fn()
+const warnMock = vi.fn()
+const errorMock = vi.fn()
+
+vi.mock('@/db/database', () => ({
+  db: {
+    selectFrom: selectFromMock,
+    deleteFrom: deleteFromMock,
+  },
+}))
+
+vi.mock('@/lib/storage', () => ({
+  storage: {
+    rm: storageRmMock,
+  },
+}))
+
+vi.mock('@/lib/logging', () => ({
+  logger: {
+    info: infoMock,
+    warn: warnMock,
+    error: errorMock,
+  },
+}))
+
+vi.mock('@/lib/env', () => ({
+  default: {
+    fileOrphanCleanup: {
+      mode: 'off',
+      cadenceMs: 60_000,
+      batchSize: 10,
+    },
+  },
+}))
+
+describe('file orphan cleanup', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  test('findOrphanFiles queries files with no ownership rows', async () => {
+    const executeMock = vi.fn().mockResolvedValue([])
+    const limitMock = vi.fn(() => ({ execute: executeMock }))
+    const whereMock = vi.fn(() => ({ limit: limitMock }))
+    const selectMock = vi.fn(() => ({ where: whereMock }))
+    const leftJoinMock = vi.fn(() => ({ select: selectMock }))
+    selectFromMock.mockReturnValue({ leftJoin: leftJoinMock })
+
+    const { findOrphanFiles } = await import('@/backend/lib/files/orphan-cleanup')
+    await findOrphanFiles(25)
+
+    expect(selectFromMock).toHaveBeenCalledWith('File')
+    expect(leftJoinMock).toHaveBeenCalledWith('FileOwnership', 'FileOwnership.fileId', 'File.id')
+    expect(whereMock).toHaveBeenCalledWith('FileOwnership.id', 'is', null)
+    expect(limitMock).toHaveBeenCalledWith(25)
+    expect(executeMock).toHaveBeenCalled()
+  })
+
+  test('dry-run reports candidates without deleting', async () => {
+    const fileSelectExecuteMock = vi.fn().mockResolvedValue([])
+    const fileLimitMock = vi.fn(() => ({ execute: fileSelectExecuteMock }))
+    const fileWhereMock = vi.fn(() => ({ limit: fileLimitMock }))
+    const fileSelectMock = vi.fn(() => ({ where: fileWhereMock }))
+    const fileLeftJoinMock = vi.fn(() => ({ select: fileSelectMock }))
+    selectFromMock.mockImplementation((table: string) => {
+      if (table === 'File') {
+        return { leftJoin: fileLeftJoinMock }
+      }
+      throw new Error(`unexpected table ${table}`)
+    })
+
+    const { runFileOrphanCleanupPass } = await import('@/backend/lib/files/orphan-cleanup')
+    const summary = await runFileOrphanCleanupPass('dry-run', {
+      db: { selectFrom: selectFromMock, deleteFrom: vi.fn() } as any,
+      storage: { rm: storageRmMock },
+      logger: { info: infoMock, warn: warnMock, error: errorMock },
+    })
+
+    expect(summary.mode).toBe('dry-run')
+    expect(summary.deleted).toBe(0)
+    expect(storageRmMock).not.toHaveBeenCalled()
+  })
+
+  test('delete mode removes orphan blobs first then file rows', async () => {
+    const orphanCandidates = [{ id: 'file-1', path: 'p/1', encrypted: 0 as const }]
+    const fileSelectExecuteMock = vi.fn().mockResolvedValue(orphanCandidates)
+    const fileLimitMock = vi.fn(() => ({ execute: fileSelectExecuteMock }))
+    const fileWhereMock = vi.fn(() => ({ limit: fileLimitMock }))
+    const fileSelectMock = vi.fn(() => ({ where: fileWhereMock }))
+    const fileLeftJoinMock = vi.fn(() => ({ select: fileSelectMock }))
+
+    const ownershipExecuteTakeFirstMock = vi.fn().mockResolvedValue(undefined)
+    const ownershipWhereMock = vi.fn(() => ({ executeTakeFirst: ownershipExecuteTakeFirstMock }))
+    const ownershipSelectMock = vi.fn(() => ({ where: ownershipWhereMock }))
+
+    const deleteExecuteTakeFirstMock = vi.fn().mockResolvedValue({ numDeletedRows: 1 })
+    const deleteWhereMock = vi.fn(() => ({ executeTakeFirst: deleteExecuteTakeFirstMock }))
+
+    selectFromMock.mockImplementation((table: string) => {
+      if (table === 'File') {
+        return { leftJoin: fileLeftJoinMock }
+      }
+      if (table === 'FileOwnership') {
+        return { select: ownershipSelectMock }
+      }
+      throw new Error(`unexpected table ${table}`)
+    })
+
+    deleteFromMock.mockReturnValue({ where: deleteWhereMock })
+
+    const { runFileOrphanCleanupPass } = await import('@/backend/lib/files/orphan-cleanup')
+    const summary = await runFileOrphanCleanupPass('delete')
+
+    expect(summary).toEqual({
+      mode: 'delete',
+      scanned: 1,
+      deleted: 1,
+      failed: 0,
+    })
+    expect(storageRmMock).toHaveBeenCalledWith('p/1')
+    expect(deleteFromMock).toHaveBeenCalledWith('File')
+    expect(deleteWhereMock).toHaveBeenCalledWith('id', '=', 'file-1')
+  })
+
+  test('delete mode never deletes files that gained ownership', async () => {
+    const orphanCandidates = [{ id: 'file-2', path: 'p/2', encrypted: 0 as const }]
+    const fileSelectExecuteMock = vi.fn().mockResolvedValue(orphanCandidates)
+    const fileLimitMock = vi.fn(() => ({ execute: fileSelectExecuteMock }))
+    const fileWhereMock = vi.fn(() => ({ limit: fileLimitMock }))
+    const fileSelectMock = vi.fn(() => ({ where: fileWhereMock }))
+    const fileLeftJoinMock = vi.fn(() => ({ select: fileSelectMock }))
+
+    const ownershipExecuteTakeFirstMock = vi.fn().mockResolvedValue({ id: 'own-1' })
+    const ownershipWhereMock = vi.fn(() => ({ executeTakeFirst: ownershipExecuteTakeFirstMock }))
+    const ownershipSelectMock = vi.fn(() => ({ where: ownershipWhereMock }))
+
+    selectFromMock.mockImplementation((table: string) => {
+      if (table === 'File') {
+        return { leftJoin: fileLeftJoinMock }
+      }
+      if (table === 'FileOwnership') {
+        return { select: ownershipSelectMock }
+      }
+      throw new Error(`unexpected table ${table}`)
+    })
+
+    deleteFromMock.mockReturnValue({
+      where: vi.fn(() => ({ executeTakeFirst: vi.fn() })),
+    })
+
+    const { runFileOrphanCleanupPass } = await import('@/backend/lib/files/orphan-cleanup')
+    const summary = await runFileOrphanCleanupPass('delete')
+
+    expect(summary).toEqual({
+      mode: 'delete',
+      scanned: 1,
+      deleted: 0,
+      failed: 1,
+    })
+    expect(storageRmMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/lib/bootstrap.ts
+++ b/apps/backend/lib/bootstrap.ts
@@ -8,6 +8,7 @@ import env from '@/lib/env'
 import { startSearchWorker } from '@/lib/search/runtime'
 import { TokenizerWorkerRuntime } from '@/backend/lib/chat/tokenizer-worker/runtime'
 import { setTokenizerWorker } from '@/backend/lib/chat/prompt-token-counter'
+import { startFileOrphanCleanupRuntime } from '@/backend/lib/files/orphan-cleanup'
 
 let backendBootstrapped = false
 
@@ -37,6 +38,8 @@ export async function bootstrapBackendRuntime() {
   if (env.search.meiliHost) {
     startSearchWorker()
   }
+
+  startFileOrphanCleanupRuntime()
 
   backendBootstrapped = true
   console.info('Backend runtime bootstrapped')

--- a/apps/backend/lib/files/orphan-cleanup.ts
+++ b/apps/backend/lib/files/orphan-cleanup.ts
@@ -1,0 +1,164 @@
+import type { DB } from '@/db/schema'
+import { db } from '@/db/database'
+import env from '@/lib/env'
+import { logger, type LoggerLike } from '@/lib/logging'
+import { storage } from '@/lib/storage'
+import { type Kysely } from 'kysely'
+
+interface OrphanFileCandidate {
+  id: string
+  path: string
+  encrypted: 0 | 1
+}
+
+export interface OrphanCleanupSummary {
+  mode: 'dry-run' | 'delete'
+  scanned: number
+  deleted: number
+  failed: number
+}
+
+interface OrphanCleanupDeps {
+  db: Kysely<DB>
+  storage: Pick<typeof storage, 'rm'>
+  logger: Pick<LoggerLike, 'info' | 'warn' | 'error'>
+}
+
+const getDependencies = (): OrphanCleanupDeps => ({
+  db,
+  storage,
+  logger,
+})
+
+export const findOrphanFiles = async (
+  batchSize: number,
+  deps: Pick<OrphanCleanupDeps, 'db'> = getDependencies()
+): Promise<OrphanFileCandidate[]> => {
+  return await deps.db
+    .selectFrom('File')
+    .leftJoin('FileOwnership', 'FileOwnership.fileId', 'File.id')
+    .select(['File.id as id', 'File.path as path', 'File.encrypted as encrypted'])
+    .where('FileOwnership.id', 'is', null)
+    .limit(batchSize)
+    .execute()
+}
+
+const hasOwnership = async (
+  fileId: string,
+  deps: Pick<OrphanCleanupDeps, 'db'>
+): Promise<boolean> => {
+  const row = await deps.db
+    .selectFrom('FileOwnership')
+    .select('id')
+    .where('fileId', '=', fileId)
+    .executeTakeFirst()
+  return Boolean(row)
+}
+
+const deleteOrphanFile = async (
+  file: OrphanFileCandidate,
+  deps: OrphanCleanupDeps
+): Promise<'deleted' | 'failed'> => {
+  if (await hasOwnership(file.id, deps)) {
+    deps.logger.info('[file-orphan-cleanup] skipping file that gained ownership', { fileId: file.id })
+    return 'failed'
+  }
+
+  await deps.storage.rm(file.path)
+
+  const result = await deps.db.deleteFrom('File').where('id', '=', file.id).executeTakeFirst()
+  if (Number(result.numDeletedRows ?? 0) !== 1) {
+    deps.logger.warn('[file-orphan-cleanup] expected to delete exactly one file row', {
+      fileId: file.id,
+      numDeletedRows: Number(result.numDeletedRows ?? 0),
+    })
+    return 'failed'
+  }
+
+  return 'deleted'
+}
+
+export const runFileOrphanCleanupPass = async (
+  mode: 'dry-run' | 'delete',
+  deps: OrphanCleanupDeps = getDependencies()
+): Promise<OrphanCleanupSummary> => {
+  const batchSize = Math.max(1, env.fileOrphanCleanup.batchSize)
+  const candidates = await findOrphanFiles(batchSize, deps)
+  const summary: OrphanCleanupSummary = {
+    mode,
+    scanned: candidates.length,
+    deleted: 0,
+    failed: 0,
+  }
+
+  if (mode === 'dry-run') {
+    deps.logger.info('[file-orphan-cleanup] dry-run completed', {
+      ...summary,
+      candidateFileIds: candidates.map((file) => file.id),
+    })
+    return summary
+  }
+
+  for (const file of candidates) {
+    try {
+      const status = await deleteOrphanFile(file, deps)
+      if (status === 'deleted') {
+        summary.deleted += 1
+      } else {
+        summary.failed += 1
+      }
+    } catch (err) {
+      summary.failed += 1
+      deps.logger.error('[file-orphan-cleanup] failed deleting orphan file', {
+        fileId: file.id,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  deps.logger.info('[file-orphan-cleanup] delete pass completed', summary)
+  return summary
+}
+
+let timer: NodeJS.Timeout | undefined
+let running = false
+
+const scheduleNext = (intervalMs: number, callback: () => Promise<void>) => {
+  if (timer) clearTimeout(timer)
+  timer = setTimeout(async () => {
+    await callback()
+    scheduleNext(intervalMs, callback)
+  }, intervalMs)
+}
+
+export const startFileOrphanCleanupRuntime = () => {
+  const { mode } = env.fileOrphanCleanup
+  if (mode === 'off') {
+    logger.info('[file-orphan-cleanup] runtime disabled (mode=off)')
+    return
+  }
+
+  const cadenceMs = Math.max(1_000, env.fileOrphanCleanup.cadenceMs)
+  logger.info('[file-orphan-cleanup] runtime enabled', {
+    mode,
+    cadenceMs,
+    batchSize: Math.max(1, env.fileOrphanCleanup.batchSize),
+  })
+
+  const runOnce = async () => {
+    if (running) {
+      logger.warn('[file-orphan-cleanup] previous run still in progress; skipping tick')
+      return
+    }
+    running = true
+    try {
+      await runFileOrphanCleanupPass(mode)
+    } finally {
+      running = false
+    }
+  }
+
+  void runOnce()
+  scheduleNext(cadenceMs, runOnce)
+}
+

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -9,6 +9,13 @@ function parseOptionalFloat(text?: string) {
   return Number.isNaN(value) ? undefined : value
 }
 
+function parseCleanupMode(raw?: string): 'off' | 'dry-run' | 'delete' {
+  if (raw === 'dry-run' || raw === 'delete' || raw === 'off') {
+    return raw
+  }
+  return 'off'
+}
+
 const env = {
   databaseUrl: `${process.env.DATABASE_URL}`,
   appUrl: `${process.env.APP_URL}`,
@@ -152,6 +159,11 @@ const env = {
   },
   fileAnalysis: {
     waitMs: parseOptionalInt(process.env.FILE_ANALYSIS_WAIT_MS) ?? 10_000,
+  },
+  fileOrphanCleanup: {
+    mode: parseCleanupMode(process.env.FILE_ORPHAN_CLEANUP_MODE),
+    cadenceMs: parseOptionalInt(process.env.FILE_ORPHAN_CLEANUP_CADENCE_MS) ?? 10 * 60 * 1000,
+    batchSize: parseOptionalInt(process.env.FILE_ORPHAN_CLEANUP_BATCH_SIZE) ?? 100,
   },
   apiKeys: {
     enable: process.env.ENABLE_APIKEYS === '1',


### PR DESCRIPTION
## Summary
Adds a scheduled backend cleanup runtime for orphaned files (files with zero `FileOwnership` rows) with safe `dry-run` and `delete` modes, including scan/delete/failure logging and startup wiring so cleanup can run continuously on a configurable cadence.

## Details
- Adds `apps/backend/lib/files/orphan-cleanup.ts` with orphan detection, dry-run reporting, and delete-path cleanup.
- In delete mode, removes storage blob first and then deletes the `File` row.
- Re-checks ownership before delete to avoid removing files that gained ownership after initial scan.
- Adds environment config in `packages/core/src/env.ts`:
- `FILE_ORPHAN_CLEANUP_MODE` (`off` | `dry-run` | `delete`, default `off`).
- `FILE_ORPHAN_CLEANUP_CADENCE_MS` (default `600000`).
- `FILE_ORPHAN_CLEANUP_BATCH_SIZE` (default `100`).
- Starts the runtime from backend bootstrap in `apps/backend/lib/bootstrap.ts`.
- Adds tests in `__tests__/fileOrphanCleanup.test.ts` for orphan query behavior and safe deletion behavior.

## Tests
- `npm run check-types` (pass)
- `npx vitest run __tests__/fileOrphanCleanup.test.ts` (pass)
- `npx vitest run` (pass)