### PR TITLE
Fix file access auth typing and enforce authenticated tool context

### DIFF
--- a/__tests__/chatAssistant.test.ts
+++ b/__tests__/chatAssistant.test.ts
@@ -83,6 +83,7 @@ vi.mock('@/backend/lib/tools/knowledge/implementation', () => ({
 import { ChatAssistant, fillTemplate, ToolSetupError } from '@/backend/lib/chat'
 import type { ProviderConfig } from '@/types/provider'
 import { ChatState } from '@/backend/lib/chat/ChatState'
+import type { LanguageModelV3 } from '@ai-sdk/provider'
 
 // ---- Helpers ----
 
@@ -126,10 +127,15 @@ const makeChatAssistant = (overrides: Partial<InstanceType<typeof ChatAssistant>
 // Class-field arrow functions (computeSafeSummary, findReasonableSummarizationBackend) are
 // instance-initialised, so they aren't on the prototype. We need a real constructed instance.
 const makeRealAssistant = () => {
-  vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({ provider: 'openai.responses' } as any)
-  vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({} as any)
+  vi
+    .spyOn(ChatAssistant, 'createLanguageModel')
+    .mockReturnValue({ provider: 'openai.responses' } as unknown as LanguageModelV3)
+  vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({
+    functions: {},
+    functionToolIdMap: new Map(),
+  })
   return new ChatAssistant(
-    { providerType: 'openai', apiKey: 'k', provisioned: false } as any,
+    { providerType: 'openai', apiKey: 'k', provisioned: false } as unknown as ProviderConfig,
     { assistantId: 'a1', model: 'gpt-4', systemPrompt: '', temperature: 0, tokenLimit: 1000, reasoning_effort: null },
     makeFakeLlmModel(),
     [],

--- a/__tests__/chatAssistant.test.ts
+++ b/__tests__/chatAssistant.test.ts
@@ -331,6 +331,32 @@ describe('ChatAssistant.withBuiltinTools', () => {
   })
 })
 
+describe('ChatAssistant.build', () => {
+  test('throws when authenticated user is missing in options', async () => {
+    const { llmModels } = await import('@/lib/models')
+    ;(llmModels as unknown as LlmModel[]).splice(0, (llmModels as unknown as LlmModel[]).length)
+    ;(llmModels as unknown as LlmModel[]).push(makeFakeLlmModel({ id: 'gpt-4', model: 'gpt-4' }))
+
+    await expect(
+      ChatAssistant.build(
+        { providerType: 'openai', apiKey: 'k', provisioned: false } as unknown as ProviderConfig,
+        {
+          assistantId: 'a1',
+          model: 'gpt-4',
+          systemPrompt: '',
+          temperature: 0,
+          tokenLimit: 1000,
+          reasoning_effort: null,
+        },
+        {},
+        [],
+        [],
+        { user: '' }
+      )
+    ).rejects.toThrow('Authenticated user is required to build ChatAssistant')
+  })
+})
+
 // ============================================================
 // ChatAssistant.computeSystemPrompt
 // ============================================================

--- a/__tests__/chatAssistant.test.ts
+++ b/__tests__/chatAssistant.test.ts
@@ -317,21 +317,21 @@ describe('ChatAssistant.assistantParamsFrom', () => {
 describe('ChatAssistant.withBuiltinTools', () => {
   test('appends KnowledgePlugin when knowledge capability is not false', async () => {
     const tools = [makeToolImpl()]
-    const model = makeFakeLlmModel({ capabilities: { knowledge: true } } as any)
+    const model = makeFakeLlmModel({ capabilities: { knowledge: true } } as unknown as Partial<LlmModel>)
     const result = await ChatAssistant.withBuiltinTools(tools, model)
     expect(result).toHaveLength(2)
   })
 
   test('does not append KnowledgePlugin when knowledge=false', async () => {
     const tools = [makeToolImpl()]
-    const model = makeFakeLlmModel({ capabilities: { knowledge: false } } as any)
+    const model = makeFakeLlmModel({ capabilities: { knowledge: false } } as unknown as Partial<LlmModel>)
     const result = await ChatAssistant.withBuiltinTools(tools, model)
     expect(result).toHaveLength(1)
   })
 
   test('defaults to adding KnowledgePlugin when knowledge capability is undefined', async () => {
     const tools: ToolImplementation[] = []
-    const model = makeFakeLlmModel({ capabilities: {} } as any)
+    const model = makeFakeLlmModel({ capabilities: {} } as unknown as Partial<LlmModel>)
     const result = await ChatAssistant.withBuiltinTools(tools, model)
     expect(result).toHaveLength(1)
   })
@@ -577,10 +577,10 @@ describe('ChatAssistant.createAiTools', () => {
 
 describe('ChatAssistant.invokeFunctionByName', () => {
   const makeUserResponse = (allow: boolean): dto.UserResponse =>
-    ({ id: 'r1', role: 'user-response', allow, conversationId: 'c1', sentAt: '', parent: 'm1', attachments: [], content: '' }) as any
+    ({ id: 'r1', role: 'user-response', allow, conversationId: 'c1', sentAt: '', parent: 'm1', attachments: [], content: '' }) as unknown as dto.UserResponse
 
   const makeToolCall = (name = 'myTool'): dto.ToolCall =>
-    ({ toolCallId: 'tc1', toolName: name, args: {} }) as any
+    ({ toolCallId: 'tc1', toolName: name, args: {} }) as unknown as dto.ToolCall
 
   test('returns error when function not found', async () => {
     const assistant = makeChatAssistant({ functions: Promise.resolve({}) })

--- a/__tests__/fileAuthorization.test.ts
+++ b/__tests__/fileAuthorization.test.ts
@@ -157,4 +157,17 @@ describe('file authorization', () => {
     await expect(canAccessFile({ userId: 'u-nope' }, 'f1')).resolves.toBe(false)
     await expect(canAccessFile({ userId: 'u-chat' }, 'f2')).resolves.toBe(true)
   })
+
+  test('canAccessFile allows non-owner authenticated users for shared chat files', async () => {
+    tables.Conversation.push({ id: 'c-shared-file', ownerId: 'u-owner' })
+    tables.File.push({ id: 'f-shared', ownerType: 'CHAT', ownerId: 'c-shared-file' })
+    tables.ConversationSharing.push({
+      id: 'share-file-1',
+      lastMessageId: 'msg-shared-1',
+      'Message.conversationId': 'c-shared-file',
+    })
+
+    const { canAccessFile } = await import('@/backend/lib/files/authorization')
+    await expect(canAccessFile({ userId: 'u-non-owner' }, 'f-shared')).resolves.toBe(true)
+  })
 })

--- a/__tests__/imagegenToolEditing.test.ts
+++ b/__tests__/imagegenToolEditing.test.ts
@@ -17,7 +17,7 @@ describe('image generator editing exposure', () => {
       model: 'gpt-image-1.5',
     })
 
-    const functions = await tool.functions({} as any)
+    const functions = await tool.functions({} as any, { userId: 'user-1' })
 
     expect(functions.EditImage).toBeDefined()
   })
@@ -28,7 +28,7 @@ describe('image generator editing exposure', () => {
       model: 'gpt-image-2',
     })
 
-    const functions = await tool.functions({} as any)
+    const functions = await tool.functions({} as any, { userId: 'user-1' })
 
     expect(functions.EditImage).toBeDefined()
   })
@@ -40,7 +40,7 @@ describe('image generator editing exposure', () => {
       supportsEditing: true,
     })
 
-    const functions = await tool.functions({} as any)
+    const functions = await tool.functions({} as any, { userId: 'user-1' })
 
     expect(functions.EditImage).toBeUndefined()
   })

--- a/__tests__/imagegenToolEditing.test.ts
+++ b/__tests__/imagegenToolEditing.test.ts
@@ -2,12 +2,24 @@ import { describe, expect, test } from 'vitest'
 import { ImageGeneratorPlugin } from '@/backend/lib/tools/imagegenerator/implementation'
 import { shouldExposeImageEditingTool } from '@/backend/lib/imagegen/models'
 import type { ToolParams } from '@/lib/chat/tools'
+import type { LlmModel } from '@/lib/chat/models'
 
 const toolParams: ToolParams = {
   id: 'tool-id',
   provisioned: false,
   promptFragment: '',
   name: 'Image tool',
+}
+
+const fakeModel: LlmModel = {
+  id: 'test-model',
+  model: 'gpt-image-1.5',
+  name: 'Test model',
+  provider: 'openai',
+  owned_by: 'openai',
+  description: '',
+  context_length: 128000,
+  capabilities: { vision: true, function_calling: true, reasoning: false, knowledge: false },
 }
 
 describe('image generator editing exposure', () => {
@@ -17,7 +29,7 @@ describe('image generator editing exposure', () => {
       model: 'gpt-image-1.5',
     })
 
-    const functions = await tool.functions({} as any, { userId: 'user-1' })
+    const functions = await tool.functions(fakeModel, { userId: 'user-1' })
 
     expect(functions.EditImage).toBeDefined()
   })
@@ -28,7 +40,7 @@ describe('image generator editing exposure', () => {
       model: 'gpt-image-2',
     })
 
-    const functions = await tool.functions({} as any, { userId: 'user-1' })
+    const functions = await tool.functions(fakeModel, { userId: 'user-1' })
 
     expect(functions.EditImage).toBeDefined()
   })
@@ -40,7 +52,7 @@ describe('image generator editing exposure', () => {
       supportsEditing: true,
     })
 
-    const functions = await tool.functions({} as any, { userId: 'user-1' })
+    const functions = await tool.functions(fakeModel, { userId: 'user-1' })
 
     expect(functions.EditImage).toBeUndefined()
   })

--- a/__tests__/parallelToolCalls.test.ts
+++ b/__tests__/parallelToolCalls.test.ts
@@ -4,6 +4,9 @@ import { ChatState } from '@/backend/lib/chat/ChatState'
 import type * as dto from '@/types/dto'
 import type { ToolFunction } from '@/lib/chat/tools'
 import type { ClientSink } from '@/backend/lib/chat/ClientSink'
+import type { ProviderConfig } from '@/types/provider'
+import type { LlmModel } from '@/lib/chat/models'
+import type { LanguageModelV3 } from '@ai-sdk/provider'
 
 // ---- Module mocks ----
 
@@ -99,12 +102,30 @@ class MockClientSink implements ClientSink {
   }
 }
 
+type TestableAssistant = {
+  invokeLlm: (...args: unknown[]) => Promise<unknown>
+  invokeLlmAndProcessResponse: (chatState: ChatState, sink: ClientSink) => Promise<void>
+  providerOptions: (tools: unknown[]) => Record<string, unknown>
+  languageModel: { provider: string }
+  tools: unknown[]
+}
+
+type ProviderOptionsShape = {
+  openai?: { parallelToolCalls?: boolean }
+  anthropic?: { disableParallelToolUse?: boolean }
+}
+
+const asTestableAssistant = (assistant: ChatAssistant): TestableAssistant =>
+  assistant as unknown as TestableAssistant
+
 function makeTool(invoke: ToolFunction['invoke'], extra: Partial<ToolFunction> = {}): ToolFunction {
   return { description: 'test tool', invoke, ...extra }
 }
 
 function makeAssistant(tools: Record<string, ToolFunction>) {
-  vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({ provider: 'openai.chat' } as any)
+  vi
+    .spyOn(ChatAssistant, 'createLanguageModel')
+    .mockReturnValue({ provider: 'openai.chat' } as unknown as LanguageModelV3)
   vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({
     functions: tools,
     functionToolIdMap: new Map(),
@@ -118,14 +139,26 @@ function makeAssistant(tools: Record<string, ToolFunction>) {
     tokenLimit: 4096,
     reasoning_effort: null,
   }
-  const llmModel = {
+  const llmModel: LlmModel = {
     id: 'gpt-4',
+    model: 'gpt-4',
+    name: 'GPT-4',
+    provider: 'openai',
+    owned_by: 'openai',
+    description: '',
+    context_length: 128000,
     maxOutputTokens: undefined,
-    capabilities: { function_calling: true, vision: false, reasoning: false, supportedMedia: [] },
-  } as any
+    capabilities: {
+      function_calling: true,
+      vision: false,
+      reasoning: false,
+      knowledge: false,
+      supportedMedia: [],
+    },
+  }
 
   return new ChatAssistant(
-    { providerType: 'openai.chat' } as any,
+    { providerType: 'openai.chat' } as unknown as ProviderConfig,
     assistantParams,
     llmModel,
     [],
@@ -160,11 +193,12 @@ describe('parallel tool execution', () => {
     const invoke1 = vi.fn().mockResolvedValue({ type: 'text', value: 'r1' } as dto.ToolCallResultOutput)
     const invoke2 = vi.fn().mockResolvedValue({ type: 'text', value: 'r2' } as dto.ToolCallResultOutput)
     const assistant = makeAssistant({ tool1: makeTool(invoke1), tool2: makeTool(invoke2) })
-    const invokeLlmSpy = vi.spyOn(assistant as any, 'invokeLlm')
+    const testableAssistant = asTestableAssistant(assistant)
+    const invokeLlmSpy = vi.spyOn(testableAssistant, 'invokeLlm')
     invokeLlmSpy.mockResolvedValueOnce(makeStream(twoToolCallChunks()))
     invokeLlmSpy.mockResolvedValueOnce(makeStream(finishStream()))
 
-    await (assistant as any).invokeLlmAndProcessResponse(makeUserChatState(), new MockClientSink())
+    await testableAssistant.invokeLlmAndProcessResponse(makeUserChatState(), new MockClientSink())
 
     expect(invoke1).toHaveBeenCalledOnce()
     expect(invoke2).toHaveBeenCalledOnce()
@@ -174,12 +208,13 @@ describe('parallel tool execution', () => {
     const invoke1 = vi.fn().mockResolvedValue({ type: 'text', value: 'r1' } as dto.ToolCallResultOutput)
     const invoke2 = vi.fn().mockResolvedValue({ type: 'text', value: 'r2' } as dto.ToolCallResultOutput)
     const assistant = makeAssistant({ tool1: makeTool(invoke1), tool2: makeTool(invoke2) })
-    const invokeLlmSpy = vi.spyOn(assistant as any, 'invokeLlm')
+    const testableAssistant = asTestableAssistant(assistant)
+    const invokeLlmSpy = vi.spyOn(testableAssistant, 'invokeLlm')
     invokeLlmSpy.mockResolvedValueOnce(makeStream(twoToolCallChunks()))
     invokeLlmSpy.mockResolvedValueOnce(makeStream(finishStream()))
 
     const sink = new MockClientSink()
-    await (assistant as any).invokeLlmAndProcessResponse(makeUserChatState(), sink)
+    await testableAssistant.invokeLlmAndProcessResponse(makeUserChatState(), sink)
 
     const resultParts = sink.events
       .filter((e): e is Extract<dto.TextStreamPart, { type: 'part' }> => e.type === 'part')
@@ -195,12 +230,13 @@ describe('parallel tool execution', () => {
     const invoke1 = vi.fn().mockResolvedValue({ type: 'text', value: 'r1' } as dto.ToolCallResultOutput)
     const invoke2 = vi.fn().mockResolvedValue({ type: 'text', value: 'r2' } as dto.ToolCallResultOutput)
     const assistant = makeAssistant({ tool1: makeTool(invoke1), tool2: makeTool(invoke2) })
-    const invokeLlmSpy = vi.spyOn(assistant as any, 'invokeLlm')
+    const testableAssistant = asTestableAssistant(assistant)
+    const invokeLlmSpy = vi.spyOn(testableAssistant, 'invokeLlm')
     invokeLlmSpy.mockResolvedValueOnce(makeStream(twoToolCallChunks()))
     invokeLlmSpy.mockResolvedValueOnce(makeStream(finishStream()))
 
     const chatState = makeUserChatState()
-    await (assistant as any).invokeLlmAndProcessResponse(chatState, new MockClientSink())
+    await testableAssistant.invokeLlmAndProcessResponse(chatState, new MockClientSink())
 
     const toolMessages = chatState.chatHistory.filter(
       (m): m is dto.ToolMessage => m.role === 'tool'
@@ -227,11 +263,12 @@ describe('parallel tool execution', () => {
     })
 
     const assistant = makeAssistant({ tool1: makeTool(invoke1), tool2: makeTool(invoke2) })
-    const invokeLlmSpy = vi.spyOn(assistant as any, 'invokeLlm')
+    const testableAssistant = asTestableAssistant(assistant)
+    const invokeLlmSpy = vi.spyOn(testableAssistant, 'invokeLlm')
     invokeLlmSpy.mockResolvedValueOnce(makeStream(twoToolCallChunks()))
     invokeLlmSpy.mockResolvedValueOnce(makeStream(finishStream()))
 
-    await (assistant as any).invokeLlmAndProcessResponse(makeUserChatState(), new MockClientSink())
+    await testableAssistant.invokeLlmAndProcessResponse(makeUserChatState(), new MockClientSink())
 
     expect(tool2StartedWhileTool1Running).toBe(true)
   })
@@ -258,11 +295,12 @@ describe('auth and requireConfirm interrupts', () => {
       tool1: makeTool(invoke1, { auth: async () => authRequest }),
       tool2: makeTool(invoke2),
     })
-    const invokeLlmSpy = vi.spyOn(assistant as any, 'invokeLlm')
+    const testableAssistant = asTestableAssistant(assistant)
+    const invokeLlmSpy = vi.spyOn(testableAssistant, 'invokeLlm')
     invokeLlmSpy.mockResolvedValueOnce(makeStream(twoToolCallChunks()))
 
     const chatState = makeUserChatState()
-    await (assistant as any).invokeLlmAndProcessResponse(chatState, new MockClientSink())
+    await testableAssistant.invokeLlmAndProcessResponse(chatState, new MockClientSink())
 
     // Neither tool should have been executed
     expect(invoke1).not.toHaveBeenCalled()
@@ -286,11 +324,12 @@ describe('auth and requireConfirm interrupts', () => {
       tool1: makeTool(invoke1),
       tool2: makeTool(invoke2, { auth: async () => authRequest }),
     })
-    const invokeLlmSpy = vi.spyOn(assistant as any, 'invokeLlm')
+    const testableAssistant = asTestableAssistant(assistant)
+    const invokeLlmSpy = vi.spyOn(testableAssistant, 'invokeLlm')
     invokeLlmSpy.mockResolvedValueOnce(makeStream(twoToolCallChunks()))
 
     const chatState = makeUserChatState()
-    await (assistant as any).invokeLlmAndProcessResponse(chatState, new MockClientSink())
+    await testableAssistant.invokeLlmAndProcessResponse(chatState, new MockClientSink())
 
     expect(invoke1).not.toHaveBeenCalled()
     expect(invoke2).not.toHaveBeenCalled()
@@ -306,12 +345,13 @@ describe('auth and requireConfirm interrupts', () => {
       tool1: makeTool(invoke1),
       tool2: makeTool(invoke2, { requireConfirm: true }),
     })
-    const invokeLlmSpy = vi.spyOn(assistant as any, 'invokeLlm')
+    const testableAssistant = asTestableAssistant(assistant)
+    const invokeLlmSpy = vi.spyOn(testableAssistant, 'invokeLlm')
     invokeLlmSpy.mockResolvedValueOnce(makeStream(twoToolCallChunks()))
 
     const chatState = makeUserChatState()
     const sink = new MockClientSink()
-    await (assistant as any).invokeLlmAndProcessResponse(chatState, sink)
+    await testableAssistant.invokeLlmAndProcessResponse(chatState, sink)
 
     expect(invoke1).not.toHaveBeenCalled()
     expect(invoke2).not.toHaveBeenCalled()
@@ -334,12 +374,13 @@ describe('auth and requireConfirm interrupts', () => {
       tool1: makeTool(invoke1, { auth: async () => null }),
       tool2: makeTool(invoke2, { auth: async () => null }),
     })
-    const invokeLlmSpy = vi.spyOn(assistant as any, 'invokeLlm')
+    const testableAssistant = asTestableAssistant(assistant)
+    const invokeLlmSpy = vi.spyOn(testableAssistant, 'invokeLlm')
     invokeLlmSpy.mockResolvedValueOnce(makeStream(twoToolCallChunks()))
     invokeLlmSpy.mockResolvedValueOnce(makeStream(finishStream()))
 
     const chatState = makeUserChatState()
-    await (assistant as any).invokeLlmAndProcessResponse(chatState, new MockClientSink())
+    await testableAssistant.invokeLlmAndProcessResponse(chatState, new MockClientSink())
 
     expect(invoke1).toHaveBeenCalledOnce()
     expect(invoke2).toHaveBeenCalledOnce()
@@ -360,13 +401,14 @@ describe('providerOptions: ENABLE_PARALLEL_TOOL_CALLS controls what is advertise
     disableParallelToolCalls = false
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'openai.responses',
-    } as any)
+    } as unknown as LanguageModelV3)
     vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map() })
 
     const assistant = makeAssistant({})
-    ;(assistant as any).languageModel = { provider: 'openai.responses' }
+    const testableAssistant = asTestableAssistant(assistant)
+    testableAssistant.languageModel = { provider: 'openai.responses' }
 
-    const opts = (assistant as any).providerOptions([]) as Record<string, any>
+    const opts = testableAssistant.providerOptions([]) as ProviderOptionsShape
     expect(opts?.openai?.parallelToolCalls).toBeUndefined()
   })
 
@@ -374,13 +416,14 @@ describe('providerOptions: ENABLE_PARALLEL_TOOL_CALLS controls what is advertise
     disableParallelToolCalls = true
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'openai.responses',
-    } as any)
+    } as unknown as LanguageModelV3)
     vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map() })
 
     const assistant = makeAssistant({})
