### PR TITLE
Add timestamp metadata to audio transcription output

### DIFF
--- a/__tests__/audioTranscription.test.ts
+++ b/__tests__/audioTranscription.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'vitest'
+import { AudioTranscriptionSchema } from '../packages/core/src/tools/schemas'
+import { AudioTranscription } from '@/backend/lib/tools/audio_transcription/implementation'
+
+const buildTool = (includeTimestamps?: boolean) =>
+  new AudioTranscription(
+    { id: 'tool-id', name: 'Audio Tool' } as any,
+    AudioTranscriptionSchema.parse({
+      apiKey: 'secret',
+      ...(includeTimestamps === undefined ? {} : { includeTimestamps }),
+    })
+  )
+
+describe('AudioTranscriptionSchema', () => {
+  test('defaults includeTimestamps to true', () => {
+    const parsed = AudioTranscriptionSchema.parse({ apiKey: 'secret' })
+    expect(parsed.includeTimestamps).toBe(true)
+  })
+})
+
+describe('AudioTranscription formatting', () => {
+  test('includes truncated second timestamps when enabled', () => {
+    const tool = buildTool(true) as any
+    const output = tool.formatTranscript('meeting.mp3', {
+      id: 'tr-1',
+      status: 'completed',
+      utterances: [
+        { speaker: 'A', text: 'Hello', start: 250, end: 69129 },
+        { speaker: 'B', text: 'Hi', start: 47000, end: 47009 },
+      ],
+    })
+
+    const payload = JSON.parse(output.split('\n\n')[1]) as {
+      transcript: Array<Record<string, unknown>>
+    }
+    expect(payload.transcript).toEqual([
+      {
+        speaker: 'SPEAKER A',
+        text: 'Hello',
+        start_time: 0.25,
+        end_time: 69.12,
+      },
+      {
+        speaker: 'SPEAKER B',
+        text: 'Hi',
+        start_time: 47,
+        end_time: 47,
+      },
+    ])
+  })
+
+  test('omits timestamp fields when disabled', () => {
+    const tool = buildTool(false) as any
+    const output = tool.formatTranscript('meeting.mp3', {
+      id: 'tr-2',
+      status: 'completed',
+      utterances: [{ speaker: 'A', text: 'Hello', start: 500, end: 1500 }],
+    })
+
+    const payload = JSON.parse(output.split('\n\n')[1]) as {
+      transcript: Array<Record<string, unknown>>
+    }
+    expect(payload.transcript).toEqual([
+      {
+        speaker: 'SPEAKER A',
+        text: 'Hello',
+      },
+    ])
+  })
+
+  test('gracefully omits missing timestamp values', () => {
+    const tool = buildTool(true) as any
+    const output = tool.formatTranscript('meeting.mp3', {
+      id: 'tr-3',
+      status: 'completed',
+      utterances: [{ speaker: 'A', text: 'Hello' }],
+    })
+
+    const payload = JSON.parse(output.split('\n\n')[1]) as {
+      transcript: Array<Record<string, unknown>>
+    }
+    expect(payload.transcript).toEqual([
+      {
+        speaker: 'SPEAKER A',
+        text: 'Hello',
+      },
+    ])
+  })
+})

