### PR TITLE
Revert lazy tool-result file context gating

### DIFF
--- a/__tests__/conversion.test.ts
+++ b/__tests__/conversion.test.ts
@@ -168,12 +168,10 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
-    delete process.env.CHAT_TOOL_RESULT_EAGER_FILE_INJECTION
-    delete process.env.CHAT_TOOL_RESULT_EAGER_FILE_INJECTION_RULES
     getFileWithId.mockResolvedValue(pdfFile)
   })
 
-  test('keeps tool-result PDF files as descriptor-only by default', async () => {
+  test('eagerly injects tool-result PDF files by default', async () => {
     ensureFileAnalysis.mockResolvedValue({
       fileId: pdfFile.id,
       kind: 'pdf',
@@ -183,19 +181,20 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
         kind: 'pdf',
         mimeType: 'application/pdf',
         sizeBytes: pdfFile.size,
-        pageCount: 101,
+        pageCount: 10,
         visionPageCount: 0,
-        textCharCount: 0,
-        hasExtractableText: false,
-        imagePageCount: 101,
-        contentMode: 'scanned',
-        extractedTextPath: null,
+        textCharCount: 50,
+        hasExtractableText: true,
+        imagePageCount: 0,
+        contentMode: 'text',
+        extractedTextPath: 'files/example.pdf.analysis-v1.txt',
       },
       error: null,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     } satisfies dto.FileAnalysis)
 
+    readBuffer.mockResolvedValue(Buffer.from('pdf-bytes'))
     const { dtoMessageToLlmMessage } = await import('@/backend/lib/chat/conversion')
     const message = await dtoMessageToLlmMessage(
       {
@@ -252,22 +251,17 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
                   ],
                 }),
               },
-              {
-                type: 'text',
-                text: `File content was not inlined to reduce context bloat. Use read_file with id "${pdfFile.id}" (${pdfFile.name}) for on-demand inspection.`,
-              },
+              { type: 'file-data', data: Buffer.from('pdf-bytes').toString('base64'), mediaType: pdfFile.type },
             ],
           },
         },
       ],
     })
-    expect(getFileWithId).not.toHaveBeenCalled()
-    expect(readBuffer).not.toHaveBeenCalled()
-    expect(ensureFileAnalysis).not.toHaveBeenCalled()
+    expect(getFileWithId).toHaveBeenCalledWith(pdfFile.id)
+    expect(readBuffer).toHaveBeenCalledWith(pdfFile.path, false)
   })
 
-  test('supports eager file injection override by tool/mime rule', async () => {
-    process.env.CHAT_TOOL_RESULT_EAGER_FILE_INJECTION_RULES = 'fetch=application/pdf'
+  test('eagerly injects tool-result PDFs', async () => {
     ensureFileAnalysis.mockResolvedValue({
       fileId: pdfFile.id,
       kind: 'pdf',
@@ -361,7 +355,7 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
     expect(readBuffer).toHaveBeenCalledWith(pdfFile.path, false)
   })
 
-  test('keeps tool-result file attachments as descriptor-only for litellm by default', async () => {
+  test('keeps tool-result file attachments as descriptor-only for litellm even when eager injection is on', async () => {
     ensureFileAnalysis.mockResolvedValue({
       fileId: pdfFile.id,
       kind: 'pdf',
@@ -442,19 +436,19 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
               },
               {
                 type: 'text',
-                text: `File content was not inlined to reduce context bloat. Use read_file with id "${pdfFile.id}" (${pdfFile.name}) for on-demand inspection.`,
+                text: `The tool returned a file attachment "${pdfFile.name}" (${pdfFile.type}, id ${pdfFile.id}) that is available in the UI, but this provider cannot receive binary tool attachments.`,
               },
             ],
           },
         },
       ],
     })
-    expect(getFileWithId).not.toHaveBeenCalled()
+    expect(getFileWithId).toHaveBeenCalledWith(pdfFile.id)
     expect(readBuffer).not.toHaveBeenCalled()
     expect(ensureFileAnalysis).not.toHaveBeenCalled()
   })
 
-  test('does not eagerly extract text when the model has no native PDF support', async () => {
+  test('eagerly extracts text when the model has no native PDF support', async () => {
     extractFromFile.mockResolvedValue('fallback pdf text')
 
     const { dtoMessageToLlmMessage } = await import('@/backend/lib/chat/conversion')
@@ -515,20 +509,20 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
               },
               {
                 type: 'text',
-                text: `File content was not inlined to reduce context bloat. Use read_file with id "${pdfFile.id}" (${pdfFile.name}) for on-demand inspection.`,
+                text: `Here is the text content of the file "${pdfFile.name}" with id ${pdfFile.id}\nfallback pdf text`,
               },
             ],
           },
         },
       ],
     })
