### PR TITLE
chore: promote reusable OpenAPI schema refs

### DIFF
--- a/apps/backend/generate_openapi.ts
+++ b/apps/backend/generate_openapi.ts
@@ -101,10 +101,12 @@ function pathFromRouteFile(filePath: string): { path: string; params: string[] }
 function zodToOpenApi(schema: ZodTypeAny): OpenAPIV3.SchemaObject {
   const anySchema = schema as any
   if (typeof anySchema.toJSONSchema === 'function') {
-    return anySchema.toJSONSchema({
+    const generated = anySchema.toJSONSchema({
       target: 'openApi3',
       $refStrategy: 'none',
-    }) as OpenAPIV3.SchemaObject
+    }) as OpenAPIV3.SchemaObject & { definitions?: Record<string, OpenAPIV3.SchemaObject> }
+    hoistDefinitionsToComponents(generated)
+    return rewriteDefinitionsRefs(generated)
   }
   if (typeof anySchema.toJSON === 'function') {
     const json = anySchema.toJSON()
@@ -113,6 +115,37 @@ function zodToOpenApi(schema: ZodTypeAny): OpenAPIV3.SchemaObject {
     }
   }
   return {} as OpenAPIV3.SchemaObject
+}
+
+function hoistDefinitionsToComponents(
+  schema: OpenAPIV3.SchemaObject & { definitions?: Record<string, OpenAPIV3.SchemaObject> }
+) {
+  if (!schema.definitions) return
+  for (const [name, definition] of Object.entries(schema.definitions)) {
+    if (!componentsSchemas[name]) {
+      componentsSchemas[name] = rewriteDefinitionsRefs(definition)
+    }
+  }
+  delete schema.definitions
+}
+
+function rewriteDefinitionsRefs<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => rewriteDefinitionsRefs(item)) as T
+  }
+  if (!value || typeof value !== 'object') {
+    return value
+  }
+  const objectValue = value as Record<string, unknown>
+  const output: Record<string, unknown> = {}
+  for (const [key, raw] of Object.entries(objectValue)) {
+    if (key === '$ref' && typeof raw === 'string' && raw.startsWith('#/definitions/')) {
+      output[key] = raw.replace('#/definitions/', '#/components/schemas/')
+      continue
+    }
+    output[key] = rewriteDefinitionsRefs(raw)
+  }
+  return output as T
 }
 
 function schemaToOpenApiOrRef(
@@ -124,7 +157,22 @@ function schemaToOpenApiOrRef(
     }
     return { $ref: '#/components/schemas/ErrorResponse' }
   }
+  const schemaName = getSchemaId(schema)
+  if (schemaName) {
+    if (!componentsSchemas[schemaName]) {
+      componentsSchemas[schemaName] = zodToOpenApi(schema)
+    }
+    return { $ref: `#/components/schemas/${schemaName}` }
+  }
   return zodToOpenApi(schema)