-    ;(assistant as any).languageModel = { provider: 'openai.responses' }
+    const testableAssistant = asTestableAssistant(assistant)
+    testableAssistant.languageModel = { provider: 'openai.responses' }
 
-    const opts = (assistant as any).providerOptions([]) as Record<string, any>
+    const opts = testableAssistant.providerOptions([]) as ProviderOptionsShape
     expect(opts?.openai?.parallelToolCalls).toBe(false)
   })
 
@@ -388,14 +431,15 @@ describe('providerOptions: ENABLE_PARALLEL_TOOL_CALLS controls what is advertise
     disableParallelToolCalls = false
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'anthropic.messages',
-    } as any)
+    } as unknown as LanguageModelV3)
     vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map() })
 
     const assistant = makeAssistant({})
-    ;(assistant as any).languageModel = { provider: 'anthropic.messages' }
-    ;(assistant as any).tools = []
+    const testableAssistant = asTestableAssistant(assistant)
+    testableAssistant.languageModel = { provider: 'anthropic.messages' }
+    testableAssistant.tools = []
 
-    const opts = (assistant as any).providerOptions([]) as Record<string, any>
+    const opts = testableAssistant.providerOptions([]) as ProviderOptionsShape
     expect(opts?.anthropic?.disableParallelToolUse).toBeUndefined()
   })
 
