### PR TITLE
Fix owner field leaking into File table insert

### DIFF
--- a/apps/backend/api/files/route.ts
+++ b/apps/backend/api/files/route.ts
@@ -14,8 +14,9 @@ export const POST = operation({
   implementation: async ({ body, session }) => {
     const id = nanoid()
     const path = `${id}-${body.name.replace(/(\W+)/gi, '-')}`
-    const created = await addFile(body, path, env.fileStorage.encryptFiles)
-    const owner = body.owner ?? { ownerType: 'USER' as const, ownerId: session.userId }
+    const { owner: bodyOwner, ...bodyWithoutOwner } = body
+    const created = await addFile(bodyWithoutOwner, path, env.fileStorage.encryptFiles)
+    const owner = bodyOwner ?? { ownerType: 'USER' as const, ownerId: session.userId }
     await db
       .insertInto('FileOwnership')
       .values({


### PR DESCRIPTION
## Summary

The `addFile` model function was spreading the full `InsertableFile` DTO (which includes an optional `owner` field) directly into the Kysely `File` INSERT. Since the `File` table has no `owner` column, this caused a `SQLITE_ERROR: table File has no column named owner` (and the equivalent PostgreSQL error) whenever a file was created with an explicit owner.

The fix destructures `owner` out of the request body in the route handler before passing the remainder to `addFile`, so the field never reaches the INSERT. Ownership is still recorded in `FileOwnership` by the route handler as intended.

## Tests

- `npm run check-types` passes