+}
+
+function getSchemaId(schema: ZodTypeAny): string | undefined {
+  const anySchema = schema as any
+  if (typeof anySchema.meta !== 'function') return undefined
+  const metadata = anySchema.meta()
+  const id = metadata?.id
+  return typeof id === 'string' && id.length > 0 ? id : undefined
 }
 
 function ensureErrorResponseRef(): OpenAPIV3.ReferenceObject {

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -335,77 +335,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    assistantId:
-                      type: string
-                    backendId:
-                      type: string
-                    description:
-                      type: string
-                    imageId:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    model:
-                      type: string
-                    name:
-                      type: string
-                    versionName:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    systemPrompt:
-                      type: string
-                    temperature:
-                      type: number
-                    tokenLimit:
-                      type: number
-                    reasoning_effort:
-                      anyOf:
-                        - type: string
-                          enum:
-                            - low
-                            - medium
-                            - high
-                        - type: "null"
-                    tags:
-                      type: string
-                    prompts:
-                      type: string
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    updatedAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    current:
-                      type: boolean
-                    published:
-                      type: boolean
-                  required:
-                    - id
-                    - assistantId
-                    - backendId
-                    - description
-                    - imageId
-                    - model
-                    - name
-                    - systemPrompt
-                    - temperature
-                    - tokenLimit
-                    - reasoning_effort
-                    - tags
-                    - prompts
-                    - createdAt
-                    - updatedAt
-                    - current
-                    - published
-                  additionalProperties: false
+                  $ref: "#/components/schemas/AssistantVersion"
       parameters:
         - name: assistantId
           in: path
@@ -459,140 +389,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  assistantId:
-                    type: string
-                  backendId:
-                    type: string
-                  description:
-                    type: string
-                  model:
-                    type: string
-                  name:
-                    type: string
-                  versionName:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  systemPrompt:
-                    type: string
-                  temperature:
-                    type: number
-                  tokenLimit:
-                    type: number
-                  reasoning_effort:
-                    anyOf:
-                      - type: string
-                        enum:
-                          - low
-                          - medium
-                          - high
-                      - type: "null"
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  updatedAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  owner:
-                    type: string
-                  tools:
-                    type: array
-                    items:
-                      type: string
-                  files:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        type:
-                          type: string
-                        size:
-                          type: number
-                      required:
-                        - id
-                        - name
-                        - type
-                        - size
-                      additionalProperties: false
-                  sharing:
-                    type: array
-                    items:
-                      oneOf:
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              const: all
-                          required:
-                            - type
-                          additionalProperties: false
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              const: workspace
-                            workspaceId:
-                              type: string
-                            workspaceName:
-                              type: string
-                          required:
-                            - type
-                            - workspaceId
-                            - workspaceName
-                          additionalProperties: false
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  prompts:
-                    type: array
-                    items:
-                      type: string
-                  iconUri:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  provisioned:
-                    type: boolean
-                  pendingChanges:
-                    type: boolean
-                  subAssistants:
-                    type: array
-                    items:
-                      type: string
-                required:
-                  - id
-                  - assistantId
-                  - backendId
-                  - description
-                  - model
-                  - name
-                  - systemPrompt
-                  - temperature
-                  - tokenLimit
-                  - reasoning_effort
-                  - createdAt
-                  - updatedAt
-                  - owner
-                  - tools
-                  - files
-                  - sharing
-                  - tags
-                  - prompts
-                  - iconUri
-                  - provisioned
-                  - pendingChanges
-                additionalProperties: false
+                $ref: "#/components/schemas/AssistantDraft"
         "403":
           $ref: "#/components/responses/Error"
         "404":
@@ -615,140 +412,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  assistantId:
-                    type: string
-                  backendId:
-                    type: string
-                  description:
-                    type: string
-                  model:
-                    type: string
-                  name:
-                    type: string
-                  versionName:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  systemPrompt:
-                    type: string
-                  temperature:
-                    type: number
-                  tokenLimit:
-                    type: number
-                  reasoning_effort:
-                    anyOf:
-                      - type: string
-                        enum:
-                          - low
-                          - medium
-                          - high
-                      - type: "null"
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  updatedAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  owner:
-                    type: string
-                  tools:
-                    type: array
-                    items:
-                      type: string
-                  files:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        type:
-                          type: string
-                        size:
-                          type: number
-                      required:
-                        - id
-                        - name
-                        - type
-                        - size
-                      additionalProperties: false
-                  sharing:
-                    type: array
-                    items:
-                      oneOf:
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              const: all
-                          required:
-                            - type
-                          additionalProperties: false
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              const: workspace
-                            workspaceId:
-                              type: string
-                            workspaceName:
-                              type: string
-                          required:
-                            - type
-                            - workspaceId
-                            - workspaceName
-                          additionalProperties: false
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  prompts:
-                    type: array
-                    items:
-                      type: string
-                  iconUri:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  provisioned:
-                    type: boolean
-                  pendingChanges:
-                    type: boolean
-                  subAssistants:
-                    type: array
-                    items:
-                      type: string
-                required:
-                  - id
-                  - assistantId
-                  - backendId
-                  - description
-                  - model
-                  - name
-                  - systemPrompt
-                  - temperature
-                  - tokenLimit
-                  - reasoning_effort
-                  - createdAt
-                  - updatedAt
-                  - owner
-                  - tools
-                  - files
-                  - sharing
-                  - tags
-                  - prompts
-                  - iconUri
-                  - provisioned
-                  - pendingChanges
-                additionalProperties: false
+                $ref: "#/components/schemas/AssistantDraft"
         "400":
           $ref: "#/components/responses/Error"
         "403":
@@ -806,74 +470,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                backendId:
-                  type: string
-                description:
-                  type: string
-                model:
-                  type: string
-                name:
-                  type: string
-                versionName:
-                  anyOf:
-                    - type: string
-                    - type: "null"
-                systemPrompt:
-                  type: string
-                temperature:
-                  type: number
-                tokenLimit:
-                  type: number
-                reasoning_effort:
-                  anyOf:
-                    - type: string
-                      enum:
-                        - low
-                        - medium
-                        - high
-                    - type: "null"
-                tools:
-                  type: array
-                  items:
-                    type: string
-                files:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                      name:
-                        type: string
-                      type:
-                        type: string
-                      size:
-                        type: number
-                    required:
-                      - id
-                      - name
-                      - type
-                      - size
-                    additionalProperties: false
-                tags:
-                  type: array
-                  items:
-                    type: string
-                prompts:
-                  type: array
-                  items:
-                    type: string
-                iconUri:
-                  anyOf:
-                    - type: string
-                    - type: "null"
-                subAssistants:
-                  type: array
-                  items:
-                    type: string
-              additionalProperties: false
+              $ref: "#/components/schemas/UpdateableAssistantDraft"
   /api/assistants/{assistantId}/sharing:
     post:
       summary: Update assistant sharing
@@ -886,29 +483,7 @@ paths:
               schema:
                 type: array
                 items:
-                  oneOf:
-                    - type: object
-                      properties:
-                        type:
-                          type: string
-                          const: all
-                      required:
-                        - type
-                      additionalProperties: false
-                    - type: object
-                      properties:
-                        type:
-                          type: string
-                          const: workspace
-                        workspaceId:
-                          type: string
-                        workspaceName:
-                          type: string
-                      required:
-                        - type
-                        - workspaceId
-                        - workspaceName
-                      additionalProperties: false
+                  $ref: "#/components/schemas/AssistantSharing"
         "403":
           $ref: "#/components/responses/Error"
         "404":
@@ -928,29 +503,7 @@ paths:
             schema:
               type: array
               items:
-                oneOf:
-                  - type: object
-                    properties:
-                      type:
-                        type: string
-                        const: all
-                    required:
-                      - type
-                    additionalProperties: false
-                  - type: object
-                    properties:
-                      type:
-                        type: string
-                        const: workspace
-                      workspaceId:
-                        type: string
-                      workspaceName:
-                        type: string
-                    required:
-                      - type
-                      - workspaceId
-                      - workspaceName
-                    additionalProperties: false
+                $ref: "#/components/schemas/AssistantSharing"
   /api/assistants/drafts/{assistantVersionId}:
     get:
       summary: Get assistant draft by version
@@ -961,140 +514,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  assistantId:
-                    type: string
-                  backendId:
-                    type: string
-                  description:
-                    type: string
-                  model:
-                    type: string
-                  name:
-                    type: string
-                  versionName:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  systemPrompt:
-                    type: string
-                  temperature:
-                    type: number
-                  tokenLimit:
-                    type: number
-                  reasoning_effort:
-                    anyOf:
-                      - type: string
-                        enum:
-                          - low
-                          - medium
-                          - high
-                      - type: "null"
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  updatedAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  owner:
-                    type: string
-                  tools:
-                    type: array
-                    items:
-                      type: string
-                  files:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        type:
-                          type: string
-                        size:
-                          type: number
-                      required:
-                        - id
-                        - name
-                        - type
-                        - size
-                      additionalProperties: false
-                  sharing:
-                    type: array
-                    items:
-                      oneOf:
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              const: all
-                          required:
-                            - type
-                          additionalProperties: false
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              const: workspace
-                            workspaceId:
-                              type: string
-                            workspaceName:
-                              type: string
-                          required:
-                            - type
-                            - workspaceId
-                            - workspaceName
-                          additionalProperties: false
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  prompts:
-                    type: array
-                    items:
-                      type: string
-                  iconUri:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  provisioned:
-                    type: boolean
-                  pendingChanges:
-                    type: boolean
-                  subAssistants:
-                    type: array
-                    items:
-                      type: string
-                required:
-                  - id
-                  - assistantId
-                  - backendId
-                  - description
-                  - model
-                  - name
-                  - systemPrompt
-                  - temperature
-                  - tokenLimit
-                  - reasoning_effort
-                  - createdAt
-                  - updatedAt
-                  - owner
-                  - tools
-                  - files
-                  - sharing
-                  - tags
-                  - prompts
-                  - iconUri
-                  - provisioned
-                  - pendingChanges
-                additionalProperties: false
+                $ref: "#/components/schemas/AssistantDraft"
         "403":
           $ref: "#/components/responses/Error"
         "404":
@@ -1159,150 +579,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                assistant:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    assistantId:
-                      type: string
-                    backendId:
-                      type: string
-                    description:
-                      type: string
-                    model:
-                      type: string
-                    name:
-                      type: string
-                    versionName:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    systemPrompt:
-                      type: string
-                    temperature:
-                      type: number
-                    tokenLimit:
-                      type: number
-                    reasoning_effort:
-                      anyOf:
-                        - type: string
-                          enum:
-                            - low
-                            - medium
-                            - high
-                        - type: "null"
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    updatedAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    owner:
-                      type: string
-                    tools:
-                      type: array
-                      items:
-                        type: string
-                    files:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          id:
-                            type: string
-                          name:
-                            type: string
-                          type:
-                            type: string
-                          size:
-                            type: number
-                        required:
-                          - id
-                          - name
-                          - type
-                          - size
-                        additionalProperties: false
-                    sharing:
-                      type: array
-                      items:
-                        oneOf:
-                          - type: object
-                            properties:
-                              type:
-                                type: string
-                                const: all
-                            required:
-                              - type
-                            additionalProperties: false
-                          - type: object
-                            properties:
-                              type:
-                                type: string
-                                const: workspace
-                              workspaceId:
-                                type: string
-                              workspaceName:
-                                type: string
-                            required:
-                              - type
-                              - workspaceId
-                              - workspaceName
-                            additionalProperties: false
-                    tags:
-                      type: array
-                      items:
-                        type: string
-                    prompts:
-                      type: array
-                      items:
-                        type: string
-                    iconUri:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    provisioned:
-                      type: boolean
-                    pendingChanges:
-                      type: boolean
-                    subAssistants:
-                      type: array
-                      items:
-                        type: string
-                  required:
-                    - id
-                    - assistantId
-                    - backendId
-                    - description
-                    - model
-                    - name
-                    - systemPrompt
-                    - temperature
-                    - tokenLimit
-                    - reasoning_effort
-                    - createdAt
-                    - updatedAt
-                    - owner
-                    - tools
-                    - files
-                    - sharing
-                    - tags
-                    - prompts
-                    - iconUri
-                    - provisioned
-                    - pendingChanges
-                  additionalProperties: false
-                messages:
-                  type: array
-                  items: {}
-              required:
-                - assistant
-                - messages
-              additionalProperties: false
+              $ref: "#/components/schemas/EvaluateAssistantRequest"
   /api/assistants:
     get:
       summary: List assistants
@@ -1328,88 +605,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                backendId:
-                  type: string
-                description:
-                  type: string
-                model:
-                  type: string
-                name:
-                  type: string
-                versionName:
-                  anyOf:
-                    - type: string
-                    - type: "null"
-                systemPrompt:
-                  type: string
-                temperature:
-                  type: number
-                tokenLimit:
-                  type: number
-                reasoning_effort:
-                  anyOf:
-                    - type: string
-                      enum:
-                        - low
-                        - medium
-                        - high
-                    - type: "null"
-                tools:
-                  type: array
-                  items:
-                    type: string
-                files:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                      name:
-                        type: string
-                      type:
-                        type: string
-                      size:
-                        type: number
-                    required:
-                      - id
-                      - name
-                      - type
-                      - size
-                    additionalProperties: false
-                tags:
-                  type: array
-                  items:
-                    type: string
-                prompts:
-                  type: array
-                  items:
-                    type: string
-                iconUri:
-                  anyOf:
-                    - type: string
-                    - type: "null"
-                subAssistants:
-                  type: array
-                  items:
-                    type: string
-              required:
-                - backendId
-                - description
-                - model
-                - name
-                - systemPrompt
-                - temperature
-                - tokenLimit
-                - reasoning_effort
-                - tools
-                - files
-                - tags
-                - prompts
-                - iconUri
-              additionalProperties: false
+              $ref: "#/components/schemas/InsertableAssistantDraft"
   /api/assistants/tags:
     get:
       summary: List assistant tags
@@ -1436,205 +632,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  assistantId:
-                    type: string
-                    description: Assistant id used for estimation.
-                  model:
-                    type: string
-                    description: Resolved model id used for estimation.
-                  tokenizer:
-                    type: string
-                    enum:
-                      - cl100k_base
-                      - o200k_base
-                      - approx_4chars
-                    description: Tokenizer strategy used to compute token estimates.
-                  estimate:
-                    type: object
-                    properties:
-                      assistant:
-                        type: number
-                        description: Estimated tokens for assistant-provided context before messages,
-                          including system prompt, tool prompt fragments, and
-                          assistant knowledge injection.
-                      messages:
-                        type: number
-                        description: Estimated tokens for the provided message list after ChatAssistant
-                          message conversion.
-                      total:
-                        type: number
-                        description: "Final estimate for next request input tokens: assistant +
-                          messages."
-                    required:
-                      - assistant
-                      - messages
-                      - total
-                    additionalProperties: false
-                  detail:
-                    description: Detailed per-component token breakdown, present only when
-                      ?detail=true is requested.
-                    type: object
-                    properties:
-                      preamble:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            type:
-                              type: string
-                              description: "Component type: system_prompt, knowledge_text, knowledge_file,
-                                text, attachment, reasoning, tool_call,
-                                tool_result."
-                            tokens:
-                              type: number
-                              description: Token count for this component.
-                            algorithm:
-                              type: string
-                              description: "Algorithm or tokenizer used: cl100k_base, o200k_base,
-                                approx_4chars, native_image, pdf_native,
-                                pdf_text_fallback, pdf_page_limit_notice."
-                            params:
-                              description: Algorithm parameters, e.g. image dimensions or PDF page counts.
-                              type: object
-                              additionalProperties: {}
-                            id:
-                              description: File id or tool call id.
-                              type: string
-                            name:
-                              description: File name.
-                              type: string
-                            mimetype:
-                              description: MIME type for attachment entries.
-                              type: string
-                            toolCallId:
-                              description: Tool call id for tool_call and tool_result entries.
-                              type: string
-                            toolName:
-                              description: Tool name for tool_call and tool_result entries.
-                              type: string
-                          required:
-                            - type
-                            - tokens
-                            - algorithm
-                          additionalProperties: false
-                        description: Per-component breakdown of preamble tokens (system prompt,
-                          knowledge).
-                      history:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            messageId:
-                              type: string
-                            role:
-                              type: string
-                              enum:
-                                - user
-                                - assistant
-                                - tool
-                            parts:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    description: "Component type: system_prompt, knowledge_text, knowledge_file,
-                                      text, attachment, reasoning, tool_call,
-                                      tool_result."
-                                  tokens:
-                                    type: number
-                                    description: Token count for this component.
-                                  algorithm:
-                                    type: string
-                                    description: "Algorithm or tokenizer used: cl100k_base, o200k_base,
-                                      approx_4chars, native_image, pdf_native,
-                                      pdf_text_fallback, pdf_page_limit_notice."
-                                  params:
-                                    description: Algorithm parameters, e.g. image dimensions or PDF page counts.
-                                    type: object
-                                    additionalProperties: {}
-                                  id:
-                                    description: File id or tool call id.
-                                    type: string
-                                  name:
-                                    description: File name.
-                                    type: string
-                                  mimetype:
-                                    description: MIME type for attachment entries.
-                                    type: string
-                                  toolCallId:
-                                    description: Tool call id for tool_call and tool_result entries.
-                                    type: string
-                                  toolName:
-                                    description: Tool name for tool_call and tool_result entries.
-                                    type: string
-                                required:
-                                  - type
-                                  - tokens
-                                  - algorithm
-                                additionalProperties: false
-                          required:
-                            - messageId
-                            - role
-                            - parts
-                          additionalProperties: false
-                        description: Per-message breakdown of history tokens.
-                      draft:
-                        description: Per-component breakdown of draft message tokens.
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            type:
-                              type: string
-                              description: "Component type: system_prompt, knowledge_text, knowledge_file,
-                                text, attachment, reasoning, tool_call,
-                                tool_result."
-                            tokens:
-                              type: number
-                              description: Token count for this component.
-                            algorithm:
-                              type: string
-                              description: "Algorithm or tokenizer used: cl100k_base, o200k_base,
-                                approx_4chars, native_image, pdf_native,
-                                pdf_text_fallback, pdf_page_limit_notice."
-                            params:
-                              description: Algorithm parameters, e.g. image dimensions or PDF page counts.
-                              type: object
-                              additionalProperties: {}
-                            id:
-                              description: File id or tool call id.
-                              type: string
-                            name:
-                              description: File name.
-                              type: string
-                            mimetype:
-                              description: MIME type for attachment entries.
-                              type: string
-                            toolCallId:
-                              description: Tool call id for tool_call and tool_result entries.
-                              type: string
-                            toolName:
-                              description: Tool name for tool_call and tool_result entries.
-                              type: string
-                          required:
-                            - type
-                            - tokens
-                            - algorithm
-                          additionalProperties: false
-                    required:
-                      - preamble
-                      - history
-                    additionalProperties: false
-                required:
-                  - assistantId
-                  - model
-                  - tokenizer
-                  - estimate
-                additionalProperties: false
+                $ref: "#/components/schemas/AssistantTokenEstimateResponse"
         "400":
           $ref: "#/components/responses/Error"
       security:
@@ -1644,150 +642,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                assistant:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    assistantId:
-                      type: string
-                    backendId:
-                      type: string
-                    description:
-                      type: string
-                    model:
-                      type: string
-                    name:
-                      type: string
-                    versionName:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    systemPrompt:
-                      type: string
-                    temperature:
-                      type: number
-                    tokenLimit:
-                      type: number
-                    reasoning_effort:
-                      anyOf:
-                        - type: string
-                          enum:
-                            - low
-                            - medium
-                            - high
-                        - type: "null"
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    updatedAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    owner:
-                      type: string
-                    tools:
-                      type: array
-                      items:
-                        type: string
-                    files:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          id:
-                            type: string
-                          name:
-                            type: string
-                          type:
-                            type: string
-                          size:
-                            type: number
-                        required:
-                          - id
-                          - name
-                          - type
-                          - size
-                        additionalProperties: false
-                    sharing:
-                      type: array
-                      items:
-                        oneOf:
-                          - type: object
-                            properties:
-                              type:
-                                type: string
-                                const: all
-                            required:
-                              - type
-                            additionalProperties: false
-                          - type: object
-                            properties:
-                              type:
-                                type: string
-                                const: workspace
-                              workspaceId:
-                                type: string
-                              workspaceName:
-                                type: string
-                            required:
-                              - type
-                              - workspaceId
-                              - workspaceName
-                            additionalProperties: false
-                    tags:
-                      type: array
-                      items:
-                        type: string
-                    prompts:
-                      type: array
-                      items:
-                        type: string
-                    iconUri:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    provisioned:
-                      type: boolean
-                    pendingChanges:
-                      type: boolean
-                    subAssistants:
-                      type: array
-                      items:
-                        type: string
-                  required:
-                    - id
-                    - assistantId
-                    - backendId
-                    - description
-                    - model
-                    - name
-                    - systemPrompt
-                    - temperature
-                    - tokenLimit
-                    - reasoning_effort
-                    - createdAt
-                    - updatedAt
-                    - owner
-                    - tools
-                    - files
-                    - sharing
-                    - tags
-                    - prompts
-                    - iconUri
-                    - provisioned
-                    - pendingChanges
-                  additionalProperties: false
-                messages:
-                  type: array
-                  items: {}
-              required:
-                - assistant
-                - messages
-              additionalProperties: false
+              $ref: "#/components/schemas/EvaluateAssistantRequest"
   /api/auth/join:
     post:
       summary: Signup
@@ -1802,21 +657,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                email:
-                  type: string
-                  format: email
-                  pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
-                password:
-                  type: string
-              required:
-                - name
-                - email
-                - password
-              additionalProperties: false
+              $ref: "#/components/schemas/JoinRequest"
   /api/auth/login:
     post:
       summary: Login
@@ -1835,18 +676,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                email:
-                  type: string
-                  format: email
-                  pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
-                password:
-                  type: string
-              required:
-                - email
-                - password
-              additionalProperties: false
+              $ref: "#/components/schemas/LoginRequest"
   /api/auth/logout:
     post:
       summary: Logout
@@ -1917,54 +747,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    expiresAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    lastSeenAt:
-                      anyOf:
-                        - type: string
-                          format: date-time
-                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                        - type: "null"
-                    userAgent:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    ipAddress:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    authMethod:
-                      type: string
-                      enum:
-                        - password
-                        - idp
-                    idpConnectionId:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    isCurrent:
-                      type: boolean
-                  required:
-                    - id
-                    - createdAt
-                    - expiresAt
-                    - lastSeenAt
-                    - userAgent
-                    - ipAddress
-                    - authMethod
-                    - idpConnectionId
-                    - isCurrent
-                  additionalProperties: false
+                  $ref: "#/components/schemas/SessionSummary"
       security:
         - bearerAuth: []
   /api/backends/{backendId}/models:
@@ -2012,161 +795,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - type: object
-                    properties:
-                      providerType:
-                        type: string
-                        const: openai
-                      name:
-                        type: string
-                        minLength: 2
-                      apiKey:
-                        type: string
-                        minLength: 2
-                      id:
-                        type: string
-                      provisioned:
-                        type: boolean
-                    required:
-                      - providerType
-                      - name
-                      - apiKey
-                      - id
-                      - provisioned
-                    additionalProperties: false
-                  - type: object
-                    properties:
-                      providerType:
-                        type: string
-                        const: anthropic
-                      name:
-                        type: string
-                        minLength: 2
-                      apiKey:
-                        type: string
-                        minLength: 2
-                      id:
-                        type: string
-                      provisioned:
-                        type: boolean
-                    required:
-                      - providerType
-                      - name
-                      - apiKey
-                      - id
-                      - provisioned
-                    additionalProperties: false
-                  - type: object
-                    properties:
-                      providerType:
-                        type: string
-                        const: logiclecloud
-                      name:
-                        type: string
-                        minLength: 2
-                      apiKey:
-                        type: string
-                        minLength: 2
-                      endPoint:
-                        type: string
-                        format: uri
-                      id:
-                        type: string
-                      provisioned:
-                        type: boolean
-                    required:
-                      - providerType
-                      - name
-                      - apiKey
-                      - endPoint
-                      - id
-                      - provisioned
-                    additionalProperties: false
-                  - type: object
-                    properties:
-                      providerType:
-                        type: string
-                        const: gcp-vertex
-                      name:
-                        type: string
-                        minLength: 2
-                      credentials:
-                        type: string
-                        minLength: 2
-                      id:
-                        type: string
-                      provisioned:
-                        type: boolean
-                    required:
-                      - providerType
-                      - name
-                      - credentials
-                      - id
-                      - provisioned
-                    additionalProperties: false
-                  - type: object
-                    properties:
-                      providerType:
-                        type: string
-                        const: perplexity
-                      name:
-                        type: string
-                        minLength: 2
-                      apiKey:
-                        type: string
-                        minLength: 2
-                      id:
-                        type: string
-                      provisioned:
-                        type: boolean
-                    required:
-                      - providerType
-                      - name
-                      - apiKey
-                      - id
-                      - provisioned
-                    additionalProperties: false
-                  - type: object
-                    properties:
-                      providerType:
-                        type: string
-                        const: gemini
-                      name:
-                        type: string
-                        minLength: 2
-                      apiKey:
-                        type: string
-                        minLength: 2
-                      id:
-                        type: string
-                      provisioned:
-                        type: boolean
-                    required:
-                      - providerType
-                      - name
-                      - apiKey
-                      - id
-                      - provisioned
-                    additionalProperties: false
-                  - type: object
-                    properties:
-                      providerType:
-                        type: string
-                        const: mock
-                      name:
-                        type: string
-                        minLength: 2
-                      id:
-                        type: string
-                      provisioned:
-                        type: boolean
-                    required:
-                      - providerType
-                      - name
-                      - id
-                      - provisioned
-                    additionalProperties: false
+                $ref: "#/components/schemas/Backend"
         "403":
           $ref: "#/components/responses/Error"
         "404":
@@ -2222,105 +851,7 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
-                - type: object
-                  properties:
-                    providerType:
-                      type: string
-                      const: openai
-                    name:
-                      type: string
-                      minLength: 2
-                    apiKey:
-                      type: string
-                      minLength: 2
-                  required:
-                    - providerType
-                  additionalProperties: false
-                - type: object
-                  properties:
-                    providerType:
-                      type: string
-                      const: anthropic
-                    name:
-                      type: string
-                      minLength: 2
-                    apiKey:
-                      type: string
-                      minLength: 2
-                  required:
-                    - providerType
-                  additionalProperties: false
-                - type: object
-                  properties:
-                    providerType:
-                      type: string
-                      const: logiclecloud
-                    name:
-                      type: string
-                      minLength: 2
-                    apiKey:
-                      type: string
-                      minLength: 2
-                    endPoint:
-                      type: string
-                      format: uri
-                  required:
-                    - providerType
-                  additionalProperties: false
-                - type: object
-                  properties:
-                    providerType:
-                      type: string
-                      const: gcp-vertex
-                    name:
-                      type: string
-                      minLength: 2
-                    credentials:
-                      type: string
-                      minLength: 2
-                  required:
-                    - providerType
-                  additionalProperties: false
-                - type: object
-                  properties:
-                    providerType:
-                      type: string
-                      const: perplexity
-                    name:
-                      type: string
-                      minLength: 2
-                    apiKey:
-                      type: string
-                      minLength: 2
-                  required:
-                    - providerType
-                  additionalProperties: false
-                - type: object
-                  properties:
-                    providerType:
-                      type: string
-                      const: gemini
-                    name:
-                      type: string
-                      minLength: 2
-                    apiKey:
-                      type: string
-                      minLength: 2
-                  required:
-                    - providerType
-                  additionalProperties: false
-                - type: object
-                  properties:
-                    providerType:
-                      type: string
-                      const: mock
-                    name:
-                      type: string
-                      minLength: 2
-                  required:
-                    - providerType
-                  additionalProperties: false
+              $ref: "#/components/schemas/UpdateableBackend"
   /api/backends/models:
     get:
       summary: List backends with models
@@ -2342,73 +873,7 @@ paths:
                     models:
                       type: array
                       items:
-                        type: object
-                        properties:
-                          id:
-                            type: string
-                          model:
-                            type: string
-                          name:
-                            type: string
-                          provider:
-                            type: string
-                          owned_by:
-                            type: string
-                          description:
-                            type: string
-                          context_length:
-                            type: number
-                          capabilities:
-                            type: object
-                            properties:
-                              vision:
-                                type: boolean
-                              function_calling:
-                                type: boolean
-                              reasoning:
-                                type: boolean
-                              supportedMedia:
-                                type: array
-                                items:
-                                  type: string
-                              web_search:
-                                type: boolean
-                              knowledge:
-                                type: boolean
-                            required:
-                              - vision
-                              - function_calling
-                              - reasoning
-                            additionalProperties: false
-                          defaultReasoning:
-                            anyOf:
-                              - type: string
-                              - type: "null"
-                          tags:
-                            type: array
-                            items:
-                              type: string
-                              enum:
-                                - latest
-                                - obsolete
-                          maxOutputTokens:
-                            type: number
-                          tokenizer:
-                            type: string
-                            enum:
-                              - cl100k_base
-                              - o200k_base
-                              - approx_4chars
-                        required:
-                          - id
-                          - model
-                          - name
-                          - provider
-                          - owned_by
-                          - description
-                          - context_length
-                          - capabilities
-                        additionalProperties: false
+                        $ref: "#/components/schemas/LlmModel"
                   required:
                     - backendId
                     - backendName
@@ -2428,161 +893,7 @@ paths:
               schema:
                 type: array
                 items:
-                  oneOf:
-                    - type: object
-                      properties:
-                        providerType:
-                          type: string
-                          const: openai
-                        name:
-                          type: string
-                          minLength: 2
-                        apiKey:
-                          type: string
-                          minLength: 2
-                        id:
-                          type: string
-                        provisioned:
-                          type: boolean
-                      required:
-                        - providerType
-                        - name
-                        - apiKey
-                        - id
-                        - provisioned
-                      additionalProperties: false
-                    - type: object
-                      properties:
-                        providerType:
-                          type: string
-                          const: anthropic
-                        name:
-                          type: string
-                          minLength: 2
-                        apiKey:
-                          type: string
-                          minLength: 2
-                        id:
-                          type: string
-                        provisioned:
-                          type: boolean
-                      required:
-                        - providerType
-                        - name
-                        - apiKey
-                        - id
-                        - provisioned
-                      additionalProperties: false
-                    - type: object
-                      properties:
-                        providerType:
-                          type: string
-                          const: logiclecloud
-                        name:
-                          type: string
-                          minLength: 2
-                        apiKey:
-                          type: string
-                          minLength: 2
-                        endPoint:
-                          type: string
-                          format: uri
-                        id:
-                          type: string
-                        provisioned:
-                          type: boolean
-                      required:
-                        - providerType
-                        - name
-                        - apiKey
-                        - endPoint
-                        - id
-                        - provisioned
-                      additionalProperties: false
-                    - type: object
-                      properties:
-                        providerType:
-                          type: string
-                          const: gcp-vertex
-                        name:
-                          type: string
-                          minLength: 2
-                        credentials:
-                          type: string
-                          minLength: 2
-                        id:
-                          type: string
-                        provisioned:
-                          type: boolean
-                      required:
-                        - providerType
-                        - name
-                        - credentials
-                        - id
-                        - provisioned
-                      additionalProperties: false
-                    - type: object
-                      properties:
-                        providerType:
-                          type: string
-                          const: perplexity
-                        name:
-                          type: string
-                          minLength: 2
-                        apiKey:
-                          type: string
-                          minLength: 2
-                        id:
-                          type: string
-                        provisioned:
-                          type: boolean
-                      required:
-                        - providerType
-                        - name
-                        - apiKey
-                        - id
-                        - provisioned
-                      additionalProperties: false
-                    - type: object
-                      properties:
-                        providerType:
-                          type: string
-                          const: gemini
-                        name:
-                          type: string
-                          minLength: 2
-                        apiKey:
-                          type: string
-                          minLength: 2
-                        id:
-                          type: string
-                        provisioned:
-                          type: boolean
-                      required:
-                        - providerType
-                        - name
-                        - apiKey
-                        - id
-                        - provisioned
-                      additionalProperties: false
-                    - type: object
-                      properties:
-                        providerType:
-                          type: string
-                          const: mock
-                        name:
-                          type: string
-                          minLength: 2
-                        id:
-                          type: string
-                        provisioned:
-                          type: boolean
-                      required:
-                        - providerType
-                        - name
-                        - id
-                        - provisioned
-                      additionalProperties: false
+                  $ref: "#/components/schemas/Backend"
       security:
         - bearerAuth: []
     post:
@@ -2594,161 +905,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - type: object
-                    properties:
-                      providerType:
-                        type: string
-                        const: openai
-                      name:
-                        type: string
-                        minLength: 2
-                      apiKey:
-                        type: string
-                        minLength: 2
-                      id:
-                        type: string
-                      provisioned:
-                        type: boolean
-                    required:
-                      - providerType
-                      - name
-                      - apiKey
-                      - id
-                      - provisioned
-                    additionalProperties: false
-                  - type: object
-                    properties:
-                      providerType:
-                        type: string
-                        const: anthropic
-                      name:
-                        type: string
-                        minLength: 2
-                      apiKey:
-                        type: string
-                        minLength: 2
-                      id:
-                        type: string
-                      provisioned:
-                        type: boolean
-                    required:
-                      - providerType
-                      - name
-                      - apiKey
-                      - id
-                      - provisioned
-                    additionalProperties: false
-                  - type: object
-                    properties:
-                      providerType:
-                        type: string
-                        const: logiclecloud
-                      name:
-                        type: string
-                        minLength: 2
-                      apiKey:
-                        type: string
-                        minLength: 2
-                      endPoint:
-                        type: string
-                        format: uri
-                      id:
-                        type: string
-                      provisioned:
-                        type: boolean
-                    required:
-                      - providerType
-                      - name
-                      - apiKey
-                      - endPoint
-                      - id
-                      - provisioned
-                    additionalProperties: false
-                  - type: object
-                    properties:
-                      providerType:
-                        type: string
-                        const: gcp-vertex
-                      name:
-                        type: string
-                        minLength: 2
-                      credentials:
-                        type: string
-                        minLength: 2
-                      id:
-                        type: string
-                      provisioned:
-                        type: boolean
-                    required:
-                      - providerType
-                      - name
-                      - credentials
-                      - id
-                      - provisioned
-                    additionalProperties: false
-                  - type: object
-                    properties:
-                      providerType:
-                        type: string
-                        const: perplexity
-                      name:
-                        type: string
-                        minLength: 2
-                      apiKey:
-                        type: string
-                        minLength: 2
-                      id:
-                        type: string
-                      provisioned:
-                        type: boolean
-                    required:
-                      - providerType
-                      - name
-                      - apiKey
-                      - id
-                      - provisioned
-                    additionalProperties: false
-                  - type: object
-                    properties:
-                      providerType:
-                        type: string
-                        const: gemini
-                      name:
-                        type: string
-                        minLength: 2
-                      apiKey:
-                        type: string
-                        minLength: 2
-                      id:
-                        type: string
-                      provisioned:
-                        type: boolean
-                    required:
-                      - providerType
-                      - name
-                      - apiKey
-                      - id
-                      - provisioned
-                    additionalProperties: false
-                  - type: object
-                    properties:
-                      providerType:
-                        type: string
-                        const: mock
-                      name:
-                        type: string
-                        minLength: 2
-                      id:
-                        type: string
-                      provisioned:
-                        type: boolean
-                    required:
-                      - providerType
-                      - name
-                      - id
-                      - provisioned
-                    additionalProperties: false
+                $ref: "#/components/schemas/Backend"
         "403":
           $ref: "#/components/responses/Error"
         "500":
@@ -2760,119 +917,7 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
-                - type: object
-                  properties:
-                    providerType:
-                      type: string
-                      const: openai
-                    name:
-                      type: string
-                      minLength: 2
-                    apiKey:
-                      type: string
-                      minLength: 2
-                  required:
-                    - providerType
-                    - name
-                    - apiKey
-                  additionalProperties: false
-                - type: object
-                  properties:
-                    providerType:
-                      type: string
-                      const: anthropic
-                    name:
-                      type: string
-                      minLength: 2
-                    apiKey:
-                      type: string
-                      minLength: 2
-                  required:
-                    - providerType
-                    - name
-                    - apiKey
-                  additionalProperties: false
-                - type: object
-                  properties:
-                    providerType:
-                      type: string
-                      const: logiclecloud
-                    name:
-                      type: string
-                      minLength: 2
-                    apiKey:
-                      type: string
-                      minLength: 2
-                    endPoint:
-                      type: string
-                      format: uri
-                  required:
-                    - providerType
-                    - name
-                    - apiKey
-                    - endPoint
-                  additionalProperties: false
-                - type: object
-                  properties:
-                    providerType:
-                      type: string
-                      const: gcp-vertex
-                    name:
-                      type: string
-                      minLength: 2
-                    credentials:
-                      type: string
-                      minLength: 2
-                  required:
-                    - providerType
-                    - name
-                    - credentials
-                  additionalProperties: false
-                - type: object
-                  properties:
-                    providerType:
-                      type: string
-                      const: perplexity
-                    name:
-                      type: string
-                      minLength: 2
-                    apiKey:
-                      type: string
-                      minLength: 2
-                  required:
-                    - providerType
-                    - name
-                    - apiKey
-                  additionalProperties: false
-                - type: object
-                  properties:
-                    providerType:
-                      type: string
-                      const: gemini
-                    name:
-                      type: string
-                      minLength: 2
-                    apiKey:
-                      type: string
-                      minLength: 2
-                  required:
-                    - providerType
-                    - name
-                    - apiKey
-                  additionalProperties: false
-                - type: object
-                  properties:
-                    providerType:
-                      type: string
-                      const: mock
-                    name:
-                      type: string
-                      minLength: 2
-                  required:
-                    - providerType
-                    - name
-                  additionalProperties: false
+              $ref: "#/components/schemas/InsertableBackend"
   /api/chat:
     post:
       summary: Chat
@@ -2924,64 +969,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  conversationId:
-                    type: string
-                  ownerId:
-                    type: string
-                  requestMessageId:
-                    type: string
-                  status:
-                    type: string
-                    enum:
-                      - running
-                      - completed
-                      - failed
-                      - stopped
-                  stopRequestedAt:
-                    anyOf:
-                      - type: string
-                        format: date-time
-                        pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                      - type: "null"
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  updatedAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  completedAt:
-                    anyOf:
-                      - type: string
-                        format: date-time
-                        pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                      - type: "null"
-                  lastEventSequence:
-                    type: integer
-                    minimum: 0
-                    maximum: 9007199254740991
-                  error:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                required:
-                  - id
-                  - conversationId
-                  - ownerId
-                  - requestMessageId
-                  - status
-                  - stopRequestedAt
-                  - createdAt
-                  - updatedAt
-                  - completedAt
-                  - lastEventSequence
-                  - error
-                additionalProperties: false
+                $ref: "#/components/schemas/ChatRun"
         "403":
           $ref: "#/components/responses/Error"
         "404":
@@ -3004,64 +992,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  conversationId:
-                    type: string
-                  ownerId:
-                    type: string
-                  requestMessageId:
-                    type: string
-                  status:
-                    type: string
-                    enum:
-                      - running
-                      - completed
-                      - failed
-                      - stopped
-                  stopRequestedAt:
-                    anyOf:
-                      - type: string
-                        format: date-time
-                        pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                      - type: "null"
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  updatedAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  completedAt:
-                    anyOf:
-                      - type: string
-                        format: date-time
-                        pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                      - type: "null"
-                  lastEventSequence:
-                    type: integer
-                    minimum: 0
-                    maximum: 9007199254740991
-                  error:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                required:
-                  - id
-                  - conversationId
-                  - ownerId
-                  - requestMessageId
-                  - status
-                  - stopRequestedAt
-                  - createdAt
-                  - updatedAt
-                  - completedAt
-                  - lastEventSequence
-                  - error
-                additionalProperties: false
+                $ref: "#/components/schemas/ChatRun"
         "400":
           $ref: "#/components/responses/Error"
         "403":
@@ -3087,72 +1018,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  run:
-                    anyOf:
-                      - type: object
-                        properties:
-                          id:
-                            type: string
-                          conversationId:
-                            type: string
-                          ownerId:
-                            type: string
-                          requestMessageId:
-                            type: string
-                          status:
-                            type: string
-                            enum:
-                              - running
-                              - completed
-                              - failed
-                              - stopped
-                          stopRequestedAt:
-                            anyOf:
-                              - type: string
-                                format: date-time
-                                pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                              - type: "null"
-                          createdAt:
-                            type: string
-                            format: date-time
-                            pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                          updatedAt:
-                            type: string
-                            format: date-time
-                            pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                          completedAt:
-                            anyOf:
-                              - type: string
-                                format: date-time
-                                pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                              - type: "null"
-                          lastEventSequence:
-                            type: integer
-                            minimum: 0
-                            maximum: 9007199254740991
-                          error:
-                            anyOf:
-                              - type: string
-                              - type: "null"
-                        required:
-                          - id
-                          - conversationId
-                          - ownerId
-                          - requestMessageId
-                          - status
-                          - stopRequestedAt
-                          - createdAt
-                          - updatedAt
-                          - completedAt
-                          - lastEventSequence
-                          - error
-                        additionalProperties: false
-                      - type: "null"
-                required:
-                  - run
-                additionalProperties: false
+                $ref: "#/components/schemas/ActiveChatRunResponse"
         "403":
           $ref: "#/components/responses/Error"
         "404":
@@ -3193,14 +1059,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                markdown:
-                  type: string
-                  description: Markdown content to render into a DOCX document.
-              required:
-                - markdown
-              additionalProperties: false
+              $ref: "#/components/schemas/ConversationDocxExportRequest"
   /api/conversations/{conversationId}/feedbacks:
     get:
       summary: List conversation feedbacks
@@ -3399,34 +1258,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  assistantId:
-                    type: string
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  ownerId:
-                    type: string
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  lastMsgSentAt:
-                    anyOf:
-                      - type: string
-                        format: date-time
-                        pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                      - type: "null"
-                required:
-                  - assistantId
-                  - id
-                  - name
-                  - ownerId
-                  - createdAt
-                  - lastMsgSentAt
-                additionalProperties: false
+                $ref: "#/components/schemas/Conversation"
         "403":
           $ref: "#/components/responses/Error"
         "404":
@@ -3490,11 +1322,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-              additionalProperties: false
+              $ref: "#/components/schemas/UpdateableConversation"
   /api/conversations/{conversationId}/share:
     get:
       summary: List conversation shares
@@ -3507,16 +1335,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    lastMessageId:
-                      type: string
-                  required:
-                    - id
-                    - lastMessageId
-                  additionalProperties: false
+                  $ref: "#/components/schemas/ConversationFragment"
         "403":
           $ref: "#/components/responses/Error"
         "404":
@@ -3540,16 +1359,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  lastMessageId:
-                    type: string
-                required:
-                  - id
-                  - lastMessageId
-                additionalProperties: false
+                $ref: "#/components/schemas/ConversationFragment"
         "403":
           $ref: "#/components/responses/Error"
         "404":
@@ -3596,56 +1406,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    assistantId:
-                      type: string
-                    id:
-                      type: string
-                    name:
-                      type: string
-                    ownerId:
-                      type: string
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    lastMsgSentAt:
-                      anyOf:
-                        - type: string
-                          format: date-time
-                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                        - type: "null"
-                    folderId:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    assistant:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        iconUri:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                      required:
-                        - id
-                        - name
-                        - iconUri
-                      additionalProperties: false
-                  required:
-                    - assistantId
-                    - id
-                    - name
-                    - ownerId
-                    - createdAt
-                    - lastMsgSentAt
-                    - folderId
-                    - assistant
-                  additionalProperties: false
+                  $ref: "#/components/schemas/ConversationWithFolder"
       security:
         - bearerAuth: []
     post:
@@ -3657,39 +1418,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  assistantId:
-                    type: string
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  ownerId:
-                    type: string
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  lastMsgSentAt:
-                    anyOf:
-                      - type: string
-                        format: date-time
-                        pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                      - type: "null"
-                  folderId:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                required:
-                  - assistantId
-                  - id
-                  - name
-                  - ownerId
-                  - createdAt
-                  - lastMsgSentAt
-                  - folderId
-                additionalProperties: false
+                $ref: "#/components/schemas/ConversationWithFolderId"
       security:
         - bearerAuth: []
       requestBody:
@@ -3697,16 +1426,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                assistantId:
-                  type: string
-                name:
-                  type: string
-              required:
-                - assistantId
-                - name
-              additionalProperties: false
+              $ref: "#/components/schemas/InsertableConversation"
   /api/conversations/search:
     post:
       summary: Search conversations
@@ -3719,51 +1439,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    conversation:
-                      type: object
-                      properties:
-                        assistantId:
-                          type: string
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        ownerId:
-                          type: string
-                        createdAt:
-                          type: string
-                          format: date-time
-                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                        lastMsgSentAt:
-                          anyOf:
-                            - type: string
-                              format: date-time
-                              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                            - type: "null"
-                        folderId:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                      required:
-                        - assistantId
-                        - id
-                        - name
-                        - ownerId
-                        - createdAt
-                        - lastMsgSentAt
-                        - folderId
-                      additionalProperties: false
-                    messages:
-                      type: array
-                      items:
-                        type: object
-                        additionalProperties: {}
-                  required:
-                    - conversation
-                    - messages
-                  additionalProperties: false
+                  $ref: "#/components/schemas/ConversationWithMessages"
         "400":
           $ref: "#/components/responses/Error"
       security:
@@ -3778,273 +1454,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  fileId:
-                    type: string
-                  kind:
-                    type: string
-                    enum:
-                      - pdf
-                      - image
-                      - spreadsheet
-                      - presentation
-                      - word
-                      - unknown
-                  status:
-                    type: string
-                    enum:
-                      - ready
-                      - failed
-                      - unavailable
-                  analyzerVersion:
-                    type: integer
-                    minimum: 0
-                    maximum: 9007199254740991
-                  payload:
-                    anyOf:
-                      - oneOf:
-                          - type: object
-                            properties:
-                              kind:
-                                type: string
-                                const: unknown
-                              mimeType:
-                                type: string
-                              sizeBytes:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              extractedTextPath:
-                                anyOf:
-                                  - type: string
-                                  - type: "null"
-                            required:
-                              - kind
-                              - mimeType
-                              - sizeBytes
-                              - extractedTextPath
-                            additionalProperties: false
-                          - type: object
-                            properties:
-                              kind:
-                                type: string
-                                const: pdf
-                              mimeType:
-                                type: string
-                                const: application/pdf
-                              sizeBytes:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              pageCount:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              visionPageCount:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              textCharCount:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              hasExtractableText:
-                                type: boolean
-                              imagePageCount:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              contentMode:
-                                type: string
-                                enum:
-                                  - text
-                                  - mixed
-                                  - scanned
-                              extractedTextPath:
-                                anyOf:
-                                  - type: string
-                                  - type: "null"
-                            required:
-                              - kind
-                              - mimeType
-                              - sizeBytes
-                              - pageCount
-                              - visionPageCount
-                              - textCharCount
-                              - hasExtractableText
-                              - imagePageCount
-                              - contentMode
-                              - extractedTextPath
-                            additionalProperties: false
-                          - type: object
-                            properties:
-                              kind:
-                                type: string
-                                const: image
-                              mimeType:
-                                type: string
-                              sizeBytes:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              width:
-                                type: integer
-                                exclusiveMinimum: 0
-                                maximum: 9007199254740991
-                              height:
-                                type: integer
-                                exclusiveMinimum: 0
-                                maximum: 9007199254740991
-                              frameCount:
-                                type: integer
-                                exclusiveMinimum: 0
-                                maximum: 9007199254740991
-                              hasAlpha:
-                                type: boolean
-                              format:
-                                anyOf:
-                                  - type: string
-                                  - type: "null"
-                              extractedTextPath:
-                                anyOf:
-                                  - type: string
-                                  - type: "null"
-                            required:
-                              - kind
-                              - mimeType
-                              - sizeBytes
-                              - width
-                              - height
-                              - frameCount
-                              - hasAlpha
-                              - format
-                              - extractedTextPath
-                            additionalProperties: false
-                          - type: object
-                            properties:
-                              kind:
-                                type: string
-                                const: spreadsheet
-                              mimeType:
-                                type: string
-                              sizeBytes:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              sheetCount:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              textCharCount:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              hasExtractableText:
-                                type: boolean
-                              extractedTextPath:
-                                anyOf:
-                                  - type: string
-                                  - type: "null"
-                            required:
-                              - kind
-                              - mimeType
-                              - sizeBytes
-                              - sheetCount
-                              - textCharCount
-                              - hasExtractableText
-                              - extractedTextPath
-                            additionalProperties: false
-                          - type: object
-                            properties:
-                              kind:
-                                type: string
-                                const: presentation
-                              mimeType:
-                                type: string
-                              sizeBytes:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              slideCount:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              textCharCount:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              hasExtractableText:
-                                type: boolean
-                              extractedTextPath:
-                                anyOf:
-                                  - type: string
-                                  - type: "null"
-                            required:
-                              - kind
-                              - mimeType
-                              - sizeBytes
-                              - slideCount
-                              - textCharCount
-                              - hasExtractableText
-                              - extractedTextPath
-                            additionalProperties: false
-                          - type: object
-                            properties:
-                              kind:
-                                type: string
-                                const: word
-                              mimeType:
-                                type: string
-                              sizeBytes:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              textCharCount:
-                                type: integer
-                                minimum: 0
-                                maximum: 9007199254740991
-                              hasExtractableText:
-                                type: boolean
-                              extractedTextPath:
-                                anyOf:
-                                  - type: string
-                                  - type: "null"
-                            required:
-                              - kind
-                              - mimeType
-                              - sizeBytes
-                              - textCharCount
-                              - hasExtractableText
-                              - extractedTextPath
-                            additionalProperties: false
-                      - type: "null"
-                  warnings:
-                    type: array
-                    items:
-                      type: string
-                  error:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  updatedAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                required:
-                  - fileId
-                  - kind
-                  - status
-                  - analyzerVersion
-                  - payload
-                  - error
-                  - createdAt
-                  - updatedAt
-                additionalProperties: false
+                $ref: "#/components/schemas/FileAnalysis"
         "403":
           $ref: "#/components/responses/Error"
         "404":
@@ -4124,37 +1534,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  path:
-                    type: string
-                  type:
-                    type: string
-                  size:
-                    type: number
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  encrypted:
-                    anyOf:
-                      - type: number
-                        const: 0
-                      - type: number
-                        const: 1
-                required:
-                  - id
-                  - name
-                  - path
-                  - type
-                  - size
-                  - createdAt
-                  - encrypted
-                additionalProperties: false
+                $ref: "#/components/schemas/File"
         "400":
           $ref: "#/components/responses/Error"
         "403":
@@ -4166,36 +1546,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                type:
-                  type: string
-                size:
-                  type: number
-                owner:
-                  type: object
-                  properties:
-                    ownerType:
-                      type: string
-                      enum:
-                        - USER
-                        - CHAT
-                        - ASSISTANT
-                        - TOOL
-                    ownerId:
-                      type: string
-                  required:
-                    - ownerType
-                    - ownerId
-                  additionalProperties: false
-              required:
-                - name
-                - type
-                - size
-                - owner
-              additionalProperties: false
+              $ref: "#/components/schemas/InsertableFile"
   /api/health:
     get:
       summary: Healthcheck
@@ -4288,40 +1639,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    key:
-                      type: string
-                    userId:
-                      type: string
-                    description:
-                      type: string
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    expiresAt:
-                      anyOf:
-                        - type: string
-                          format: date-time
-                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                        - type: "null"
-                    enabled:
-                      type: number
-                    provisioned:
-                      type: boolean
-                  required:
-                    - id
-                    - key
-                    - userId
-                    - description
-                    - createdAt
-                    - expiresAt
-                    - enabled
-                    - provisioned
-                  additionalProperties: false
+                  $ref: "#/components/schemas/ApiKey"
       security:
         - bearerAuth: []
     post:
@@ -4333,40 +1651,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  key:
-                    type: string
-                  userId:
-                    type: string
-                  description:
-                    type: string
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  expiresAt:
-                    anyOf:
-                      - type: string
-                        format: date-time
-                        pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                      - type: "null"
-                  enabled:
-                    type: number
-                  provisioned:
-                    type: boolean
-                required:
-                  - id
-                  - key
-                  - userId
-                  - description
-                  - createdAt
-                  - expiresAt
-                  - enabled
-                  - provisioned
-                additionalProperties: false
+                $ref: "#/components/schemas/ApiKey"
       security:
         - bearerAuth: []
       requestBody:
@@ -4374,20 +1659,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                description:
-                  type: string
-                expiresAt:
-                  anyOf:
-                    - type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    - type: "null"
-              required:
-                - description
-                - expiresAt
-              additionalProperties: false
+              $ref: "#/components/schemas/InsertableUserApiKey"
   /api/me/assistants/{assistantId}:
     get:
       summary: Get assistant for user
@@ -4398,203 +1670,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  iconUri:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  versionId:
-                    type: string
-                  backendId:
-                    type: string
-                  description:
-                    type: string
-                  model:
-                    type: string
-                  usability:
-                    oneOf:
-                      - type: object
-                        properties:
-                          state:
-                            type: string
-                            const: usable
-                        required:
-                          - state
-                        additionalProperties: false
-                      - type: object
-                        properties:
-                          state:
-                            type: string
-                            const: need-api-key
-                          backendId:
-                            type: string
-                          backendName:
-                            type: string
-                        required:
-                          - state
-                          - backendId
-                          - backendName
-                        additionalProperties: false
-                      - type: object
-                        properties:
-                          state:
-                            type: string
-                            const: not-usable
-                          constraint:
-                            type: string
-                        required:
-                          - state
-                          - constraint
-                        additionalProperties: false
-                  pinned:
-                    type: boolean
-                  lastUsed:
-                    anyOf:
-                      - type: string
-                        format: date-time
-                        pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                      - type: "null"
-                  owner:
-                    type: string
-                  ownerName:
-                    type: string
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  prompts:
-                    type: array
-                    items:
-                      type: string
-                  sharing:
-                    type: array
-                    items:
-                      oneOf:
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              const: all
-                          required:
-                            - type
-                          additionalProperties: false
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              const: workspace
-                            workspaceId:
-                              type: string
-                            workspaceName:
-                              type: string
-                          required:
-                            - type
-                            - workspaceId
-                            - workspaceName
-                          additionalProperties: false
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  updatedAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  cloneable:
-                    type: boolean
-                  tokenLimit:
-                    type: number
-                  tools:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        type:
-                          type: string
-                        availability:
-                          type: string
-                          enum:
-                            - ok
-                            - require-auth
-                      required:
-                        - id
-                        - name
-                        - type
-                        - availability
-                      additionalProperties: false
-                  subAssistants:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                      required:
-                        - id
-                        - name
-                      additionalProperties: false
-                  pendingChanges:
-                    type: boolean
-                  supportedMedia:
-                    type: array
-                    items:
-                      type: string
-                  systemPrompt:
-                    type: string
-                  files:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        type:
-                          type: string
-                        size:
-                          type: number
-                      required:
-                        - id
-                        - name
-                        - type
-                        - size
-                      additionalProperties: false
-                required:
-                  - id
-                  - name
-                  - iconUri
-                  - versionId
-                  - backendId
-                  - description
-                  - model
-                  - usability
-                  - pinned
-                  - lastUsed
-                  - owner
-                  - ownerName
-                  - tags
-                  - prompts
-                  - sharing
-                  - createdAt
-                  - updatedAt
-                  - cloneable
-                  - tokenLimit
-                  - tools
-                  - pendingChanges
-                  - supportedMedia
-                additionalProperties: false
+                $ref: "#/components/schemas/UserAssistantWithMedia"
         "404":
           $ref: "#/components/responses/Error"
       parameters:
@@ -4624,11 +1700,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                pinned:
-                  type: boolean
-              additionalProperties: false
+              $ref: "#/components/schemas/UpdateableAssistantUserData"
   /api/me/assistants/{assistantId}/systemPrompt:
     get:
       summary: Get assistant system prompt
@@ -4667,212 +1739,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  assistantId:
-                    type: string
-                    description: Assistant id used for estimation.
-                  model:
-                    type: string
-                    description: Resolved model id used for estimation.
-                  tokenizer:
-                    type: string
-                    enum:
-                      - cl100k_base
-                      - o200k_base
-                      - approx_4chars
-                    description: Tokenizer strategy used to compute token estimates.
-                  estimate:
-                    type: object
-                    properties:
-                      assistant:
-                        type: number
-                        description: Estimated tokens for assistant-provided context before chat
-                          history, including system prompt, tool prompt
-                          fragments, and assistant knowledge injection.
-                      history:
-                        type: number
-                        description: Estimated tokens for prior branch messages after ChatAssistant
-                          message conversion, excluding the rendered prompt
-                          context.
-                      draft:
-                        type: number
-                        description: Estimated tokens for the pending user message after ChatAssistant
-                          message conversion, including draft text and
-                          attachments.
-                      total:
-                        type: number
-                        description: "Final estimate for next request input tokens: assistant + history
-                          + draft."
-                    required:
-                      - assistant
-                      - history
-                      - draft
-                      - total
-                    additionalProperties: false
-                  detail:
-                    description: Detailed per-component token breakdown, present only when
-                      ?detail=true is requested.
-                    type: object
-                    properties:
-                      preamble:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            type:
-                              type: string
-                              description: "Component type: system_prompt, knowledge_text, knowledge_file,
-                                text, attachment, reasoning, tool_call,
-                                tool_result."
-                            tokens:
-                              type: number
-                              description: Token count for this component.
-                            algorithm:
-                              type: string
-                              description: "Algorithm or tokenizer used: cl100k_base, o200k_base,
-                                approx_4chars, native_image, pdf_native,
-                                pdf_text_fallback, pdf_page_limit_notice."
-                            params:
-                              description: Algorithm parameters, e.g. image dimensions or PDF page counts.
-                              type: object
-                              additionalProperties: {}
-                            id:
-                              description: File id or tool call id.
-                              type: string
-                            name:
-                              description: File name.
-                              type: string
-                            mimetype:
-                              description: MIME type for attachment entries.
-                              type: string
-                            toolCallId:
-                              description: Tool call id for tool_call and tool_result entries.
-                              type: string
-                            toolName:
-                              description: Tool name for tool_call and tool_result entries.
-                              type: string
-                          required:
-                            - type
-                            - tokens
-                            - algorithm
-                          additionalProperties: false
-                        description: Per-component breakdown of preamble tokens (system prompt,
-                          knowledge).
-                      history:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            messageId:
-                              type: string
-                            role:
-                              type: string
-                              enum:
-                                - user
-                                - assistant
-                                - tool
-                            parts:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    description: "Component type: system_prompt, knowledge_text, knowledge_file,
-                                      text, attachment, reasoning, tool_call,
-                                      tool_result."
-                                  tokens:
-                                    type: number
-                                    description: Token count for this component.
-                                  algorithm:
-                                    type: string
-                                    description: "Algorithm or tokenizer used: cl100k_base, o200k_base,
-                                      approx_4chars, native_image, pdf_native,
-                                      pdf_text_fallback, pdf_page_limit_notice."
-                                  params:
-                                    description: Algorithm parameters, e.g. image dimensions or PDF page counts.
-                                    type: object
-                                    additionalProperties: {}
-                                  id:
-                                    description: File id or tool call id.
-                                    type: string
-                                  name:
-                                    description: File name.
-                                    type: string
-                                  mimetype:
-                                    description: MIME type for attachment entries.
-                                    type: string
-                                  toolCallId:
-                                    description: Tool call id for tool_call and tool_result entries.
-                                    type: string
-                                  toolName:
-                                    description: Tool name for tool_call and tool_result entries.
-                                    type: string
-                                required:
-                                  - type
-                                  - tokens
-                                  - algorithm
-                                additionalProperties: false
-                          required:
-                            - messageId
-                            - role
-                            - parts
-                          additionalProperties: false
-                        description: Per-message breakdown of history tokens.
-                      draft:
-                        description: Per-component breakdown of draft message tokens.
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            type:
-                              type: string
-                              description: "Component type: system_prompt, knowledge_text, knowledge_file,
-                                text, attachment, reasoning, tool_call,
-                                tool_result."
-                            tokens:
-                              type: number
-                              description: Token count for this component.
-                            algorithm:
-                              type: string
-                              description: "Algorithm or tokenizer used: cl100k_base, o200k_base,
-                                approx_4chars, native_image, pdf_native,
-                                pdf_text_fallback, pdf_page_limit_notice."
-                            params:
-                              description: Algorithm parameters, e.g. image dimensions or PDF page counts.
-                              type: object
-                              additionalProperties: {}
-                            id:
-                              description: File id or tool call id.
-                              type: string
-                            name:
-                              description: File name.
-                              type: string
-                            mimetype:
-                              description: MIME type for attachment entries.
-                              type: string
-                            toolCallId:
-                              description: Tool call id for tool_call and tool_result entries.
-                              type: string
-                            toolName:
-                              description: Tool name for tool_call and tool_result entries.
-                              type: string
-                          required:
-                            - type
-                            - tokens
-                            - algorithm
-                          additionalProperties: false
-                    required:
-                      - preamble
-                      - history
-                    additionalProperties: false
-                required:
-                  - assistantId
-                  - model
-                  - tokenizer
-                  - estimate
-                additionalProperties: false
+                $ref: "#/components/schemas/TokenEstimateResponse"
         "400":
           $ref: "#/components/responses/Error"
         "404":
@@ -4890,32 +1757,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                conversationId:
-                  description: Conversation id used to include prior branch history in the
-                    estimate.
-                  type: string
-                targetMessageId:
-                  description: Optional message id that selects the target branch in a tree chat;
-                    history is linearized up to this node.
-                  anyOf:
-                    - type: string
-                    - type: "null"
-                attachmentFileIds:
-                  default: []
-                  description: Attachment file ids for the pending user message.
-                  type: array
-                  items:
-                    type: string
-                draftText:
-                  default: ""
-                  description: Current draft text for the pending user message.
-                  type: string
-              required:
-                - attachmentFileIds
-                - draftText
-              additionalProperties: false
+              $ref: "#/components/schemas/TokenEstimateRequest"
   /api/me/assistants/explore:
     get:
       summary: List published assistants
@@ -4928,177 +1770,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    name:
-                      type: string
-                    iconUri:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    versionId:
-                      type: string
-                    backendId:
-                      type: string
-                    description:
-                      type: string
-                    model:
-                      type: string
-                    usability:
-                      oneOf:
-                        - type: object
-                          properties:
-                            state:
-                              type: string
-                              const: usable
-                          required:
-                            - state
-                          additionalProperties: false
-                        - type: object
-                          properties:
-                            state:
-                              type: string
-                              const: need-api-key
-                            backendId:
-                              type: string
-                            backendName:
-                              type: string
-                          required:
-                            - state
-                            - backendId
-                            - backendName
-                          additionalProperties: false
-                        - type: object
-                          properties:
-                            state:
-                              type: string
-                              const: not-usable
-                            constraint:
-                              type: string
-                          required:
-                            - state
-                            - constraint
-                          additionalProperties: false
-                    pinned:
-                      type: boolean
-                    lastUsed:
-                      anyOf:
-                        - type: string
-                          format: date-time
-                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                        - type: "null"
-                    owner:
-                      type: string
-                    ownerName:
-                      type: string
-                    tags:
-                      type: array
-                      items:
-                        type: string
-                    prompts:
-                      type: array
-                      items:
-                        type: string
-                    sharing:
-                      type: array
-                      items:
-                        oneOf:
-                          - type: object
-                            properties:
-                              type:
-                                type: string
-                                const: all
-                            required:
-                              - type
-                            additionalProperties: false
-                          - type: object
-                            properties:
-                              type:
-                                type: string
-                                const: workspace
-                              workspaceId:
-                                type: string
-                              workspaceName:
-                                type: string
-                            required:
-                              - type
-                              - workspaceId
-                              - workspaceName
-                            additionalProperties: false
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    updatedAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    cloneable:
-                      type: boolean
-                    tokenLimit:
-                      type: number
-                    tools:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          id:
-                            type: string
-                          name:
-                            type: string
-                          type:
-                            type: string
-                          availability:
-                            type: string
-                            enum:
-                              - ok
-                              - require-auth
-                        required:
-                          - id
-                          - name
-                          - type
-                          - availability
-                        additionalProperties: false
-                    subAssistants:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          id:
-                            type: string
-                          name:
-                            type: string
-                        required:
-                          - id
-                          - name
-                        additionalProperties: false
-                    pendingChanges:
-                      type: boolean
-                  required:
-                    - id
-                    - name
-                    - iconUri
-                    - versionId
-                    - backendId
-                    - description
-                    - model
-                    - usability
-                    - pinned
-                    - lastUsed
-                    - owner
-                    - ownerName
-                    - tags
-                    - prompts
-                    - sharing
-                    - createdAt
-                    - updatedAt
-                    - cloneable
-                    - tokenLimit
-                    - tools
-                    - pendingChanges
-                  additionalProperties: false
+                  $ref: "#/components/schemas/UserAssistant"
       security:
         - bearerAuth: []
   /api/me/assistants/mine:
@@ -5113,177 +1785,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    name:
-                      type: string
-                    iconUri:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    versionId:
-                      type: string
-                    backendId:
-                      type: string
-                    description:
-                      type: string
-                    model:
-                      type: string
-                    usability:
-                      oneOf:
-                        - type: object
-                          properties:
-                            state:
-                              type: string
-                              const: usable
-                          required:
-                            - state
-                          additionalProperties: false
-                        - type: object
-                          properties:
-                            state:
-                              type: string
-                              const: need-api-key
-                            backendId:
-                              type: string
-                            backendName:
-                              type: string
-                          required:
-                            - state
-                            - backendId
-                            - backendName
-                          additionalProperties: false
-                        - type: object
-                          properties:
-                            state:
-                              type: string
-                              const: not-usable
-                            constraint:
-                              type: string
-                          required:
-                            - state
-                            - constraint
-                          additionalProperties: false
-                    pinned:
-                      type: boolean
-                    lastUsed:
-                      anyOf:
-                        - type: string
-                          format: date-time
-                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                        - type: "null"
-                    owner:
-                      type: string
-                    ownerName:
-                      type: string
-                    tags:
-                      type: array
-                      items:
-                        type: string
-                    prompts:
-                      type: array
-                      items:
-                        type: string
-                    sharing:
-                      type: array
-                      items:
-                        oneOf:
-                          - type: object
-                            properties:
-                              type:
-                                type: string
-                                const: all
-                            required:
-                              - type
-                            additionalProperties: false
-                          - type: object
-                            properties:
-                              type:
-                                type: string
-                                const: workspace
-                              workspaceId:
-                                type: string
-                              workspaceName:
-                                type: string
-                            required:
-                              - type
-                              - workspaceId
-                              - workspaceName
-                            additionalProperties: false
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    updatedAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    cloneable:
-                      type: boolean
-                    tokenLimit:
-                      type: number
-                    tools:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          id:
-                            type: string
-                          name:
-                            type: string
-                          type:
-                            type: string
-                          availability:
-                            type: string
-                            enum:
-                              - ok
-                              - require-auth
-                        required:
-                          - id
-                          - name
-                          - type
-                          - availability
-                        additionalProperties: false
-                    subAssistants:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          id:
-                            type: string
-                          name:
-                            type: string
-                        required:
-                          - id
-                          - name
-                        additionalProperties: false
-                    pendingChanges:
-                      type: boolean
-                  required:
-                    - id
-                    - name
-                    - iconUri
-                    - versionId
-                    - backendId
-                    - description
-                    - model
-                    - usability
-                    - pinned
-                    - lastUsed
-                    - owner
-                    - ownerName
-                    - tags
-                    - prompts
-                    - sharing
-                    - createdAt
-                    - updatedAt
-                    - cloneable
-                    - tokenLimit
-                    - tools
-                    - pendingChanges
-                  additionalProperties: false
+                  $ref: "#/components/schemas/UserAssistant"
       security:
         - bearerAuth: []
   /api/me/assistants/mine/stats:
@@ -5328,110 +1830,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    assistantId:
-                      type: string
-                    backendId:
-                      type: string
-                    description:
-                      type: string
-                    model:
-                      type: string
-                    name:
-                      type: string
-                    systemPrompt:
-                      type: string
-                    temperature:
-                      type: number
-                    tokenLimit:
-                      type: number
-                    reasoning_effort:
-                      anyOf:
-                        - type: string
-                          enum:
-                            - low
-                            - medium
-                            - high
-                        - type: "null"
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    updatedAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    owner:
-                      type: string
-                    ownerName:
-                      type: string
-                    modelName:
-                      type: string
-                    sharing:
-                      type: array
-                      items:
-                        oneOf:
-                          - type: object
-                            properties:
-                              type:
-                                type: string
-                                const: all
-                            required:
-                              - type
-                            additionalProperties: false
-                          - type: object
-                            properties:
-                              type:
-                                type: string
-                                const: workspace
-                              workspaceId:
-                                type: string
-                              workspaceName:
-                                type: string
-                            required:
-                              - type
-                              - workspaceId
-                              - workspaceName
-                            additionalProperties: false
-                    tags:
-                      type: array
-                      items:
-                        type: string
-                    prompts:
-                      type: array
-                      items:
-                        type: string
-                    iconUri:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    provisioned:
-                      type: boolean
-                  required:
-                    - id
-                    - assistantId
-                    - backendId
-                    - description
-                    - model
-                    - name
-                    - systemPrompt
-                    - temperature
-                    - tokenLimit
-                    - reasoning_effort
-                    - createdAt
-                    - updatedAt
-                    - owner
-                    - ownerName
-                    - modelName
-                    - sharing
-                    - tags
-                    - prompts
-                    - iconUri
-                    - provisioned
-                  additionalProperties: false
+                  $ref: "#/components/schemas/AssistantWithOwner"
       security:
         - bearerAuth: []
   /api/me/folders/{folderId}/conversations:
@@ -5446,56 +1845,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    assistantId:
-                      type: string
-                    id:
-                      type: string
-                    name:
-                      type: string
-                    ownerId:
-                      type: string
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    lastMsgSentAt:
-                      anyOf:
-                        - type: string
-                          format: date-time
-                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                        - type: "null"
-                    folderId:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    assistant:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        iconUri:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                      required:
-                        - id
-                        - name
-                        - iconUri
-                      additionalProperties: false
-                  required:
-                    - assistantId
-                    - id
-                    - name
-                    - ownerId
-                    - createdAt
-                    - lastMsgSentAt
-                    - folderId
-                    - assistant
-                  additionalProperties: false
+                  $ref: "#/components/schemas/ConversationWithFolder"
         "403":
           $ref: "#/components/responses/Error"
         "404":
@@ -5518,19 +1868,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  ownerId:
-                    type: string
-                required:
-                  - id
-                  - name
-                  - ownerId
-                additionalProperties: false
+                $ref: "#/components/schemas/ConversationFolder"
         "403":
           $ref: "#/components/responses/Error"
         "404":
@@ -5564,13 +1902,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                conversationId:
-                  type: string
-              required:
-                - conversationId
-              additionalProperties: false
+              $ref: "#/components/schemas/AddConversationToFolder"
     delete:
       summary: Delete folder
       description: Delete a folder for the current user.
@@ -5608,11 +1940,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-              additionalProperties: false
+              $ref: "#/components/schemas/UpdateableConversationFolder"
   /api/me/folders:
     get:
       summary: List user folders
@@ -5625,19 +1953,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    name:
-                      type: string
-                    ownerId:
-                      type: string
-                  required:
-                    - id
-                    - name
-                    - ownerId
-                  additionalProperties: false
+                  $ref: "#/components/schemas/ConversationFolder"
       security:
         - bearerAuth: []
     post:
@@ -5649,19 +1965,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  ownerId:
-                    type: string
-                required:
-                  - id
-                  - name
-                  - ownerId
-                additionalProperties: false
+                $ref: "#/components/schemas/ConversationFolder"
       security:
         - bearerAuth: []
       requestBody:
@@ -5669,13 +1973,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-              required:
-                - name
-              additionalProperties: false
+              $ref: "#/components/schemas/InsertableConversationFolder"
   /api/me/profile:
     get:
       summary: Get user profile
@@ -5686,615 +1984,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  email:
-                    type: string
-                    format: email
-                    pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
-                  name:
-                    type: string
-                  role:
-                    type: string
-                    enum:
-                      - USER
-                      - ADMIN
-                  provisioned:
-                    type: boolean
-                  updatedAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  image:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  ssoUser:
-                    type: boolean
-                  properties:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  workspaces:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        role:
-                          type: string
-                          enum:
-                            - ADMIN
-                            - OWNER
-                            - MEMBER
-                            - EDITOR
-                      required:
-                        - id
-                        - name
-                        - role
-                      additionalProperties: false
-                  lastUsedAssistant:
-                    anyOf:
-                      - type: object
-                        properties:
-                          id:
-                            type: string
-                          name:
-                            type: string
-                          iconUri:
-                            anyOf:
-                              - type: string
-                              - type: "null"
-                          versionId:
-                            type: string
-                          backendId:
-                            type: string
-                          description:
-                            type: string
-                          model:
-                            type: string
-                          usability:
-                            oneOf:
-                              - type: object
-                                properties:
-                                  state:
-                                    type: string
-                                    const: usable
-                                required:
-                                  - state
-                                additionalProperties: false
-                              - type: object
-                                properties:
-                                  state:
-                                    type: string
-                                    const: need-api-key
-                                  backendId:
-                                    type: string
-                                  backendName:
-                                    type: string
-                                required:
-                                  - state
-                                  - backendId
-                                  - backendName
-                                additionalProperties: false
-                              - type: object
-                                properties:
-                                  state:
-                                    type: string
-                                    const: not-usable
-                                  constraint:
-                                    type: string
-                                required:
-                                  - state
-                                  - constraint
-                                additionalProperties: false
-                          pinned:
-                            type: boolean
-                          lastUsed:
-                            anyOf:
-                              - type: string
-                                format: date-time
-                                pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                              - type: "null"
-                          owner:
-                            type: string
-                          ownerName:
-                            type: string
-                          tags:
-                            type: array
-                            items:
-                              type: string
-                          prompts:
-                            type: array
-                            items:
-                              type: string
-                          sharing:
-                            type: array
-                            items:
-                              oneOf:
-                                - type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      const: all
-                                  required:
-                                    - type
-                                  additionalProperties: false
-                                - type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      const: workspace
-                                    workspaceId:
-                                      type: string
-                                    workspaceName:
-                                      type: string
-                                  required:
-                                    - type
-                                    - workspaceId
-                                    - workspaceName
-                                  additionalProperties: false
-                          createdAt:
-                            type: string
-                            format: date-time
-                            pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                          updatedAt:
-                            type: string
-                            format: date-time
-                            pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                          cloneable:
-                            type: boolean
-                          tokenLimit:
-                            type: number
-                          tools:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                id:
-                                  type: string
-                                name:
-                                  type: string
-                                type:
-                                  type: string
-                                availability:
-                                  type: string
-                                  enum:
-                                    - ok
-                                    - require-auth
-                              required:
-                                - id
-                                - name
-                                - type
-                                - availability
-                              additionalProperties: false
-                          subAssistants:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                id:
-                                  type: string
-                                name:
-                                  type: string
-                              required:
-                                - id
-                                - name
-                              additionalProperties: false
-                          pendingChanges:
-                            type: boolean
-                        required:
-                          - id
-                          - name
-                          - iconUri
-                          - versionId
-                          - backendId
-                          - description
-                          - model
-                          - usability
-                          - pinned
-                          - lastUsed
-                          - owner
-                          - ownerName
-                          - tags
-                          - prompts
-                          - sharing
-                          - createdAt
-                          - updatedAt
-                          - cloneable
-                          - tokenLimit
-                          - tools
-                          - pendingChanges
-                        additionalProperties: false
-                      - type: "null"
-                  pinnedAssistants:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        iconUri:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                        versionId:
-                          type: string
-                        backendId:
-                          type: string
-                        description:
-                          type: string
-                        model:
-                          type: string
-                        usability:
-                          oneOf:
-                            - type: object
-                              properties:
-                                state:
-                                  type: string
-                                  const: usable
-                              required:
-                                - state
-                              additionalProperties: false
-                            - type: object
-                              properties:
-                                state:
-                                  type: string
-                                  const: need-api-key
-                                backendId:
-                                  type: string
-                                backendName:
-                                  type: string
-                              required:
-                                - state
-                                - backendId
-                                - backendName
-                              additionalProperties: false
-                            - type: object
-                              properties:
-                                state:
-                                  type: string
-                                  const: not-usable
-                                constraint:
-                                  type: string
-                              required:
-                                - state
-                                - constraint
-                              additionalProperties: false
-                        pinned:
-                          type: boolean
-                        lastUsed:
-                          anyOf:
-                            - type: string
-                              format: date-time
-                              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                            - type: "null"
-                        owner:
-                          type: string
-                        ownerName:
-                          type: string
-                        tags:
-                          type: array
-                          items:
-                            type: string
-                        prompts:
-                          type: array
-                          items:
-                            type: string
-                        sharing:
-                          type: array
-                          items:
-                            oneOf:
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    const: all
-                                required:
-                                  - type
-                                additionalProperties: false
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    const: workspace
-                                  workspaceId:
-                                    type: string
-                                  workspaceName:
-                                    type: string
-                                required:
-                                  - type
-                                  - workspaceId
-                                  - workspaceName
-                                additionalProperties: false
-                        createdAt:
-                          type: string
-                          format: date-time
-                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                        updatedAt:
-                          type: string
-                          format: date-time
-                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                        cloneable:
-                          type: boolean
-                        tokenLimit:
-                          type: number
-                        tools:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              id:
-                                type: string
-                              name:
-                                type: string
-                              type:
-                                type: string
-                              availability:
-                                type: string
-                                enum:
-                                  - ok
-                                  - require-auth
-                            required:
-                              - id
-                              - name
-                              - type
-                              - availability
-                            additionalProperties: false
-                        subAssistants:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              id:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                              - id
-                              - name
-                            additionalProperties: false
-                        pendingChanges:
-                          type: boolean
-                      required:
-                        - id
-                        - name
-                        - iconUri
-                        - versionId
-                        - backendId
-                        - description
-                        - model
-                        - usability
-                        - pinned
-                        - lastUsed
-                        - owner
-                        - ownerName
-                        - tags
-                        - prompts
-                        - sharing
-                        - createdAt
-                        - updatedAt
-                        - cloneable
-                        - tokenLimit
-                        - tools
-                        - pendingChanges
-                      additionalProperties: false
-                  assistants:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        iconUri:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                        versionId:
-                          type: string
-                        backendId:
-                          type: string
-                        description:
-                          type: string
-                        model:
-                          type: string
-                        usability:
-                          oneOf:
-                            - type: object
-                              properties:
-                                state:
-                                  type: string
-                                  const: usable
-                              required:
-                                - state
-                              additionalProperties: false
-                            - type: object
-                              properties:
-                                state:
-                                  type: string
-                                  const: need-api-key
-                                backendId:
-                                  type: string
-                                backendName:
-                                  type: string
-                              required:
-                                - state
-                                - backendId
-                                - backendName
-                              additionalProperties: false
-                            - type: object
-                              properties:
-                                state:
-                                  type: string
-                                  const: not-usable
-                                constraint:
-                                  type: string
-                              required:
-                                - state
-                                - constraint
-                              additionalProperties: false
-                        pinned:
-                          type: boolean
-                        lastUsed:
-                          anyOf:
-                            - type: string
-                              format: date-time
-                              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                            - type: "null"
-                        owner:
-                          type: string
-                        ownerName:
-                          type: string
-                        tags:
-                          type: array
-                          items:
-                            type: string
-                        prompts:
-                          type: array
-                          items:
-                            type: string
-                        sharing:
-                          type: array
-                          items:
-                            oneOf:
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    const: all
-                                required:
-                                  - type
-                                additionalProperties: false
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    const: workspace
-                                  workspaceId:
-                                    type: string
-                                  workspaceName:
-                                    type: string
-                                required:
-                                  - type
-                                  - workspaceId
-                                  - workspaceName
-                                additionalProperties: false
-                        createdAt:
-                          type: string
-                          format: date-time
-                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                        updatedAt:
-                          type: string
-                          format: date-time
-                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                        cloneable:
-                          type: boolean
-                        tokenLimit:
-                          type: number
-                        tools:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              id:
-                                type: string
-                              name:
-                                type: string
-                              type:
-                                type: string
-                              availability:
-                                type: string
-                                enum:
-                                  - ok
-                                  - require-auth
-                            required:
-                              - id
-                              - name
-                              - type
-                              - availability
-                            additionalProperties: false
-                        subAssistants:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              id:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                              - id
-                              - name
-                            additionalProperties: false
-                        pendingChanges:
-                          type: boolean
-                      required:
-                        - id
-                        - name
-                        - iconUri
-                        - versionId
-                        - backendId
-                        - description
-                        - model
-                        - usability
-                        - pinned
-                        - lastUsed
-                        - owner
-                        - ownerName
-                        - tags
-                        - prompts
-                        - sharing
-                        - createdAt
-                        - updatedAt
-                        - cloneable
-                        - tokenLimit
-                        - tools
-                        - pendingChanges
-                      additionalProperties: false
-                  preferences:
-                    type: object
-                    properties:
-                      language:
-                        type: string
-                      conversationEditing:
-                        type: boolean
-                      showIconsInChatbar:
-                        type: boolean
-                      advancedSystemPromptEditor:
-                        type: boolean
-                      advancedMessageEditor:
-                        type: boolean
-                    additionalProperties: false
-                required:
-                  - id
-                  - createdAt
-                  - email
-                  - name
-                  - role
-                  - provisioned
-                  - updatedAt
-                  - image
-                  - ssoUser
-                  - properties
-                  - workspaces
-                  - lastUsedAssistant
-                  - pinnedAssistants
-                  - assistants
-                  - preferences
-                additionalProperties: false
+                $ref: "#/components/schemas/UserProfile"
         "404":
           $ref: "#/components/responses/Error"
       security:
@@ -6312,25 +2002,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                email:
-                  type: string
-                  format: email
-                  pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
-                name:
-                  type: string
-                preferences:
-                  type: string
-                image:
-                  anyOf:
-                    - type: string
-                    - type: "null"
-                properties:
-                  type: object
-                  additionalProperties:
-                    type: string
-              additionalProperties: false
+              $ref: "#/components/schemas/UpdateableUserSelf"
   /api/me/prompts/{promptId}:
     get:
       summary: Get user prompt
@@ -6341,25 +2013,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  content:
-                    type: string
-                  description:
-                    type: string
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  ownerId:
-                    type: string
-                required:
-                  - content
-                  - description
-                  - id
-                  - name
-                  - ownerId
-                additionalProperties: false
+                $ref: "#/components/schemas/Prompt"
         "403":
           $ref: "#/components/responses/Error"
         "404":
@@ -6402,25 +2056,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    content:
-                      type: string
-                    description:
-                      type: string
-                    id:
-                      type: string
-                    name:
-                      type: string
-                    ownerId:
-                      type: string
-                  required:
-                    - content
-                    - description
-                    - id
-                    - name
-                    - ownerId
-                  additionalProperties: false
+                  $ref: "#/components/schemas/Prompt"
       security:
         - bearerAuth: []
     post:
@@ -6432,25 +2068,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  content:
-                    type: string
-                  description:
-                    type: string
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  ownerId:
-                    type: string
-                required:
-                  - content
-                  - description
-                  - id
-                  - name
-                  - ownerId
-                additionalProperties: false
+                $ref: "#/components/schemas/Prompt"
       security:
         - bearerAuth: []
       requestBody:
@@ -6458,19 +2076,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                content:
-                  type: string
-                description:
-                  type: string
-                name:
-                  type: string
-              required:
-                - content
-                - description
-                - name
-              additionalProperties: false
+              $ref: "#/components/schemas/InsertablePrompt"
   /api/me/secrets/{id}:
     delete:
       summary: Delete user secret
@@ -6502,30 +2108,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    context:
-                      type: string
-                    type:
-                      anyOf:
-                        - type: string
-                          enum:
-                            - backend-credentials
-                            - mcp-oauth
-                        - type: string
-                    label:
-                      type: string
-                    readable:
-                      type: boolean
-                  required:
-                    - id
-                    - context
-                    - type
-                    - label
-                    - readable
-                  additionalProperties: false
+                  $ref: "#/components/schemas/UserSecretStatus"
       security:
         - bearerAuth: []
     post:
@@ -6537,30 +2120,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  context:
-                    type: string
-                  type:
-                    anyOf:
-                      - type: string
-                        enum:
-                          - backend-credentials
-                          - mcp-oauth
-                      - type: string
-                  label:
-                    type: string
-                  readable:
-                    type: boolean
-                required:
-                  - id
-                  - context
-                  - type
-                  - label
-                  - readable
-                additionalProperties: false
+                $ref: "#/components/schemas/UserSecretStatus"
         "400":
           $ref: "#/components/responses/Error"
         "409":
@@ -6572,28 +2132,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                context:
-                  type: string
-                  minLength: 1
-                type:
-                  type: string
-                  enum:
-                    - backend-credentials
-                    - mcp-oauth
-                label:
-                  type: string
-                  minLength: 1
-                value:
-                  type: string
-                  minLength: 1
-              required:
-                - context
-                - type
-                - label
-                - value
-              additionalProperties: false
+              $ref: "#/components/schemas/InsertableUserSecret"
   /api/me/tools:
     get:
       summary: List tools for user
@@ -6606,25 +2145,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    name:
-                      type: string
-                    capability:
-                      type: boolean
-                    provisioned:
-                      type: boolean
-                    visible:
-                      type: boolean
-                  required:
-                    - id
-                    - name
-                    - capability
-                    - provisioned
-                    - visible
-                  additionalProperties: false
+                  $ref: "#/components/schemas/AssistantTool"
       security:
         - bearerAuth: []
   /api/oauth/oidc:
@@ -6695,9 +2216,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties:
-                  type: string
+                $ref: "#/components/schemas/PropertyPatch"
       security:
         - bearerAuth: []
     patch:
@@ -6713,9 +2232,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              additionalProperties:
-                type: string
+              $ref: "#/components/schemas/PropertyPatch"
   /api/share/{shareId}/clone:
     post:
       summary: Clone shared conversation
@@ -6758,14 +2275,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                markdown:
-                  type: string
-                  description: Markdown content to render into a DOCX document.
-              required:
-                - markdown
-              additionalProperties: false
+              $ref: "#/components/schemas/ConversationDocxExportRequest"
   /api/share/{shareId}/messages:
     get:
       summary: Get shared conversation messages
@@ -6798,71 +2308,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  title:
-                    type: string
-                  assistant:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                      name:
-                        type: string
-                      iconUri:
-                        anyOf:
-                          - type: string
-                          - type: "null"
-                    required:
-                      - id
-                      - name
-                      - iconUri
-                    additionalProperties: false
-                  assistantUsability:
-                    oneOf:
-                      - type: object
-                        properties:
-                          state:
-                            type: string
-                            const: usable
-                        required:
-                          - state
-                        additionalProperties: false
-                      - type: object
-                        properties:
-                          state:
-                            type: string
-                            const: need-api-key
-                          backendId:
-                            type: string
-                          backendName:
-                            type: string
-                        required:
-                          - state
-                          - backendId
-                          - backendName
-                        additionalProperties: false
-                      - type: object
-                        properties:
-                          state:
-                            type: string
-                            const: not-usable
-                          constraint:
-                            type: string
-                        required:
-                          - state
-                          - constraint
-                        additionalProperties: false
-                  messages:
-                    type: array
-                    items:
-                      type: object
-                      additionalProperties: {}
-                required:
-                  - title
-                  - assistant
-                  - messages
-                additionalProperties: false
+                $ref: "#/components/schemas/SharedConversation"
       parameters:
         - name: shareId
           in: path
@@ -6881,76 +2327,7 @@ paths:
           content:
             application/json:
               schema:
-                anyOf:
-                  - type: object
-                    properties:
-                      id:
-                        type: string
-                      name:
-                        type: string
-                      description:
-                        type: string
-                      type:
-                        type: string
-                        const: SAML
-                      config:
-                        type: object
-                        properties:
-                          entityID:
-                            type: string
-                          sso:
-                            type: object
-                            properties:
-                              postUrl:
-                                type: string
-                              redirectUrl:
-                                type: string
-                            additionalProperties: false
-                          publicKey:
-                            type: string
-                        required:
-                          - entityID
-                          - sso
-                        additionalProperties: false
-                    required:
-                      - id
-                      - name
-                      - description
-                      - type
-                      - config
-                    additionalProperties: false
-                  - type: object
-                    properties:
-                      id:
-                        type: string
-                      name:
-                        type: string
-                      description:
-                        type: string
-                      type:
-                        type: string
-                        const: OIDC
-                      config:
-                        type: object
-                        properties:
-                          discoveryUrl:
-                            type: string
-                          clientId:
-                            type: string
-                          clientSecret:
-                            type: string
-                        required:
-                          - discoveryUrl
-                          - clientId
-                          - clientSecret
-                        additionalProperties: false
-                    required:
-                      - id
-                      - name
-                      - description
-                      - type
-                      - config
-                    additionalProperties: false
+                $ref: "#/components/schemas/IdpConnection"
         "404":
           $ref: "#/components/responses/Error"
       parameters:
@@ -7002,13 +2379,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                description:
-                  type: string
-              additionalProperties: false
+              $ref: "#/components/schemas/UpdateableSsoConnection"
   /api/sso/oidc:
     post:
       summary: Create OIDC SSO connection
@@ -7031,26 +2402,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                description:
-                  type: string
-                discoveryUrl:
-                  type: string
-                  format: uri
-                clientId:
-                  type: string
-                clientSecret:
-                  type: string
-              required:
-                - name
-                - description
-                - discoveryUrl
-                - clientId
-                - clientSecret
-              additionalProperties: false
+              $ref: "#/components/schemas/InsertableOidcConnection"
   /api/sso:
     get:
       summary: List SSO connections
@@ -7063,76 +2415,7 @@ paths:
               schema:
                 type: array
                 items:
-                  anyOf:
-                    - type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        description:
-                          type: string
-                        type:
-                          type: string
-                          const: SAML
-                        config:
-                          type: object
-                          properties:
-                            entityID:
-                              type: string
-                            sso:
-                              type: object
-                              properties:
-                                postUrl:
-                                  type: string
-                                redirectUrl:
-                                  type: string
-                              additionalProperties: false
-                            publicKey:
-                              type: string
-                          required:
-                            - entityID
-                            - sso
-                          additionalProperties: false
-                      required:
-                        - id
-                        - name
-                        - description
-                        - type
-                        - config
-                      additionalProperties: false
-                    - type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        description:
-                          type: string
-                        type:
-                          type: string
-                          const: OIDC
-                        config:
-                          type: object
-                          properties:
-                            discoveryUrl:
-                              type: string
-                            clientId:
-                              type: string
-                            clientSecret:
-                              type: string
-                          required:
-                            - discoveryUrl
-                            - clientId
-                            - clientSecret
-                          additionalProperties: false
-                      required:
-                        - id
-                        - name
-                        - description
-                        - type
-                        - config
-                      additionalProperties: false
+                  $ref: "#/components/schemas/IdpConnection"
       security:
         - bearerAuth: []
   /api/sso/saml:
@@ -7159,19 +2442,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                description:
-                  type: string
-                rawMetadata:
-                  type: string
-              required:
-                - name
-                - description
-                - rawMetadata
-              additionalProperties: false
+              $ref: "#/components/schemas/InsertableSamlConnection"
   /api/tools/{toolId}:
     get:
       summary: Get tool
@@ -7182,87 +2453,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  type:
-                    type: string
-                  name:
-                    type: string
-                  description:
-                    type: string
-                  configuration:
-                    type: object
-                    additionalProperties: {}
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  icon:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  sharing:
-                    oneOf:
-                      - type: object
-                        properties:
-                          type:
-                            type: string
-                            const: private
-                        required:
-                          - type
-                        additionalProperties: false
-                      - type: object
-                        properties:
-                          type:
-                            type: string
-                            const: public
-                        required:
-                          - type
-                        additionalProperties: false
-                      - type: object
-                        properties:
-                          type:
-                            type: string
-                            const: workspace
-                          workspaces:
-                            type: array
-                            items:
-                              type: string
-                        required:
-                          - type
-                          - workspaces
-                        additionalProperties: false
-                  provisioned:
-                    type: boolean
-                  capability:
-                    type: boolean
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  updatedAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  promptFragment:
-                    type: string
-                required:
-                  - id
-                  - type
-                  - name
-                  - description
-                  - configuration
-                  - tags
-                  - icon
-                  - sharing
-                  - provisioned
-                  - capability
-                  - createdAt
-                  - updatedAt
-                  - promptFragment
-                additionalProperties: false
+                $ref: "#/components/schemas/Tool"
         "404":
           $ref: "#/components/responses/Error"
       parameters:
@@ -7318,57 +2509,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                description:
-                  type: string
-                configuration:
-                  type: object
-                  additionalProperties: {}
-                tags:
-                  type: array
-                  items:
-                    type: string
-                icon:
-                  anyOf:
-                    - type: string
-                    - type: "null"
-                sharing:
-                  oneOf:
-                    - type: object
-                      properties:
-                        type:
-                          type: string
-                          const: private
-                      required:
-                        - type
-                      additionalProperties: false
-                    - type: object
-                      properties:
-                        type:
-                          type: string
-                          const: public
-                      required:
-                        - type
-                      additionalProperties: false
-                    - type: object
-                      properties:
-                        type:
-                          type: string
-                          const: workspace
-                        workspaces:
-                          type: array
-                          items:
-                            type: string
-                      required:
-                        - type
-                        - workspaces
-                      additionalProperties: false
-                promptFragment:
-                  type: string
-              additionalProperties: false
+              $ref: "#/components/schemas/UpdateableTool"
   /api/tools:
     get:
       summary: List tools
@@ -7381,87 +2522,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    type:
-                      type: string
-                    name:
-                      type: string
-                    description:
-                      type: string
-                    configuration:
-                      type: object
-                      additionalProperties: {}
-                    tags:
-                      type: array
-                      items:
-                        type: string
-                    icon:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    sharing:
-                      oneOf:
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              const: private
-                          required:
-                            - type
-                          additionalProperties: false
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              const: public
-                          required:
-                            - type
-                          additionalProperties: false
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              const: workspace
-                            workspaces:
-                              type: array
-                              items:
-                                type: string
-                          required:
-                            - type
-                            - workspaces
-                          additionalProperties: false
-                    provisioned:
-                      type: boolean
-                    capability:
-                      type: boolean
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    updatedAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    promptFragment:
-                      type: string
-                  required:
-                    - id
-                    - type
-                    - name
-                    - description
-                    - configuration
-                    - tags
-                    - icon
-                    - sharing
-                    - provisioned
-                    - capability
-                    - createdAt
-                    - updatedAt
-                    - promptFragment
-                  additionalProperties: false
+                  $ref: "#/components/schemas/Tool"
       security:
         - bearerAuth: []
     post:
@@ -7473,87 +2534,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  type:
-                    type: string
-                  name:
-                    type: string
-                  description:
-                    type: string
-                  configuration:
-                    type: object
-                    additionalProperties: {}
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  icon:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  sharing:
-                    oneOf:
-                      - type: object
-                        properties:
-                          type:
-                            type: string
-                            const: private
-                        required:
-                          - type
-                        additionalProperties: false
-                      - type: object
-                        properties:
-                          type:
-                            type: string
-                            const: public
-                        required:
-                          - type
-                        additionalProperties: false
-                      - type: object
-                        properties:
-                          type:
-                            type: string
-                            const: workspace
-                          workspaces:
-                            type: array
-                            items:
-                              type: string
-                        required:
-                          - type
-                          - workspaces
-                        additionalProperties: false
-                  provisioned:
-                    type: boolean
-                  capability:
-                    type: boolean
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  updatedAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  promptFragment:
-                    type: string
-                required:
-                  - id
-                  - type
-                  - name
-                  - description
-                  - configuration
-                  - tags
-                  - icon
-                  - sharing
-                  - provisioned
-                  - capability
-                  - createdAt
-                  - updatedAt
-                  - promptFragment
-                additionalProperties: false
+                $ref: "#/components/schemas/Tool"
         "500":
           $ref: "#/components/responses/Error"
       security:
@@ -7563,68 +2544,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                type:
-                  type: string
-                name:
-                  type: string
-                description:
-                  type: string
-                configuration:
-                  type: object
-                  additionalProperties: {}
-                tags:
-                  type: array
-                  items:
-                    type: string
-                icon:
-                  anyOf:
-                    - type: string
-                    - type: "null"
-                sharing:
-                  oneOf:
-                    - type: object
-                      properties:
-                        type:
-                          type: string
-                          const: private
-                      required:
-                        - type
-                      additionalProperties: false
-                    - type: object
-                      properties:
-                        type:
-                          type: string
-                          const: public
-                      required:
-                        - type
-                      additionalProperties: false
-                    - type: object
-                      properties:
-                        type:
-                          type: string
-                          const: workspace
-                        workspaces:
-                          type: array
-                          items:
-                            type: string
-                      required:
-                        - type
-                        - workspaces
-                      additionalProperties: false
-                promptFragment:
-                  type: string
-              required:
-                - type
-                - name
-                - description
-                - configuration
-                - tags
-                - icon
-                - sharing
-                - promptFragment
-              additionalProperties: false
+              $ref: "#/components/schemas/InsertableTool"
   /api/tools/tags:
     get:
       summary: List tool tags
@@ -7678,40 +2598,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    key:
-                      type: string
-                    userId:
-                      type: string
-                    description:
-                      type: string
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    expiresAt:
-                      anyOf:
-                        - type: string
-                          format: date-time
-                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                        - type: "null"
-                    enabled:
-                      type: number
-                    provisioned:
-                      type: boolean
-                  required:
-                    - id
-                    - key
-                    - userId
-                    - description
-                    - createdAt
-                    - expiresAt
-                    - enabled
-                    - provisioned
-                  additionalProperties: false
+                  $ref: "#/components/schemas/ApiKey"
         "404":
           $ref: "#/components/responses/Error"
       parameters:
@@ -7731,40 +2618,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  key:
-                    type: string
-                  userId:
-                    type: string
-                  description:
-                    type: string
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  expiresAt:
-                    anyOf:
-                      - type: string
-                        format: date-time
-                        pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                      - type: "null"
-                  enabled:
-                    type: number
-                  provisioned:
-                    type: boolean
-                required:
-                  - id
-                  - key
-                  - userId
-                  - description
-                  - createdAt
-                  - expiresAt
-                  - enabled
-                  - provisioned
-                additionalProperties: false
+                $ref: "#/components/schemas/ApiKey"
         "404":
           $ref: "#/components/responses/Error"
       parameters:
@@ -7780,20 +2634,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                description:
-                  type: string
-                expiresAt:
-                  anyOf:
-                    - type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    - type: "null"
-              required:
-                - description
-                - expiresAt
-              additionalProperties: false
+              $ref: "#/components/schemas/InsertableUserApiKey"
   /api/users/{userId}/password:
     delete:
       summary: Delete user password
@@ -7823,64 +2664,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  email:
-                    type: string
-                    format: email
-                    pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
-                  name:
-                    type: string
-                  password:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  role:
-                    type: string
-                    enum:
-                      - USER
-                      - ADMIN
-                  provisioned:
-                    type: boolean
-                  updatedAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  preferences:
-                    type: string
-                  image:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  ssoUser:
-                    type: boolean
-                  properties:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  enabled:
-                    type: boolean
-                required:
-                  - id
-                  - createdAt
-                  - email
-                  - name
-                  - password
-                  - role
-                  - provisioned
-                  - updatedAt
-                  - preferences
-                  - image
-                  - ssoUser
-                  - properties
-                  - enabled
-                additionalProperties: false
+                $ref: "#/components/schemas/AdminUser"
         "404":
           $ref: "#/components/responses/Error"
       parameters:
@@ -7934,38 +2718,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                email:
-                  type: string
-                  format: email
-                  pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
-                name:
-                  type: string
-                ssoUser:
-                  type: boolean
-                password:
-                  anyOf:
-                    - type: string
-                    - type: "null"
-                role:
-                  type: string
-                  enum:
-                    - USER
-                    - ADMIN
-                preferences:
-                  type: string
-                image:
-                  anyOf:
-                    - type: string
-                    - type: "null"
-                properties:
-                  type: object
-                  additionalProperties:
-                    type: string
-                enabled:
-                  type: boolean
-              additionalProperties: false
+              $ref: "#/components/schemas/AdminUpdateableUser"
   /api/users:
     get:
       summary: List users
@@ -7978,64 +2731,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    email:
-                      type: string
-                      format: email
-                      pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
-                    name:
-                      type: string
-                    password:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    role:
-                      type: string
-                      enum:
-                        - USER
-                        - ADMIN
-                    provisioned:
-                      type: boolean
-                    updatedAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    preferences:
-                      type: string
-                    image:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    ssoUser:
-                      type: boolean
-                    properties:
-                      type: object
-                      additionalProperties:
-                        type: string
-                    enabled:
-                      type: boolean
-                  required:
-                    - id
-                    - createdAt
-                    - email
-                    - name
-                    - password
-                    - role
-                    - provisioned
-                    - updatedAt
-                    - preferences
-                    - image
-                    - ssoUser
-                    - properties
-                    - enabled
-                  additionalProperties: false
+                  $ref: "#/components/schemas/AdminUser"
       security:
         - bearerAuth: []
     post:
@@ -8047,64 +2743,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  email:
-                    type: string
-                    format: email
-                    pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
-                  name:
-                    type: string
-                  password:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  role:
-                    type: string
-                    enum:
-                      - USER
-                      - ADMIN
-                  provisioned:
-                    type: boolean
-                  updatedAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  preferences:
-                    type: string
-                  image:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  ssoUser:
-                    type: boolean
-                  properties:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  enabled:
-                    type: boolean
-                required:
-                  - id
-                  - createdAt
-                  - email
-                  - name
-                  - password
-                  - role
-                  - provisioned
-                  - updatedAt
-                  - preferences
-                  - image
-                  - ssoUser
-                  - properties
-                  - enabled
-                additionalProperties: false
+                $ref: "#/components/schemas/AdminUser"
       security:
         - bearerAuth: []
       requestBody:
@@ -8112,45 +2751,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                email:
-                  type: string
-                  format: email
-                  pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
-                name:
-                  type: string
-                ssoUser:
-                  type: boolean
-                password:
-                  anyOf:
-                    - type: string
-                    - type: "null"
-                role:
-                  type: string
-                  enum:
-                    - USER
-                    - ADMIN
-                preferences:
-                  type: string
-                image:
-                  anyOf:
-                    - type: string
-                    - type: "null"
-                properties:
-                  type: object
-                  additionalProperties:
-                    type: string
-              required:
-                - email
-                - name
-                - ssoUser
-                - password
-                - role
-                - preferences
-                - image
-                - properties
-              additionalProperties: false
+              $ref: "#/components/schemas/InsertableUser"
   /api/v1/responses:
     post:
       summary: Chat v1 responses
@@ -8261,18 +2862,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                role:
-                  type: string
-                  enum:
-                    - ADMIN
-                    - OWNER
-                    - MEMBER
-                    - EDITOR
-              required:
-                - role
-              additionalProperties: false
+              $ref: "#/components/schemas/UpdateableWorkspaceMember"
   /api/workspaces/{workspaceId}/members:
     get:
       summary: List workspace members
@@ -8285,43 +2875,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    userId:
-                      type: string
-                    workspaceId:
-                      type: string
-                    role:
-                      type: string
-                      enum:
-                        - ADMIN
-                        - OWNER
-                        - MEMBER
-                        - EDITOR
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    updatedAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    name:
-                      type: string
-                    email:
-                      type: string
-                  required:
-                    - id
-                    - userId
-                    - workspaceId
-                    - role
-                    - createdAt
-                    - updatedAt
-                    - name
-                    - email
-                  additionalProperties: false
+                  $ref: "#/components/schemas/WorkspaceMember"
       parameters:
         - name: workspaceId
           in: path
@@ -8353,21 +2907,7 @@ paths:
             schema:
               type: array
               items:
-                type: object
-                properties:
-                  userId:
-                    type: string
-                  role:
-                    type: string
-                    enum:
-                      - ADMIN
-                      - OWNER
-                      - MEMBER
-                      - EDITOR
-                required:
-                  - userId
-                  - role
-                additionalProperties: false
+                $ref: "#/components/schemas/InsertableWorkspaceMember"
     delete:
       summary: Remove workspace member
       description: Remove a member from a workspace.
@@ -8392,34 +2932,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  slug:
-                    type: string
-                  domain:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  updatedAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                required:
-                  - id
-                  - name
-                  - slug
-                  - domain
-                  - createdAt
-                  - updatedAt
-                additionalProperties: false
+                $ref: "#/components/schemas/Workspace"
       parameters:
         - name: workspaceId
           in: path
@@ -8454,34 +2967,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    name:
-                      type: string
-                    slug:
-                      type: string
-                    domain:
-                      anyOf:
-                        - type: string
-                        - type: "null"
-                    createdAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                    updatedAt:
-                      type: string
-                      format: date-time
-                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  required:
-                    - id
-                    - name
-                    - slug
-                    - domain
-                    - createdAt
-                    - updatedAt
-                  additionalProperties: false
+                  $ref: "#/components/schemas/Workspace"
       security:
         - bearerAuth: []
     post:
@@ -8493,34 +2979,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  slug:
-                    type: string
-                  domain:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                  createdAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                  updatedAt:
-                    type: string
-                    format: date-time
-                    pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-                required:
-                  - id
-                  - name
-                  - slug
-                  - domain
-                  - createdAt
-                  - updatedAt
-                additionalProperties: false
+                $ref: "#/components/schemas/Workspace"
         "409":
           $ref: "#/components/responses/Error"
       security:
@@ -8530,13 +2989,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-              required:
-                - name
-              additionalProperties: false
+              $ref: "#/components/schemas/InsertableWorkspace"
 components:
   securitySchemes:
     bearerAuth:
@@ -8562,6 +3015,2969 @@ components:
       required:
         - error
       additionalProperties: false
+    AssistantVersion:
+      type: object
+      properties:
+        id:
+          type: string
+        assistantId:
+          type: string
+        backendId:
+          type: string
+        description:
+          type: string
+        imageId:
+          anyOf:
+            - type: string
+            - type: "null"
+        model:
+          type: string
+        name:
+          type: string
+        versionName:
+          anyOf:
+            - type: string
+            - type: "null"
+        systemPrompt:
+          type: string
+        temperature:
+          type: number
+        tokenLimit:
+          type: number
+        reasoning_effort:
+          anyOf:
+            - type: string
+              enum:
+                - low
+                - medium
+                - high
+            - type: "null"
+        tags:
+          type: string
+        prompts:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        updatedAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        current:
+          type: boolean
+        published:
+          type: boolean
+      required:
+        - id
+        - assistantId
+        - backendId
+        - description
+        - imageId
+        - model
+        - name
+        - systemPrompt
+        - temperature
+        - tokenLimit
+        - reasoning_effort
+        - tags
+        - prompts
+        - createdAt
+        - updatedAt
+        - current
+        - published
+      additionalProperties: false
+      id: AssistantVersion
+    AssistantFile:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+        size:
+          type: number
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        order:
+          anyOf:
+            - type: integer
+              minimum: -9007199254740991
+              maximum: 9007199254740991
+            - type: "null"
+      required:
+        - id
+        - name
+        - type
+        - size
+      additionalProperties: false
+      id: AssistantFile
+    AssistantSharing:
+      oneOf:
+        - $ref: "#/components/schemas/AssistantSharingAll"
+        - $ref: "#/components/schemas/AssistantSharingWorkspace"
+      id: AssistantSharing
+    AssistantSharingAll:
+      type: object
+      properties:
+        type:
+          type: string
+          const: all
+      required:
+        - type
+      additionalProperties: false
+      id: AssistantSharingAll
+    AssistantSharingWorkspace:
+      type: object
+      properties:
+        type:
+          type: string
+          const: workspace
+        workspaceId:
+          type: string
+        workspaceName:
+          type: string
+      required:
+        - type
+        - workspaceId
+        - workspaceName
+      additionalProperties: false
+      id: AssistantSharingWorkspace
+    AssistantDraft:
+      type: object
+      properties:
+        id:
+          type: string
+        assistantId:
+          type: string
+        backendId:
+          type: string
+        description:
+          type: string
+        model:
+          type: string
+        name:
+          type: string
+        versionName:
+          anyOf:
+            - type: string
+            - type: "null"
+        systemPrompt:
+          type: string
+        temperature:
+          type: number
+        tokenLimit:
+          type: number
+        reasoning_effort:
+          anyOf:
+            - type: string
+              enum:
+                - low
+                - medium
+                - high
+            - type: "null"
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        updatedAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        owner:
+          type: string
+        tools:
+          type: array
+          items:
+            type: string
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssistantFile"
+        sharing:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssistantSharing"
+        tags:
+          type: array
+          items:
+            type: string
+        prompts:
+          type: array
+          items:
+            type: string
+        iconUri:
+          anyOf:
+            - type: string
+            - type: "null"
+        provisioned:
+          type: boolean
+        pendingChanges:
+          type: boolean
+        subAssistants:
+          type: array
+          items:
+            type: string
+      required:
+        - id
+        - assistantId
+        - backendId
+        - description
+        - model
+        - name
+        - systemPrompt
+        - temperature
+        - tokenLimit
+        - reasoning_effort
+        - createdAt
+        - updatedAt
+        - owner
+        - tools
+        - files
+        - sharing
+        - tags
+        - prompts
+        - iconUri
+        - provisioned
+        - pendingChanges
+      additionalProperties: false
+      id: AssistantDraft
+    UpdateableAssistantDraft:
+      type: object
+      properties:
+        backendId:
+          type: string
+        description:
+          type: string
+        model:
+          type: string
+        name:
+          type: string
+        versionName:
+          anyOf:
+            - type: string
+            - type: "null"
+        systemPrompt:
+          type: string
+        temperature:
+          type: number
+        tokenLimit:
+          type: number
+        reasoning_effort:
+          anyOf:
+            - type: string
+              enum:
+                - low
+                - medium
+                - high
+            - type: "null"
+        tools:
+          type: array
+          items:
+            type: string
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssistantFile"
+        tags:
+          type: array
+          items:
+            type: string
+        prompts:
+          type: array
+          items:
+            type: string
+        iconUri:
+          anyOf:
+            - type: string
+            - type: "null"
+        subAssistants:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+      id: UpdateableAssistantDraft
+    EvaluateAssistantRequest:
+      type: object
+      properties:
+        assistant:
+          $ref: "#/components/schemas/AssistantDraft"
+        messages:
+          type: array
+          items: {}
+      required:
+        - assistant
+        - messages
+      additionalProperties: false
+      id: EvaluateAssistantRequest
+    InsertableAssistantDraft:
+      type: object
+      properties:
+        backendId:
+          type: string
+        description:
+          type: string
+        model:
+          type: string
+        name:
+          type: string
+        versionName:
+          anyOf:
+            - type: string
+            - type: "null"
+        systemPrompt:
+          type: string
+        temperature:
+          type: number
+        tokenLimit:
+          type: number
+        reasoning_effort:
+          anyOf:
+            - type: string
+              enum:
+                - low
+                - medium
+                - high
+            - type: "null"
+        tools:
+          type: array
+          items:
+            type: string
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssistantFile"
+        tags:
+          type: array
+          items:
+            type: string
+        prompts:
+          type: array
+          items:
+            type: string
+        iconUri:
+          anyOf:
+            - type: string
+            - type: "null"
+        subAssistants:
+          type: array
+          items:
+            type: string
+      required:
+        - backendId
+        - description
+        - model
+        - name
+        - systemPrompt
+        - temperature
+        - tokenLimit
+        - reasoning_effort
+        - tools
+        - files
+        - tags
+        - prompts
+        - iconUri
+      additionalProperties: false
+      id: InsertableAssistantDraft
+    TokenEstimateDetail:
+      type: object
+      properties:
+        preamble:
+          type: array
+          items:
+            $ref: "#/components/schemas/TokenDetailPart"
+          description: Per-component breakdown of preamble tokens (system prompt,
+            knowledge).
+        history:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageTokenDetail"
+          description: Per-message breakdown of history tokens.
+        draft:
+          description: Per-component breakdown of draft message tokens.
+          type: array
+          items:
+            $ref: "#/components/schemas/TokenDetailPart"
+      required:
+        - preamble
+        - history
+      additionalProperties: false
+      id: TokenEstimateDetail
+    TokenDetailPart:
+      type: object
+      properties:
+        type:
+          type: string
+          description: "Component type: system_prompt, knowledge_text, knowledge_file,
+            text, attachment, reasoning, tool_call, tool_result."
+        tokens:
+          type: number
+          description: Token count for this component.
+        algorithm:
+          type: string
+          description: "Algorithm or tokenizer used: cl100k_base, o200k_base,
+            approx_4chars, native_image, pdf_native, pdf_text_fallback,
+            pdf_page_limit_notice."
+        params:
+          description: Algorithm parameters, e.g. image dimensions or PDF page counts.
+          type: object
+          additionalProperties: {}
+        id:
+          description: File id or tool call id.
+          type: string
+        name:
+          description: File name.
+          type: string
+        mimetype:
+          description: MIME type for attachment entries.
+          type: string
+        toolCallId:
+          description: Tool call id for tool_call and tool_result entries.
+          type: string
+        toolName:
+          description: Tool name for tool_call and tool_result entries.
+          type: string
+      required:
+        - type
+        - tokens
+        - algorithm
+      additionalProperties: false
+      id: TokenDetailPart
+    MessageTokenDetail:
+      type: object
+      properties:
+        messageId:
+          type: string
+        role:
+          type: string
+          enum:
+            - user
+            - assistant
+            - tool
+        parts:
+          type: array
+          items:
+            $ref: "#/components/schemas/TokenDetailPart"
+      required:
+        - messageId
+        - role
+        - parts
+      additionalProperties: false
+      id: MessageTokenDetail
+    AssistantTokenEstimateResponse:
+      type: object
+      properties:
+        assistantId:
+          type: string
+          description: Assistant id used for estimation.
+        model:
+          type: string
+          description: Resolved model id used for estimation.
+        tokenizer:
+          type: string
+          enum:
+            - cl100k_base
+            - o200k_base
+            - approx_4chars
+          description: Tokenizer strategy used to compute token estimates.
+        estimate:
+          type: object
+          properties:
+            assistant:
+              type: number
+              description: Estimated tokens for assistant-provided context before messages,
+                including system prompt, tool prompt fragments, and assistant
+                knowledge injection.
+            messages:
+              type: number
+              description: Estimated tokens for the provided message list after ChatAssistant
+                message conversion.
+            total:
+              type: number
+              description: "Final estimate for next request input tokens: assistant +
+                messages."
+          required:
+            - assistant
+            - messages
+            - total
+          additionalProperties: false
+        detail:
+          description: Detailed per-component token breakdown, present only when
+            ?detail=true is requested.
+          $ref: "#/components/schemas/TokenEstimateDetail"
+      required:
+        - assistantId
+        - model
+        - tokenizer
+        - estimate
+      additionalProperties: false
+      id: AssistantTokenEstimateResponse
+    JoinRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+          pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
+        password:
+          type: string
+      required:
+        - name
+        - email
+        - password
+      additionalProperties: false
+      id: JoinRequest
+    LoginRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
+        password:
+          type: string
+      required:
+        - email
+        - password
+      additionalProperties: false
+      id: LoginRequest
+    SessionSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        expiresAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        lastSeenAt:
+          anyOf:
+            - type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            - type: "null"
+        userAgent:
+          anyOf:
+            - type: string
+            - type: "null"
+        ipAddress:
+          anyOf:
+            - type: string
+            - type: "null"
+        authMethod:
+          type: string
+          enum:
+            - password
+            - idp
+        idpConnectionId:
+          anyOf:
+            - type: string
+            - type: "null"
+        isCurrent:
+          type: boolean
+      required:
+        - id
+        - createdAt
+        - expiresAt
+        - lastSeenAt
+        - userAgent
+        - ipAddress
+        - authMethod
+        - idpConnectionId
+        - isCurrent
+      additionalProperties: false
+      id: SessionSummary
+    Backend:
+      oneOf:
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: openai
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+            id:
+              type: string
+            provisioned:
+              type: boolean
+          required:
+            - providerType
+            - name
+            - apiKey
+            - id
+            - provisioned
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: anthropic
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+            id:
+              type: string
+            provisioned:
+              type: boolean
+          required:
+            - providerType
+            - name
+            - apiKey
+            - id
+            - provisioned
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: logiclecloud
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+            endPoint:
+              type: string
+              format: uri
+            id:
+              type: string
+            provisioned:
+              type: boolean
+          required:
+            - providerType
+            - name
+            - apiKey
+            - endPoint
+            - id
+            - provisioned
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: gcp-vertex
+            name:
+              type: string
+              minLength: 2
+            credentials:
+              type: string
+              minLength: 2
+            id:
+              type: string
+            provisioned:
+              type: boolean
+          required:
+            - providerType
+            - name
+            - credentials
+            - id
+            - provisioned
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: perplexity
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+            id:
+              type: string
+            provisioned:
+              type: boolean
+          required:
+            - providerType
+            - name
+            - apiKey
+            - id
+            - provisioned
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: gemini
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+            id:
+              type: string
+            provisioned:
+              type: boolean
+          required:
+            - providerType
+            - name
+            - apiKey
+            - id
+            - provisioned
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: mock
+            name:
+              type: string
+              minLength: 2
+            id:
+              type: string
+            provisioned:
+              type: boolean
+          required:
+            - providerType
+            - name
+            - id
+            - provisioned
+          additionalProperties: false
+      id: Backend
+    UpdateableBackend:
+      oneOf:
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: openai
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+          required:
+            - providerType
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: anthropic
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+          required:
+            - providerType
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: logiclecloud
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+            endPoint:
+              type: string
+              format: uri
+          required:
+            - providerType
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: gcp-vertex
+            name:
+              type: string
+              minLength: 2
+            credentials:
+              type: string
+              minLength: 2
+          required:
+            - providerType
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: perplexity
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+          required:
+            - providerType
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: gemini
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+          required:
+            - providerType
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: mock
+            name:
+              type: string
+              minLength: 2
+          required:
+            - providerType
+          additionalProperties: false
+      id: UpdateableBackend
+    LlmModel:
+      type: object
+      properties:
+        id:
+          type: string
+        model:
+          type: string
+        name:
+          type: string
+        provider:
+          type: string
+        owned_by:
+          type: string
+        description:
+          type: string
+        context_length:
+          type: number
+        capabilities:
+          $ref: "#/components/schemas/LlmModelCapabilities"
+        defaultReasoning:
+          anyOf:
+            - type: string
+            - type: "null"
+        tags:
+          type: array
+          items:
+            type: string
+            enum:
+              - latest
+              - obsolete
+        maxOutputTokens:
+          type: number
+        tokenizer:
+          type: string
+          enum:
+            - cl100k_base
+            - o200k_base
+            - approx_4chars
+      required:
+        - id
+        - model
+        - name
+        - provider
+        - owned_by
+        - description
+        - context_length
+        - capabilities
+      additionalProperties: false
+      id: LlmModel
+    LlmModelCapabilities:
+      type: object
+      properties:
+        vision:
+          type: boolean
+        function_calling:
+          type: boolean
+        reasoning:
+          type: boolean
+        supportedMedia:
+          type: array
+          items:
+            type: string
+        web_search:
+          type: boolean
+        knowledge:
+          type: boolean
+      required:
+        - vision
+        - function_calling
+        - reasoning
+      additionalProperties: false
+      id: LlmModelCapabilities
+    InsertableBackend:
+      oneOf:
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: openai
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+          required:
+            - providerType
+            - name
+            - apiKey
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: anthropic
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+          required:
+            - providerType
+            - name
+            - apiKey
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: logiclecloud
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+            endPoint:
+              type: string
+              format: uri
+          required:
+            - providerType
+            - name
+            - apiKey
+            - endPoint
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: gcp-vertex
+            name:
+              type: string
+              minLength: 2
+            credentials:
+              type: string
+              minLength: 2
+          required:
+            - providerType
+            - name
+            - credentials
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: perplexity
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+          required:
+            - providerType
+            - name
+            - apiKey
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: gemini
+            name:
+              type: string
+              minLength: 2
+            apiKey:
+              type: string
+              minLength: 2
+          required:
+            - providerType
+            - name
+            - apiKey
+          additionalProperties: false
+        - type: object
+          properties:
+            providerType:
+              type: string
+              const: mock
+            name:
+              type: string
+              minLength: 2
+          required:
+            - providerType
+            - name
+          additionalProperties: false
+      id: InsertableBackend
+    ChatRun:
+      type: object
+      properties:
+        id:
+          type: string
+        conversationId:
+          type: string
+        ownerId:
+          type: string
+        requestMessageId:
+          type: string
+        status:
+          type: string
+          enum:
+            - running
+            - completed
+            - failed
+            - stopped
+        stopRequestedAt:
+          anyOf:
+            - type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            - type: "null"
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        updatedAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        completedAt:
+          anyOf:
+            - type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            - type: "null"
+        lastEventSequence:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        error:
+          anyOf:
+            - type: string
+            - type: "null"
+      required:
+        - id
+        - conversationId
+        - ownerId
+        - requestMessageId
+        - status
+        - stopRequestedAt
+        - createdAt
+        - updatedAt
+        - completedAt
+        - lastEventSequence
+        - error
+      additionalProperties: false
+      id: ChatRun
+    ActiveChatRunResponse:
+      type: object
+      properties:
+        run:
+          anyOf:
+            - $ref: "#/components/schemas/ChatRun"
+            - type: "null"
+      required:
+        - run
+      additionalProperties: false
+      id: ActiveChatRunResponse
+    ConversationDocxExportRequest:
+      type: object
+      properties:
+        markdown:
+          type: string
+          description: Markdown content to render into a DOCX document.
+      required:
+        - markdown
+      additionalProperties: false
+      id: ConversationDocxExportRequest
+    Conversation:
+      type: object
+      properties:
+        assistantId:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        ownerId:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        lastMsgSentAt:
+          anyOf:
+            - type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            - type: "null"
+      required:
+        - assistantId
+        - id
+        - name
+        - ownerId
+        - createdAt
+        - lastMsgSentAt
+      additionalProperties: false
+      id: Conversation
+    UpdateableConversation:
+      type: object
+      properties:
+        name:
+          type: string
+      additionalProperties: false
+      id: UpdateableConversation
+    ConversationFragment:
+      type: object
+      properties:
+        id:
+          type: string
+        lastMessageId:
+          type: string
+      required:
+        - id
+        - lastMessageId
+      additionalProperties: false
+      id: ConversationFragment
+    ConversationWithFolder:
+      type: object
+      properties:
+        assistantId:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        ownerId:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        lastMsgSentAt:
+          anyOf:
+            - type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            - type: "null"
+        folderId:
+          anyOf:
+            - type: string
+            - type: "null"
+        assistant:
+          $ref: "#/components/schemas/AssistantIdentification"
+      required:
+        - assistantId
+        - id
+        - name
+        - ownerId
+        - createdAt
+        - lastMsgSentAt
+        - folderId
+        - assistant
+      additionalProperties: false
+      id: ConversationWithFolder
+    AssistantIdentification:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        iconUri:
+          anyOf:
+            - type: string
+            - type: "null"
+      required:
+        - id
+        - name
+        - iconUri
+      additionalProperties: false
+      id: AssistantIdentification
+    InsertableConversation:
+      type: object
+      properties:
+        assistantId:
+          type: string
+        name:
+          type: string
+      required:
+        - assistantId
+        - name
+      additionalProperties: false
+      id: InsertableConversation
+    ConversationWithFolderId:
+      type: object
+      properties:
+        assistantId:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        ownerId:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        lastMsgSentAt:
+          anyOf:
+            - type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            - type: "null"
+        folderId:
+          anyOf:
+            - type: string
+            - type: "null"
+      required:
+        - assistantId
+        - id
+        - name
+        - ownerId
+        - createdAt
+        - lastMsgSentAt
+        - folderId
+      additionalProperties: false
+      id: ConversationWithFolderId
+    ConversationWithMessages:
+      type: object
+      properties:
+        conversation:
+          $ref: "#/components/schemas/ConversationWithFolderId"
+        messages:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+      required:
+        - conversation
+        - messages
+      additionalProperties: false
+      id: ConversationWithMessages
+    FileAnalysisPayload:
+      oneOf:
+        - $ref: "#/components/schemas/UnknownFileAnalysisPayload"
+        - $ref: "#/components/schemas/PdfFileAnalysisPayload"
+        - $ref: "#/components/schemas/ImageFileAnalysisPayload"
+        - $ref: "#/components/schemas/SpreadsheetFileAnalysisPayload"
+        - $ref: "#/components/schemas/PresentationFileAnalysisPayload"
+        - $ref: "#/components/schemas/WordFileAnalysisPayload"
+      id: FileAnalysisPayload
+    UnknownFileAnalysisPayload:
+      type: object
+      properties:
+        kind:
+          type: string
+          const: unknown
+        mimeType:
+          type: string
+        sizeBytes:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        extractedTextPath:
+          anyOf:
+            - type: string
+            - type: "null"
+      required:
+        - kind
+        - mimeType
+        - sizeBytes
+        - extractedTextPath
+      additionalProperties: false
+      id: UnknownFileAnalysisPayload
+    PdfFileAnalysisPayload:
+      type: object
+      properties:
+        kind:
+          type: string
+          const: pdf
+        mimeType:
+          type: string
+          const: application/pdf
+        sizeBytes:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        pageCount:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        visionPageCount:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        textCharCount:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        hasExtractableText:
+          type: boolean
+        imagePageCount:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        contentMode:
+          type: string
+          enum:
+            - text
+            - mixed
+            - scanned
+        extractedTextPath:
+          anyOf:
+            - type: string
+            - type: "null"
+      required:
+        - kind
+        - mimeType
+        - sizeBytes
+        - pageCount
+        - visionPageCount
+        - textCharCount
+        - hasExtractableText
+        - imagePageCount
+        - contentMode
+        - extractedTextPath
+      additionalProperties: false
+      id: PdfFileAnalysisPayload
+    ImageFileAnalysisPayload:
+      type: object
+      properties:
+        kind:
+          type: string
+          const: image
+        mimeType:
+          type: string
+        sizeBytes:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        width:
+          type: integer
+          exclusiveMinimum: 0
+          maximum: 9007199254740991
+        height:
+          type: integer
+          exclusiveMinimum: 0
+          maximum: 9007199254740991
+        frameCount:
+          type: integer
+          exclusiveMinimum: 0
+          maximum: 9007199254740991
+        hasAlpha:
+          type: boolean
+        format:
+          anyOf:
+            - type: string
+            - type: "null"
+        extractedTextPath:
+          anyOf:
+            - type: string
+            - type: "null"
+      required:
+        - kind
+        - mimeType
+        - sizeBytes
+        - width
+        - height
+        - frameCount
+        - hasAlpha
+        - format
+        - extractedTextPath
+      additionalProperties: false
+      id: ImageFileAnalysisPayload
+    SpreadsheetFileAnalysisPayload:
+      type: object
+      properties:
+        kind:
+          type: string
+          const: spreadsheet
+        mimeType:
+          type: string
+        sizeBytes:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        sheetCount:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        textCharCount:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        hasExtractableText:
+          type: boolean
+        extractedTextPath:
+          anyOf:
+            - type: string
+            - type: "null"
+      required:
+        - kind
+        - mimeType
+        - sizeBytes
+        - sheetCount
+        - textCharCount
+        - hasExtractableText
+        - extractedTextPath
+      additionalProperties: false
+      id: SpreadsheetFileAnalysisPayload
+    PresentationFileAnalysisPayload:
+      type: object
+      properties:
+        kind:
+          type: string
+          const: presentation
+        mimeType:
+          type: string
+        sizeBytes:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        slideCount:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        textCharCount:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        hasExtractableText:
+          type: boolean
+        extractedTextPath:
+          anyOf:
+            - type: string
+            - type: "null"
+      required:
+        - kind
+        - mimeType
+        - sizeBytes
+        - slideCount
+        - textCharCount
+        - hasExtractableText
+        - extractedTextPath
+      additionalProperties: false
+      id: PresentationFileAnalysisPayload
+    WordFileAnalysisPayload:
+      type: object
+      properties:
+        kind:
+          type: string
+          const: word
+        mimeType:
+          type: string
+        sizeBytes:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        textCharCount:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        hasExtractableText:
+          type: boolean
+        extractedTextPath:
+          anyOf:
+            - type: string
+            - type: "null"
+      required:
+        - kind
+        - mimeType
+        - sizeBytes
+        - textCharCount
+        - hasExtractableText
+        - extractedTextPath
+      additionalProperties: false
+      id: WordFileAnalysisPayload
+    FileAnalysis:
+      type: object
+      properties:
+        fileId:
+          type: string
+        kind:
+          type: string
+          enum:
+            - pdf
+            - image
+            - spreadsheet
+            - presentation
+            - word
+            - unknown
+        status:
+          type: string
+          enum:
+            - ready
+            - failed
+            - unavailable
+        analyzerVersion:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        payload:
+          anyOf:
+            - $ref: "#/components/schemas/FileAnalysisPayload"
+            - type: "null"
+        warnings:
+          type: array
+          items:
+            type: string
+        error:
+          anyOf:
+            - type: string
+            - type: "null"
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        updatedAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+      required:
+        - fileId
+        - kind
+        - status
+        - analyzerVersion
+        - payload
+        - error
+        - createdAt
+        - updatedAt
+      additionalProperties: false
+      id: FileAnalysis
+    FileOwner:
+      type: object
+      properties:
+        ownerType:
+          type: string
+          enum:
+            - USER
+            - CHAT
+            - ASSISTANT
+            - TOOL
+        ownerId:
+          type: string
+      required:
+        - ownerType
+        - ownerId
+      additionalProperties: false
+      id: FileOwner
+    InsertableFile:
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        size:
+          type: number
+        owner:
+          $ref: "#/components/schemas/FileOwner"
+      required:
+        - name
+        - type
+        - size
+        - owner
+      additionalProperties: false
+      id: InsertableFile
+    File:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        path:
+          type: string
+        type:
+          type: string
+        size:
+          type: number
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        encrypted:
+          anyOf:
+            - type: number
+              const: 0
+            - type: number
+              const: 1
+      required:
+        - id
+        - name
+        - path
+        - type
+        - size
+        - createdAt
+        - encrypted
+      additionalProperties: false
+      id: File
+    ApiKey:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        userId:
+          type: string
+        description:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        expiresAt:
+          anyOf:
+            - type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            - type: "null"
+        enabled:
+          type: number
+        provisioned:
+          type: boolean
+      required:
+        - id
+        - key
+        - userId
+        - description
+        - createdAt
+        - expiresAt
+        - enabled
+        - provisioned
+      additionalProperties: false
+      id: ApiKey
+    InsertableUserApiKey:
+      type: object
+      properties:
+        description:
+          type: string
+        expiresAt:
+          anyOf:
+            - type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            - type: "null"
+      required:
+        - description
+        - expiresAt
+      additionalProperties: false
+      id: InsertableUserApiKey
+    AssistantUsability:
+      oneOf:
+        - type: object
+          properties:
+            state:
+              type: string
+              const: usable
+          required:
+            - state
+          additionalProperties: false
+        - type: object
+          properties:
+            state:
+              type: string
+              const: need-api-key
+            backendId:
+              type: string
+            backendName:
+              type: string
+          required:
+            - state
+            - backendId
+            - backendName
+          additionalProperties: false
+        - type: object
+          properties:
+            state:
+              type: string
+              const: not-usable
+            constraint:
+              type: string
+          required:
+            - state
+            - constraint
+          additionalProperties: false
+      id: AssistantUsability
+    UserAssistantWithMedia:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        iconUri:
+          anyOf:
+            - type: string
+            - type: "null"
+        versionId:
+          type: string
+        backendId:
+          type: string
+        description:
+          type: string
+        model:
+          type: string
+        usability:
+          $ref: "#/components/schemas/AssistantUsability"
+        pinned:
+          type: boolean
+        lastUsed:
+          anyOf:
+            - type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            - type: "null"
+        owner:
+          type: string
+        ownerName:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        prompts:
+          type: array
+          items:
+            type: string
+        sharing:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssistantSharing"
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        updatedAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        cloneable:
+          type: boolean
+        tokenLimit:
+          type: number
+        tools:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              type:
+                type: string
+              availability:
+                type: string
+                enum:
+                  - ok
+                  - require-auth
+            required:
+              - id
+              - name
+              - type
+              - availability
+            additionalProperties: false
+        subAssistants:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+            required:
+              - id
+              - name
+            additionalProperties: false
+        pendingChanges:
+          type: boolean
+        supportedMedia:
+          type: array
+          items:
+            type: string
+        systemPrompt:
+          type: string
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssistantFile"
+      required:
+        - id
+        - name
+        - iconUri
+        - versionId
+        - backendId
+        - description
+        - model
+        - usability
+        - pinned
+        - lastUsed
+        - owner
+        - ownerName
+        - tags
+        - prompts
+        - sharing
+        - createdAt
+        - updatedAt
+        - cloneable
+        - tokenLimit
+        - tools
+        - pendingChanges
+        - supportedMedia
+      additionalProperties: false
+      id: UserAssistantWithMedia
+    UpdateableAssistantUserData:
+      type: object
+      properties:
+        pinned:
+          type: boolean
+      additionalProperties: false
+      id: UpdateableAssistantUserData
+    TokenEstimateRequest:
+      type: object
+      properties:
+        conversationId:
+          description: Conversation id used to include prior branch history in the estimate.
+          type: string
+        targetMessageId:
+          description: Optional message id that selects the target branch in a tree chat;
+            history is linearized up to this node.
+          anyOf:
+            - type: string
+            - type: "null"
+        attachmentFileIds:
+          default: []
+          description: Attachment file ids for the pending user message.
+          type: array
+          items:
+            type: string
+        draftText:
+          default: ""
+          description: Current draft text for the pending user message.
+          type: string
+      required:
+        - attachmentFileIds
+        - draftText
+      additionalProperties: false
+      id: TokenEstimateRequest
+    TokenEstimateResponse:
+      type: object
+      properties:
+        assistantId:
+          type: string
+          description: Assistant id used for estimation.
+        model:
+          type: string
+          description: Resolved model id used for estimation.
+        tokenizer:
+          type: string
+          enum:
+            - cl100k_base
+            - o200k_base
+            - approx_4chars
+          description: Tokenizer strategy used to compute token estimates.
+        estimate:
+          type: object
+          properties:
+            assistant:
+              type: number
+              description: Estimated tokens for assistant-provided context before chat
+                history, including system prompt, tool prompt fragments, and
+                assistant knowledge injection.
+            history:
+              type: number
+              description: Estimated tokens for prior branch messages after ChatAssistant
+                message conversion, excluding the rendered prompt context.
+            draft:
+              type: number
+              description: Estimated tokens for the pending user message after ChatAssistant
+                message conversion, including draft text and attachments.
+            total:
+              type: number
+              description: "Final estimate for next request input tokens: assistant + history
+                + draft."
+          required:
+            - assistant
+            - history
+            - draft
+            - total
+          additionalProperties: false
+        detail:
+          description: Detailed per-component token breakdown, present only when
+            ?detail=true is requested.
+          $ref: "#/components/schemas/TokenEstimateDetail"
+      required:
+        - assistantId
+        - model
+        - tokenizer
+        - estimate
+      additionalProperties: false
+      id: TokenEstimateResponse
+    UserAssistant:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        iconUri:
+          anyOf:
+            - type: string
+            - type: "null"
+        versionId:
+          type: string
+        backendId:
+          type: string
+        description:
+          type: string
+        model:
+          type: string
+        usability:
+          $ref: "#/components/schemas/AssistantUsability"
+        pinned:
+          type: boolean
+        lastUsed:
+          anyOf:
+            - type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            - type: "null"
+        owner:
+          type: string
+        ownerName:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        prompts:
+          type: array
+          items:
+            type: string
+        sharing:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssistantSharing"
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        updatedAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        cloneable:
+          type: boolean
+        tokenLimit:
+          type: number
+        tools:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              type:
+                type: string
+              availability:
+                type: string
+                enum:
+                  - ok
+                  - require-auth
+            required:
+              - id
+              - name
+              - type
+              - availability
+            additionalProperties: false
+        subAssistants:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+            required:
+              - id
+              - name
+            additionalProperties: false
+        pendingChanges:
+          type: boolean
+      required:
+        - id
+        - name
+        - iconUri
+        - versionId
+        - backendId
+        - description
+        - model
+        - usability
+        - pinned
+        - lastUsed
+        - owner
+        - ownerName
+        - tags
+        - prompts
+        - sharing
+        - createdAt
+        - updatedAt
+        - cloneable
+        - tokenLimit
+        - tools
+        - pendingChanges
+      additionalProperties: false
+      id: UserAssistant
+    AssistantWithOwner:
+      type: object
+      properties:
+        id:
+          type: string
+        assistantId:
+          type: string
+        backendId:
+          type: string
+        description:
+          type: string
+        model:
+          type: string
+        name:
+          type: string
+        systemPrompt:
+          type: string
+        temperature:
+          type: number
+        tokenLimit:
+          type: number
+        reasoning_effort:
+          anyOf:
+            - type: string
+              enum:
+                - low
+                - medium
+                - high
+            - type: "null"
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        updatedAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        owner:
+          type: string
+        ownerName:
+          type: string
+        modelName:
+          type: string
+        sharing:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssistantSharing"
+        tags:
+          type: array
+          items:
+            type: string
+        prompts:
+          type: array
+          items:
+            type: string
+        iconUri:
+          anyOf:
+            - type: string
+            - type: "null"
+        provisioned:
+          type: boolean
+      required:
+        - id
+        - assistantId
+        - backendId
+        - description
+        - model
+        - name
+        - systemPrompt
+        - temperature
+        - tokenLimit
+        - reasoning_effort
+        - createdAt
+        - updatedAt
+        - owner
+        - ownerName
+        - modelName
+        - sharing
+        - tags
+        - prompts
+        - iconUri
+        - provisioned
+      additionalProperties: false
+      id: AssistantWithOwner
+    ConversationFolder:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        ownerId:
+          type: string
+      required:
+        - id
+        - name
+        - ownerId
+      additionalProperties: false
+      id: ConversationFolder
+    AddConversationToFolder:
+      type: object
+      properties:
+        conversationId:
+          type: string
+      required:
+        - conversationId
+      additionalProperties: false
+      id: AddConversationToFolder
+    UpdateableConversationFolder:
+      type: object
+      properties:
+        name:
+          type: string
+      additionalProperties: false
+      id: UpdateableConversationFolder
+    InsertableConversationFolder:
+      type: object
+      properties:
+        name:
+          type: string
+      required:
+        - name
+      additionalProperties: false
+      id: InsertableConversationFolder
+    WorkspaceMembership:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        role:
+          type: string
+          enum:
+            - ADMIN
+            - OWNER
+            - MEMBER
+            - EDITOR
+      required:
+        - id
+        - name
+        - role
+      additionalProperties: false
+      id: WorkspaceMembership
+    UserProfile:
+      type: object
+      properties:
+        id:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        email:
+          type: string
+          format: email
+          pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
+        name:
+          type: string
+        role:
+          type: string
+          enum:
+            - USER
+            - ADMIN
+        provisioned:
+          type: boolean
+        updatedAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        image:
+          anyOf:
+            - type: string
+            - type: "null"
+        ssoUser:
+          type: boolean
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+        workspaces:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkspaceMembership"
+        lastUsedAssistant:
+          anyOf:
+            - $ref: "#/components/schemas/UserAssistant"
+            - type: "null"
+        pinnedAssistants:
+          type: array
+          items:
+            $ref: "#/components/schemas/UserAssistant"
+        assistants:
+          type: array
+          items:
+            $ref: "#/components/schemas/UserAssistant"
+        preferences:
+          type: object
+          properties:
+            language:
+              type: string
+            conversationEditing:
+              type: boolean
+            showIconsInChatbar:
+              type: boolean
+            advancedSystemPromptEditor:
+              type: boolean
+            advancedMessageEditor:
+              type: boolean
+          additionalProperties: false
+      required:
+        - id
+        - createdAt
+        - email
+        - name
+        - role
+        - provisioned
+        - updatedAt
+        - image
+        - ssoUser
+        - properties
+        - workspaces
+        - lastUsedAssistant
+        - pinnedAssistants
+        - assistants
+        - preferences
+      additionalProperties: false
+      id: UserProfile
+    UpdateableUserSelf:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
+        name:
+          type: string
+        preferences:
+          type: string
+        image:
+          anyOf:
+            - type: string
+            - type: "null"
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+      additionalProperties: false
+      id: UpdateableUserSelf
+    Prompt:
+      type: object
+      properties:
+        content:
+          type: string
+        description:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        ownerId:
+          type: string
+      required:
+        - content
+        - description
+        - id
+        - name
+        - ownerId
+      additionalProperties: false
+      id: Prompt
+    InsertablePrompt:
+      type: object
+      properties:
+        content:
+          type: string
+        description:
+          type: string
+        name:
+          type: string
+      required:
+        - content
+        - description
+        - name
+      additionalProperties: false
+      id: InsertablePrompt
+    UserSecretStatus:
+      type: object
+      properties:
+        id:
+          type: string
+        context:
+          type: string
+        type:
+          anyOf:
+            - type: string
+              enum:
+                - backend-credentials
+                - mcp-oauth
+            - type: string
+        label:
+          type: string
+        readable:
+          type: boolean
+      required:
+        - id
+        - context
+        - type
+        - label
+        - readable
+      additionalProperties: false
+      id: UserSecretStatus
+    InsertableUserSecret:
+      type: object
+      properties:
+        context:
+          type: string
+          minLength: 1
+        type:
+          type: string
+          enum:
+            - backend-credentials
+            - mcp-oauth
+        label:
+          type: string
+          minLength: 1
+        value:
+          type: string
+          minLength: 1
+      required:
+        - context
+        - type
+        - label
+        - value
+      additionalProperties: false
+      id: InsertableUserSecret
+    AssistantTool:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        capability:
+          type: boolean
+        provisioned:
+          type: boolean
+        visible:
+          type: boolean
+      required:
+        - id
+        - name
+        - capability
+        - provisioned
+        - visible
+      additionalProperties: false
+      id: AssistantTool
+    PropertyPatch:
+      type: object
+      additionalProperties:
+        type: string
+      id: PropertyPatch
+    SharedConversation:
+      type: object
+      properties:
+        title:
+          type: string
+        assistant:
+          $ref: "#/components/schemas/AssistantIdentification"
+        assistantUsability:
+          $ref: "#/components/schemas/AssistantUsability"
+        messages:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+      required:
+        - title
+        - assistant
+        - messages
+      additionalProperties: false
+      id: SharedConversation
+    SamlIdpConnection:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        type:
+          type: string
+          const: SAML
+        config:
+          $ref: "#/components/schemas/SamlConfig"
+      required:
+        - id
+        - name
+        - description
+        - type
+        - config
+      additionalProperties: false
+      id: SamlIdpConnection
+    SamlConfig:
+      type: object
+      properties:
+        entityID:
+          type: string
+        sso:
+          type: object
+          properties:
+            postUrl:
+              type: string
+            redirectUrl:
+              type: string
+          additionalProperties: false
+        publicKey:
+          type: string
+      required:
+        - entityID
+        - sso
+      additionalProperties: false
+      id: SamlConfig
+    OidcIdpConnection:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        type:
+          type: string
+          const: OIDC
+        config:
+          $ref: "#/components/schemas/OidcConfig"
+      required:
+        - id
+        - name
+        - description
+        - type
+        - config
+      additionalProperties: false
+      id: OidcIdpConnection
+    OidcConfig:
+      type: object
+      properties:
+        discoveryUrl:
+          type: string
+        clientId:
+          type: string
+        clientSecret:
+          type: string
+      required:
+        - discoveryUrl
+        - clientId
+        - clientSecret
+      additionalProperties: false
+      id: OidcConfig
+    IdpConnection:
+      anyOf:
+        - $ref: "#/components/schemas/SamlIdpConnection"
+        - $ref: "#/components/schemas/OidcIdpConnection"
+      id: IdpConnection
+    UpdateableSsoConnection:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+      additionalProperties: false
+      id: UpdateableSsoConnection
+    InsertableOidcConnection:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        discoveryUrl:
+          type: string
+          format: uri
+        clientId:
+          type: string
+        clientSecret:
+          type: string
+      required:
+        - name
+        - description
+        - discoveryUrl
+        - clientId
+        - clientSecret
+      additionalProperties: false
+      id: InsertableOidcConnection
+    InsertableSamlConnection:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        rawMetadata:
+          type: string
+      required:
+        - name
+        - description
+        - rawMetadata
+      additionalProperties: false
+      id: InsertableSamlConnection
+    ToolSharing:
+      oneOf:
+        - $ref: "#/components/schemas/ToolSharingPrivate"
+        - $ref: "#/components/schemas/ToolSharingPublic"
+        - $ref: "#/components/schemas/ToolSharingWorkspace"
+      id: ToolSharing
+    ToolSharingPrivate:
+      type: object
+      properties:
+        type:
+          type: string
+          const: private
+      required:
+        - type
+      additionalProperties: false
+      id: ToolSharingPrivate
+    ToolSharingPublic:
+      type: object
+      properties:
+        type:
+          type: string
+          const: public
+      required:
+        - type
+      additionalProperties: false
+      id: ToolSharingPublic
+    ToolSharingWorkspace:
+      type: object
+      properties:
+        type:
+          type: string
+          const: workspace
+        workspaces:
+          type: array
+          items:
+            type: string
+      required:
+        - type
+        - workspaces
+      additionalProperties: false
+      id: ToolSharingWorkspace
+    Tool:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        configuration:
+          type: object
+          additionalProperties: {}
+        tags:
+          type: array
+          items:
+            type: string
+        icon:
+          anyOf:
+            - type: string
+            - type: "null"
+        sharing:
+          $ref: "#/components/schemas/ToolSharing"
+        provisioned:
+          type: boolean
+        capability:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        updatedAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        promptFragment:
+          type: string
+      required:
+        - id
+        - type
+        - name
+        - description
+        - configuration
+        - tags
+        - icon
+        - sharing
+        - provisioned
+        - capability
+        - createdAt
+        - updatedAt
+        - promptFragment
+      additionalProperties: false
+      id: Tool
+    UpdateableTool:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        configuration:
+          type: object
+          additionalProperties: {}
+        tags:
+          type: array
+          items:
+            type: string
+        icon:
+          anyOf:
+            - type: string
+            - type: "null"
+        sharing:
+          $ref: "#/components/schemas/ToolSharing"
+        promptFragment:
+          type: string
+      additionalProperties: false
+      id: UpdateableTool
+    InsertableTool:
+      type: object
+      properties:
+        type:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        configuration:
+          type: object
+          additionalProperties: {}
+        tags:
+          type: array
+          items:
+            type: string
+        icon:
+          anyOf:
+            - type: string
+            - type: "null"
+        sharing:
+          $ref: "#/components/schemas/ToolSharing"
+        promptFragment:
+          type: string
+      required:
+        - type
+        - name
+        - description
+        - configuration
+        - tags
+        - icon
+        - sharing
+        - promptFragment
+      additionalProperties: false
+      id: InsertableTool
+    AdminUser:
+      type: object
+      properties:
+        id:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        email:
+          type: string
+          format: email
+          pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
+        name:
+          type: string
+        password:
+          anyOf:
+            - type: string
+            - type: "null"
+        role:
+          type: string
+          enum:
+            - USER
+            - ADMIN
+        provisioned:
+          type: boolean
+        updatedAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        preferences:
+          type: string
+        image:
+          anyOf:
+            - type: string
+            - type: "null"
+        ssoUser:
+          type: boolean
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+        enabled:
+          type: boolean
+      required:
+        - id
+        - createdAt
+        - email
+        - name
+        - password
+        - role
+        - provisioned
+        - updatedAt
+        - preferences
+        - image
+        - ssoUser
+        - properties
+        - enabled
+      additionalProperties: false
+      id: AdminUser
+    AdminUpdateableUser:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
+        name:
+          type: string
+        ssoUser:
+          type: boolean
+        password:
+          anyOf:
+            - type: string
+            - type: "null"
+        role:
+          type: string
+          enum:
+            - USER
+            - ADMIN
+        preferences:
+          type: string
+        image:
+          anyOf:
+            - type: string
+            - type: "null"
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+        enabled:
+          type: boolean
+      additionalProperties: false
+      id: AdminUpdateableUser
+    InsertableUser:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          pattern: ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
+        name:
+          type: string
+        ssoUser:
+          type: boolean
+        password:
+          anyOf:
+            - type: string
+            - type: "null"
+        role:
+          type: string
+          enum:
+            - USER
+            - ADMIN
+        preferences:
+          type: string
+        image:
+          anyOf:
+            - type: string
+            - type: "null"
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - email
+        - name
+        - ssoUser
+        - password
+        - role
+        - preferences
+        - image
+        - properties
+      additionalProperties: false
+      id: InsertableUser
+    UpdateableWorkspaceMember:
+      type: object
+      properties:
+        role:
+          type: string
+          enum:
+            - ADMIN
+            - OWNER
+            - MEMBER
+            - EDITOR
+      required:
+        - role
+      additionalProperties: false
+      id: UpdateableWorkspaceMember
+    WorkspaceMember:
+      type: object
+      properties:
+        id:
+          type: string
+        userId:
+          type: string
+        workspaceId:
+          type: string
+        role:
+          type: string
+          enum:
+            - ADMIN
+            - OWNER
+            - MEMBER
+            - EDITOR
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        updatedAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        name:
+          type: string
+        email:
+          type: string
+      required:
+        - id
+        - userId
+        - workspaceId
+        - role
+        - createdAt
+        - updatedAt
+        - name
+        - email
+      additionalProperties: false
+      id: WorkspaceMember
+    InsertableWorkspaceMember:
+      type: object
+      properties:
+        userId:
+          type: string
+        role:
+          type: string
+          enum:
+            - ADMIN
+            - OWNER
+            - MEMBER
+            - EDITOR
+      required:
+        - userId
+        - role
+      additionalProperties: false
+      id: InsertableWorkspaceMember
+    Workspace:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        slug:
+          type: string
+        domain:
+          anyOf:
+            - type: string
+            - type: "null"
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        updatedAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+      required:
+        - id
+        - name
+        - slug
+        - domain
+        - createdAt
+        - updatedAt
+      additionalProperties: false
+      id: Workspace
+    InsertableWorkspace:
+      type: object
+      properties:
+        name:
+          type: string
+      required:
+        - name
+      additionalProperties: false
+      id: InsertableWorkspace
   responses:
     Error:
       description: Error response

--- a/packages/core/src/types/dto/apikey.ts
+++ b/packages/core/src/types/dto/apikey.ts
@@ -10,7 +10,7 @@ export const apiKeySchema = z.object({
   expiresAt: iso8601UtcDateTimeSchema.nullable(),
   enabled: z.number(),
   provisioned: z.boolean(),
-})
+}).meta({ id: 'ApiKey' })
 
 export const insertableApiKeySchema = apiKeySchema.omit({
   key: true,
@@ -18,11 +18,11 @@ export const insertableApiKeySchema = apiKeySchema.omit({
   provisioned: true,
   createdAt: true,
   enabled: true,
-})
+}).meta({ id: 'InsertableApiKey' })
 
 export const insertableUserApiKeySchema = insertableApiKeySchema.omit({
   userId: true,
-})
+}).meta({ id: 'InsertableUserApiKey' })
 
 export type ApiKey = z.infer<typeof apiKeySchema>
 export type InsertableApiKey = z.infer<typeof insertableApiKeySchema>

