### PR TITLE
Assign FileOwnership rows on user file upload

### DIFF
--- a/apps/backend/api/files/route.ts
+++ b/apps/backend/api/files/route.ts
@@ -1,3 +1,4 @@
+import { db } from '@/db/database'
 import env from '@/lib/env'
 import { ok, operation, responseSpec } from '@/lib/routes'
 import { addFile } from '@/models/file'
@@ -10,11 +11,21 @@ export const POST = operation({
   authentication: 'user',
   requestBodySchema: dto.insertableFileSchema,
   responses: [responseSpec(201, dto.fileSchema)] as const,
-  implementation: async ({ body }) => {
+  implementation: async ({ body, session }) => {
     const id = nanoid()
-    const file = body
-    const path = `${id}-${file.name.replace(/(\W+)/gi, '-')}`
-    const created = await addFile(file, path, env.fileStorage.encryptFiles)
+    const path = `${id}-${body.name.replace(/(\W+)/gi, '-')}`
+    const created = await addFile(body, path, env.fileStorage.encryptFiles)
+    const owner = body.owner ?? { ownerType: 'USER' as const, ownerId: session.userId }
+    await db
+      .insertInto('FileOwnership')
+      .values({
+        id: nanoid(),
+        fileId: created.id,
+        ownerType: owner.ownerType,
+        ownerId: owner.ownerId,
+        createdAt: new Date().toISOString(),
+      })
+      .execute()
     return ok(created, 201)
   },
 })

--- a/apps/frontend/app/admin/tools/[id]/page.tsx
+++ b/apps/frontend/app/admin/tools/[id]/page.tsx
@@ -49,7 +49,7 @@ const ToolPage = () => {
       error={error}
       title={`Tool ${tool?.name ?? ''}`}
     >
-      {tool && <ToolForm tool={tool} type={tool.type} onSubmit={onSubmit} />}
+      {tool && <ToolForm tool={tool} type={tool.type} toolId={tool.id} onSubmit={onSubmit} />}
       {tool && sharingDialogVisible && (
         <ToolSharingDialog
           onClose={() => {

--- a/apps/frontend/app/admin/tools/components/ToolForm.tsx
+++ b/apps/frontend/app/admin/tools/components/ToolForm.tsx
@@ -54,6 +54,7 @@ interface Props {
   className?: string
   type: ToolType
   tool: dto.InsertableTool
+  toolId?: string
   onSubmit: (tool: dto.UpdateableTool) => void
 }
 
@@ -96,7 +97,7 @@ const configurationSchema = (type: ToolType, apiKeys: string[]) => {
   }
 }
 
-const ToolForm: FC<Props> = ({ className, type, tool, onSubmit }) => {
+const ToolForm: FC<Props> = ({ className, type, tool, toolId, onSubmit }) => {
   const { t } = useTranslation()
   const { data: tagSuggestions } = useToolTagSuggestions()
 
@@ -247,7 +248,7 @@ const ToolForm: FC<Props> = ({ className, type, tool, onSubmit }) => {
       )}
       {type === DummyToolInterface.toolName && (
         <FormItem label={t('knowledge')}>
-          <ToolKnowledgeSection form={form} />
+          <ToolKnowledgeSection form={form} toolId={toolId} />
         </FormItem>
       )}
       <Button type="button" onClick={form.handleSubmit(handleSubmit)}>

--- a/apps/frontend/app/admin/tools/components/ToolKnowledgeSection.tsx
+++ b/apps/frontend/app/admin/tools/components/ToolKnowledgeSection.tsx
@@ -11,15 +11,18 @@ import { post } from '@/lib/fetch'
 import toast from 'react-hot-toast'
 import { IconUpload } from '@tabler/icons-react'
 import { ToolFormFields } from './toolFormTypes'
+import { useUserProfile } from '@/components/providers/userProfileContext'
 
 interface ToolKnowledgeSectionProps {
   form: UseFormReturn<ToolFormFields>
+  toolId?: string
 }
 
-export const ToolKnowledgeSection = ({ form }: ToolKnowledgeSectionProps) => {
+export const ToolKnowledgeSection = ({ form, toolId }: ToolKnowledgeSectionProps) => {
   const uploadFileRef = useRef<HTMLInputElement>(null)
   const [isDragActive, setIsDragActive] = useState(false)
 
+  const userProfile = useUserProfile()
   // All uploads (pre-existing at mount and newly added), tracked by XHR callbacks via ref,
   // mirrored into state for rendering. The `order` field drives display order and form rebuild order.
   const initialFiles = form.getValues('files')
@@ -100,6 +103,9 @@ export const ToolKnowledgeSection = ({ form }: ToolKnowledgeSectionProps) => {
       size: file.size,
       type: file.type,
       name: fileName,
+      owner: toolId
+        ? { ownerType: 'TOOL', ownerId: toolId }
+        : { ownerType: 'USER', ownerId: userProfile!.id },
     }
     const response = await post<dto.File>(`/api/files`, insertRequest)
     if (response.error) {

--- a/apps/frontend/app/assistants/components/AssistantForm.tsx
+++ b/apps/frontend/app/assistants/components/AssistantForm.tsx
@@ -363,6 +363,7 @@ export const AssistantForm = ({
           form={form}
           visible={activeTab === 'knowledge'}
           modelId={selectedModel?.modelId}
+          assistantId={assistant.id}
           onHasWarnings={onKnowledgeHasWarnings}
         />
         <AdvancedTabPanel

--- a/apps/frontend/app/assistants/components/KnowledgeTabPanel.tsx
+++ b/apps/frontend/app/assistants/components/KnowledgeTabPanel.tsx
@@ -12,19 +12,22 @@ import toast from 'react-hot-toast'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { IconMistOff, IconUpload } from '@tabler/icons-react'
 import { FormFields } from './AssistantFormField'
+import { useUserProfile } from '@/components/providers/userProfileContext'
 
 interface KnowledgeTabPanelProps {
   className: string
   form: UseFormReturn<FormFields>
   visible: boolean
   modelId?: string
+  assistantId?: string
   onHasWarnings?: (hasWarnings: boolean) => void
 }
 
-export const KnowledgeTabPanel = ({ form, visible, className, modelId, onHasWarnings }: KnowledgeTabPanelProps) => {
+export const KnowledgeTabPanel = ({ form, visible, className, modelId, assistantId, onHasWarnings }: KnowledgeTabPanelProps) => {
   const uploadFileRef = useRef<HTMLInputElement>(null)
   const lastWarningStateRef = useRef<boolean | undefined>(undefined)
   const { t } = useTranslation()
+  const userProfile = useUserProfile()
   const [isDragActive, setIsDragActive] = useState(false)
 
   // All uploads (pre-existing at mount and newly added), tracked by XHR callbacks via ref,
@@ -134,6 +137,9 @@ export const KnowledgeTabPanel = ({ form, visible, className, modelId, onHasWarn
       size: file.size,
       type: file.type,
       name: fileName,
+      owner: assistantId
+        ? { ownerType: 'ASSISTANT', ownerId: assistantId }
+        : { ownerType: 'USER', ownerId: userProfile!.id },
     }
     const response = await post<dto.File>(`/api/files`, insertRequest)
     if (response.error) {

--- a/apps/frontend/app/chat/components/ChatInput.tsx
+++ b/apps/frontend/app/chat/components/ChatInput.tsx
@@ -21,6 +21,7 @@ import { post } from '@/lib/fetch'
 import * as dto from '@/types/dto'
 import toast from 'react-hot-toast'
 import { useEnvironment } from '@/app/context/environmentProvider'
+import { useUserProfile } from '@/components/providers/userProfileContext'
 import { limitImageSize } from '@/lib/resizeImage'
 import { isMimeTypeAllowed, mimeTypeOfFile } from '@/lib/mimeTypes'
 import { filesize } from 'filesize'
@@ -76,6 +77,7 @@ export const ChatInput = ({
   tokenLimit,
 }: Props) => {
   const { t } = useTranslation()
+  const userProfile = useUserProfile()
   const {
     state: { chatStatus },
     requestStopActiveRun,
@@ -371,6 +373,9 @@ export const ChatInput = ({
       size: file.size,
       type: type,
       name: fileName,
+      owner: conversationId
+        ? { ownerType: 'CHAT', ownerId: conversationId }
+        : { ownerType: 'USER', ownerId: userProfile!.id },
     }
     const response = await post<dto.File>('/api/files', insertRequest)
     if (response.error) {

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -1790,6 +1790,8 @@ paths:
                 properties:
                   expiresAt:
                     type: string
+                    format: date-time
+                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                 required:
                   - expiresAt
                 additionalProperties: false
@@ -3965,6 +3967,8 @@ paths:
                   - createdAt
                   - updatedAt
                 additionalProperties: false
+        "403":
+          $ref: "#/components/responses/Error"
         "404":
           $ref: "#/components/responses/Error"
         "409":
@@ -3987,6 +3991,8 @@ paths:
           content:
             application/json:
               schema: {}
+        "403":
+          $ref: "#/components/responses/Error"
         "404":
           $ref: "#/components/responses/Error"
       parameters:
@@ -4060,6 +4066,22 @@ paths:
                   type: string
                 size:
                   type: number
+                owner:
+                  type: object
+                  properties:
+                    ownerType:
+                      type: string
+                      enum:
+                        - USER
+                        - CHAT
+                        - ASSISTANT
+                        - TOOL
+                    ownerId:
+                      type: string
+                  required:
+                    - ownerType
+                    - ownerId
+                  additionalProperties: false
               required:
                 - name
                 - type
@@ -4124,6 +4146,22 @@ paths:
                   type: string
                 size:
                   type: number
+                owner:
+                  type: object
+                  properties:
+                    ownerType:
+                      type: string
+                      enum:
+                        - USER
+                        - CHAT
+                        - ASSISTANT
+                        - TOOL
+                    ownerId:
+                      type: string
+                  required:
+                    - ownerType
+                    - ownerId
+                  additionalProperties: false
               required:
                 - name
                 - type
@@ -4196,9 +4234,13 @@ paths:
                       type: string
                     createdAt:
                       type: string
+                      format: date-time
+                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     expiresAt:
                       anyOf:
                         - type: string
+                          format: date-time
+                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                         - type: "null"
                     enabled:
                       type: number
@@ -4237,9 +4279,13 @@ paths:
                     type: string
                   createdAt:
                     type: string
+                    format: date-time
+                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                   expiresAt:
                     anyOf:
                       - type: string
+                        format: date-time
+                        pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                       - type: "null"
                   enabled:
                     type: number
@@ -4269,6 +4315,8 @@ paths:
                 expiresAt:
                   anyOf:
                     - type: string
+                      format: date-time
+                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     - type: "null"
               required:
                 - description
@@ -4342,6 +4390,8 @@ paths:
                   lastUsed:
                     anyOf:
                       - type: string
+                        format: date-time
+                        pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                       - type: "null"
                   owner:
                     type: string
@@ -4383,8 +4433,12 @@ paths:
                           additionalProperties: false
                   createdAt:
                     type: string
+                    format: date-time
+                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                   updatedAt:
                     type: string
+                    format: date-time
+                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                   cloneable:
                     type: boolean
                   tokenLimit:
@@ -4407,6 +4461,19 @@ paths:
                         - id
                         - name
                         - availability
+                      additionalProperties: false
+                  subAssistants:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                        - id
+                        - name
                       additionalProperties: false
                   pendingChanges:
                     type: boolean
@@ -4850,6 +4917,8 @@ paths:
                     lastUsed:
                       anyOf:
                         - type: string
+                          format: date-time
+                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                         - type: "null"
                     owner:
                       type: string
@@ -4891,8 +4960,12 @@ paths:
                             additionalProperties: false
                     createdAt:
                       type: string
+                      format: date-time
+                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     updatedAt:
                       type: string
+                      format: date-time
+                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     cloneable:
                       type: boolean
                     tokenLimit:
@@ -4915,6 +4988,19 @@ paths:
                           - id
                           - name
                           - availability
+                        additionalProperties: false
+                    subAssistants:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                          - id
+                          - name
                         additionalProperties: false
                     pendingChanges:
                       type: boolean
@@ -5013,6 +5099,8 @@ paths:
                     lastUsed:
                       anyOf:
                         - type: string
+                          format: date-time
+                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                         - type: "null"
                     owner:
                       type: string
@@ -5054,8 +5142,12 @@ paths:
                             additionalProperties: false
                     createdAt:
                       type: string
+                      format: date-time
+                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     updatedAt:
                       type: string
+                      format: date-time
+                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     cloneable:
                       type: boolean
                     tokenLimit:
@@ -5078,6 +5170,19 @@ paths:
                           - id
                           - name
                           - availability
+                        additionalProperties: false
+                    subAssistants:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                          - id
+                          - name
                         additionalProperties: false
                     pendingChanges:
                       type: boolean
@@ -5178,8 +5283,12 @@ paths:
                         - type: "null"
                     createdAt:
                       type: string
+                      format: date-time
+                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     updatedAt:
                       type: string
+                      format: date-time
+                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     owner:
                       type: string
                     ownerName:
@@ -5618,6 +5727,8 @@ paths:
                           lastUsed:
                             anyOf:
                               - type: string
+                                format: date-time
+                                pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                               - type: "null"
                           owner:
                             type: string
@@ -5659,8 +5770,12 @@ paths:
                                   additionalProperties: false
                           createdAt:
                             type: string
+                            format: date-time
+                            pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                           updatedAt:
                             type: string
+                            format: date-time
+                            pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                           cloneable:
                             type: boolean
                           tokenLimit:
@@ -5683,6 +5798,19 @@ paths:
                                 - id
                                 - name
                                 - availability
+                              additionalProperties: false
+                          subAssistants:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                id:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                                - id
+                                - name
                               additionalProperties: false
                           pendingChanges:
                             type: boolean
@@ -5771,6 +5899,8 @@ paths:
                         lastUsed:
                           anyOf:
                             - type: string
+                              format: date-time
+                              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                             - type: "null"
                         owner:
                           type: string
@@ -5812,8 +5942,12 @@ paths:
                                 additionalProperties: false
                         createdAt:
                           type: string
+                          format: date-time
+                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                         updatedAt:
                           type: string
+                          format: date-time
+                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                         cloneable:
                           type: boolean
                         tokenLimit:
@@ -5836,6 +5970,19 @@ paths:
                               - id
                               - name
                               - availability
+                            additionalProperties: false
+                        subAssistants:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                              - id
+                              - name
                             additionalProperties: false
                         pendingChanges:
                           type: boolean
@@ -7287,9 +7434,13 @@ paths:
                       type: string
                     createdAt:
                       type: string
+                      format: date-time
+                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     expiresAt:
                       anyOf:
                         - type: string
+                          format: date-time
+                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                         - type: "null"
                     enabled:
                       type: number
@@ -7336,9 +7487,13 @@ paths:
                     type: string
                   createdAt:
                     type: string
+                    format: date-time
+                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                   expiresAt:
                     anyOf:
                       - type: string
+                        format: date-time
+                        pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                       - type: "null"
                   enabled:
                     type: number
@@ -7376,6 +7531,8 @@ paths:
                 expiresAt:
                   anyOf:
                     - type: string
+                      format: date-time
+                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     - type: "null"
               required:
                 - description

--- a/packages/core/src/types/dto/file.ts
+++ b/packages/core/src/types/dto/file.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod'
 import { iso8601UtcDateTimeSchema } from './common'
 
+export const fileOwnerSchema = z.object({
+  ownerType: z.enum(['USER', 'CHAT', 'ASSISTANT', 'TOOL']),
+  ownerId: z.string(),
+})
+
 export const fileSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -12,13 +17,18 @@ export const fileSchema = z.object({
   encrypted: z.union([z.literal(0), z.literal(1)]),
 })
 
-export const insertableFileSchema = fileSchema.omit({
-  id: true,
-  createdAt: true,
-  uploaded: true,
-  encrypted: true,
-  path: true,
-})
+export const insertableFileSchema = fileSchema
+  .omit({
+    id: true,
+    createdAt: true,
+    uploaded: true,
+    encrypted: true,
+    path: true,
+  })
+  .extend({
+    owner: fileOwnerSchema.optional(),
+  })
 
+export type FileOwner = z.infer<typeof fileOwnerSchema>
 export type File = z.infer<typeof fileSchema>
 export type InsertableFile = z.infer<typeof insertableFileSchema>


### PR DESCRIPTION
## Summary

Closes the Story 2 gap: user-uploaded files now get a \`FileOwnership\` row at creation time, so they are no longer subject to the legacy coexistence clause (zero ownership rows → world-readable).

\`POST /api/files\` accepts an optional \`owner: { ownerType, ownerId }\` in the request body and inserts a \`FileOwnership\` row alongside the \`File\` row. If no owner is supplied the server falls back to \`USER\` ownership using the authenticated session's \`userId\`.

## Details

- \`insertableFileSchema\` extended with optional \`owner\` field (\`FileOwner\` type exported from core)
- Three frontend upload paths now pass explicit ownership:
  - **Chat attachments** (\`ChatInput\`): \`CHAT\` when \`conversationId\` is available, \`USER\` for new conversations
  - **Assistant knowledge** (\`KnowledgeTabPanel\`): \`ASSISTANT\` when editing an existing assistant, \`USER\` for new ones; \`assistantId\` prop added and wired from \`AssistantForm\`
  - **Tool knowledge** (\`ToolKnowledgeSection\`): \`TOOL\` when editing an existing tool, \`USER\` for new ones; \`toolId\` prop added and wired through \`ToolForm\` from the edit page

## Tests

- \`npm run check-types\` — clean
- Full test suite: 654 tests passing