@@ -403,14 +447,15 @@ describe('providerOptions: ENABLE_PARALLEL_TOOL_CALLS controls what is advertise
     disableParallelToolCalls = true
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'anthropic.messages',
-    } as any)
+    } as unknown as LanguageModelV3)
     vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map() })
 
     const assistant = makeAssistant({})
-    ;(assistant as any).languageModel = { provider: 'anthropic.messages' }
-    ;(assistant as any).tools = []
+    const testableAssistant = asTestableAssistant(assistant)
+    testableAssistant.languageModel = { provider: 'anthropic.messages' }
+    testableAssistant.tools = []
 
-    const opts = (assistant as any).providerOptions([]) as Record<string, any>
+    const opts = testableAssistant.providerOptions([]) as ProviderOptionsShape
     expect(opts?.anthropic?.disableParallelToolUse).toBe(true)
   })
 })

--- a/__tests__/parallelToolCalls.test.ts
+++ b/__tests__/parallelToolCalls.test.ts
@@ -129,7 +129,7 @@ function makeAssistant(tools: Record<string, ToolFunction>) {
     assistantParams,
     llmModel,
     [],
-    {},
+    { user: 'user-1' },
     {},
     []
   )

--- a/__tests__/prepareTools.test.ts
+++ b/__tests__/prepareTools.test.ts
@@ -12,11 +12,11 @@ const fnTool = (name: string): NonNullable<LanguageModelV2CallOptions['tools']>[
 const providerTool = (): NonNullable<LanguageModelV2CallOptions['tools']>[number] => ({
   type: 'provider-defined',
   id: 'provider-tool-id',
-} as any)
+} as unknown as NonNullable<LanguageModelV2CallOptions['tools']>[number])
 
 describe('prepareTools', () => {
   test('returns undefined tools when tools is null', () => {
-    const result = prepareTools({ tools: null as any })
+    const result = prepareTools({ tools: null })
     expect(result.tools).toBeUndefined()
     expect(result.toolChoice).toBeUndefined()
     expect(result.toolWarnings).toEqual([])

--- a/__tests__/prepareTools.test.ts
+++ b/__tests__/prepareTools.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { prepareTools } from '@/lib/chat/litellm/litellm-prepare-tools'
-import type { LanguageModelV2CallOptions } from '@ai-sdk/provider'
+import type { LanguageModelV2CallOptions, LanguageModelV2ProviderDefinedTool } from '@ai-sdk/provider'
 
 const fnTool = (name: string): NonNullable<LanguageModelV2CallOptions['tools']>[number] => ({
   type: 'function',
@@ -9,10 +9,12 @@ const fnTool = (name: string): NonNullable<LanguageModelV2CallOptions['tools']>[
   inputSchema: { type: 'object', properties: {} },
 })
 
-const providerTool = (): NonNullable<LanguageModelV2CallOptions['tools']>[number] => ({
+const providerTool = (): LanguageModelV2ProviderDefinedTool => ({
   type: 'provider-defined',
-  id: 'provider-tool-id',
-} as unknown as NonNullable<LanguageModelV2CallOptions['tools']>[number])
+  id: 'provider.tool-id',
+  name: 'providerTool',
+  args: {},
+})
 
 describe('prepareTools', () => {
   test('returns undefined tools when tools is null', () => {

--- a/__tests__/retrieveFileTool.test.ts
+++ b/__tests__/retrieveFileTool.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { ToolFunction, ToolInvokeParams } from '@/lib/chat/tools'
 
 const executeTakeFirst = vi.fn()
 const extractFromFile = vi.fn()
@@ -53,8 +54,18 @@ describe('file-manager read_file', () => {
 
     const { FileManagerPlugin } = await import('@/backend/lib/tools/retrieve-file/implementation')
     const plugin = new FileManagerPlugin({ id: 't1', name: 'fm', provisioned: false, promptFragment: '' }, {})
-    const readFile = plugin.functions_.read_file as any
-    const result = await readFile.invoke({ params: { id: 'file-1' }, userId: 'u1' } as any)
+    const readFile = plugin.functions_.read_file
+    if (readFile.type === 'provider') {
+      throw new Error('Expected read_file to be a function tool')
+    }
+    const result = await readFile.invoke({
+      llmModel: {} as ToolInvokeParams['llmModel'],
+      messages: [],
+      assistantId: 'a1',
+      userId: 'u1',
+      params: { id: 'file-1' },
+      uiLink: { debugMessage: vi.fn(), addCitations: vi.fn(), attachments: [], citations: [] },
+    })
 
     expect(result).toEqual({ type: 'text', value: 'hello world' })
     expect(canAccessFile).toHaveBeenCalledWith({ userId: 'u1' }, 'file-1')
@@ -76,8 +87,18 @@ describe('file-manager read_file', () => {
 
     const { FileManagerPlugin } = await import('@/backend/lib/tools/retrieve-file/implementation')
     const plugin = new FileManagerPlugin({ id: 't1', name: 'fm', provisioned: false, promptFragment: '' }, {})
-    const readFile = plugin.functions_.read_file as any
-    const result = await readFile.invoke({ params: { id: 'file-2' }, userId: 'u1' } as any)
+    const readFile = plugin.functions_.read_file
+    if (readFile.type === 'provider') {
+      throw new Error('Expected read_file to be a function tool')
+    }
+    const result = await readFile.invoke({
+      llmModel: {} as ToolInvokeParams['llmModel'],
+      messages: [],
+      assistantId: 'a1',
+      userId: 'u1',
+      params: { id: 'file-2' },
+      uiLink: { debugMessage: vi.fn(), addCitations: vi.fn(), attachments: [], citations: [] },
+    })
 
     expect(result).toEqual({ type: 'text', value: Buffer.from([1, 2, 3]).toString('base64') })
     expect(readBuffer).toHaveBeenCalledWith(fileEntry.path, true)
@@ -97,8 +118,18 @@ describe('file-manager read_file', () => {
 
     const { FileManagerPlugin } = await import('@/backend/lib/tools/retrieve-file/implementation')
     const plugin = new FileManagerPlugin({ id: 't1', name: 'fm', provisioned: false, promptFragment: '' }, {})
-    const readFile = plugin.functions_.read_file as any
-    const result = await readFile.invoke({ params: { id: 'file-private' }, userId: 'u2' } as any)
+    const readFile = plugin.functions_.read_file
+    if (readFile.type === 'provider') {
+      throw new Error('Expected read_file to be a function tool')
+    }
+    const result = await readFile.invoke({
+      llmModel: {} as ToolInvokeParams['llmModel'],
+      messages: [],
+      assistantId: 'a1',
+      userId: 'u2',
+      params: { id: 'file-private' },
+      uiLink: { debugMessage: vi.fn(), addCitations: vi.fn(), attachments: [], citations: [] },
+    })
 
     expect(result).toEqual({ type: 'error-text', value: 'File not found' })
     expect(extractFromFile).not.toHaveBeenCalled()

--- a/__tests__/retrieveFileTool.test.ts
+++ b/__tests__/retrieveFileTool.test.ts
@@ -57,7 +57,7 @@ describe('file-manager read_file', () => {
     const result = await readFile.invoke({ params: { id: 'file-1' }, userId: 'u1' } as any)
 
     expect(result).toEqual({ type: 'text', value: 'hello world' })
-    expect(canAccessFile).toHaveBeenCalledWith('u1', 'file-1')
+    expect(canAccessFile).toHaveBeenCalledWith({ userId: 'u1' }, 'file-1')
     expect(readBuffer).not.toHaveBeenCalled()
   })
 

--- a/__tests__/routes.test.ts
+++ b/__tests__/routes.test.ts
@@ -19,6 +19,7 @@ import {
   parseCookieHeader,
   serializeCookie,
 } from '@/lib/http/cookies'
+import { UserRole } from '@/types/dto'
 
 vi.mock('@/api/utils/auth', () => ({
   authenticate: vi.fn(),
@@ -162,7 +163,7 @@ describe('operation route layer', () => {
       value: {
         sessionId: 'session-1',
         userId: 'user-1',
-        userRole: 'ADMIN',
+        userRole: UserRole.ADMIN,
       },
     })
 
@@ -205,7 +206,7 @@ describe('operation route layer', () => {
       value: {
         sessionId: 'session-3',
         userId: 'user-3',
-        userRole: 'USER',
+        userRole: UserRole.USER,
       },
     })
 
@@ -422,7 +423,7 @@ describe('operation route layer', () => {
       value: {
         sessionId: 'session-2',
         userId: 'user-2',
-        userRole: 'USER',
+        userRole: UserRole.USER,
       },
     })
 
@@ -527,7 +528,7 @@ describe('operation route layer', () => {
       value: {
         sessionId: 'session-4',
         userId: 'user-4',
-        userRole: 'USER',
+        userRole: UserRole.USER,
       },
     })
 

--- a/__tests__/subassistantTool.test.ts
+++ b/__tests__/subassistantTool.test.ts
@@ -190,7 +190,7 @@ describe('SubAssistantTool.invoke_assistant', () => {
     const tool = new SubAssistantTool(fakeToolParams, [
       { id: 'asst-1', name: 'Sub Bot', description: 'A sub-assistant for testing' },
     ])
-    const fns = await tool.functions(fakeLlmModel)
+    const fns = await tool.functions(fakeLlmModel, { userId: 'user-1' })
     invoke = (fns.invoke_assistant as any).invoke
   })
 

--- a/__tests__/subassistantTool.test.ts
+++ b/__tests__/subassistantTool.test.ts
@@ -107,7 +107,8 @@ vi.mock('@/lib/models', () => ({
 import { SubAssistantTool } from '@/backend/lib/tools/subassistant/implementation'
 import { ChatAssistant } from '@/backend/lib/chat'
 import type { LlmModel } from '@/lib/chat/models'
-import type { ToolParams } from '@/lib/chat/tools'
+import type { ToolFunction, ToolParams } from '@/lib/chat/tools'
+import type { LanguageModelV3 } from '@ai-sdk/provider'
 
 // --- test fixtures ---
 
@@ -173,14 +174,16 @@ function makeStreamResult(text: string) {
 // --- tests ---
 
 describe('SubAssistantTool.invoke_assistant', () => {
-  let invoke: Function
+  let invoke: ToolFunction['invoke']
 
   beforeEach(async () => {
     vi.clearAllMocks()
 
     // Prevent real LLM client construction; the model object itself is irrelevant
     // because ai.streamText is spied on per-test.
-    vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({ provider: 'openai', modelId: 'gpt-4o-mini' } as any)
+    vi
+      .spyOn(ChatAssistant, 'createLanguageModel')
+      .mockReturnValue({ provider: 'openai', modelId: 'gpt-4o-mini' } as unknown as LanguageModelV3)
 
     // Default: happy-path state
     mockCanUserAccessAssistant.mockResolvedValue(true)
@@ -191,7 +194,11 @@ describe('SubAssistantTool.invoke_assistant', () => {
       { id: 'asst-1', name: 'Sub Bot', description: 'A sub-assistant for testing' },
     ])
     const fns = await tool.functions(fakeLlmModel, { userId: 'user-1' })
-    invoke = (fns.invoke_assistant as any).invoke
+    const invokeAssistantFn = fns.invoke_assistant
+    if (invokeAssistantFn.type === 'provider') {
+      throw new Error('Expected invoke_assistant to be a function tool')
+    }
+    invoke = invokeAssistantFn.invoke
   })
 
   test('returns text on successful invocation', async () => {
@@ -228,6 +235,9 @@ describe('SubAssistantTool.invoke_assistant', () => {
 
     expect(result.type).toBe('error-text')
     expect(typeof result.value).toBe('string')
+    if (typeof result.value !== 'string') {
+      throw new Error('Expected error-text value to be a string')
+    }
     expect(result.value.length).toBeGreaterThan(0)
   })
 

--- a/__tests__/toolOutputNormalization.test.ts
+++ b/__tests__/toolOutputNormalization.test.ts
@@ -41,7 +41,7 @@ describe('tool output normalization', () => {
           },
         ],
       },
-      { assistantId: 'a1' }
+      { assistantId: 'a1', userId: 'u1' }
     )
 
     expect(res.type).toBe('content')
@@ -54,6 +54,7 @@ describe('tool output normalization', () => {
     const payload = Buffer.from('binary-openapi').toString('base64')
     const persisted = await persistFileLikePayload({
       assistantId: 'a1',
+      userId: 'u1',
       base64Data: payload,
       mimeType: 'application/pdf',
       nameHint: 'report.pdf',
@@ -71,12 +72,14 @@ describe('tool output normalization', () => {
     const payload = Buffer.from('same-bytes').toString('base64')
     const first = await persistFileLikePayload({
       assistantId: 'a1',
+      userId: 'u1',
       base64Data: payload,
       mimeType: 'image/png',
       source: 'MCP',
     })
     const second = await persistFileLikePayload({
       assistantId: 'a1',
+      userId: 'u1',
       base64Data: payload,
       mimeType: 'image/png',
       source: 'MCP',
@@ -92,6 +95,7 @@ describe('tool output normalization', () => {
     const payload = Buffer.from('fake').toString('base64')
     const persisted = await persistFileLikePayload({
       assistantId: 'a1',
+      userId: 'u1',
       base64Data: payload,
       mimeType: 'application/x-msdownload',
       source: 'MCP',

--- a/apps/backend/api/files/[fileId]/analysis/route.ts
+++ b/apps/backend/api/files/[fileId]/analysis/route.ts
@@ -31,7 +31,7 @@ export const GET = operation({
       return notFound()
     }
 
-    if (!(await canAccessFile(session, params.fileId))) {
+    if (!(await canAccessFile({ userId: session.userId, userRole: session.userRole }, params.fileId))) {
       return forbidden()
     }
 

--- a/apps/backend/api/files/[fileId]/content/route.ts
+++ b/apps/backend/api/files/[fileId]/content/route.ts
@@ -77,7 +77,7 @@ export const PUT = operation({
     if (!file) {
       return notFound()
     }
-    if (!(await canAccessFile(session, params.fileId))) {
+    if (!(await canAccessFile({ userId: session.userId, userRole: session.userRole }, params.fileId))) {
       return forbidden()
     }
     let clientDisconnected = false
@@ -162,7 +162,7 @@ export const GET = operation({
     if (!file) {
       return notFound()
     }
-    if (!(await canAccessFile(session, params.fileId))) {
+    if (!(await canAccessFile({ userId: session.userId, userRole: session.userRole }, params.fileId))) {
       return forbidden()
     }
     const fileContent = await storage.readStream(file.path, !!file.encrypted)

--- a/apps/backend/api/files/route.ts
+++ b/apps/backend/api/files/route.ts
@@ -15,7 +15,7 @@ export const POST = operation({
     const id = nanoid()
     const path = `${id}-${body.name.replace(/(\W+)/gi, '-')}`
     const { owner, ...bodyWithoutOwner } = body
-    if (!(await canAccess(session, owner.ownerType, owner.ownerId))) {
+    if (!(await canAccess({ userId: session.userId, userRole: session.userRole }, owner.ownerType, owner.ownerId))) {
       return forbidden()
     }
     const created = await addFile(bodyWithoutOwner, path, env.fileStorage.encryptFiles, owner)

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -92,7 +92,7 @@ interface Options {
   saveMessage?: (message: dto.Message, usage?: Usage) => Promise<void>
   updateChatTitle?: (title: string) => Promise<void>
   userLanguage?: string
-  user?: string
+  user: string
   conversationId?: string
   rootOwner?: {
     type: 'CHAT' | 'USER' | 'ASSISTANT'
@@ -234,9 +234,9 @@ export class ChatAssistant {
   static async computeFunctions(
     tools: ToolImplementation[],
     llmModel: LlmModel,
-    context?: {
-      userId?: string
-      assistantId?: string
+    context: {
+      userId: string
+      assistantId: string
       rootOwner?: {
         type: 'CHAT' | 'USER' | 'ASSISTANT'
         id: string
@@ -265,7 +265,7 @@ export class ChatAssistant {
     const { callSatelliteMethod } = satelliteHub
     const connections = satelliteHub.connections
     connections.forEach((conn) => {
-      if (conn.userId !== context?.userId) return
+      if (conn.userId !== context.userId) return
       conn.tools.forEach((tool) => {
         const toolFunction: ToolFunction = {
           description: tool.description,
@@ -285,10 +285,10 @@ export class ChatAssistant {
               for (const r of content) {
                 if (r.type === 'image' && typeof r.data === 'string') {
                   const persisted = await persistFileLikePayload({
-                    rootOwner: context?.rootOwner,
+                    rootOwner: context.rootOwner,
                     conversationId: undefined,
-                    userId: context?.userId,
-                    assistantId: context?.assistantId ?? '',
+                    userId: context.userId,
+                    assistantId: context.assistantId,
                     base64Data: r.data,
                     mimeType: r.mimeType ?? 'application/octet-stream',
                     source: 'Satellite',
@@ -298,10 +298,10 @@ export class ChatAssistant {
                   const normalized = await normalizeMcpToolResult(
                     { content: [r] },
                     {
-                      rootOwner: context?.rootOwner,
+                      rootOwner: context.rootOwner,
                       conversationId: undefined,
-                      userId: context?.userId,
-                      assistantId: context?.assistantId ?? '',
+                      userId: context.userId,
+                      assistantId: context.assistantId,
                     }
                   )
                   if (normalized.type === 'content') {

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -742,9 +742,10 @@ export class ChatAssistant {
       return result
     } catch (e) {
       this.logInternalError(chatState, `Failed invoking tool "${toolCall.toolName}"`, e)
+      const errorMessage = e instanceof Error ? e.message : 'Tool invocation failed'
       return {
         type: 'error-text',
-        value: (e as any).message ?? 'Tool invocation failed',
+        value: errorMessage,
       }
     }
   }

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -353,6 +353,9 @@ export class ChatAssistant {
     const llmModel = llmModels.find(
       (m) => m.id === assistantParams.model && m.provider === providerConfig.providerType
     )
+    if (!options.user) {
+      throw new Error('Authenticated user is required to build ChatAssistant')
+    }
     if (!llmModel) {
       throw new Error(
         `Can't find model ${assistantParams.model} for provider ${providerConfig.providerType}`

--- a/apps/backend/lib/chat/litellm/litellm-prepare-tools.ts
+++ b/apps/backend/lib/chat/litellm/litellm-prepare-tools.ts
@@ -8,7 +8,7 @@ export function prepareTools({
   tools,
   toolChoice,
 }: {
-  tools: LanguageModelV2CallOptions['tools']
+  tools: LanguageModelV2CallOptions['tools'] | null
   toolChoice?: LanguageModelV2CallOptions['toolChoice']
 }): {
   tools:

--- a/apps/backend/lib/chat/summarizer.ts
+++ b/apps/backend/lib/chat/summarizer.ts
@@ -34,7 +34,8 @@ export async function findReasonableSummarizationBackend(): Promise<LanguageMode
   const backends = await getBackends()
   if (backends.length === 0) return undefined
 
-  const bestBackend = backends.reduce((maxItem: any, currentItem: any) =>
+  type Backend = (typeof backends)[number]
+  const bestBackend = backends.reduce((maxItem: Backend, currentItem: Backend) =>
     providerScore(currentItem) > providerScore(maxItem) ? currentItem : maxItem
   )
   const models = llmModels.filter((m) => m.provider === bestBackend.providerType)
@@ -55,15 +56,15 @@ export async function summarize(
 ): Promise<string | undefined> {
   function truncateStrings<T>(obj: T, max: number): T {
     if (typeof obj === 'string') {
-      return (obj.length > max ? `${obj.slice(0, max)}…` : obj) as any
+      return (obj.length > max ? `${obj.slice(0, max)}…` : obj) as unknown as T
     } else if (Array.isArray(obj)) {
-      return obj.map((item) => truncateStrings(item, max)) as any
+      return obj.map((item) => truncateStrings(item, max)) as unknown as T
     } else if (obj !== null && typeof obj === 'object') {
-      const clone: any = {}
+      const clone: Record<string, unknown> = {}
       for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
-        clone[key] = truncateStrings(value as any, max)
+        clone[key] = truncateStrings(value, max)
       }
-      return clone
+      return clone as unknown as T
     }
     return obj
   }

--- a/apps/backend/lib/files/authorization.ts
+++ b/apps/backend/lib/files/authorization.ts
@@ -3,34 +3,14 @@ import type * as schema from '@/db/schema'
 import { canUserAccessAssistant } from '@/models/assistant'
 import { getUserWorkspaceMemberships } from '@/models/user'
 
-type AccessUser =
-  | string
-  | {
-      id?: string
-      role?: string
-      userId?: string
-      userRole?: string
-    }
-  | null
-  | undefined
-
-const normalizeUser = (user: AccessUser): { id: string; role?: string } | null => {
-  if (!user) return null
-  if (typeof user === 'string') {
-    const id = user.trim()
-    return id ? { id } : null
-  }
-
-  const id = (user.userId ?? user.id ?? '').trim()
-  if (!id) return null
-
-  const role = user.userRole ?? user.role
-  return role ? { id, role } : { id }
+type AccessUser = {
+  userId: string
+  userRole?: string
 }
 
-const isAdminUser = async (userId: string, roleHint?: string): Promise<boolean> => {
-  if (roleHint) {
-    return roleHint === 'ADMIN'
+const isAdminUser = async (userId: string, userRoleHint?: string): Promise<boolean> => {
+  if (userRoleHint) {
+    return userRoleHint === 'ADMIN'
   }
 
   const row = await db.selectFrom('User').select('role').where('id', '=', userId).executeTakeFirst()
@@ -42,21 +22,18 @@ export const canAccess = async (
   ownerType: schema.FileOwnerType,
   ownerId: string
 ): Promise<boolean> => {
-  const normalizedUser = normalizeUser(user)
-  if (!normalizedUser) {
-    return false
-  }
+  const userId = user.userId
 
   switch (ownerType) {
     case 'USER':
-      return normalizedUser.id === ownerId
+      return userId === ownerId
     case 'CHAT': {
       const conversation = await db
         .selectFrom('Conversation')
         .select('ownerId')
         .where('id', '=', ownerId)
         .executeTakeFirst()
-      if (conversation?.ownerId === normalizedUser.id) return true
+      if (conversation?.ownerId === userId) return true
       // Any authenticated user can access files from a shared conversation.
       const share = await db
         .selectFrom('ConversationSharing')
@@ -69,7 +46,7 @@ export const canAccess = async (
       return !!share
     }
     case 'ASSISTANT':
-      return await canUserAccessAssistant(normalizedUser.id, ownerId)
+      return await canUserAccessAssistant(userId, ownerId)
     case 'TOOL': {
       const tool = await db
         .selectFrom('Tool')
@@ -85,7 +62,7 @@ export const canAccess = async (
       }
 
       if (tool.sharing === 'workspace') {
-        const memberships = await getUserWorkspaceMemberships(normalizedUser.id)
+        const memberships = await getUserWorkspaceMemberships(userId)
         if (memberships.length === 0) {
           return false
         }
@@ -99,7 +76,7 @@ export const canAccess = async (
         return !!shared
       }
 
-      return await isAdminUser(normalizedUser.id, normalizedUser.role)
+      return await isAdminUser(userId, user.userRole)
     }
   }
 }

--- a/apps/backend/lib/files/authorization.ts
+++ b/apps/backend/lib/files/authorization.ts
@@ -2,19 +2,20 @@ import { db } from '@/db/database'
 import type * as schema from '@/db/schema'
 import { canUserAccessAssistant } from '@/models/assistant'
 import { getUserWorkspaceMemberships } from '@/models/user'
+import { UserRole } from '@/types/dto'
 
 type AccessUser = {
   userId: string
-  userRole?: string
+  userRole?: schema.UserRole
 }
 
-const isAdminUser = async (userId: string, userRoleHint?: string): Promise<boolean> => {
+const isAdminUser = async (userId: string, userRoleHint?: schema.UserRole): Promise<boolean> => {
   if (userRoleHint) {
-    return userRoleHint === 'ADMIN'
+    return userRoleHint === UserRole.ADMIN
   }
 
   const row = await db.selectFrom('User').select('role').where('id', '=', userId).executeTakeFirst()
-  return row?.role === 'ADMIN'
+  return row?.role === UserRole.ADMIN
 }
 
 export const canAccess = async (

--- a/apps/backend/lib/tools/anthropic.web_search/implementation.ts
+++ b/apps/backend/lib/tools/anthropic.web_search/implementation.ts
@@ -19,7 +19,7 @@ export class AnthropicWebSearch extends AnthropicWebSearchInterface implements T
     return model.owned_by === 'anthropic'
   }
 
-  async functions(_model: LlmModel, _context?: ToolFunctionContext): Promise<ToolFunctions> {
+  async functions(_model: LlmModel, _context: ToolFunctionContext): Promise<ToolFunctions> {
     return {
       web_search: {
         type: 'provider',

--- a/apps/backend/lib/tools/audio_transcription/implementation.ts
+++ b/apps/backend/lib/tools/audio_transcription/implementation.ts
@@ -131,7 +131,7 @@ export class AudioTranscription extends AudioTranscriptionInterface implements T
       return { type: 'error-text', value: 'fileId is required' }
     }
 
-    if (!(await canAccessFile(userId, fileId))) {
+    if (!(await canAccessFile({ userId }, fileId))) {
       return { type: 'error-text', value: `You are not authorized to access file: ${fileId}` }
     }
 

--- a/apps/backend/lib/tools/audio_transcription/implementation.ts
+++ b/apps/backend/lib/tools/audio_transcription/implementation.ts
@@ -81,7 +81,7 @@ export class AudioTranscription extends AudioTranscriptionInterface implements T
     super()
   }
 
-  functions = async (_model: LlmModel, _context?: ToolFunctionContext) => this.functions_
+  functions = async (_model: LlmModel, _context: ToolFunctionContext) => this.functions_
 
   private functions_: ToolFunctions = {
     transcribe_audio: {

--- a/apps/backend/lib/tools/code_interpreter/implementation.ts
+++ b/apps/backend/lib/tools/code_interpreter/implementation.ts
@@ -292,7 +292,7 @@ export class CodeInterpreter
     return storedFiles
   }
 
-  async functions(_model: LlmModel, _context?: ToolFunctionContext): Promise<ToolFunctions> {
+  async functions(_model: LlmModel, _context: ToolFunctionContext): Promise<ToolFunctions> {
     return {
       create_container: {
         description: 'Create a code interpreter container and return its id.',

--- a/apps/backend/lib/tools/code_interpreter/implementation.ts
+++ b/apps/backend/lib/tools/code_interpreter/implementation.ts
@@ -133,7 +133,7 @@ export class CodeInterpreter
       if (!fileId) {
         return { type: 'error-text', value: 'file_id is required for each file' }
       }
-      if (!(await canAccessFile(userId, fileId))) {
+      if (!(await canAccessFile({ userId }, fileId))) {
         return { type: 'error-text', value: `You are not authorized to access file: ${fileId}` }
       }
       const fileEntry = await getFileWithId(fileId)

--- a/apps/backend/lib/tools/dummy/implementation.ts
+++ b/apps/backend/lib/tools/dummy/implementation.ts
@@ -22,7 +22,7 @@ export class DummyTool extends DummyToolInterface implements ToolImplementation 
     this.knowledge = params.files ?? []
   }
 
-  async functions(_model: LlmModel, _context?: ToolFunctionContext): Promise<ToolFunctions> {
+  async functions(_model: LlmModel, _context: ToolFunctionContext): Promise<ToolFunctions> {
     return {}
   }
 }

--- a/apps/backend/lib/tools/google.web_search/implementation.ts
+++ b/apps/backend/lib/tools/google.web_search/implementation.ts
@@ -24,7 +24,7 @@ export class GoogleWebSearch extends GoogleWebSearchInterface implements ToolImp
     )
   }
 
-  async functions(_model: LlmModel, _context?: ToolFunctionContext): Promise<ToolFunctions> {
+  async functions(_model: LlmModel, _context: ToolFunctionContext): Promise<ToolFunctions> {
     return {}
   }
   providerOptions(_model: LlmModel): SharedV2ProviderOptions {

--- a/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
@@ -111,7 +111,7 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
     }
   }
 
-  functions = async (_model: LlmModel, _context?: ToolFunctionContext) => this.functions_
+  functions = async (_model: LlmModel, _context: ToolFunctionContext) => this.functions_
 
   protected abstract supportsModel(model: string): boolean
   protected abstract providerName(): string

--- a/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
@@ -164,8 +164,8 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
     })
   }
 
-  private async loadImage(fileId: string, userId?: string) {
-    if (!(await canAccessFile(userId, fileId))) {
+  private async loadImage(fileId: string, userId: string) {
+    if (!(await canAccessFile({ userId }, fileId))) {
       throw new Error(`Tool invocation unauthorized for file: ${fileId}`)
     }
     const fileEntry = await getFileWithId(fileId)
@@ -223,7 +223,7 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
     aiResponse: GeneratedImagesResponse,
     ownerContext: {
       conversationId?: string
-      userId?: string
+      userId: string
       assistantId: string
       rootOwner?: { type: 'CHAT' | 'USER' | 'ASSISTANT'; id: string }
     }

--- a/apps/backend/lib/tools/imagegenerator/implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/implementation.ts
@@ -125,8 +125,8 @@ export class ImageGeneratorPlugin
     })
   }
 
-  private async loadImageAsWebFile(fileId: string, userId?: string) {
-    if (!(await canAccessFile(userId, fileId))) {
+  private async loadImageAsWebFile(fileId: string, userId: string) {
+    if (!(await canAccessFile({ userId }, fileId))) {
       throw new Error(`Tool invocation unauthorized for file: ${fileId}`)
     }
     const fileEntry = await getFileWithId(fileId)
@@ -178,7 +178,7 @@ export class ImageGeneratorPlugin
     aiResponse: ImagesResponse,
     ownerContext: {
       conversationId?: string
-      userId?: string
+      userId: string
       assistantId: string
       rootOwner?: { type: 'CHAT' | 'USER' | 'ASSISTANT'; id: string }
     }

--- a/apps/backend/lib/tools/imagegenerator/implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/implementation.ts
@@ -94,7 +94,7 @@ export class ImageGeneratorPlugin
     }
   }
 
-  functions = async (_model: LlmModel, _context?: ToolFunctionContext) => this.functions_
+  functions = async (_model: LlmModel, _context: ToolFunctionContext) => this.functions_
 
   private async invokeGenerate({
     params: invocationParams,

--- a/apps/backend/lib/tools/knowledge/implementation.ts
+++ b/apps/backend/lib/tools/knowledge/implementation.ts
@@ -29,7 +29,7 @@ export class KnowledgePlugin extends KnowledgePluginInterface implements ToolImp
     super()
   }
 
-  functions = async (_model: LlmModel, _context?: ToolFunctionContext) => {
+  functions = async (_model: LlmModel, _context: ToolFunctionContext) => {
     if (env.knowledge.sendInPrompt) {
       return {}
     }

--- a/apps/backend/lib/tools/mcp/implementation.ts
+++ b/apps/backend/lib/tools/mcp/implementation.ts
@@ -218,7 +218,7 @@ export class McpPlugin extends McpInterface implements ToolImplementation {
     return this.config
   }
 
-  async functions(_model: LlmModel, context?: ToolFunctionContext): Promise<ToolFunctions> {
+  async functions(_model: LlmModel, context: ToolFunctionContext): Promise<ToolFunctions> {
     const userId = context?.userId ?? ''
     if (
       this.config.authentication.type === 'oauth' &&
@@ -243,7 +243,7 @@ export class McpPlugin extends McpInterface implements ToolImplementation {
     )
   }
 
-  async getAuthRequest(context?: ToolFunctionContext): Promise<dto.UserRequest | null> {
+  async getAuthRequest(context: ToolFunctionContext): Promise<dto.UserRequest | null> {
     if (this.config.authentication.type !== 'oauth') return null
     if ((this.config.authentication.activationMode ?? 'preflight') !== 'preflight') {
       return null

--- a/apps/backend/lib/tools/nativetool/implementation.ts
+++ b/apps/backend/lib/tools/nativetool/implementation.ts
@@ -19,7 +19,7 @@ export class NativeTool extends NativeToolInterface implements ToolImplementatio
     super()
   }
 
-  async functions(_model: LlmModel, _context?: ToolFunctionContext): Promise<ToolFunctions> {
+  async functions(_model: LlmModel, _context: ToolFunctionContext): Promise<ToolFunctions> {
     let name = this.params.name
     let type = this.params.type
     if (name === 'openai.web_search_preview') {

--- a/apps/backend/lib/tools/openai.image_generation/implementation.ts
+++ b/apps/backend/lib/tools/openai.image_generation/implementation.ts
@@ -18,7 +18,7 @@ export class OpenaiImageGeneration
     super()
   }
 
-  async functions(_model: LlmModel, _context?: ToolFunctionContext): Promise<ToolFunctions> {
+  async functions(_model: LlmModel, _context: ToolFunctionContext): Promise<ToolFunctions> {
     return {
       image_generation: {
         type: 'provider',

--- a/apps/backend/lib/tools/openai.web_search/implementation.ts
+++ b/apps/backend/lib/tools/openai.web_search/implementation.ts
@@ -19,7 +19,7 @@ export class OpenaiWebSearch extends OpenAiWebSearchInterface implements ToolImp
     return model.owned_by === 'openai'
   }
 
-  async functions(_model: LlmModel, _context?: ToolFunctionContext): Promise<ToolFunctions> {
+  async functions(_model: LlmModel, _context: ToolFunctionContext): Promise<ToolFunctions> {
     return {
       web_search: {
         type: 'provider',

--- a/apps/backend/lib/tools/openapi/body.ts
+++ b/apps/backend/lib/tools/openapi/body.ts
@@ -18,11 +18,11 @@ interface BodyAndHeader {
 type BodyCreator = (
   invocationParams: Record<string, unknown>,
   schema: OpenAPIV3.SchemaObject,
-  userId?: string
+  userId: string
 ) => Promise<BodyAndHeader>
 
 export interface BodyHandler {
-  createBody: (invocationParams: Record<string, unknown>, userId?: string) => Promise<BodyAndHeader>
+  createBody: (invocationParams: Record<string, unknown>, userId: string) => Promise<BodyAndHeader>
   mergeParamsIntoToolFunctionSchema: (toolParams: ToolFunctionSchemaParams) => void
 }
 
@@ -67,7 +67,7 @@ async function formDataToBuffer(form: FormData): Promise<Uint8Array<ArrayBuffer>
 async function createFormBody(
   invocationParams: Record<string, unknown>,
   schema: OpenAPIV3.SchemaObject,
-  userId?: string
+  userId: string
 ): Promise<BodyAndHeader> {
   const bodyParamInstances = invocationParams.body as Record<string, any>
   const form = new FormData()
@@ -95,7 +95,7 @@ async function createFormBody(
           `Tool invocation requires a body, but param ${definedPropertyName} is missing`
         )
       }
-      if (!(await canAccessFile(userId, `${propInvocationValue}`))) {
+      if (!(await canAccessFile({ userId }, `${propInvocationValue}`))) {
         throw new Error(`Tool invocation unauthorized for file: ${propInvocationValue}`)
       }
       const fileEntry = await getFileWithId(`${propInvocationValue}`)
@@ -183,7 +183,7 @@ export function findBodyHandler(spec: OpenAPIV3.RequestBodyObject): BodyHandler 
         if (mediaObject?.schema) {
           const schema = mediaObject.schema as OpenAPIV3.SchemaObject
           return {
-            createBody: (invocationParams: Record<string, unknown>, userId?: string) => {
+            createBody: (invocationParams: Record<string, unknown>, userId: string) => {
               return bodyHandler[1](invocationParams, schema, userId)
             },
             mergeParamsIntoToolFunctionSchema: (toolParams: ToolFunctionSchemaParams) => {

--- a/apps/backend/lib/tools/openapi/implementation.ts
+++ b/apps/backend/lib/tools/openapi/implementation.ts
@@ -386,5 +386,5 @@ export class OpenApiPlugin extends OpenApiInterface implements ToolImplementatio
   ) {
     super()
   }
-  functions = async (_model: LlmModel, _context?: ToolFunctionContext) => this.functions_
+  functions = async (_model: LlmModel, _context: ToolFunctionContext) => this.functions_
 }

--- a/apps/backend/lib/tools/retrieve-file/implementation.ts
+++ b/apps/backend/lib/tools/retrieve-file/implementation.ts
@@ -72,7 +72,7 @@ export class FileManagerPlugin extends FileManagerPluginInterface implements Too
             value: 'File not found',
           }
         }
-        if (!(await canAccessFile(userId, fileEntry.id))) {
+        if (!(await canAccessFile({ userId }, fileEntry.id))) {
           return {
             type: 'error-text',
             value: 'File not found',
@@ -114,7 +114,7 @@ export class FileManagerPlugin extends FileManagerPluginInterface implements Too
             value: 'File not found',
           }
         }
-        if (!(await canAccessFile(userId, fileEntry.id))) {
+        if (!(await canAccessFile({ userId }, fileEntry.id))) {
           return {
             type: 'error-text',
             value: 'File not found',

--- a/apps/backend/lib/tools/retrieve-file/implementation.ts
+++ b/apps/backend/lib/tools/retrieve-file/implementation.ts
@@ -28,7 +28,7 @@ export class FileManagerPlugin extends FileManagerPluginInterface implements Too
     super()
   }
 
-  functions = async (_model: LlmModel, _context?: ToolFunctionContext) => this.functions_
+  functions = async (_model: LlmModel, _context: ToolFunctionContext) => this.functions_
 
   private async getFileDbRowBy(where: { id?: string; name?: string }): Promise<FileDbRow | undefined> {
     let query = db.selectFrom('File').selectAll()

--- a/apps/backend/lib/tools/router/implementation.ts
+++ b/apps/backend/lib/tools/router/implementation.ts
@@ -74,7 +74,7 @@ export class Router extends RouterInterface implements ToolImplementation {
     return {}
   }
 
-  async functions(model: LlmModel, context?: ToolFunctionContext): Promise<ToolFunctions> {
+  async functions(model: LlmModel, context: ToolFunctionContext): Promise<ToolFunctions> {
     for (const choice of this.choices) {
       if (
         choice.implementation.isModelSupported &&

--- a/apps/backend/lib/tools/subassistant/implementation.ts
+++ b/apps/backend/lib/tools/subassistant/implementation.ts
@@ -36,7 +36,7 @@ export class SubAssistantTool implements ToolImplementation {
     private assistants: SubAssistantEntry[]
   ) {}
 
-  async functions(_model: LlmModel, _context?: ToolFunctionContext): Promise<ToolFunctions> {
+  async functions(_model: LlmModel, _context: ToolFunctionContext): Promise<ToolFunctions> {
     const assistants = this.assistants
     return {
       invoke_assistant: {

--- a/apps/backend/lib/tools/subassistant/implementation.ts
+++ b/apps/backend/lib/tools/subassistant/implementation.ts
@@ -64,7 +64,7 @@ export class SubAssistantTool implements ToolImplementation {
           const entry = assistants.find((a) => a.id === assistantId)
           const label = entry?.name ?? assistantId
           try {
-            if (!userId || !(await canUserAccessAssistant(userId, assistantId))) {
+            if (!(await canUserAccessAssistant(userId, assistantId))) {
               return { type: 'error-text', value: `Access to sub-assistant "${label}" is denied` }
             }
 
@@ -92,7 +92,7 @@ export class SubAssistantTool implements ToolImplementation {
             const [tools, files, parameters] = await Promise.all([
               availableToolsForAssistantVersion(assistantVersion.id, assistantVersion.model),
               assistantVersionFiles(assistantVersion.id),
-              userId ? getUserParameters(userId) : Promise.resolve({}),
+              getUserParameters(userId),
             ])
 
             const assistantParams: AssistantParams = {

--- a/apps/backend/lib/tools/timeofday/implementation.ts
+++ b/apps/backend/lib/tools/timeofday/implementation.ts
@@ -15,7 +15,7 @@ export class TimeOfDay extends TimeOfDayInterface implements ToolImplementation 
   }
   supportedMedia = []
 
-  functions = async (_model: LlmModel, _context?: ToolFunctionContext) => this.functions_
+  functions = async (_model: LlmModel, _context: ToolFunctionContext) => this.functions_
 
   private functions_: ToolFunctions = {
     timeOfDay: {

--- a/apps/backend/lib/tools/websearch/implementation.ts
+++ b/apps/backend/lib/tools/websearch/implementation.ts
@@ -42,7 +42,7 @@ export class WebSearch extends WebSearchInterface implements ToolImplementation 
     super()
   }
 
-  functions = async (_model: LlmModel, _context?: ToolFunctionContext) => this.functions_
+  functions = async (_model: LlmModel, _context: ToolFunctionContext) => this.functions_
 
   functions_: ToolFunctions = {
     WebSearch: {

--- a/packages/core/src/chat/tools.ts
+++ b/packages/core/src/chat/tools.ts
@@ -13,7 +13,7 @@ export interface ToolInvokeParams {
   llmModel: LlmModel
   messages: dto.Message[]
   assistantId: string
-  userId?: string
+  userId: string
   conversationId?: string
   rootOwner?: {
     type: 'CHAT' | 'USER' | 'ASSISTANT'
@@ -27,7 +27,7 @@ export interface ToolInvokeParams {
 }
 
 export interface ToolFunctionContext {
-  userId?: string
+  userId: string
   rootOwner?: {
     type: 'CHAT' | 'USER' | 'ASSISTANT'
     id: string
@@ -38,7 +38,7 @@ export interface ToolAuthParams {
   llmModel: LlmModel
   messages: dto.Message[]
   assistantId: string
-  userId?: string
+  userId: string
   rootOwner?: {
     type: 'CHAT' | 'USER' | 'ASSISTANT'
     id: string

--- a/packages/core/src/chat/tools.ts
+++ b/packages/core/src/chat/tools.ts
@@ -90,8 +90,8 @@ export interface ToolImplementation {
   supportedMedia: string[]
   toolParams: ToolParams
   knowledge?: dto.AssistantFile[]
-  functions: (model: LlmModel, context?: ToolFunctionContext) => Promise<ToolFunctions>
-  getAuthRequest?: (context?: ToolFunctionContext) => Promise<dto.UserRequest | null>
+  functions: (model: LlmModel, context: ToolFunctionContext) => Promise<ToolFunctions>
+  getAuthRequest?: (context: ToolFunctionContext) => Promise<dto.UserRequest | null>
   isModelSupported?: (model: LlmModel) => boolean
   providerOptions?: (model: LlmModel) => SharedV2ProviderOptions
 }

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -1,8 +1,10 @@
+import { UserRole } from './dto/user'
+
 export type SimpleSession = {
   sessionId: string
   userId: string
 }
 
 export type AuthenticatedSession = SimpleSession & {
-  userRole: string
+  userRole: UserRole
 }


### PR DESCRIPTION
## Summary
This change enforces authenticated-user context across tool invocation and file authorization, and tightens file access checks to use a single strict access-user shape. Shared-chat file content behavior remains authenticated-only while removing legacy nullable user handling in authorization paths.

## Details
- Require  in , , and .
- Require  in  options and tighten  context to authenticated values.
- Refactor file authorization input to a strict non-null  shape ().
- Remove /implicit normalization and caller-side fallback patterns for nullable users.
- Keep shared conversation file access scoped to authenticated users.
- Update tool call sites (, , , , ) to pass explicit .
- Update sub-assistant execution to rely on authenticated  and remove unauthenticated fallback parameter loading.
- Update tests to match new signatures and authenticated context assumptions.

## Risks
- Any future non-authenticated tool invocation path will now fail at compile time unless explicitly modeled.
- Downstream callers outside current backend paths must provide  to satisfy tool invocation contracts.
