### PR TITLE
Remove unused i18n keys from image editor

### DIFF
--- a/apps/frontend/locales/en/logicle.json
+++ b/apps/frontend/locales/en/logicle.json
@@ -633,14 +633,5 @@
   "your-email": "Your email",
   "your-name": "Your name",
   "edit_image": "Edit image",
-  "edit_image_prompt_placeholder": "Describe what to change…",
-  "edit_image_submit": "Apply edit",
-  "editing": "Editing",
-  "edit_result": "Edit result",
-  "edit_again": "Edit again",
-  "use_in_chat": "Use in chat",
-  "brush": "Brush",
-  "eraser": "Eraser",
-  "clear_mask": "Clear mask",
-  "no_mask_whole_image_edit": "No area selected — will edit whole image"
+  "edit_image_prompt_placeholder": "Describe what to change…"
 }

--- a/apps/frontend/locales/it/logicle.json
+++ b/apps/frontend/locales/it/logicle.json
@@ -633,14 +633,5 @@
   "your-email": "La tua email",
   "your-name": "Il tuo nome",
   "edit_image": "Modifica immagine",
-  "edit_image_prompt_placeholder": "Descrivi cosa modificare…",
-  "edit_image_submit": "Applica modifica",
-  "editing": "Modifica in corso",
-  "edit_result": "Risultato modifica",
-  "edit_again": "Modifica di nuovo",
-  "use_in_chat": "Usa in chat",
-  "brush": "Pennello",
-  "eraser": "Gomma",
-  "clear_mask": "Cancella maschera",
-  "no_mask_whole_image_edit": "Nessuna area selezionata — verrà modificata l'immagine intera"
+  "edit_image_prompt_placeholder": "Descrivi cosa modificare…"
 }


### PR DESCRIPTION
## Summary

Removes 9 translation keys (EN + IT) that were added for a richer image editor UI (mask brush, eraser, edit result panel, etc.) that was not included in the shipped modal. Only `edit_image` and `edit_image_prompt_placeholder` are actually referenced in the current `ImageEditorModal` component.

## Tests

- Grepped all `.tsx`/`.ts` component files for each removed key — zero references found.