--- a/packages/core/src/types/dto/assistant.ts
+++ b/packages/core/src/types/dto/assistant.ts
@@ -7,23 +7,52 @@ export const assistantFileSchema = z.object({
   name: z.string(),
   type: z.string(),
   size: z.number(),
-})
+  createdAt: iso8601UtcDateTimeSchema.optional(),
+  order: z.number().int().nullable().optional(),
+}).meta({ id: 'AssistantFile' })
+
+export const compareAssistantFiles = (
+  left: z.infer<typeof assistantFileSchema>,
+  right: z.infer<typeof assistantFileSchema>
+) => {
+  const leftOrderDefined = left.order !== undefined && left.order !== null
+  const rightOrderDefined = right.order !== undefined && right.order !== null
+  if (leftOrderDefined && rightOrderDefined) {
+    const leftOrder = left.order as number
+    const rightOrder = right.order as number
+    if (leftOrder !== rightOrder) {
+      return leftOrder - rightOrder
+    }
+  }
+  if (leftOrderDefined !== rightOrderDefined) {
+    return leftOrderDefined ? -1 : 1
+  }
+  const leftCreatedAt = left.createdAt ?? ''
+  const rightCreatedAt = right.createdAt ?? ''
+  if (leftCreatedAt !== rightCreatedAt) {
+    return leftCreatedAt.localeCompare(rightCreatedAt)
+  }
+  return left.id.localeCompare(right.id)
+}
+
+export const sortAssistantFiles = <T extends z.infer<typeof assistantFileSchema>>(files: T[]): T[] =>
+  [...files].sort(compareAssistantFiles)
 
 /** Sharing */
 export const allSharingSchema = z.object({
   type: z.literal('all'),
-})
+}).meta({ id: 'AssistantSharingAll' })
 
 const workspaceSharingSchema = z.object({
   type: z.literal('workspace'),
   workspaceId: z.string(),
   workspaceName: z.string(),
-})
+}).meta({ id: 'AssistantSharingWorkspace' })
 
 export const sharingSchema = z.discriminatedUnion('type', [
   allSharingSchema,
   workspaceSharingSchema,
-])
+]).meta({ id: 'AssistantSharing' })
 
 /** Matches your AssistantVersion interface */
 export const assistantVersionSchema = z.object({
@@ -45,7 +74,7 @@ export const assistantVersionSchema = z.object({
   updatedAt: iso8601UtcDateTimeSchema,
   current: z.boolean(),
   published: z.boolean(),
-})
+}).meta({ id: 'AssistantVersion' })
 
 export type AssistantVersion = z.infer<typeof assistantVersionSchema>
 
