### PR TITLE
Deduplicate user uploads by hashing content on PUT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
 <!-- Project instructions live in AGENTS.md — see that file. -->
 
 @AGENTS.md
+
+## Claude-specific notes
+
+- Before running any `npm` or `npx` command, activate the correct Node version: `source ~/.nvm/nvm.sh && nvm use 24`.

--- a/__tests__/fileDeduplication.test.ts
+++ b/__tests__/fileDeduplication.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+// ── shared mocks ──────────────────────────────────────────────────────────────
+
+const selectFromMock = vi.fn()
+const deleteFromMock = vi.fn()
+const updateTableMock = vi.fn()
+const insertIntoMock = vi.fn()
+const transactionMock = vi.fn()
+const storageWriteBufferMock = vi.fn()
+const storageRmMock = vi.fn()
+
+vi.mock('@/db/database', () => ({
+  db: {
+    selectFrom: selectFromMock,
+    deleteFrom: deleteFromMock,
+    updateTable: updateTableMock,
+    insertInto: insertIntoMock,
+    transaction: () => ({ execute: transactionMock }),
+  },
+}))
+
+vi.mock('@/lib/storage', () => ({
+  storage: {
+    writeBuffer: storageWriteBufferMock,
+    rm: storageRmMock,
+  },
+}))
+
+vi.mock('@/lib/env', () => ({
+  default: {
+    fileStorage: { encryptFiles: false },
+  },
+}))
+
+vi.mock('nanoid', () => ({ nanoid: () => 'test-id' }))
+
+// Builds a selectFrom chain: .select().where().where().where().executeTakeFirst()
+function makeSelectChain(result: unknown) {
+  const executeTakeFirstMock = vi.fn().mockResolvedValue(result)
+  const terminal = { executeTakeFirst: executeTakeFirstMock }
+  const w3 = vi.fn(() => terminal)
+  const w2 = vi.fn(() => ({ where: w3 }))
+  const w1 = vi.fn(() => ({ where: w2 }))
+  const selectMock = vi.fn(() => ({ where: w1 }))
+  return { chain: { select: selectMock }, executeTakeFirstMock }
+}
+
+// ── finalizeUploadedFile ──────────────────────────────────────────────────────
+
+describe('finalizeUploadedFile', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  test('returns null and marks file uploaded when no duplicate exists', async () => {
+    const { chain } = makeSelectChain(undefined)
+    selectFromMock.mockReturnValue(chain)
+
+    const updateExecuteMock = vi.fn().mockResolvedValue(undefined)
+    const updateWhereMock = vi.fn(() => ({ execute: updateExecuteMock }))
+    const updateSetMock = vi.fn(() => ({ where: updateWhereMock }))
+    updateTableMock.mockReturnValue({ set: updateSetMock })
+
+    const { finalizeUploadedFile } = await import('@/backend/lib/files/upload-dedup')
+    const result = await finalizeUploadedFile({
+      fileId: 'new-id',
+      filePath: 'new-id-file.pdf',
+      contentHash: 'abc123',
+    })
+
+    expect(result).toBeNull()
+    expect(updateTableMock).toHaveBeenCalledWith('File')
+    expect(updateSetMock).toHaveBeenCalledWith({ uploaded: 1, contentHash: 'abc123' })
+    expect(storageRmMock).not.toHaveBeenCalled()
+    expect(deleteFromMock).not.toHaveBeenCalled()
+  })
+
+  test('returns canonical ID, removes new blob, and deletes new File row when duplicate exists', async () => {
+    const { chain } = makeSelectChain({ id: 'existing-id' })
+    selectFromMock.mockReturnValue(chain)
+
+    storageRmMock.mockResolvedValue(undefined)
+    const deleteExecuteMock = vi.fn().mockResolvedValue(undefined)
+    const deleteWhereMock = vi.fn(() => ({ execute: deleteExecuteMock }))
+    deleteFromMock.mockReturnValue({ where: deleteWhereMock })
+
+    const { finalizeUploadedFile } = await import('@/backend/lib/files/upload-dedup')
+    const result = await finalizeUploadedFile({
+      fileId: 'new-id',
+      filePath: 'new-id-file.pdf',
+      contentHash: 'abc123',
+    })
+
+    expect(result).toBe('existing-id')
+    expect(storageRmMock).toHaveBeenCalledWith('new-id-file.pdf')
+    expect(deleteFromMock).toHaveBeenCalledWith('File')
+    expect(deleteWhereMock).toHaveBeenCalledWith('id', '=', 'new-id')
+    expect(updateTableMock).not.toHaveBeenCalled()
+  })
+
+  test('does not delete File row if storage.rm throws', async () => {
+    const { chain } = makeSelectChain({ id: 'existing-id' })
+    selectFromMock.mockReturnValue(chain)
+
+    storageRmMock.mockRejectedValue(new Error('storage failure'))
+
+    const { finalizeUploadedFile } = await import('@/backend/lib/files/upload-dedup')
+    await expect(
+      finalizeUploadedFile({ fileId: 'new-id', filePath: 'new-id-file.pdf', contentHash: 'abc123' })
+    ).rejects.toThrow('storage failure')
+
+    expect(deleteFromMock).not.toHaveBeenCalled()
+  })
+})
+
+// ── materializeFile deduplication ─────────────────────────────────────────────
+
+describe('materializeFile deduplication', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  const existingFile = {
+    id: 'existing-id',
+    name: 'photo.png',
+    path: 'existing-id-photo-png',
+    type: 'image/png',
+    size: 1024,
+    uploaded: 1 as const,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    encrypted: 0 as const,
+    contentHash: 'deadbeef',
+  }
+
+  // materializeFile hash lookup: .selectAll().where().where().executeTakeFirst()
+  function makeHashLookupChain(result: unknown) {
+    const executeTakeFirstMock = vi.fn().mockResolvedValue(result)
+    const w2 = vi.fn(() => ({ executeTakeFirst: executeTakeFirstMock }))
+    const w1 = vi.fn(() => ({ where: w2 }))
+    const selectAllMock = vi.fn(() => ({ where: w1 }))
+    return { chain: { selectAll: selectAllMock } }
+  }
+
+  // getFileWithId lookup: .selectAll().where().executeTakeFirst()
+  function makeGetByIdChain(result: unknown) {
+    const executeTakeFirstMock = vi.fn().mockResolvedValue(result)
+    const whereMock = vi.fn(() => ({ executeTakeFirst: executeTakeFirstMock }))
+    const selectAllMock = vi.fn(() => ({ where: whereMock }))
+    return { chain: { selectAll: selectAllMock } }
+  }
+
+  test('reuses existing File row when content hash matches', async () => {
+    const { chain } = makeHashLookupChain(existingFile)
+    selectFromMock.mockReturnValue(chain)
+
+    const insertExecuteMock = vi.fn().mockResolvedValue(undefined)
+    insertIntoMock.mockReturnValue({
+      values: vi.fn(() => ({
+        onConflict: vi.fn(() => ({ execute: insertExecuteMock })),
+      })),
+    })
+
+    const { materializeFile } = await import('@/backend/lib/files/materialize')
+    const result = await materializeFile({
+      content: Buffer.from('hello'),
+      name: 'photo.png',
+      mimeType: 'image/png',
+      owner: { ownerType: 'CHAT', ownerId: 'chat-1' },
+    })
+
+    expect(result.id).toBe('existing-id')
+    expect(storageWriteBufferMock).not.toHaveBeenCalled()
+    expect(insertIntoMock).toHaveBeenCalledWith('FileOwnership')
+  })
+
+  test('writes blob and inserts new File and FileOwnership rows when no hash match', async () => {
+    const newFile = { ...existingFile, id: 'test-id', contentHash: 'newhash' }
+
+    // First call: hash lookup → no match; second call: getFileWithId → new file
+    const { chain: hashChain } = makeHashLookupChain(undefined)
+    const { chain: getByIdChain } = makeGetByIdChain(newFile)
+    selectFromMock.mockReturnValueOnce(hashChain).mockReturnValueOnce(getByIdChain)
+
+    storageWriteBufferMock.mockResolvedValue(undefined)
+
+    const insertFileExecuteMock = vi.fn().mockResolvedValue(undefined)
+    const insertOwnershipExecuteMock = vi.fn().mockResolvedValue(undefined)
+    transactionMock.mockImplementation(async (fn: (trx: any) => Promise<void>) => {
+      const trx = {
+        insertInto: vi.fn((table: string) => {
+          if (table === 'FileOwnership') {
+            return { values: vi.fn(() => ({ execute: insertOwnershipExecuteMock })) }
+          }
+          return { values: vi.fn(() => ({ execute: insertFileExecuteMock })) }
+        }),
+      }
+      await fn(trx)
+    })
+
+    const { materializeFile } = await import('@/backend/lib/files/materialize')
+    const result = await materializeFile({
+      content: Buffer.from('new content'),
+      name: 'doc.pdf',
+      mimeType: 'application/pdf',
+      owner: { ownerType: 'CHAT', ownerId: 'chat-2' },
+    })
+
+    expect(result.id).toBe('test-id')
+    expect(storageWriteBufferMock).toHaveBeenCalledOnce()
+    expect(insertFileExecuteMock).toHaveBeenCalledOnce()
+    expect(insertOwnershipExecuteMock).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/backend/api/files/[fileId]/content/route.ts
+++ b/apps/backend/api/files/[fileId]/content/route.ts
@@ -1,9 +1,11 @@
 import { db } from '@/db/database'
 import { canAccessFile } from '@/backend/lib/files/authorization'
-import { error, noBody, notFound, forbidden, operation, responseSpec, errorSpec } from '@/lib/routes'
+import { error, noBody, notFound, forbidden, ok, operation, responseSpec, errorSpec } from '@/lib/routes'
 import { storage } from '@/lib/storage'
 import { logger } from '@/lib/logging'
 import { scheduleFileAnalysisForFile } from '@/lib/file-analysis'
+import { finalizeUploadedFile } from '@/backend/lib/files/upload-dedup'
+import { createHash } from 'node:crypto'
 import { z } from 'zod'
 
 // A synchronized tee, i.e. faster reader has to wait
@@ -52,10 +54,18 @@ function _synchronizedTee(
   return [result[0], result[1]]
 }
 
+const deduplicatedFileSchema = z.object({ id: z.string() })
+
 export const PUT = operation({
   name: 'Upload file content',
   authentication: 'user',
-  responses: [responseSpec(204), errorSpec(400), errorSpec(404), errorSpec(500)] as const,
+  responses: [
+    responseSpec(204),
+    responseSpec(200, deduplicatedFileSchema),
+    errorSpec(400),
+    errorSpec(404),
+    errorSpec(500),
+  ] as const,
   implementation: async ({ params, request, signal }) => {
     const file = await db
       .selectFrom('File')
@@ -78,21 +88,40 @@ export const PUT = operation({
       return error(400, 'Missing body')
     }
 
+    const hash = createHash('sha256')
+    const hashingStream = requestBodyStream.pipeThrough(
+      new TransformStream<Uint8Array, Uint8Array>({
+        transform(chunk, controller) {
+          hash.update(chunk)
+          controller.enqueue(chunk)
+        },
+      })
+    )
+
     try {
-      await storage.writeStream(file.path, requestBodyStream, !!file.encrypted)
+      await storage.writeStream(file.path, hashingStream, !!file.encrypted)
     } catch (e) {
       if (clientDisconnected) {
         logger.error('Upload aborted by user')
-        // The client has gone away. It is quite unlikely that this response will reach it
         return error(500, 'Upload aborted')
       } else {
         logger.error('Upload failure', e)
         return error(500, 'Upload failure')
       }
     }
-    await db.updateTable('File').set({ uploaded: 1 }).where('id', '=', params.fileId).execute()
-    scheduleFileAnalysisForFile(file)
 
+    const contentHash = hash.digest('hex')
+    const canonicalId = await finalizeUploadedFile({
+      fileId: params.fileId,
+      filePath: file.path,
+      contentHash,
+    })
+
+    if (canonicalId) {
+      return ok({ id: canonicalId })
+    }
+
+    scheduleFileAnalysisForFile(file)
     return noBody()
   },
 })

--- a/apps/backend/lib/files/upload-dedup.ts
+++ b/apps/backend/lib/files/upload-dedup.ts
@@ -1,0 +1,35 @@
+import { db } from '@/db/database'
+import { storage } from '@/lib/storage'
+
+/**
+ * Called after the upload stream has been written to storage.
+ * Checks for an existing file with the same content hash.
+ * - Duplicate found: deletes the just-written blob and File row, returns canonical file ID.
+ * - No duplicate: marks the file as uploaded with its hash, returns null.
+ */
+export const finalizeUploadedFile = async (params: {
+  fileId: string
+  filePath: string
+  contentHash: string
+}): Promise<string | null> => {
+  const duplicate = await db
+    .selectFrom('File')
+    .select(['id'])
+    .where('contentHash', '=', params.contentHash)
+    .where('id', '!=', params.fileId)
+    .where('uploaded', '=', 1)
+    .executeTakeFirst()
+
+  if (duplicate) {
+    await storage.rm(params.filePath)
+    await db.deleteFrom('File').where('id', '=', params.fileId).execute()
+    return duplicate.id
+  }
+
+  await db
+    .updateTable('File')
+    .set({ uploaded: 1, contentHash: params.contentHash })
+    .where('id', '=', params.fileId)
+    .execute()
+  return null
+}

--- a/apps/frontend/app/admin/tools/components/ToolKnowledgeSection.tsx
+++ b/apps/frontend/app/admin/tools/components/ToolKnowledgeSection.tsx
@@ -145,8 +145,9 @@ export const ToolKnowledgeSection = ({ form }: ToolKnowledgeSectionProps) => {
     xhr.onreadystatechange = () => {
       if (xhr.readyState !== XMLHttpRequest.DONE) return
       if (xhr.status >= 200 && xhr.status < 300) {
+        const canonicalId: string = xhr.response?.id ?? id
         uploadsRef.current = uploadsRef.current.map((u) =>
-          u.fileId === id ? { ...u, progress: 1, done: true } : u
+          u.fileId === id ? { ...u, fileId: canonicalId, progress: 1, done: true } : u
         )
         syncState()
         rebuildFormFiles()

--- a/apps/frontend/app/assistants/components/KnowledgeTabPanel.tsx
+++ b/apps/frontend/app/assistants/components/KnowledgeTabPanel.tsx
@@ -175,8 +175,9 @@ export const KnowledgeTabPanel = ({ form, visible, className, modelId, onHasWarn
         return
       }
       if (xhr.status >= 200 && xhr.status < 300) {
+        const canonicalId: string = xhr.response?.id ?? id
         uploadsRef.current = uploadsRef.current.map((u) =>
-          u.fileId === id ? { ...u, progress: 1, done: true } : u
+          u.fileId === id ? { ...u, fileId: canonicalId, progress: 1, done: true } : u
         )
         syncState()
         rebuildFormFiles()

--- a/apps/frontend/app/chat/components/ChatInput.tsx
+++ b/apps/frontend/app/chat/components/ChatInput.tsx
@@ -413,8 +413,9 @@ export const ChatInput = ({
     xhr.onreadystatechange = () => {
       if (xhr.readyState !== XMLHttpRequest.DONE) return
       if (xhr.status >= 200 && xhr.status < 300) {
+        const canonicalId: string = xhr.response?.id ?? id
         uploadedFiles.current = uploadedFiles.current.map((u) =>
-          u.fileId === id ? { ...u, done: true } : u
+          u.fileId === id ? { ...u, fileId: canonicalId, done: true } : u
         )
         setRefresh(Math.random())
       } else {


### PR DESCRIPTION
## Summary

Extends content-hash deduplication to user uploads. The \`PUT /api/files/:id/content\` handler now hashes the incoming stream incrementally via a \`TransformStream\` while writing to storage. After the write, if a \`File\` row with the same SHA-256 already exists, the just-written blob and the placeholder \`File\` row are deleted and the canonical file ID is returned as \`200 { id }\`. If no duplicate is found, the file is marked uploaded with its hash and \`204\` is returned as before.

## Details

- Dedup logic extracted into \`apps/backend/lib/files/upload-dedup.ts\` for testability
- All three frontend upload call sites (\`ChatInput\`, \`KnowledgeTabPanel\`, \`ToolKnowledgeSection\`) swap their tracked \`fileId\` to the canonical ID on a \`200\` response
- \`contentHash\` is now populated for all user uploads, not just tool outputs
- Storage blob is deleted before the \`File\` row — if \`rm\` throws, the row is left intact for orphan cleanup to handle

## Tests

- \`npm run check-types\` — clean
- 5 new unit tests in \`__tests__/fileDeduplication.test.ts\` covering \`finalizeUploadedFile\` (no-dup, dup cleanup, rm-failure safety) and \`materializeFile\` (hash match reuse, new file write)
- Full test suite: 652 tests passing on Node 24