### PR TITLE
Add assistant picker to image editor modal for library edits

### DIFF
--- a/apps/backend/api/me/profile/route.ts
+++ b/apps/backend/api/me/profile/route.ts
@@ -72,6 +72,7 @@ export const GET = operation({
       }),
       lastUsedAssistant: lastUsedAssistant,
       pinnedAssistants,
+      assistants: userAssistants,
       preferences: JSON.parse(user.preferences),
       properties: parameters,
       ssoUser: user.ssoUser !== 0,

--- a/apps/frontend/app/chat/components/ChatPageContextProvider.tsx
+++ b/apps/frontend/app/chat/components/ChatPageContextProvider.tsx
@@ -484,17 +484,15 @@ export const ChatPageContextProvider: FC<Props> = ({ children }) => {
       {imageEditorState && (
         <ImageEditorModal
           attachment={imageEditorState.attachment}
+          assistants={imageEditorState.startNewChat ? userProfile?.assistants : undefined}
           onClose={() => setImageEditorState(null)}
-          onSubmit={async (prompt, attachment) => {
+          onSubmit={async (prompt, attachment, pickedAssistantId) => {
             setImageEditorState(null)
             const shouldStartNewChat = !!imageEditorState.startNewChat
             let targetConversation = selectedConversationRef.current
 
             if (shouldStartNewChat) {
-              const assistantId =
-                selectedConversationRef.current?.assistantId ??
-                contextValue.state.newChatAssistantId ??
-                userProfile?.lastUsedAssistant?.id
+              const assistantId = pickedAssistantId
               if (!assistantId) {
                 toast.error(t('something-went-wrong'))
                 return

--- a/apps/frontend/app/chat/components/ImageEditorModal.tsx
+++ b/apps/frontend/app/chat/components/ImageEditorModal.tsx
@@ -7,23 +7,47 @@ import {
   Dialog,
   DialogContent,
 } from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import type * as dto from '@/types/dto'
 import { IconSend2 } from '@tabler/icons-react'
 
-interface Props {
-  attachment: dto.Attachment
-  onClose: () => void
-  onSubmit: (prompt: string, attachment: dto.Attachment) => void
+const STORAGE_KEY = 'imageEditAssistantId'
+
+function resolveInitialAssistant(assistants: dto.UserAssistant[]): string {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (stored && assistants.some((a) => a.id === stored)) return stored
+  return assistants[0]?.id ?? ''
 }
 
-export const ImageEditorModal: FC<Props> = ({ attachment, onClose, onSubmit }) => {
+interface Props {
+  attachment: dto.Attachment
+  assistants?: dto.UserAssistant[]
+  onClose: () => void
+  onSubmit: (prompt: string, attachment: dto.Attachment, assistantId?: string) => void
+}
+
+export const ImageEditorModal: FC<Props> = ({ attachment, assistants, onClose, onSubmit }) => {
   const { t } = useTranslation()
   const [prompt, setPrompt] = useState('')
+  const [assistantId, setAssistantId] = useState<string>(() =>
+    assistants?.length ? resolveInitialAssistant(assistants) : ''
+  )
 
   const handleSubmit = () => {
     if (!prompt.trim()) return
-    onSubmit(prompt.trim(), attachment)
+    if (assistants?.length && assistantId) {
+      localStorage.setItem(STORAGE_KEY, assistantId)
+    }
+    onSubmit(prompt.trim(), attachment, assistants?.length ? assistantId : undefined)
   }
+
+  const canSubmit = !!prompt.trim() && (!assistants?.length || !!assistantId)
 
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
@@ -45,6 +69,23 @@ export const ImageEditorModal: FC<Props> = ({ attachment, onClose, onSubmit }) =
 
           <div className="px-4 pt-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
             <div className="mx-auto flex max-w-4xl items-center gap-2 rounded-xl border bg-background px-3 py-2">
+              {assistants?.length && (
+                <>
+                  <Select value={assistantId} onValueChange={setAssistantId}>
+                    <SelectTrigger className="h-auto w-auto shrink-0 border-0 bg-transparent p-0 text-body2 text-muted-foreground shadow-none focus:ring-0 focus:ring-offset-0 [&>svg]:ml-1">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {assistants.map((a) => (
+                        <SelectItem key={a.id} value={a.id}>
+                          {a.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <div className="h-4 w-px bg-border" />
+                </>
+              )}
               <Input
                 placeholder={t('edit_image_prompt_placeholder')}
                 value={prompt}
@@ -57,7 +98,7 @@ export const ImageEditorModal: FC<Props> = ({ attachment, onClose, onSubmit }) =
                 }}
                 className="border-0 bg-transparent focus-visible:ring-0"
               />
-              <Button variant="primary" size="icon" onClick={handleSubmit} disabled={!prompt.trim()}>
+              <Button variant="primary" size="icon" onClick={handleSubmit} disabled={!canSubmit}>
                 <IconSend2 size={16} />
               </Button>
             </div>

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -5999,6 +5999,177 @@ paths:
                         - tools
                         - pendingChanges
                       additionalProperties: false
+                  assistants:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        iconUri:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        versionId:
+                          type: string
+                        backendId:
+                          type: string
+                        description:
+                          type: string
+                        model:
+                          type: string
+                        usability:
+                          oneOf:
+                            - type: object
+                              properties:
+                                state:
+                                  type: string
+                                  const: usable
+                              required:
+                                - state
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                state:
+                                  type: string
+                                  const: need-api-key
+                                backendId:
+                                  type: string
+                                backendName:
+                                  type: string
+                              required:
+                                - state
+                                - backendId
+                                - backendName
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                state:
+                                  type: string
+                                  const: not-usable
+                                constraint:
+                                  type: string
+                              required:
+                                - state
+                                - constraint
+                              additionalProperties: false
+                        pinned:
+                          type: boolean
+                        lastUsed:
+                          anyOf:
+                            - type: string
+                              format: date-time
+                              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+                            - type: "null"
+                        owner:
+                          type: string
+                        ownerName:
+                          type: string
+                        tags:
+                          type: array
+                          items:
+                            type: string
+                        prompts:
+                          type: array
+                          items:
+                            type: string
+                        sharing:
+                          type: array
+                          items:
+                            oneOf:
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    const: all
+                                required:
+                                  - type
+                                additionalProperties: false
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    const: workspace
+                                  workspaceId:
+                                    type: string
+                                  workspaceName:
+                                    type: string
+                                required:
+                                  - type
+                                  - workspaceId
+                                  - workspaceName
+                                additionalProperties: false
+                        createdAt:
+                          type: string
+                          format: date-time
+                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+                        updatedAt:
+                          type: string
+                          format: date-time
+                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+                        cloneable:
+                          type: boolean
+                        tokenLimit:
+                          type: number
+                        tools:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              availability:
+                                type: string
+                                enum:
+                                  - ok
+                                  - require-auth
+                            required:
+                              - id
+                              - name
+                              - availability
+                            additionalProperties: false
+                        subAssistants:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                              - id
+                              - name
+                            additionalProperties: false
+                        pendingChanges:
+                          type: boolean
+                      required:
+                        - id
+                        - name
+                        - iconUri
+                        - versionId
+                        - backendId
+                        - description
+                        - model
+                        - usability
+                        - pinned
+                        - lastUsed
+                        - owner
+                        - ownerName
+                        - tags
+                        - prompts
+                        - sharing
+                        - createdAt
+                        - updatedAt
+                        - cloneable
+                        - tokenLimit
+                        - tools
+                        - pendingChanges
+                      additionalProperties: false
                   preferences:
                     type: object
                     properties:
@@ -6027,6 +6198,7 @@ paths:
                   - workspaces
                   - lastUsedAssistant
                   - pinnedAssistants
+                  - assistants
                   - preferences
                 additionalProperties: false
         "404":

--- a/packages/core/src/types/dto/user.ts
+++ b/packages/core/src/types/dto/user.ts
@@ -84,6 +84,7 @@ export const userProfileSchema = z.object({
   workspaces: workspaceMembershipSchema.array(),
   lastUsedAssistant: userAssistantSchema.nullable(),
   pinnedAssistants: userAssistantSchema.array(),
+  assistants: userAssistantSchema.array(),
   preferences: userPreferencesSchema.partial(),
 })
 


### PR DESCRIPTION
## Summary

When editing an image from the `/images` library page, there is no current assistant context — the previous code fell back to `lastUsedAssistant`, which could be any assistant (including text-only ones with no image editing tool). This adds an explicit assistant selector to the modal's message bar for library edits, with the choice persisted in `localStorage`.

## Details

- `UserProfile` DTO and `GET /api/me/profile` now include `assistants: UserAssistant[]` — the full list was already fetched server-side but discarded; no new DB query.
- `ImageEditorModal` accepts an optional `assistants` prop. When present, a `Select` is rendered before the prompt input with a thin separator. The send button stays disabled until both an assistant and a prompt are set.
- On submit the selected assistant ID is saved to `localStorage` (`imageEditAssistantId`) and pre-selected on next open if it is still in the list.
- `ChatPageContextProvider` passes `userProfile.assistants` to the modal only for `startNewChat` flows. In-chat edits are unchanged — the current conversation's assistant is used directly.
- The old `lastUsedAssistant` fallback chain for new-chat image edits is replaced by the picker's value.

## Tests

- `npm run check-types` — no errors.
- `npm run generate:openapi` — spec regenerated.