@@ -74,6 +103,7 @@ export const assistantDraftSchema = assistantVersionSchema
     pendingChanges: z.boolean(),
     subAssistants: z.array(z.string()).optional(),
   })
+  .meta({ id: 'AssistantDraft' })
 
 export const insertableAssistantDraftSchema = assistantDraftSchema.omit({
   id: true,
@@ -84,16 +114,18 @@ export const insertableAssistantDraftSchema = assistantDraftSchema.omit({
   provisioned: true,
   assistantId: true,
   pendingChanges: true,
-})
+}).meta({ id: 'InsertableAssistantDraft' })
 
-export const updateableAssistantDraftSchema = insertableAssistantDraftSchema.partial()
+export const updateableAssistantDraftSchema = insertableAssistantDraftSchema
+  .partial()
+  .meta({ id: 'UpdateableAssistantDraft' })
 
 export const assistantSharingSchema = z.object({
   id: z.string(),
   assistantId: z.string(),
   workspaceId: z.string().nullable(),
   provisioned: z.boolean(),
-})
+}).meta({ id: 'AssistantSharingRow' })
 
 export const assistantToolSchema = z.object({
   id: z.string(),
@@ -101,7 +133,7 @@ export const assistantToolSchema = z.object({
   capability: z.boolean(),
   provisioned: z.boolean(),
   visible: z.boolean(),
-})
+}).meta({ id: 'AssistantTool' })
 
 export type AssistantTool = z.infer<typeof assistantToolSchema>
 
