### PR TITLE
Fix dedup silently destroying uploader's file ownership

### DIFF
--- a/__tests__/fileDeduplication.test.ts
+++ b/__tests__/fileDeduplication.test.ts
@@ -35,7 +35,7 @@ vi.mock('@/lib/env', () => ({
 
 vi.mock('nanoid', () => ({ nanoid: () => 'test-id' }))
 
-// Builds a selectFrom chain: .select().where().where().where().executeTakeFirst()
+// Builds the duplicate-lookup chain: .select().where().where().where().executeTakeFirst()
 function makeSelectChain(result: unknown) {
   const executeTakeFirstMock = vi.fn().mockResolvedValue(result)
   const terminal = { executeTakeFirst: executeTakeFirstMock }
@@ -44,6 +44,25 @@ function makeSelectChain(result: unknown) {
   const w1 = vi.fn(() => ({ where: w2 }))
   const selectMock = vi.fn(() => ({ where: w1 }))
   return { chain: { select: selectMock }, executeTakeFirstMock }
+}
+
+// Builds the ownership-lookup chain: .select().where().execute()
+function makeOwnershipChain(result: unknown[]) {
+  const executeMock = vi.fn().mockResolvedValue(result)
+  const whereMock = vi.fn(() => ({ execute: executeMock }))
+  const selectMock = vi.fn(() => ({ where: whereMock }))
+  return { chain: { select: selectMock }, executeMock }
+}
+
+// Builds an insertInto chain with .values().onConflict(...).execute()
+function makeInsertChain() {
+  const executeMock = vi.fn().mockResolvedValue(undefined)
+  const onConflictMock = vi.fn((cb: (oc: any) => any) => {
+    cb({ columns: vi.fn(() => ({ doNothing: vi.fn(() => ({})) })) })
+    return { execute: executeMock }
+  })
+  const valuesMock = vi.fn(() => ({ onConflict: onConflictMock }))
+  return { chain: { values: valuesMock }, executeMock }
 }
 
 // ── finalizeUploadedFile ──────────────────────────────────────────────────────
@@ -77,9 +96,10 @@ describe('finalizeUploadedFile', () => {
     expect(deleteFromMock).not.toHaveBeenCalled()
   })
 
-  test('returns canonical ID, removes new blob, and deletes new File row when duplicate exists', async () => {
-    const { chain } = makeSelectChain({ id: 'existing-id' })
-    selectFromMock.mockReturnValue(chain)
+  test('returns canonical ID, removes new blob, and deletes new File row when duplicate exists (no ownerships)', async () => {
+    const { chain: dupChain } = makeSelectChain({ id: 'existing-id' })
+    const { chain: ownChain } = makeOwnershipChain([])
+    selectFromMock.mockReturnValueOnce(dupChain).mockReturnValueOnce(ownChain)
 
     storageRmMock.mockResolvedValue(undefined)
     const deleteExecuteMock = vi.fn().mockResolvedValue(undefined)
@@ -98,11 +118,13 @@ describe('finalizeUploadedFile', () => {
     expect(deleteFromMock).toHaveBeenCalledWith('File')
     expect(deleteWhereMock).toHaveBeenCalledWith('id', '=', 'new-id')
     expect(updateTableMock).not.toHaveBeenCalled()
+    expect(insertIntoMock).not.toHaveBeenCalled()
   })
 
   test('does not delete File row if storage.rm throws', async () => {
-    const { chain } = makeSelectChain({ id: 'existing-id' })
-    selectFromMock.mockReturnValue(chain)
+    const { chain: dupChain } = makeSelectChain({ id: 'existing-id' })
+    const { chain: ownChain } = makeOwnershipChain([])
+    selectFromMock.mockReturnValueOnce(dupChain).mockReturnValueOnce(ownChain)
 
     storageRmMock.mockRejectedValue(new Error('storage failure'))
 
@@ -112,6 +134,37 @@ describe('finalizeUploadedFile', () => {
     ).rejects.toThrow('storage failure')
 
     expect(deleteFromMock).not.toHaveBeenCalled()
+  })
+
+  test('transfers ownership rows to canonical file before deleting duplicate', async () => {
+    const { chain: dupChain } = makeSelectChain({ id: 'existing-id' })
+    const { chain: ownChain } = makeOwnershipChain([
+      { ownerType: 'USER', ownerId: 'user-1' },
+      { ownerType: 'ASSISTANT', ownerId: 'asst-1' },
+    ])
+    selectFromMock.mockReturnValueOnce(dupChain).mockReturnValueOnce(ownChain)
+
+    const { chain: insertChain, executeMock: insertExecuteMock } = makeInsertChain()
+    insertIntoMock.mockReturnValue(insertChain)
+
+    storageRmMock.mockResolvedValue(undefined)
+    const deleteExecuteMock = vi.fn().mockResolvedValue(undefined)
+    deleteFromMock.mockReturnValue({ where: vi.fn(() => ({ execute: deleteExecuteMock })) })
+
+    const { finalizeUploadedFile } = await import('@/backend/lib/files/upload-dedup')
+    const result = await finalizeUploadedFile({
+      fileId: 'new-id',
+      filePath: 'new-id-file.pdf',
+      contentHash: 'abc123',
+    })
+
+    expect(result).toBe('existing-id')
+    // One insert per ownership row
+    expect(insertIntoMock).toHaveBeenCalledTimes(2)
+    expect(insertIntoMock).toHaveBeenCalledWith('FileOwnership')
+    expect(insertExecuteMock).toHaveBeenCalledTimes(2)
+    expect(storageRmMock).toHaveBeenCalledWith('new-id-file.pdf')
+    expect(deleteFromMock).toHaveBeenCalledWith('File')
   })
 })
 

--- a/apps/backend/lib/files/upload-dedup.ts
+++ b/apps/backend/lib/files/upload-dedup.ts
@@ -1,10 +1,12 @@
 import { db } from '@/db/database'
 import { storage } from '@/lib/storage'
+import { nanoid } from 'nanoid'
 
 /**
  * Called after the upload stream has been written to storage.
  * Checks for an existing file with the same content hash.
- * - Duplicate found: deletes the just-written blob and File row, returns canonical file ID.
+ * - Duplicate found: transfers ownership rows to the canonical file, deletes the
+ *   just-written blob and File row, returns canonical file ID.
  * - No duplicate: marks the file as uploaded with its hash, returns null.
  */
 export const finalizeUploadedFile = async (params: {
@@ -21,6 +23,29 @@ export const finalizeUploadedFile = async (params: {
     .executeTakeFirst()
 
   if (duplicate) {
+    const ownerships = await db
+      .selectFrom('FileOwnership')
+      .select(['ownerType', 'ownerId'])
+      .where('fileId', '=', params.fileId)
+      .execute()
+
+    if (ownerships.length > 0) {
+      const timestamp = new Date().toISOString()
+      for (const o of ownerships) {
+        await db
+          .insertInto('FileOwnership')
+          .values({
+            id: nanoid(),
+            fileId: duplicate.id,
+            ownerType: o.ownerType,
+            ownerId: o.ownerId,
+            createdAt: timestamp,
+          })
+          .onConflict((oc) => oc.columns(['fileId', 'ownerType', 'ownerId']).doNothing())
+          .execute()
+      }
+    }
+
     await storage.rm(params.filePath)
     await db.deleteFrom('File').where('id', '=', params.fileId).execute()
     return duplicate.id


### PR DESCRIPTION
## Summary

When `finalizeUploadedFile` detected a duplicate upload it deleted the new `File` row, which cascaded to remove its `FileOwnership` rows, but never added those ownerships to the canonical file. The uploader lost authorisation to the file they just uploaded.

## Details

- Before deleting the new `File` row, read its `FileOwnership` rows and upsert each one onto the canonical file (`onConflict doNothing` to skip already-existing entries).
- Added `nanoid` import to `upload-dedup.ts` for the new ownership row IDs.

## Tests

- `npx vitest run __tests__/fileDeduplication.test.ts` — 6 tests pass (added new test covering ownership transfer; updated two existing duplicate-found tests to handle the extra `selectFrom` call)
- `npx vitest run __tests__/fileAuthorization.test.ts` — 8 tests pass, no regressions
- `npm run check-types` — clean