### PR TITLE
Require explicit ownership for file upload metadata creation

### DIFF
--- a/apps/backend/api/files/route.ts
+++ b/apps/backend/api/files/route.ts
@@ -10,12 +10,11 @@ export const POST = operation({
   description: 'Create file metadata entry.',
   authentication: 'user',
   requestBodySchema: dto.insertableFileSchema,
-  responses: [responseSpec(201, dto.fileSchema), errorSpec(403)] as const,
+  responses: [responseSpec(201, dto.fileSchema), errorSpec(400), errorSpec(403)] as const,
   implementation: async ({ body, session }) => {
     const id = nanoid()
     const path = `${id}-${body.name.replace(/(\W+)/gi, '-')}`
-    const { owner: bodyOwner, ...bodyWithoutOwner } = body
-    const owner = bodyOwner ?? { ownerType: 'USER' as const, ownerId: session.userId }
+    const { owner, ...bodyWithoutOwner } = body
     if (!(await canAccess(session, owner.ownerType, owner.ownerId))) {
       return forbidden()
     }

--- a/apps/backend/models/file.ts
+++ b/apps/backend/models/file.ts
@@ -28,7 +28,7 @@ export const getFileWithId = async (id: string): Promise<FileDbRow | undefined> 
 }
 
 export const addFile = async (
-  file: dto.InsertableFile,
+  file: Omit<dto.InsertableFile, 'owner'>,
   path: string,
   _encrypted: boolean,
   owner: dto.FileOwner

--- a/apps/backend/scripts/integration-baseline.ts
+++ b/apps/backend/scripts/integration-baseline.ts
@@ -394,6 +394,7 @@ async function main() {
   if (!profileJson.id || !profileJson.email || !profileJson.role) {
     throw new Error('Profile payload missing required fields')
   }
+  const userOwner = { ownerType: 'USER', ownerId: profileJson.id as string }
 
   console.log('Integration: core 4xx validation')
   await request('POST', '/api/me/folders', {
@@ -409,6 +410,31 @@ async function main() {
     headers: jsonHeaders,
     json: { name: 'x' },
     allowStatus: [404],
+  })
+  await request('POST', '/api/files', {
+    headers: jsonHeaders,
+    json: { name: `integration-${runId}.txt`, type: 'text/plain', size: 1 },
+    allowStatus: [400],
+  })
+  await request('POST', '/api/files', {
+    headers: jsonHeaders,
+    json: {
+      name: `integration-${runId}-forbidden.txt`,
+      type: 'text/plain',
+      size: 1,
+      owner: { ownerType: 'USER', ownerId: adminUserId },
+    },
+    allowStatus: [403],
+  })
+  await request('POST', '/api/files', {
+    expectedStatus: 201,
+    headers: jsonHeaders,
+    json: {
+      name: `integration-${runId}-owned.txt`,
+      type: 'text/plain',
+      size: 1,
+      owner: userOwner,
+    },
   })
 
   console.log('Integration: CRUD side-effects for folder resource')

--- a/apps/backend/scripts/smoke.ts
+++ b/apps/backend/scripts/smoke.ts
@@ -237,6 +237,7 @@ async function main() {
   if (!profileJson.id) {
     throw new Error('Missing user id in profile response')
   }
+  const owner = { ownerType: 'USER', ownerId: profileJson.id }
 
   console.log('Smoke: CRUD baseline with folders')
   const folderCreated = await request('POST', '/api/me/folders', {
@@ -267,6 +268,7 @@ async function main() {
       name: `smoke-${runId}.txt`,
       type: 'text/plain',
       size: 11,
+      owner,
     },
   })
   const fileId = (parseJson(fileCreated.text, '/api/files POST') as { id: string }).id
@@ -292,6 +294,7 @@ async function main() {
       name: `smoke-${runId}.pdf`,
       type: 'application/pdf',
       size: pdfBuffer.byteLength,
+      owner,
     },
   })
   const pdfFileId = (parseJson(pdfCreated.text, '/api/files POST pdf') as { id: string }).id

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -4155,6 +4155,8 @@ paths:
                   - createdAt
                   - encrypted
                 additionalProperties: false
+        "400":
+          $ref: "#/components/responses/Error"
         "403":
           $ref: "#/components/responses/Error"
       security:
@@ -4192,6 +4194,7 @@ paths:
                 - name
                 - type
                 - size
+                - owner
               additionalProperties: false
   /api/health:
     get:

--- a/packages/core/src/types/dto/file.ts
+++ b/packages/core/src/types/dto/file.ts
@@ -24,7 +24,7 @@ export const insertableFileSchema = fileSchema
     path: true,
   })
   .extend({
-    owner: fileOwnerSchema.optional(),
+    owner: fileOwnerSchema,
   })
 
 export type FileOwner = z.infer<typeof fileOwnerSchema>


### PR DESCRIPTION
## Summary
Require explicit `owner` metadata in `POST /api/files` so new uploads never fall back silently to default USER ownership.

## Details
- Make `owner` required in `insertableFileSchema` (`ownerType` + `ownerId` mandatory).
- Remove implicit fallback ownership in `POST /api/files` and keep explicit authorization via `canAccess`.
- Add `400` to the route response spec for invalid/missing ownership payloads.
- Update smoke upload requests to send explicit owner metadata.
- Extend integration baseline to assert `POST /api/files` returns `400` when `owner` is missing and `403` for unauthorized ownership.
- Regenerate OpenAPI to reflect required owner fields.

## Risks
- Older clients that omit `owner` when creating files will now fail with `400` until updated.

## Tests
- `npm run generate:openapi` (pass)
- `npm run check-types` (pass)