@@ -110,6 +142,8 @@ export interface AssistantFile {
   name: string
   type: string
   size: number
+  createdAt?: string
+  order?: number | null
 }
 
 export type AssistantDraft = z.infer<typeof assistantDraftSchema>
@@ -139,18 +173,19 @@ export const assistantWithOwnerSchema = z.object({
   prompts: z.array(z.string()),
   iconUri: z.string().nullable(),
   provisioned: z.boolean(),
-})
+}).meta({ id: 'AssistantWithOwner' })
 
 export type AssistantWithOwner = z.infer<typeof assistantWithOwnerSchema>
 
 export const assistantUserDataSchema = z.object({
   pinned: z.boolean(),
   lastUsed: iso8601UtcDateTimeSchema.nullable(),
-})
+}).meta({ id: 'AssistantUserData' })
 
 export const updateableAssistantUserDataSchema = assistantUserDataSchema
   .omit({ lastUsed: true })
   .partial()
+  .meta({ id: 'UpdateableAssistantUserData' })
 
 export type AssistantUserData = z.infer<typeof assistantUserDataSchema>
 
@@ -162,7 +197,7 @@ export const assistantIdentificationSchema = z.object({
   id: z.string(),
   name: z.string(),
   iconUri: z.string().nullable(),
-})
+}).meta({ id: 'AssistantIdentification' })
 
 export type AssistantIdentification = z.infer<typeof assistantIdentificationSchema>
 
