### PR TITLE
fix(knowledge): qualify File.id to avoid ambiguity after FileBlob join

### DIFF
--- a/apps/backend/lib/tools/knowledge/implementation.ts
+++ b/apps/backend/lib/tools/knowledge/implementation.ts
@@ -66,7 +66,7 @@ export class KnowledgePlugin extends KnowledgePluginInterface implements ToolImp
             'FileBlob.size as size',
             'FileBlob.encrypted as encrypted',
           ])
-          .where('id', '=', `${params.id}`)
+          .where('File.id', '=', `${params.id}`)
           .executeTakeFirst() as FileDbRow | undefined
         if (!fileEntry) {
           return { type: 'error-text', value: 'File not found' }
@@ -112,7 +112,7 @@ export class KnowledgePlugin extends KnowledgePluginInterface implements ToolImp
         'FileBlob.size as size',
         'FileBlob.encrypted as encrypted',
       ])
-      .where('id', '=', `${knowledgeFile.id}`)
+      .where('File.id', '=', `${knowledgeFile.id}`)
       .executeTakeFirst() as FileDbRow | undefined
     if (!fileEntry) {
       return {


### PR DESCRIPTION
## Summary

Qualifies two `.where('id', ...)` calls in the knowledge tool implementation to `.where('File.id', ...)`. The `FileBlob` join introduced in #880 made the bare `id` column reference ambiguous, which would cause a runtime query error when the knowledge plugin resolves files.

## Tests

- `npm run check-types` — passes