### PR TITLE
Drop displayName from FileOwnership

### DIFF
--- a/apps/backend/db/migrations/20260502-file_ownership.ts
+++ b/apps/backend/db/migrations/20260502-file_ownership.ts
@@ -16,7 +16,7 @@ export async function up(db: Kysely<any>, dialect: 'sqlite' | 'postgresql'): Pro
       .addColumn('fileId', 'text', (col) => col.notNull())
       .addColumn('ownerType', sql`"FileOwnerType"`, (col) => col.notNull())
       .addColumn('ownerId', 'text', (col) => col.notNull())
-      .addColumn('displayName', 'text')
+
       .addColumn('createdAt', 'text', (col) => col.notNull())
       .addForeignKeyConstraint('fk_FileOwnership_File', ['fileId'], 'File', ['id'], (cb) =>
         cb.onDelete('cascade')
@@ -34,7 +34,7 @@ export async function up(db: Kysely<any>, dialect: 'sqlite' | 'postgresql'): Pro
       .addColumn('fileId', 'text', (col) => col.notNull())
       .addColumn('ownerType', 'text', (col) => col.notNull())
       .addColumn('ownerId', 'text', (col) => col.notNull())
-      .addColumn('displayName', 'text')
+
       .addColumn('createdAt', 'text', (col) => col.notNull())
       .addForeignKeyConstraint('fk_FileOwnership_File', ['fileId'], 'File', ['id'], (cb) =>
         cb.onDelete('cascade')

--- a/apps/backend/db/schema.ts
+++ b/apps/backend/db/schema.ts
@@ -136,7 +136,6 @@ export interface FileOwnership {
   fileId: string
   ownerType: FileOwnerType
   ownerId: string
-  displayName: string | null
   createdAt: string
 }
 

--- a/apps/backend/lib/files/materialize.ts
+++ b/apps/backend/lib/files/materialize.ts
@@ -8,7 +8,6 @@ import { createHash } from 'node:crypto'
 export interface FileOwnerRef {
   ownerType: schema.FileOwnerType
   ownerId: string
-  displayName?: string | null
 }
 
 export interface MaterializeFileParams {
@@ -42,14 +41,9 @@ const upsertOwnership = async (
       fileId,
       ownerType: owner.ownerType,
       ownerId: owner.ownerId,
-      displayName: owner.displayName ?? null,
       createdAt: timestamp,
     })
-    .onConflict((oc) =>
-      oc.columns(['fileId', 'ownerType', 'ownerId']).doUpdateSet({
-        displayName: owner.displayName ?? null,
-      })
-    )
+    .onConflict((oc) => oc.columns(['fileId', 'ownerType', 'ownerId']).doNothing())
     .execute()
 }
 
@@ -99,7 +93,6 @@ export const materializeFile = async (params: MaterializeFileParams): Promise<sc
         fileId,
         ownerType: params.owner.ownerType,
         ownerId: params.owner.ownerId,
-        displayName: params.owner.displayName ?? null,
         createdAt: timestamp,
       })
       .execute()

--- a/apps/backend/lib/tools/audio_transcription/implementation.ts
+++ b/apps/backend/lib/tools/audio_transcription/implementation.ts
@@ -218,7 +218,7 @@ export class AudioTranscription extends AudioTranscriptionInterface implements T
         content: transcriptBuffer,
         name: transcriptFileName,
         mimeType: 'text/plain',
-        owner: resolveFileOwner({ rootOwner, conversationId, userId, assistantId }, transcriptFileName),
+        owner: resolveFileOwner({ rootOwner, conversationId, userId, assistantId }),
       })
 
       return {

--- a/apps/backend/lib/tools/code_interpreter/implementation.ts
+++ b/apps/backend/lib/tools/code_interpreter/implementation.ts
@@ -272,7 +272,7 @@ export class CodeInterpreter
           response.headers.get('content-type') ??
           mimeTypeOfFile(fileName) ??
           'application/octet-stream',
-        owner: resolveFileOwner({ rootOwner, conversationId, userId, assistantId }, fileName),
+        owner: resolveFileOwner({ rootOwner, conversationId, userId, assistantId }),
       })
       storedMetadata.push({ file_id: file.fileId, stored_id: dbFile.id })
       storedFiles.value.push({

--- a/apps/backend/lib/tools/file-output-normalization.ts
+++ b/apps/backend/lib/tools/file-output-normalization.ts
@@ -113,7 +113,7 @@ export const persistFileLikePayload = async (
     content: bytes,
     name: fileName,
     mimeType,
-    owner: resolveFileOwner(params, fileName),
+    owner: resolveFileOwner(params),
   })
   return { kind: 'file', value: toFilePart(dbFile) }
 }

--- a/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
@@ -249,7 +249,7 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
         content: imgBinaryData,
         name,
         mimeType,
-        owner: resolveFileOwner(ownerContext, name),
+        owner: resolveFileOwner(ownerContext),
       })
       result.value.push({
         type: 'file',

--- a/apps/backend/lib/tools/imagegenerator/implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/implementation.ts
@@ -206,7 +206,7 @@ export class ImageGeneratorPlugin
         content: imgBinaryData,
         name,
         mimeType: 'image/png',
-        owner: resolveFileOwner(ownerContext, name),
+        owner: resolveFileOwner(ownerContext),
       })
       result.value.push({
         type: 'file' as const,

--- a/apps/backend/lib/tools/ownership.ts
+++ b/apps/backend/lib/tools/ownership.ts
@@ -2,34 +2,29 @@ import type { FileOwnerRef } from '@/backend/lib/files/materialize'
 import type { ToolInvokeParams } from '@/lib/chat/tools'
 
 export const resolveFileOwner = (
-  params: Pick<ToolInvokeParams, 'rootOwner' | 'conversationId' | 'userId' | 'assistantId'>,
-  displayName: string
+  params: Pick<ToolInvokeParams, 'rootOwner' | 'conversationId' | 'userId' | 'assistantId'>
 ): FileOwnerRef => {
   const rootOwner = params.rootOwner
   if (rootOwner) {
     return {
       ownerType: rootOwner.type,
       ownerId: rootOwner.id,
-      displayName,
     }
   }
   if (params.conversationId) {
     return {
       ownerType: 'CHAT',
       ownerId: params.conversationId,
-      displayName,
     }
   }
   if (params.userId) {
     return {
       ownerType: 'USER',
       ownerId: params.userId,
-      displayName,
     }
   }
   return {
     ownerType: 'ASSISTANT',
     ownerId: params.assistantId,
-    displayName,
   }
 }


### PR DESCRIPTION
## Summary

Removes the `displayName` column from `FileOwnership`. The column was added with the ownership schema but never populated with anything different from `File.name`. `FileOwnership` is an authorization primitive — per-context display names belong on caller-site join tables (e.g. `AssistantVersionFile`) if a concrete need arises.

## Details

- `displayName` removed from the `FileOwnership` creation migration (never shipped, so no drop migration needed)
- `FileOwnerRef` interface simplified; `resolveFileOwner` no longer takes a `displayName` argument
- `onConflict` handler in `materializeFile` simplified to `doNothing` (nothing left to update)

## Tests

- `npm run check-types` — clean