@@ -179,7 +214,7 @@ export const assistantUsabilitySchema = z.discriminatedUnion('state', [
     state: z.literal('not-usable'),
     constraint: z.string(),
   }),
-])
+]).meta({ id: 'AssistantUsability' })
 
 export type AssistantUsability = z.infer<typeof assistantUsabilitySchema>
 
@@ -220,7 +255,7 @@ export const userAssistantSchema = z.object({
     )
     .optional(),
   pendingChanges: z.boolean(),
-})
+}).meta({ id: 'UserAssistant' })
 
 export type UserAssistant = z.infer<typeof userAssistantSchema>
 
@@ -228,6 +263,6 @@ export const userAssistantWithMediaSchema = userAssistantSchema.extend({
   supportedMedia: z.array(z.string()),
   systemPrompt: z.string().optional(),
   files: z.array(assistantFileSchema).optional(),
-})
+}).meta({ id: 'UserAssistantWithMedia' })
 
 export type UserAssistantWithSupportedMedia = z.infer<typeof userAssistantWithMediaSchema>

--- a/packages/core/src/types/dto/auth.ts
+++ b/packages/core/src/types/dto/auth.ts
@@ -4,21 +4,21 @@ export const joinRequestSchema = z.object({
   name: z.string(),
   email: z.string().email(),
   password: z.string(),
-})
+}).meta({ id: 'JoinRequest' })
 
 export const loginRequestSchema = z.object({
   email: z.string().email(),
   password: z.string(),
-})
+}).meta({ id: 'LoginRequest' })
 
 export const changePasswordRequestSchema = z.object({
   currentPassword: z.string(),
   newPassword: z.string(),
-})
+}).meta({ id: 'ChangePasswordRequest' })
 
 export const adminChangePasswordRequestSchema = z.object({
   newPassword: z.string(),
-})
+}).meta({ id: 'AdminChangePasswordRequest' })
 
 export const insertableOidcConnectionSchema = z.object({
   name: z.string(),
@@ -26,18 +26,18 @@ export const insertableOidcConnectionSchema = z.object({
   discoveryUrl: z.string().url(),
   clientId: z.string(),
   clientSecret: z.string(),
-})
+}).meta({ id: 'InsertableOidcConnection' })
 
 export const insertableSamlConnectionSchema = z.object({
   name: z.string(),
   description: z.string(),
   rawMetadata: z.string(),
-})
+}).meta({ id: 'InsertableSamlConnection' })
 
 export const updateableSsoConnectionSchema = z.object({
   name: z.string().optional(),
   description: z.string().optional(),
-})
+}).meta({ id: 'UpdateableSsoConnection' })
 
 export type JoinRequest = z.infer<typeof joinRequestSchema>
 export type LoginRequest = z.infer<typeof loginRequestSchema>

