### PR TITLE
fix(db): create FileOwnerType enum in file_blob migration

### DIFF
--- a/apps/backend/db/migrations/20260505-file_blob.ts
+++ b/apps/backend/db/migrations/20260505-file_blob.ts
@@ -20,6 +20,8 @@ export async function up(db: Kysely<any>, dialect: 'sqlite' | 'postgresql'): Pro
     .execute()
 
   if (dialect === 'postgresql') {
+    await db.schema.createType('FileOwnerType').asEnum(['USER', 'CHAT', 'ASSISTANT', 'TOOL']).execute()
+
     await db.schema
       .alterTable('File')
       .addColumn('fileBlobId', 'text')


### PR DESCRIPTION
## Summary
Fixes the `20260505-file_blob` migration on PostgreSQL by creating the `FileOwnerType` enum before adding the `File.ownerType` column, so the migration no longer fails with `type "FileOwnerType" does not exist`.

## Details
- add `CREATE TYPE "FileOwnerType" AS ENUM ('USER', 'CHAT', 'ASSISTANT', 'TOOL')` in the PostgreSQL branch of `20260505-file_blob`
- keep SQLite behavior unchanged