-    expect(extractFromFile).not.toHaveBeenCalled()
-    expect(getFileWithId).not.toHaveBeenCalled()
+    expect(extractFromFile).toHaveBeenCalledWith(pdfFile)
+    expect(getFileWithId).toHaveBeenCalledWith(pdfFile.id)
     expect(readBuffer).not.toHaveBeenCalled()
     expect(ensureFileAnalysis).not.toHaveBeenCalled()
   })
 
-  test('keeps tool-result image attachments as descriptor-only for litellm by default', async () => {
+  test('keeps tool-result image attachments as descriptor-only for litellm even when eager injection is on', async () => {
     const imageFile = {
       ...pdfFile,
       id: 'img-1',
@@ -596,14 +590,14 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
               },
               {
                 type: 'text',
-                text: `File content was not inlined to reduce context bloat. Use read_file with id "${imageFile.id}" (${imageFile.name}) for on-demand inspection.`,
+                text: `The tool returned a file attachment "${imageFile.name}" (${imageFile.type}, id ${imageFile.id}) that is available in the UI, but this provider cannot receive binary tool attachments.`,
               },
             ],
           },
         },
       ],
     })
-    expect(getFileWithId).not.toHaveBeenCalled()
+    expect(getFileWithId).toHaveBeenCalledWith(imageFile.id)
     expect(readBuffer).not.toHaveBeenCalled()
     expect(ensureFileAnalysis).not.toHaveBeenCalled()
   })

