### PR TITLE
fix: exclude unowned files from dedup targets

### DIFF
--- a/__tests__/fileDeduplication.test.ts
+++ b/__tests__/fileDeduplication.test.ts
@@ -32,7 +32,7 @@ vi.mock('@/lib/env', () => ({ default: mockEnvConfig }))
 
 vi.mock('nanoid', () => ({ nanoid: () => 'test-id' }))
 
-// Builds the duplicate-lookup chain: .select().where().where().where().executeTakeFirst()
+// Builds the duplicate-lookup chain: .innerJoin().select().where().where().where().executeTakeFirst()
 function makeSelectChain(result: unknown) {
   const executeTakeFirstMock = vi.fn().mockResolvedValue(result)
   const terminal = { executeTakeFirst: executeTakeFirstMock }
@@ -40,7 +40,8 @@ function makeSelectChain(result: unknown) {
   const w2 = vi.fn(() => ({ where: w3 }))
   const w1 = vi.fn(() => ({ where: w2 }))
   const selectMock = vi.fn(() => ({ where: w1 }))
-  return { chain: { select: selectMock }, executeTakeFirstMock }
+  const innerJoinMock = vi.fn(() => ({ select: selectMock }))
+  return { chain: { innerJoin: innerJoinMock }, executeTakeFirstMock }
 }
 
 // Builds the ownership-lookup chain: .select().where().execute()
@@ -131,6 +132,31 @@ describe('finalizeUploadedFile', () => {
     ).rejects.toThrow('storage failure')
 
     expect(deleteFromMock).not.toHaveBeenCalled()
+  })
+
+  test('does not use an unowned file as a dedup target', async () => {
+    // The dedup query uses innerJoin(FileOwnership) so unowned files are excluded.
+    // Simulate that by returning undefined from the duplicate lookup.
+    const { chain } = makeSelectChain(undefined)
+    selectFromMock.mockReturnValue(chain)
+
+    const updateExecuteMock = vi.fn().mockResolvedValue(undefined)
+    const updateWhereMock = vi.fn(() => ({ execute: updateExecuteMock }))
+    const updateSetMock = vi.fn(() => ({ where: updateWhereMock }))
+    updateTableMock.mockReturnValue({ set: updateSetMock })
+
+    const { finalizeUploadedFile } = await import('@/backend/lib/files/upload-dedup')
+    const result = await finalizeUploadedFile({
+      fileId: 'new-id',
+      filePath: 'new-id-file.pdf',
+      contentHash: 'abc123',
+    })
+
+    // No duplicate found → file should be marked uploaded, not deduplicated
+    expect(result).toBeNull()
+    expect(storageRmMock).not.toHaveBeenCalled()
+    expect(deleteFromMock).not.toHaveBeenCalled()
+    expect(updateTableMock).toHaveBeenCalledWith('File')
   })
 
   test('transfers ownership rows to canonical file before deleting duplicate', async () => {

--- a/__tests__/fileUploadRoutes.test.ts
+++ b/__tests__/fileUploadRoutes.test.ts
@@ -179,6 +179,16 @@ describe('PUT /api/files/:fileId/content', () => {
     const contentHash = createHash('sha256').update(content).digest('hex')
 
     await insertFile({ id: 'canonical', path: 'canonical.txt', uploaded: 1, contentHash })
+    await db
+      .insertInto('FileOwnership')
+      .values({
+        id: 'own-canonical',
+        fileId: 'canonical',
+        ownerType: 'USER',
+        ownerId: testUserId,
+        createdAt: new Date().toISOString(),
+      })
+      .execute()
     await insertFile({ id: 'new-file', path: 'new-file.txt', uploaded: 0 })
     await db
       .insertInto('FileOwnership')

--- a/apps/backend/lib/files/upload-dedup.ts
+++ b/apps/backend/lib/files/upload-dedup.ts
@@ -16,10 +16,11 @@ export const finalizeUploadedFile = async (params: {
 }): Promise<string | null> => {
   const duplicate = await db
     .selectFrom('File')
-    .select(['id'])
-    .where('contentHash', '=', params.contentHash)
-    .where('id', '!=', params.fileId)
-    .where('uploaded', '=', 1)
+    .innerJoin('FileOwnership', 'FileOwnership.fileId', 'File.id')
+    .select(['File.id'])
+    .where('File.contentHash', '=', params.contentHash)
+    .where('File.id', '!=', params.fileId)
+    .where('File.uploaded', '=', 1)
     .executeTakeFirst()
 
   if (duplicate) {


### PR DESCRIPTION
## Summary

Prevents unowned (legacy/orphaned) files from being used as dedup targets during file upload. Until the ownership backfill migration runs, unowned files are world-readable — so deduplicating against one would silently hand a new uploader a publicly accessible canonical file. The fix adds an `INNER JOIN FileOwnership` to the duplicate-lookup query, restricting dedup to files that have at least one ownership row.

## Details

- `apps/backend/lib/files/upload-dedup.ts`: added `innerJoin('FileOwnership', ...)` to the `finalizeUploadedFile` duplicate query
- `__tests__/fileDeduplication.test.ts`: updated `makeSelectChain` helper to include the new `innerJoin` step; added a test asserting that when the lookup returns no match (as it will for unowned files), the new file is marked uploaded rather than deduplicated

## Tests

- `npx vitest run __tests__/fileDeduplication.test.ts` — 9 tests passed
- `npm run check-types` — clean