--- a/packages/core/src/types/dto/backend.ts
+++ b/packages/core/src/types/dto/backend.ts
@@ -72,8 +72,10 @@ const backendOptions = [
 ] as const
 
 export const backendSchema = z.discriminatedUnion('providerType', backendOptions)
+  .meta({ id: 'Backend' })
 
 export const insertableBackendSchema = z.discriminatedUnion('providerType', options)
+  .meta({ id: 'InsertableBackend' })
 
 export const updateableBackendSchema = z.discriminatedUnion('providerType', [
   backendOptions[0].omit({ id: true, provisioned: true }).partial().extend({
@@ -98,6 +100,7 @@ export const updateableBackendSchema = z.discriminatedUnion('providerType', [
     providerType: backendOptions[6].shape.providerType,
   }),
 ])
+  .meta({ id: 'UpdateableBackend' })
 
 export type Backend = z.infer<typeof backendSchema>
 export type InsertableBackend = z.infer<typeof insertableBackendSchema>

--- a/packages/core/src/types/dto/chat.ts
+++ b/packages/core/src/types/dto/chat.ts
@@ -16,7 +16,7 @@ export const conversationSchema = z.object({
   ownerId: z.string(),
   createdAt: iso8601UtcDateTimeSchema,
   lastMsgSentAt: iso8601UtcDateTimeSchema.nullable(),
-})
+}).meta({ id: 'Conversation' })
 
 export type Conversation = z.infer<typeof conversationSchema>
 
@@ -25,7 +25,7 @@ export const insertableConversationSchema = conversationSchema.omit({
   createdAt: true,
   lastMsgSentAt: true,
   ownerId: true,
-})
+}).meta({ id: 'InsertableConversation' })
 
 export type InsertableConversation = z.infer<typeof insertableConversationSchema>
 
@@ -34,13 +34,14 @@ export const updateableConversationSchema = insertableConversationSchema
     assistantId: true,
   })
   .partial()
+  .meta({ id: 'UpdateableConversation' })
 
 export type UpdateableConversation = z.infer<typeof updateableConversationSchema>
 
 export const conversationFragmentSchema = z.object({
   id: z.string(),
   lastMessageId: z.string(),
-})
+}).meta({ id: 'ConversationFragment' })
 
 export type ConversationFragment = z.infer<typeof conversationFragmentSchema>
 
@@ -62,13 +63,13 @@ export const chatRunSchema = z.object({
   completedAt: iso8601UtcDateTimeSchema.nullable(),
   lastEventSequence: z.number().int().nonnegative(),
   error: z.string().nullable(),
-})
+}).meta({ id: 'ChatRun' })
 
 export type ChatRun = z.infer<typeof chatRunSchema>
 
 export const activeChatRunResponseSchema = z.object({
   run: chatRunSchema.nullable(),
-})
+}).meta({ id: 'ActiveChatRunResponse' })
 
 export type ActiveChatRunResponse = z.infer<typeof activeChatRunResponseSchema>
 
