### PR TITLE
Allow shared-conversation file access in CHAT authorization

### DIFF
--- a/__tests__/fileAuthorization.test.ts
+++ b/__tests__/fileAuthorization.test.ts
@@ -8,6 +8,8 @@ const getUserWorkspaceMembershipsMock = vi.fn()
 
 const tables: Record<string, Row[]> = {
   Conversation: [],
+  ConversationSharing: [],
+  Message: [],
   Tool: [],
   ToolSharing: [],
   User: [],
@@ -42,6 +44,8 @@ function mockDbQueries() {
     const builder = {
       select: vi.fn(() => builder),
       selectAll: vi.fn(() => builder),
+      // innerJoin is a no-op in the mock; test data must be pre-joined (denormalized rows)
+      innerJoin: vi.fn(() => builder),
       where: vi.fn((column: string, op: string, value: unknown) => {
         whereClauses.push({ column, op, value })
         return builder
@@ -81,6 +85,27 @@ describe('file authorization', () => {
     const { canAccess } = await import('@/backend/lib/files/authorization')
     await expect(canAccess({ userId: 'u1' }, 'CHAT', 'c1')).resolves.toBe(true)
     await expect(canAccess({ userId: 'u2' }, 'CHAT', 'c1')).resolves.toBe(false)
+  })
+
+  test('canAccess CHAT allows any authenticated user when conversation is shared', async () => {
+    tables.Conversation.push({ id: 'c-shared', ownerId: 'u-owner' })
+    // Denormalized: ConversationSharing row includes Message.conversationId for the mock join
+    tables.ConversationSharing.push({
+      id: 'share-1',
+      lastMessageId: 'msg-1',
+      'Message.conversationId': 'c-shared',
+    })
+
+    const { canAccess } = await import('@/backend/lib/files/authorization')
+    await expect(canAccess({ userId: 'u-owner' }, 'CHAT', 'c-shared')).resolves.toBe(true)
+    await expect(canAccess({ userId: 'u-stranger' }, 'CHAT', 'c-shared')).resolves.toBe(true)
+  })
+
+  test('canAccess CHAT denies non-owner when conversation is not shared', async () => {
+    tables.Conversation.push({ id: 'c-private', ownerId: 'u-owner' })
+
+    const { canAccess } = await import('@/backend/lib/files/authorization')
+    await expect(canAccess({ userId: 'u-stranger' }, 'CHAT', 'c-private')).resolves.toBe(false)
   })
 
   test('canAccess ASSISTANT owner type (positive and negative)', async () => {

--- a/apps/backend/lib/files/authorization.ts
+++ b/apps/backend/lib/files/authorization.ts
@@ -56,7 +56,17 @@ export const canAccess = async (
         .select('ownerId')
         .where('id', '=', ownerId)
         .executeTakeFirst()
-      return conversation?.ownerId === normalizedUser.id
+      if (conversation?.ownerId === normalizedUser.id) return true
+      // Any authenticated user can access files from a shared conversation.
+      const share = await db
+        .selectFrom('ConversationSharing')
+        .innerJoin('Message', (join) =>
+          join.onRef('Message.id', '=', 'ConversationSharing.lastMessageId')
+        )
+        .where('Message.conversationId', '=', ownerId)
+        .select('ConversationSharing.id')
+        .executeTakeFirst()
+      return !!share
     }
     case 'ASSISTANT':
       return await canUserAccessAssistant(normalizedUser.id, ownerId)


### PR DESCRIPTION
## Summary

Fixes a gap in the file authorization service where files owned by a shared conversation were inaccessible to non-owners. The \`CHAT\` case in \`canAccess\` now checks \`ConversationSharing\` when the requesting user is not the conversation owner — if any share row exists, access is granted. This matches the existing behavior of \`GET /api/share/:shareId\`, which allows any authenticated user to view a shared conversation.

## Details

- \`canAccess('CHAT', conversationId)\` falls through to a \`ConversationSharing\` lookup when the user is not the owner
- No change to the public API surface; the fix is internal to the authorization service

## Tests

- \`npm run check-types\` — clean
- 2 new test cases in \`fileAuthorization.test.ts\`: shared conversation grants access to non-owners; unshared conversation denies non-owners
- All 8 authorization tests passing