### PR TITLE
Show toast errors on image edit submission failures

### DIFF
--- a/apps/frontend/app/chat/components/ChatPageContextProvider.tsx
+++ b/apps/frontend/app/chat/components/ChatPageContextProvider.tsx
@@ -19,6 +19,7 @@ import { getActiveChatRun, startChatRun, stopChatRun, subscribeToChatRun } from 
 import { createConversation, getConversation, getConversationMessages } from '@/services/conversation'
 import { mutate } from 'swr'
 import { useRouter } from 'next/navigation'
+import toast from 'react-hot-toast'
 import {
   chatRunMachineToStatus,
   getResumeSequence,
@@ -494,14 +495,20 @@ export const ChatPageContextProvider: FC<Props> = ({ children }) => {
                 selectedConversationRef.current?.assistantId ??
                 contextValue.state.newChatAssistantId ??
                 userProfile?.lastUsedAssistant?.id
-              if (!assistantId) return
+              if (!assistantId) {
+                toast.error(t('something-went-wrong'))
+                return
+              }
 
               const customName = t('new-chat')
               const created = await createConversation({
                 name: customName,
                 assistantId,
               })
-              if (created.error) return
+              if (created.error) {
+                toast.error(created.error.message ?? t('something-went-wrong'))
+                return
+              }
               await mutate('/api/conversations')
               targetConversation = { ...created.data, messages: [] }
               setSelectedConversationState(targetConversation)


### PR DESCRIPTION
## Summary

The `ImageEditorModal` `onSubmit` handler had three silent early returns that left users with no feedback when something went wrong. This adds `toast.error(...)` on each failure path so the user sees a meaningful error instead of the modal just disappearing.

## Details

- No assistant ID resolved → `toast.error(t('something-went-wrong'))`
- `createConversation` returns an error → `toast.error(error.message ?? t('something-went-wrong'))`
- `targetConversation` still null after the new-chat path (shouldn't be reachable, but defensive) — left as a silent return since it's the impossible case

## Tests

- `npm run check-types` — no errors.