@@ -81,18 +82,18 @@ export interface Attachment {
 
 export const ConversationWithFolderIdSchema = conversationSchema.extend({
   folderId: z.string().nullable(),
-})
+}).meta({ id: 'ConversationWithFolderId' })
 
 export type ConversationWithFolderId = z.infer<typeof ConversationWithFolderIdSchema>
 
 export const ConversationWithFolderSchema = ConversationWithFolderIdSchema.extend({
   assistant: assistantIdentificationSchema,
-})
+}).meta({ id: 'ConversationWithFolder' })
 
 export const ConversationWithMessagesSchema = z.object({
   conversation: ConversationWithFolderIdSchema,
   messages: z.array(z.record(z.string(), z.unknown())) as unknown as z.ZodType<Message[]>,
-})
+}).meta({ id: 'ConversationWithMessages' })
 
 export type ConversationWithFolder = z.infer<typeof ConversationWithFolderSchema>
 
@@ -364,7 +365,7 @@ export const sharedConversationSchema = z.object({
   assistant: assistantIdentificationSchema,
   assistantUsability: assistantUsabilitySchema.optional(),
   messages: messageSchema.array(),
-})
+}).meta({ id: 'SharedConversation' })
 export type SharedConversation = {
   title: string
   assistant: AssistantIdentification
@@ -375,6 +376,6 @@ export type SharedConversation = {
 export const evaluateAssistantRequestSchema = z.object({
   assistant: assistantDraftSchema,
   messages: z.array(z.any()) as z.ZodType<Message[]>,
-})
+}).meta({ id: 'EvaluateAssistantRequest' })
 
 export type EvaluateAssistantRequest = z.infer<typeof evaluateAssistantRequestSchema>

--- a/packages/core/src/types/dto/conversationfolder.ts
+++ b/packages/core/src/types/dto/conversationfolder.ts
@@ -4,18 +4,20 @@ export const conversationFolderSchema = z.object({
   id: z.string(),
   name: z.string(),
   ownerId: z.string(),
-})
+}).meta({ id: 'ConversationFolder' })
 
 export const insertableConversationFolderSchema = conversationFolderSchema.omit({
   id: true,
   ownerId: true,
-})
+}).meta({ id: 'InsertableConversationFolder' })
 
 export const addConversationToFolderSchema = z.object({
   conversationId: z.string(),
-})
+}).meta({ id: 'AddConversationToFolder' })
 
-export const updateableConversationFolderSchema = insertableConversationFolderSchema.partial()
+export const updateableConversationFolderSchema = insertableConversationFolderSchema
+  .partial()
+  .meta({ id: 'UpdateableConversationFolder' })
 
 export type ConversationFolder = z.infer<typeof conversationFolderSchema>
 

--- a/packages/core/src/types/dto/docx-export.ts
+++ b/packages/core/src/types/dto/docx-export.ts
@@ -2,6 +2,6 @@ import { z } from 'zod'
 
 export const conversationDocxExportRequestSchema = z.object({
   markdown: z.string().describe('Markdown content to render into a DOCX document.'),
-})
+}).meta({ id: 'ConversationDocxExportRequest' })
 
 export type ConversationDocxExportRequest = z.infer<typeof conversationDocxExportRequestSchema>

--- a/packages/core/src/types/dto/file-analysis.ts
+++ b/packages/core/src/types/dto/file-analysis.ts
@@ -21,7 +21,7 @@ export const unknownFileAnalysisPayloadSchema = z.object({
   mimeType: z.string(),
   sizeBytes: z.number().int().nonnegative(),
   extractedTextPath: z.string().nullable(),
-})
+}).meta({ id: 'UnknownFileAnalysisPayload' })
 
 export const pdfFileAnalysisPayloadSchema = z.object({
   kind: z.literal('pdf'),
@@ -34,7 +34,7 @@ export const pdfFileAnalysisPayloadSchema = z.object({
   imagePageCount: z.number().int().nonnegative(),
   contentMode: z.enum(['text', 'mixed', 'scanned']),
   extractedTextPath: z.string().nullable(),
-})
+}).meta({ id: 'PdfFileAnalysisPayload' })
 
 export const imageFileAnalysisPayloadSchema = z.object({
   kind: z.literal('image'),
@@ -46,7 +46,7 @@ export const imageFileAnalysisPayloadSchema = z.object({
   hasAlpha: z.boolean(),
   format: z.string().nullable(),
   extractedTextPath: z.string().nullable(),
-})
+}).meta({ id: 'ImageFileAnalysisPayload' })
 
 export const spreadsheetFileAnalysisPayloadSchema = z.object({
   kind: z.literal('spreadsheet'),
@@ -56,7 +56,7 @@ export const spreadsheetFileAnalysisPayloadSchema = z.object({
   textCharCount: z.number().int().nonnegative(),
   hasExtractableText: z.boolean(),
   extractedTextPath: z.string().nullable(),
-})
+}).meta({ id: 'SpreadsheetFileAnalysisPayload' })
 
 export const presentationFileAnalysisPayloadSchema = z.object({
   kind: z.literal('presentation'),
@@ -66,7 +66,7 @@ export const presentationFileAnalysisPayloadSchema = z.object({
   textCharCount: z.number().int().nonnegative(),
   hasExtractableText: z.boolean(),
   extractedTextPath: z.string().nullable(),
-})
+}).meta({ id: 'PresentationFileAnalysisPayload' })
 
 export const wordFileAnalysisPayloadSchema = z.object({
   kind: z.literal('word'),
@@ -75,7 +75,7 @@ export const wordFileAnalysisPayloadSchema = z.object({
   textCharCount: z.number().int().nonnegative(),
   hasExtractableText: z.boolean(),
   extractedTextPath: z.string().nullable(),
-})
+}).meta({ id: 'WordFileAnalysisPayload' })
 
 export const fileAnalysisPayloadSchema = z.discriminatedUnion('kind', [
   unknownFileAnalysisPayloadSchema,
@@ -84,7 +84,7 @@ export const fileAnalysisPayloadSchema = z.discriminatedUnion('kind', [
   spreadsheetFileAnalysisPayloadSchema,
   presentationFileAnalysisPayloadSchema,
   wordFileAnalysisPayloadSchema,
-])
+]).meta({ id: 'FileAnalysisPayload' })
 
 export const fileAnalysisSchema = z.object({
   fileId: z.string(),
@@ -96,7 +96,7 @@ export const fileAnalysisSchema = z.object({
   error: z.string().nullable(),
   createdAt: iso8601UtcDateTimeSchema,
   updatedAt: iso8601UtcDateTimeSchema,
-})
+}).meta({ id: 'FileAnalysis' })
 
 export type FileAnalysisPayload = z.infer<typeof fileAnalysisPayloadSchema>
 export type FileAnalysis = z.infer<typeof fileAnalysisSchema>

--- a/packages/core/src/types/dto/file.ts
+++ b/packages/core/src/types/dto/file.ts
@@ -4,7 +4,7 @@ import { iso8601UtcDateTimeSchema } from './common'
 export const fileOwnerSchema = z.object({
   ownerType: z.enum(['USER', 'CHAT', 'ASSISTANT', 'TOOL']),
   ownerId: z.string(),
-})
+}).meta({ id: 'FileOwner' })
 
 export const fileSchema = z.object({
   id: z.string(),
@@ -14,7 +14,7 @@ export const fileSchema = z.object({
   size: z.number(),
   createdAt: iso8601UtcDateTimeSchema,
   encrypted: z.union([z.literal(0), z.literal(1)]),
-})
+}).meta({ id: 'File' })
 
 export const insertableFileSchema = fileSchema
   .omit({
@@ -26,6 +26,7 @@ export const insertableFileSchema = fileSchema
   .extend({
     owner: fileOwnerSchema,
   })
+  .meta({ id: 'InsertableFile' })
 
 export type FileOwner = z.infer<typeof fileOwnerSchema>
 export type File = z.infer<typeof fileSchema>

--- a/packages/core/src/types/dto/llmmodel.ts
+++ b/packages/core/src/types/dto/llmmodel.ts
@@ -9,7 +9,7 @@ export const llmModelCapabilitiesSchema = z.object({
   supportedMedia: z.array(z.string()).optional(),
   web_search: z.boolean().optional(),
   knowledge: z.boolean().optional(),
-})
+}).meta({ id: 'LlmModelCapabilities' })
 
 export const llmModelSchema = z.object({
   id: z.string(),
@@ -24,6 +24,6 @@ export const llmModelSchema = z.object({
   tags: z.array(z.enum(['latest', 'obsolete'])).optional(),
   maxOutputTokens: z.number().optional(),
   tokenizer: tokenizerStrategySchema.optional(),
-})
+}).meta({ id: 'LlmModel' })
 
 export type LlmModel = z.infer<typeof llmModelSchema>

--- a/packages/core/src/types/dto/parameter.ts
+++ b/packages/core/src/types/dto/parameter.ts
@@ -6,6 +6,6 @@ export const parameterSchema = z.object({
   description: z.string(),
   defaultValue: z.string().nullable(),
   provisioned: z.boolean(),
-})
+}).meta({ id: 'Parameter' })
 
 export type Parameter = z.infer<typeof parameterSchema>

--- a/packages/core/src/types/dto/prompt.ts
+++ b/packages/core/src/types/dto/prompt.ts
@@ -6,9 +6,11 @@ export const promptSchema = z.object({
   id: z.string(),
   name: z.string(),
   ownerId: z.string(),
-})
+}).meta({ id: 'Prompt' })
 
-export const insertablePromptSchema = promptSchema.omit({ id: true, ownerId: true })
+export const insertablePromptSchema = promptSchema
+  .omit({ id: true, ownerId: true })
+  .meta({ id: 'InsertablePrompt' })
 
 export type Prompt = z.infer<typeof promptSchema>
 export type InsertablePrompt = z.infer<typeof insertablePromptSchema>

--- a/packages/core/src/types/dto/property.ts
+++ b/packages/core/src/types/dto/property.ts
@@ -4,13 +4,13 @@ export const propertySchema = z.object({
   id: z.string(),
   name: z.string(),
   value: z.string(),
-})
+}).meta({ id: 'Property' })
 
 export const insertablePropertySchema = propertySchema.omit({
   id: true,
-})
+}).meta({ id: 'InsertableProperty' })
 
-export const propertyPatchSchema = z.record(z.string(), z.string())
+export const propertyPatchSchema = z.record(z.string(), z.string()).meta({ id: 'PropertyPatch' })
 
 export type Property = z.infer<typeof propertySchema>
 export type InsertableProperty = z.infer<typeof insertablePropertySchema>

--- a/packages/core/src/types/dto/session.ts
+++ b/packages/core/src/types/dto/session.ts
@@ -11,6 +11,6 @@ export const sessionSummarySchema = z.object({
   authMethod: z.enum(['password', 'idp']),
   idpConnectionId: z.string().nullable(),
   isCurrent: z.boolean(),
-})
+}).meta({ id: 'SessionSummary' })
 
 export type SessionSummary = z.infer<typeof sessionSummarySchema>

--- a/packages/core/src/types/dto/sso.ts
+++ b/packages/core/src/types/dto/sso.ts
@@ -4,13 +4,13 @@ export const idpConnectionBaseSchema = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string(),
-})
+}).meta({ id: 'IdpConnectionBase' })
 
 export const oidcConfigSchema = z.object({
   discoveryUrl: z.string(),
   clientId: z.string(),
   clientSecret: z.string(),
-})
+}).meta({ id: 'OidcConfig' })
 
 export const samlConfigSchema = z.object({
   entityID: z.string(),
@@ -21,19 +21,21 @@ export const samlConfigSchema = z.object({
     })
     .strict(),
   publicKey: z.string().optional(),
-})
+}).meta({ id: 'SamlConfig' })
 
 export const samlIdpConnectionSchema = idpConnectionBaseSchema.extend({
   type: z.literal('SAML'),
   config: samlConfigSchema,
-})
+}).meta({ id: 'SamlIdpConnection' })
 
 export const oidcIdpConnectionSchema = idpConnectionBaseSchema.extend({
   type: z.literal('OIDC'),
   config: oidcConfigSchema,
-})
+}).meta({ id: 'OidcIdpConnection' })
 
-export const idpConnectionSchema = z.union([samlIdpConnectionSchema, oidcIdpConnectionSchema])
+export const idpConnectionSchema = z
+  .union([samlIdpConnectionSchema, oidcIdpConnectionSchema])
+  .meta({ id: 'IdpConnection' })
 
 export type IdpConnectionBase = z.infer<typeof idpConnectionBaseSchema>
 export type OIDCConfig = z.infer<typeof oidcConfigSchema>

--- a/packages/core/src/types/dto/tokenestimate.ts
+++ b/packages/core/src/types/dto/tokenestimate.ts
@@ -17,7 +17,7 @@ export const tokenEstimateRequestSchema = z.object({
     .default([])
     .describe('Attachment file ids for the pending user message.'),
   draftText: z.string().default('').describe('Current draft text for the pending user message.'),
-})
+}).meta({ id: 'TokenEstimateRequest' })
 
 export type TokenEstimateRequest = z.infer<typeof tokenEstimateRequestSchema>
 
@@ -30,7 +30,7 @@ const tokenEstimateMetaSchema = z.object({
   tokenizer: z
     .enum(['cl100k_base', 'o200k_base', 'approx_4chars'])
     .describe('Tokenizer strategy used to compute token estimates.'),
-})
+}).meta({ id: 'TokenEstimateMeta' })
 
 export const tokenDetailPartSchema = z.object({
   type: z
@@ -53,7 +53,7 @@ export const tokenDetailPartSchema = z.object({
   mimetype: z.string().optional().describe('MIME type for attachment entries.'),
   toolCallId: z.string().optional().describe('Tool call id for tool_call and tool_result entries.'),
   toolName: z.string().optional().describe('Tool name for tool_call and tool_result entries.'),
-})
+}).meta({ id: 'TokenDetailPart' })
 
 export type TokenDetailPart = z.infer<typeof tokenDetailPartSchema>
 
@@ -61,7 +61,7 @@ export const messageTokenDetailSchema = z.object({
   messageId: z.string(),
   role: z.enum(['user', 'assistant', 'tool']),
   parts: z.array(tokenDetailPartSchema),
-})
+}).meta({ id: 'MessageTokenDetail' })
 
 export type MessageTokenDetail = z.infer<typeof messageTokenDetailSchema>
 
@@ -76,7 +76,7 @@ export const tokenEstimateDetailSchema = z.object({
     .array(tokenDetailPartSchema)
     .optional()
     .describe('Per-component breakdown of draft message tokens.'),
-})
+}).meta({ id: 'TokenEstimateDetail' })
 
 export type TokenEstimateDetail = z.infer<typeof tokenEstimateDetailSchema>
 
@@ -100,7 +100,7 @@ export const tokenEstimateResponseSchema = tokenEstimateMetaSchema.extend({
       .describe('Final estimate for next request input tokens: assistant + history + draft.'),
   }),
   detail: tokenEstimateDetailSchema.optional().describe('Detailed per-component token breakdown, present only when ?detail=true is requested.'),
-})
+}).meta({ id: 'TokenEstimateResponse' })
 
 export type TokenEstimateResponse = z.infer<typeof tokenEstimateResponseSchema>
 
@@ -117,6 +117,6 @@ export const assistantTokenEstimateResponseSchema = tokenEstimateMetaSchema.exte
     total: z.number().describe('Final estimate for next request input tokens: assistant + messages.'),
   }),
   detail: tokenEstimateDetailSchema.optional().describe('Detailed per-component token breakdown, present only when ?detail=true is requested.'),
-})
+}).meta({ id: 'AssistantTokenEstimateResponse' })
 
 export type AssistantTokenEstimateResponse = z.infer<typeof assistantTokenEstimateResponseSchema>

--- a/packages/core/src/types/dto/tool.ts
+++ b/packages/core/src/types/dto/tool.ts
@@ -3,22 +3,22 @@ import { iso8601UtcDateTimeSchema } from './common'
 
 export const privateSharingSchema = z.object({
   type: z.literal('private'),
-})
+}).meta({ id: 'ToolSharingPrivate' })
 
 export const publicSharingSchema = z.object({
   type: z.literal('public'),
-})
+}).meta({ id: 'ToolSharingPublic' })
 
 const workspaceSharingSchema = z.object({
   type: z.literal('workspace'),
   workspaces: z.array(z.string()),
-})
+}).meta({ id: 'ToolSharingWorkspace' })
 
 export const sharing2Schema = z.discriminatedUnion('type', [
   privateSharingSchema,
   publicSharingSchema,
   workspaceSharingSchema,
-])
+]).meta({ id: 'ToolSharing' })
 
 export const toolSchema = z.object({
   id: z.string(),
@@ -34,7 +34,7 @@ export const toolSchema = z.object({
   createdAt: iso8601UtcDateTimeSchema,
   updatedAt: iso8601UtcDateTimeSchema,
   promptFragment: z.string(),
-})
+}).meta({ id: 'Tool' })
 
 export const insertableToolSchema = toolSchema.omit({
   id: true,
@@ -42,13 +42,14 @@ export const insertableToolSchema = toolSchema.omit({
   createdAt: true,
   updatedAt: true,
   capability: true,
-})
+}).meta({ id: 'InsertableTool' })
 
 export const updateableToolSchema = insertableToolSchema
   .omit({
     type: true,
   })
   .partial()
+  .meta({ id: 'UpdateableTool' })
 
 export type Tool = z.infer<typeof toolSchema>
 

--- a/packages/core/src/types/dto/user.ts
+++ b/packages/core/src/types/dto/user.ts
@@ -22,11 +22,11 @@ export const userSchema = z.object({
   image: z.string().nullable(),
   ssoUser: z.boolean(),
   properties: z.record(z.string(), z.string()),
-})
+}).meta({ id: 'User' })
 
 export const adminUserSchema = userSchema.extend({
   enabled: z.boolean(),
-})
+}).meta({ id: 'AdminUser' })
 
 export const insertableUserSchema = z.object({
   email: z.string().email(),
@@ -37,19 +37,19 @@ export const insertableUserSchema = z.object({
   preferences: z.string(),
   image: z.string().nullable(),
   properties: z.record(z.string(), z.string()),
-})
+}).meta({ id: 'InsertableUser' })
 
-export const updateableUserSchema = insertableUserSchema.partial()
+export const updateableUserSchema = insertableUserSchema.partial().meta({ id: 'UpdateableUser' })
 
 export const adminUpdateableUserSchema = updateableUserSchema.extend({
   enabled: z.boolean().optional(),
-})
+}).meta({ id: 'AdminUpdateableUser' })
 
 export const updateableUserSelfSchema = updateableUserSchema.omit({
   role: true,
   password: true,
   ssoUser: true,
-})
+}).meta({ id: 'UpdateableUserSelf' })
 
 export type User = z.infer<typeof userSchema>
 export type AdminUser = z.infer<typeof adminUserSchema>
@@ -68,7 +68,7 @@ export const workspaceMembershipSchema = z.object({
   id: z.string(),
   name: z.string(),
   role: z.nativeEnum(WorkspaceRole),
-})
+}).meta({ id: 'WorkspaceMembership' })
 
 export const userProfileSchema = z.object({
   id: z.string(),
@@ -86,6 +86,6 @@ export const userProfileSchema = z.object({
   pinnedAssistants: userAssistantSchema.array(),
   assistants: userAssistantSchema.array(),
   preferences: userPreferencesSchema.partial(),
-})
+}).meta({ id: 'UserProfile' })
 
 export type UserProfile = z.infer<typeof userProfileSchema>

--- a/packages/core/src/types/dto/userpreferences.ts
+++ b/packages/core/src/types/dto/userpreferences.ts
@@ -6,7 +6,7 @@ export const userPreferencesSchema = z.object({
   showIconsInChatbar: z.boolean(),
   advancedSystemPromptEditor: z.boolean(),
   advancedMessageEditor: z.boolean(),
-})
+}).meta({ id: 'UserPreferences' })
 
 export type UserPreferences = z.infer<typeof userPreferencesSchema>
 

--- a/packages/core/src/types/dto/usersecret.ts
+++ b/packages/core/src/types/dto/usersecret.ts
@@ -8,14 +8,14 @@ export const userSecretStatusSchema = z.object({
   type: z.union([userSecretTypeSchema, z.string()]),
   label: z.string(),
   readable: z.boolean(),
-})
+}).meta({ id: 'UserSecretStatus' })
 
 export const insertableUserSecretSchema = z.object({
   context: z.string().min(1),
   type: userSecretTypeSchema,
   label: z.string().min(1),
   value: z.string().min(1),
-})
+}).meta({ id: 'InsertableUserSecret' })
 
 export type UserSecretStatus = z.infer<typeof userSecretStatusSchema>
 export type InsertableUserSecret = z.infer<typeof insertableUserSecretSchema>

--- a/packages/core/src/types/dto/workspace.ts
+++ b/packages/core/src/types/dto/workspace.ts
@@ -9,7 +9,7 @@ export const workspaceSchema = z.object({
   domain: z.string().nullable(),
   createdAt: iso8601UtcDateTimeSchema,
   updatedAt: iso8601UtcDateTimeSchema,
-})
+}).meta({ id: 'Workspace' })
 
 export const insertableWorkspaceSchema = workspaceSchema.omit({
   id: true,
@@ -17,7 +17,7 @@ export const insertableWorkspaceSchema = workspaceSchema.omit({
   domain: true,
   createdAt: true,
   updatedAt: true,
-})
+}).meta({ id: 'InsertableWorkspace' })
 
 export const updateableWorkspaceSchema = workspaceSchema
   .omit({
@@ -26,6 +26,7 @@ export const updateableWorkspaceSchema = workspaceSchema
     updatedAt: true,
   })
   .partial()
+  .meta({ id: 'UpdateableWorkspace' })
 
 export type Workspace = z.infer<typeof workspaceSchema>
 export type InsertableWorkspace = z.infer<typeof insertableWorkspaceSchema>
@@ -40,16 +41,16 @@ export const workspaceMemberSchema = z.object({
   updatedAt: iso8601UtcDateTimeSchema,
   name: z.string(),
   email: z.string(),
-})
+}).meta({ id: 'WorkspaceMember' })
 
 export const insertableWorkspaceMemberSchema = workspaceMemberSchema.pick({
   userId: true,
   role: true,
-})
+}).meta({ id: 'InsertableWorkspaceMember' })
 
 export const updateableWorkspaceMemberSchema = workspaceMemberSchema.pick({
   role: true,
-})
+}).meta({ id: 'UpdateableWorkspaceMember' })
 
 export type InsertableWorkspaceMember = z.infer<typeof insertableWorkspaceMemberSchema>
 export type UpdateableWorkspaceMember = z.infer<typeof updateableWorkspaceMemberSchema>


### PR DESCRIPTION
## Summary
Promotes reusable OpenAPI schema components by naming shared Zod DTO schemas and teaching the OpenAPI generator to hoist/rewrite Zod definitions into `components.schemas`, so assistant and related API payloads can reference stable `$ref` types instead of large inline objects.

## Details
- Added generic root-schema `$ref` support in the OpenAPI generator for Zod schemas with `meta.id`.
- Hoisted Zod `definitions` into OpenAPI `components.schemas` and rewrote `#/definitions/*` references to `#/components/schemas/*`.
- Added `meta({ id: ... })` to shared DTO schemas across assistant, file, user, workspace, tool, auth, chat, session, API key, and related modules.
- Regenerated `apps/frontend/public/openapi.yaml` to emit component refs for named DTOs.

## Tests
- `npm run generate:openapi`
- `npm run check-types`