--- a/__tests__/promptTokenCounter.test.ts
+++ b/__tests__/promptTokenCounter.test.ts
@@ -109,7 +109,7 @@ describe('countModelMessageTokens', () => {
 
     expect(llmMessage).toBeDefined()
     const tokens = await countModelMessageTokens(fakeModel, llmMessage!)
-    const placeholderText = `File content was not inlined to reduce context bloat. Use read_file with id "${imageFile.id}" (${imageFile.name}) for on-demand inspection.`
+    const placeholderText = `The tool returned a file attachment "${imageFile.name}" (${imageFile.type}, id ${imageFile.id}) that is available in the UI, but this provider cannot receive binary tool attachments.`
 
     expect(tokens).toBe(
       JSON.stringify({ toolCallId: 'call_456', toolName: 'GenerateImage' }).length +

--- a/apps/backend/lib/chat/conversion.ts
+++ b/apps/backend/lib/chat/conversion.ts
@@ -8,7 +8,6 @@ import { logger } from '@/lib/logging'
 import { storage } from '@/lib/storage'
 import { LlmModelCapabilities } from '@/lib/chat/models'
 import { cachingExtractor } from '@/lib/textextraction/cache'
-import env from '@/lib/env'
 import {
   acceptableImageTypes,
   canSendAsNativeFile,
@@ -25,9 +24,6 @@ const toolResultAttachmentText = (fileEntry: FileDbRow) =>
   `The tool returned a file attachment "${fileEntry.name}" (${fileEntry.type}, id ${fileEntry.id}) that is available in the UI, but this provider cannot receive binary tool attachments.`
 type ToolCallResultOutput = ai.ToolResultPart['output']
 
-const toolResultReadFileHint = (file: { id: string; name: string }) =>
-  `File content was not inlined to reduce context bloat. Use read_file with id "${file.id}" (${file.name}) for on-demand inspection.`
-
 const describeAttachedFiles = (
   files: Array<{ id: string; name: string; size: number; mimetype: string }>
 ) => ({
@@ -38,43 +34,6 @@ const describeAttachedFiles = (
     mimetype: f.mimetype,
   })),
 })
-
-type EagerFileRule = {
-  toolPattern: string
-  mimePattern: string
-}
-
-const parseEagerFileRules = (rawRules: string): EagerFileRule[] => {
-  return rawRules
-    .split(';')
-    .map((rule) => rule.trim())
-    .filter((rule) => rule.length > 0)
-    .flatMap((rule) => {
-      const [toolRaw, mimeRaw] = rule.split('=').map((s) => s?.trim() ?? '')
-      if (!toolRaw || !mimeRaw) return []
-      return mimeRaw
-        .split('|')
-        .map((mimePattern) => mimePattern.trim().toLowerCase())
-        .filter((mimePattern) => mimePattern.length > 0)
-        .map((mimePattern) => ({ toolPattern: toolRaw, mimePattern }))
-    })
-}
-
-const patternMatches = (value: string, pattern: string): boolean => {
-  if (pattern === '*') return true
-  if (pattern.endsWith('/*')) return value.startsWith(pattern.slice(0, -1))
-  return value === pattern
-}
-
-const shouldEagerInjectToolFile = (toolName: string, mimeType: string): boolean => {
-  if (env.chat.toolResults.eagerFileInjectionDefault) return true
-  const normalizedMime = mimeType.toLowerCase()
-  const rules = parseEagerFileRules(env.chat.toolResults.eagerFileInjectionRules)
-  return rules.some(
-    (rule) =>
-      patternMatches(toolName, rule.toolPattern) && patternMatches(normalizedMime, rule.mimePattern)
-  )
-}
 
 export const loadImagePartFromFileEntry = async (fileEntry: FileDbRow): Promise<ai.ImagePart> => {
   let fileContent: Buffer
@@ -217,10 +176,7 @@ export const dtoMessageToLlmMessage = async (
   if (m.role === 'tool') {
     const results = m.parts.filter((m) => m.type === 'tool-result')
     if (results.length === 0) return undefined
-    const convertOutput = async (
-      output: dto.ToolCallResultOutput,
-      toolName: string
-    ): Promise<ToolCallResultOutput> => {
+    const convertOutput = async (output: dto.ToolCallResultOutput): Promise<ToolCallResultOutput> => {
       if ((output as dto.ToolCallResultOutput).type) {
         switch (output.type) {
           case 'text':
@@ -237,12 +193,6 @@ export const dtoMessageToLlmMessage = async (
                   case 'text':
                     return v
                   case 'file': {
-                    if (!shouldEagerInjectToolFile(toolName, v.mimetype)) {
-                      return {
-                        type: 'text' as const,
-                        text: toolResultReadFileHint(v),
-                      }
-                    }
                     const fileEntry = await getFileWithId(v.id)
                     if (!fileEntry) {
                       throw new Error(`Can't find entry for attachment ${v.id}`)
@@ -282,7 +232,7 @@ export const dtoMessageToLlmMessage = async (
           return {
             toolCallId: result.toolCallId,
             toolName: result.toolName,
-            output: await convertOutput(result.result, result.toolName),
+            output: await convertOutput(result.result),
             type: 'tool-result',
           }
         })

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -131,10 +131,6 @@ const env = {
       maxImgDimPx: parseInt(process.env.CHAT_ATTACHMENTS_MAX_IMG_DIM_PX ?? '2048', 10),
       maxSize: parseInt(process.env.CHAT_ATTACHMENTS_MAX_SIZE ?? '50000000', 10),
     },
-    toolResults: {
-      eagerFileInjectionDefault: process.env.CHAT_TOOL_RESULT_EAGER_FILE_INJECTION === '1',
-      eagerFileInjectionRules: process.env.CHAT_TOOL_RESULT_EAGER_FILE_INJECTION_RULES ?? '',
-    },
     maxOutputTokens: parseOptionalInt(process.env.CHAT_MAX_OUTPUT_TOKENS),
   },
   assistants: {


### PR DESCRIPTION
## Summary
Reverts the lazy tool-result file context behavior introduced in #859 and restores eager tool-result file injection by default so file outputs are sent in model context without requiring a follow-up `read_file` call.

## Details
- Remove lazy gating logic from tool-result conversion (`shouldEagerInjectToolFile` and rule parsing).
- Remove `CHAT_TOOL_RESULT_EAGER_FILE_INJECTION` and `CHAT_TOOL_RESULT_EAGER_FILE_INJECTION_RULES` env wiring.
- Always resolve tool-result file descriptors into model-facing content when provider supports tool attachments.
- Keep LiteLLM provider fallback behavior for binary tool-result attachments.
- Update conversion and token-counter tests to match reverted behavior and current LiteLLM placeholder text.

## Risks
- Increased context size and token usage for tool calls returning large file payloads.

## Tests
- `npm test -- __tests__/conversion.test.ts`
- `npm test`