### PR TITLE
Fix opaque 'Internal error' when a file is unreadable in chat

### DIFF
--- a/apps/backend/lib/chat/conversion.ts
+++ b/apps/backend/lib/chat/conversion.ts
@@ -3,6 +3,7 @@ import * as schema from '@/db/schema'
 import { getFileWithId } from '@/models/file'
 import * as dto from '@/types/dto'
 import { ensureFileAnalysis } from '@/lib/file-analysis'
+import { UserVisibleError } from '@/backend/lib/chat'
 import { logger } from '@/lib/logging'
 import { storage } from '@/lib/storage'
 import { LlmModelCapabilities } from '@/lib/chat/models'
@@ -76,7 +77,12 @@ const shouldEagerInjectToolFile = (toolName: string, mimeType: string): boolean 
 }
 
 export const loadImagePartFromFileEntry = async (fileEntry: schema.File): Promise<ai.ImagePart> => {
-  const fileContent = await storage.readBuffer(fileEntry.path, !!fileEntry.encrypted)
+  let fileContent: Buffer
+  try {
+    fileContent = await storage.readBuffer(fileEntry.path, !!fileEntry.encrypted)
+  } catch (err) {
+    throw new UserVisibleError(`File not readable: "${fileEntry.name}" (id: ${fileEntry.id})`, { cause: err })
+  }
   const image: ai.ImagePart = {
     type: 'image',
     image: `data:${fileEntry.type};base64,${fileContent.toString('base64')}`,
@@ -85,7 +91,12 @@ export const loadImagePartFromFileEntry = async (fileEntry: schema.File): Promis
 }
 
 export const loadFilePartFromFileEntry = async (fileEntry: schema.File): Promise<ai.FilePart> => {
-  const fileContent = await storage.readBuffer(fileEntry.path, !!fileEntry.encrypted)
+  let fileContent: Buffer
+  try {
+    fileContent = await storage.readBuffer(fileEntry.path, !!fileEntry.encrypted)
+  } catch (err) {
+    throw new UserVisibleError(`File not readable: "${fileEntry.name}" (id: ${fileEntry.id})`, { cause: err })
+  }
   const image: ai.FilePart = {
     type: 'file',
     filename: fileEntry.name,

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -109,6 +109,13 @@ export class ChatAbortedError extends Error {
   }
 }
 
+export class UserVisibleError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'UserVisibleError'
+  }
+}
+
 class ClientSinkImpl implements ClientSink {
   clientGone: boolean = false
   constructor(
@@ -945,10 +952,11 @@ export class ChatAssistant {
           clientSink.enqueue({ type: 'part', part: errorPart })
         } else {
           this.logInternalError(chatState, 'LLM invocation failure', e)
-          clientSink.enqueue({ type: 'part', part: { type: 'error', error: 'Internal error' } })
+          const message = e instanceof UserVisibleError ? e.message : 'Internal error'
+          clientSink.enqueue({ type: 'part', part: { type: 'error', error: message } })
           chatState.applyStreamPart({
             type: 'part',
-            part: { type: 'error', error: 'Internal error' },
+            part: { type: 'error', error: message },
           })
         }
       } finally {


### PR DESCRIPTION
## Summary

When a knowledge or attachment file could not be read from storage (e.g. missing from disk), the chat stream returned a generic "Internal error" with no actionable context. This change surfaces a safe, human-readable message — `File not readable: "<name>" (id: <id>)` — while keeping internal details (filesystem path, OS error) server-side in logs only.

## Details

- Introduces `UserVisibleError` in `chat/index.ts`: a typed boundary between errors intentionally safe to forward to the client and unexpected internal failures (which still produce "Internal error").
- `loadImagePartFromFileEntry` and `loadFilePartFromFileEntry` in `conversion.ts` now catch `storage.readBuffer` failures and re-throw as `UserVisibleError` with file name and id; the underlying cause (including the internal path) is attached as `cause` for server-side logging.
- The catch block in `invokeLlmAndProcessResponse` checks `instanceof UserVisibleError` before forwarding the message; everything else stays opaque.

## Tests

- Manually reproduced the ENOENT scenario; chat now shows `File not readable: "Luca Firma.png" (id: ...)` instead of "Internal error".
- `npm run check-types` passes.