--- a/apps/backend/lib/tools/audio_transcription/implementation.ts
+++ b/apps/backend/lib/tools/audio_transcription/implementation.ts
@@ -28,6 +28,8 @@ type AssemblyAiUploadResponse = {
 type AssemblyAiUtterance = {
   speaker: string | number
   text: string
+  start?: number
+  end?: number
 }
 
 type AssemblyAiTranscriptResponse = {
@@ -38,6 +40,13 @@ type AssemblyAiTranscriptResponse = {
   language_code?: string | null
   audio_duration?: number | null
   utterances?: AssemblyAiUtterance[] | null
+}
+
+type FormattedTranscriptChunk = {
+  speaker: string
+  text: string
+  start_time?: number
+  end_time?: number
 }
 
 const DEFAULT_API_URL = 'https://api.eu.assemblyai.com'
@@ -159,8 +168,10 @@ export class AudioTranscription extends AudioTranscriptionInterface implements T
       }
 
       const uploadBody = (await uploadResponse.json()) as AssemblyAiUploadResponse
-      const speakerLabels =
+      const configuredSpeakerLabels =
         typeof params.speakerLabels === 'boolean' ? params.speakerLabels : this.params.speakerLabels
+      const includeTimestamps = this.params.includeTimestamps ?? true
+      const speakerLabels = includeTimestamps ? true : configuredSpeakerLabels
       const language = this.params.defaultLanguage
 
       const transcriptCreateResponse = await fetch(`${this.getApiUrl()}/v2/transcript`, {
@@ -271,6 +282,7 @@ export class AudioTranscription extends AudioTranscriptionInterface implements T
   }
 
   private formatTranscript(fileName: string, transcript: AssemblyAiTranscriptResponse) {
+    const includeTimestamps = this.params.includeTimestamps ?? true
     const headerParts = [`Transcript for ${fileName}.`]
     if (transcript.language_code) {
       headerParts.push(`Detected language: ${transcript.language_code}.`)
@@ -279,18 +291,39 @@ export class AudioTranscription extends AudioTranscriptionInterface implements T
       headerParts.push(`Duration: ${(transcript.audio_duration / 1000).toFixed(1)} seconds.`)
     }
 
-    const utterances =
-      transcript.utterances?.map((utterance) => {
+    const formattedTranscript =
+      transcript.utterances?.map((utterance): FormattedTranscriptChunk => {
         const speaker = `${utterance.speaker}`.trim()
         const speakerLabel = speaker ? `SPEAKER ${speaker}` : 'SPEAKER'
-        return `${speakerLabel}: ${utterance.text}`
+        const chunk: FormattedTranscriptChunk = {
+          speaker: speakerLabel,
+          text: utterance.text,
+        }
+        if (includeTimestamps) {
+          const startTime = this.toSeconds(utterance.start)
+          const endTime = this.toSeconds(utterance.end)
+          if (startTime !== undefined) {
+            chunk.start_time = startTime
+          }
+          if (endTime !== undefined) {
+            chunk.end_time = endTime
+          }
+        }
+        return chunk
       }) ?? []
 
-    const textBody =
-      utterances.length > 0
-        ? utterances.join('\n')
-        : transcript.text?.trim() ?? 'No transcript text was returned.'
+    if (formattedTranscript.length > 0) {
+      return `${headerParts.join(' ')}\n\n${JSON.stringify({ transcript: formattedTranscript }, null, 2)}`
+    }
 
-    return `${headerParts.join(' ')}\n\n${textBody}`
+    const fallbackText = transcript.text?.trim() ?? 'No transcript text was returned.'
+    return `${headerParts.join(' ')}\n\n${fallbackText}`
+  }
+
+  private toSeconds(milliseconds?: number | null): number | undefined {
+    if (typeof milliseconds !== 'number' || !Number.isFinite(milliseconds)) {
+      return undefined
+    }
+    return Math.trunc(milliseconds / 10) / 100
   }
 }

--- a/apps/frontend/app/admin/tools/components/AudioTranscriptionToolFields.tsx
+++ b/apps/frontend/app/admin/tools/components/AudioTranscriptionToolFields.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useTranslation } from 'react-i18next'
 import { UseFormReturn } from 'react-hook-form'
-import { FormField, FormItem } from '@/components/ui/form'
+import { FormDescription, FormField, FormItem } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { ToolFormWithConfig } from './toolFormTypes'
@@ -102,6 +102,27 @@ const AudioTranscriptionToolFields = ({ form }: Props) => {
               checked={field.value ?? true}
               onCheckedChange={(checked) => field.onChange(checked)}
             />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="configuration.includeTimestamps"
+        render={({ field }) => (
+          <FormItem
+            label={t('audio_transcription_include_timestamps')}
+            className="flex flex-row items-center space-y-0"
+          >
+            <div className="flex w-full items-center gap-3">
+              <FormDescription className="text-xs">
+                {t('audio_transcription_include_timestamps_description')}
+              </FormDescription>
+              <Switch
+                className="ml-auto"
+                checked={field.value ?? true}
+                onCheckedChange={(checked) => field.onChange(checked)}
+              />
+            </div>
           </FormItem>
         )}
       />

--- a/apps/frontend/locales/en/logicle.json
+++ b/apps/frontend/locales/en/logicle.json
@@ -54,6 +54,8 @@
   "audio_transcription_default_language_placeholder": "Optional default language, for example en or it",
   "audio_transcription_poll_interval_ms": "Poll interval (ms)",
   "audio_transcription_speaker_labels": "Enable speaker labels by default",
+  "audio_transcription_include_timestamps": "Include chunk timestamps",
+  "audio_transcription_include_timestamps_description": "Adds start_time and end_time in seconds for each transcript chunk.",
   "audio_transcription_timeout_ms": "Timeout (ms)",
   "apikey-added": "API key added successfully",
   "apikey-created": "API key created",

--- a/apps/frontend/locales/it/logicle.json
+++ b/apps/frontend/locales/it/logicle.json
@@ -54,6 +54,8 @@
   "audio_transcription_default_language_placeholder": "Lingua predefinita opzionale, per esempio en o it",
   "audio_transcription_poll_interval_ms": "Intervallo di polling (ms)",
   "audio_transcription_speaker_labels": "Abilita speaker labels di default",
+  "audio_transcription_include_timestamps": "Includi timestamp dei segmenti",
+  "audio_transcription_include_timestamps_description": "Aggiunge start_time ed end_time in secondi per ogni segmento trascritto.",
   "audio_transcription_timeout_ms": "Timeout (ms)",
   "apikey-added": "API key aggiunta con successo",
   "apikey-created": "API key creata",

--- a/packages/core/src/tools/schemas.ts
+++ b/packages/core/src/tools/schemas.ts
@@ -12,6 +12,7 @@ export const AudioTranscriptionSchema = z
     apiUrl: z.string().url().optional(),
     defaultLanguage: z.string().optional(),
     speakerLabels: z.boolean().optional().default(true),
+    includeTimestamps: z.boolean().optional().default(true),
     pollIntervalMs: z.number().int().positive().optional().default(2000),
     timeoutMs: z.number().int().positive().optional(),
   })


### PR DESCRIPTION
## Summary
Adds timestamp metadata support to the AssemblyAI audio transcription tool output, including `start_time`/`end_time` in numeric seconds per transcript chunk when enabled, with truncation to 2 decimals for direct media seeking use cases.

## Details
- Added `includeTimestamps` to `AudioTranscriptionSchema` with default `true`.
- Updated transcription request behavior so `speaker_labels` is forced on when `includeTimestamps` is enabled, ensuring `utterances` are available for timestamp propagation.
- Extended utterance typing and formatting to attach `start_time` and `end_time` in seconds (truncated, not rounded).
- Preserved prior chunk shape (`speaker`, `text`) when timestamps are disabled.
- Added admin tool configuration UI toggle and i18n labels/descriptions (`en`, `it`).
- Added focused tests for schema defaulting, timestamp formatting, disabled mode, and missing timestamp fallback.

## Risks
- Existing consumers that parsed the transcript attachment strictly as line-based plain text may need to handle JSON transcript payloads when utterances are present.

## Tests
- `pnpm vitest run __tests__/audioTranscription.test.ts` (pass)
- `npm run check-types` (pass)