### PR TITLE
Paginate assistant selector search

### DIFF
--- a/apps/backend/api/me/assistants/search/route.ts
+++ b/apps/backend/api/me/assistants/search/route.ts
@@ -1,0 +1,56 @@
+import { ok, operation, responseSpec } from '@/lib/routes'
+import { getUserAssistants } from '@/models/assistant'
+import * as dto from '@/types/dto'
+import { z } from 'zod'
+
+export const dynamic = 'force-dynamic'
+
+const assistantSearchQuerySchema = z.object({
+  search: z.string().optional(),
+  tag: z.string().optional(),
+  orderBy: z.enum(['name', 'lastused']).optional(),
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+  ids: z.string().optional(),
+  excludeIds: z.string().optional(),
+})
+
+const parseIds = (value: string | undefined): string[] | undefined => {
+  const ids = value
+    ?.split(',')
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0)
+  return ids && ids.length > 0 ? ids : undefined
+}
+
+export const GET = operation({
+  name: 'Search published assistants',
+  description: 'Search published assistants visible to the current user with cursor-style pagination.',
+  authentication: 'user',
+  querySchema: assistantSearchQuerySchema,
+  responses: [responseSpec(200, dto.assistantSearchResponseSchema)] as const,
+  implementation: async ({ session, query }) => {
+    const limit = query.limit ?? 50
+    const offset = query.offset ?? 0
+    const assistants = await getUserAssistants(
+      {
+        userId: session.userId,
+        search: query.search,
+        tag: query.tag,
+        ordering: query.orderBy ?? 'lastused',
+        ids: parseIds(query.ids),
+        excludeIds: parseIds(query.excludeIds),
+        limit: limit + 1,
+        offset,
+      },
+      'published'
+    )
+    const items = assistants.slice(0, limit)
+    return ok({
+      items,
+      limit,
+      offset,
+      nextOffset: assistants.length > limit ? offset + limit : null,
+    })
+  },
+})

--- a/apps/backend/lib/router/routes.generated.ts
+++ b/apps/backend/lib/router/routes.generated.ts
@@ -63,6 +63,7 @@ export const backendRouteModules = [
   { pathname: '/api/me/assistants/mine', load: () => import('@/backend/api/me/assistants/mine/route') },
   { pathname: '/api/me/assistants/mine/stats', load: () => import('@/backend/api/me/assistants/mine/stats/route') },
   { pathname: '/api/me/assistants', load: () => import('@/backend/api/me/assistants/route') },
+  { pathname: '/api/me/assistants/search', load: () => import('@/backend/api/me/assistants/search/route') },
   { pathname: '/api/me/folders/[folderId]/conversations', load: () => import('@/backend/api/me/folders/[folderId]/conversations/route') },
   { pathname: '/api/me/folders/[folderId]', load: () => import('@/backend/api/me/folders/[folderId]/route') },
   { pathname: '/api/me/folders', load: () => import('@/backend/api/me/folders/route') },

--- a/apps/backend/models/assistant.ts
+++ b/apps/backend/models/assistant.ts
@@ -164,14 +164,28 @@ export const getUserAssistants = async (
     userId,
     assistantId,
     pinned,
+    search,
+    tag,
+    ids,
+    excludeIds,
+    limit,
+    offset,
+    ordering,
   }: {
     userId: string
     assistantId?: string
     pinned?: boolean
+    search?: string
+    tag?: string
+    ids?: string[]
+    excludeIds?: string[]
+    limit?: number
+    offset?: number
+    ordering?: 'name' | 'lastused'
   },
   type: 'draft' | 'published'
 ): Promise<dto.UserAssistant[]> => {
-  const assistants = await db
+  let assistantsQuery = db
     .selectFrom('Assistant')
     .innerJoin('AssistantVersion', (join) =>
       type === 'draft'
@@ -244,9 +258,43 @@ export const getUserAssistants = async (
       if (assistantId) {
         conditions.push(eb('Assistant.id', '=', assistantId))
       }
+      if (ids && ids.length > 0) {
+        conditions.push(eb('Assistant.id', 'in', ids))
+      }
+      if (excludeIds && excludeIds.length > 0) {
+        conditions.push(eb('Assistant.id', 'not in', excludeIds))
+      }
+      const trimmedSearch = search?.trim().toLocaleLowerCase()
+      if (trimmedSearch) {
+        const pattern = `%${trimmedSearch}%`
+        conditions.push(
+          eb.or([
+            sql<SqlBool>`lower("AssistantVersion"."name") like ${pattern}`,
+            sql<SqlBool>`lower("AssistantVersion"."description") like ${pattern}`,
+            sql<SqlBool>`lower("AssistantVersion"."tags") like ${pattern}`,
+          ])
+        )
+      }
+      const trimmedTag = tag?.trim().toLocaleLowerCase()
+      if (trimmedTag) {
+        conditions.push(sql<SqlBool>`lower("AssistantVersion"."tags") like ${`%"${trimmedTag}"%`}`)
+      }
       return eb.and(conditions)
     })
-    .execute()
+
+  assistantsQuery =
+    ordering === 'name'
+      ? assistantsQuery.orderBy('AssistantVersion.name', 'asc')
+      : assistantsQuery.orderBy(sql`coalesce("AssistantUserData"."lastUsed", '1970-01-01')`, 'desc')
+
+  if (offset !== undefined) {
+    assistantsQuery = assistantsQuery.offset(offset)
+  }
+  if (limit !== undefined) {
+    assistantsQuery = assistantsQuery.limit(limit)
+  }
+
+  const assistants = await assistantsQuery.execute()
   if (assistants.length === 0) {
     return []
   }

--- a/apps/frontend/app/assistants/components/AddAssistantDialog.tsx
+++ b/apps/frontend/app/assistants/components/AddAssistantDialog.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { useState } from 'react'
+import useSWRInfinite from 'swr/infinite'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import * as dto from '@/types/dto'
@@ -9,13 +10,43 @@ import { SearchBarWithButtonsOnRight } from '@/components/app/SearchBarWithButto
 interface Props {
   onClose: () => void
   onAddAssistants: (assistants: dto.UserAssistant[]) => void
-  candidates: dto.UserAssistant[]
+  excludeIds: string[]
 }
 
-export const AddAssistantDialog = ({ onClose, onAddAssistants, candidates }: Props) => {
+const PAGE_SIZE = 50
+
+const fetchJson = async (url: string) => {
+  const response = await fetch(url)
+  const json = await response.json()
+  if (!response.ok) {
+    throw new Error(json.error?.message || 'An error occurred while fetching the data')
+  }
+  return json
+}
+
+export const AddAssistantDialog = ({ onClose, onAddAssistants, excludeIds }: Props) => {
   const { t } = useTranslation()
   const [selection, setSelection] = useState<Map<string, dto.UserAssistant>>(new Map())
   const [searchTerm, setSearchTerm] = useState<string>('')
+  const getSearchKey = (
+    pageIndex: number,
+    previousPage: dto.AssistantSearchResponse | null
+  ) => {
+    if (previousPage && previousPage.nextOffset === null) return null
+    const offset = previousPage?.nextOffset ?? pageIndex * PAGE_SIZE
+    const params = new URLSearchParams({
+      limit: String(PAGE_SIZE),
+      offset: String(offset),
+      orderBy: 'name',
+    })
+    if (searchTerm.trim().length > 0) params.set('search', searchTerm.trim())
+    if (excludeIds.length > 0) params.set('excludeIds', excludeIds.join(','))
+    return `/api/me/assistants/search?${params.toString()}`
+  }
+  const { data, size, setSize, isValidating } = useSWRInfinite<dto.AssistantSearchResponse>(
+    getSearchKey,
+    fetchJson
+  )
 
   const toggleAssistant = (assistant: dto.UserAssistant) => {
     const newMap = new Map(selection)
@@ -25,11 +56,9 @@ export const AddAssistantDialog = ({ onClose, onAddAssistants, candidates }: Pro
     setSelection(newMap)
   }
 
-  const searchTermLowerCase = searchTerm.toLocaleLowerCase()
-  const filtered =
-    searchTerm.length === 0
-      ? candidates
-      : candidates.filter((a) => a.name.toLocaleLowerCase().includes(searchTermLowerCase))
+  const rows = (data ?? []).flatMap((page) => page.items)
+  const lastPage = data?.[data.length - 1]
+  const hasMore = lastPage !== undefined && lastPage.nextOffset !== null
 
   const columns = [
     column(t('table-column-name'), (a: dto.UserAssistant) => <span>{a.name}</span>),
@@ -65,9 +94,16 @@ export const AddAssistantDialog = ({ onClose, onAddAssistants, candidates }: Pro
             className="flex-1 text-body1 h-[24rem] table-auto"
             columns={columns}
             onRowClick={toggleAssistant}
-            rows={filtered}
+            rows={rows}
             keygen={(a) => a.id}
           />
+          {hasMore && (
+            <div className="flex justify-center pt-3">
+              <Button disabled={isValidating} onClick={() => setSize(size + 1)}>
+                {t('load_more')}
+              </Button>
+            </div>
+          )}
         </div>
         <div className="flex justify-center">
           <Button onClick={() => onSubmit()}>{t('add')}</Button>

--- a/apps/frontend/app/assistants/components/ToolsTabPanel.tsx
+++ b/apps/frontend/app/assistants/components/ToolsTabPanel.tsx
@@ -25,9 +25,17 @@ export const ToolsTabPanel = ({ form, visible, className, assistantId }: ToolsTa
   const [isAddToolsDialogVisible, setAddToolsDialogVisible] = useState(false)
   const [isAddAssistantDialogVisible, setAddAssistantDialogVisible] = useState(false)
   const { data: allTools } = useSWRJson<dto.AssistantTool[]>('/api/me/tools')
-  const { data: allAssistants } = useSWRJson<dto.UserAssistant[]>('/api/me/assistants/explore')
   const allCapabilities = allTools?.filter((t) => t.capability) || []
   const allNonCapabilities = allTools?.filter((t) => !t.capability) || []
+  const currentSubAssistantIds = form.watch('subAssistants') ?? []
+  const selectedAssistantQuery =
+    currentSubAssistantIds.length > 0
+      ? `/api/me/assistants/search?ids=${encodeURIComponent(
+          currentSubAssistantIds.join(',')
+        )}&limit=${currentSubAssistantIds.length}&orderBy=name`
+      : null
+  const { data: selectedAssistantPage } =
+    useSWRJson<dto.AssistantSearchResponse>(selectedAssistantQuery)
   return (
     <>
       <ScrollArea className={`${className}`} style={{ display: visible ? undefined : 'none' }}>
@@ -127,9 +135,7 @@ export const ToolsTabPanel = ({ form, visible, className, assistantId }: ToolsTa
             name="subAssistants"
             render={({ field }) => {
               const currentSubAssistants = field.value ?? []
-              const selectedAssistants = (allAssistants ?? []).filter((a) =>
-                currentSubAssistants.includes(a.id)
-              )
+              const selectedAssistants = selectedAssistantPage?.items ?? []
               return (
                 <Card>
                   <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
@@ -191,11 +197,7 @@ export const ToolsTabPanel = ({ form, visible, className, assistantId }: ToolsTa
       )}
       {isAddAssistantDialogVisible && (
         <AddAssistantDialog
-          candidates={(allAssistants ?? []).filter(
-            (a) =>
-              a.id !== assistantId &&
-              !(form.getValues().subAssistants ?? []).includes(a.id)
-          )}
+          excludeIds={[assistantId, ...(form.getValues().subAssistants ?? [])]}
           onClose={() => setAddAssistantDialogVisible(false)}
           onAddAssistants={(assistants: dto.UserAssistant[]) => {
             const idsToAdd = assistants.map((a) => a.id)

--- a/apps/frontend/app/chat/assistants/select/page.tsx
+++ b/apps/frontend/app/chat/assistants/select/page.tsx
@@ -4,6 +4,7 @@ import ChatPageContext from '@/app/chat/components/context'
 import { useRouter } from 'next/navigation'
 import { useContext, useState } from 'react'
 import { useSWRJson } from '@/hooks/swr'
+import useSWRInfinite from 'swr/infinite'
 import { WithLoadingAndError } from '@/components/ui'
 import { useUserProfile } from '@/components/providers/userProfileContext'
 import { useTranslation } from 'react-i18next'
@@ -27,6 +28,16 @@ const EMPTY_ASSISTANT_NAME = ''
 
 const orderingValues = ['name', 'lastused'] as const
 type Ordering = (typeof orderingValues)[number]
+const PAGE_SIZE = 60
+
+const fetchJson = async (url: string) => {
+  const response = await fetch(url)
+  const json = await response.json()
+  if (!response.ok) {
+    throw new Error(json.error?.message || 'An error occurred while fetching the data')
+  }
+  return json
+}
 
 const SelectAssistantPage = () => {
   const { setNewChatAssistantId } = useContext(ChatPageContext)
@@ -37,11 +48,30 @@ const SelectAssistantPage = () => {
   const [tagsFilter, setTagsFilter] = useState<string | null>(null)
   const [ordering, setOrdering] = useUiState<Ordering>('assistants_select_ordering', 'lastused')
 
+  const { data: availableTags } = useSWRJson<string[]>('/api/assistants/tags')
+  const getAssistantSearchKey = (
+    pageIndex: number,
+    previousPage: dto.AssistantSearchResponse | null
+  ) => {
+    if (previousPage && previousPage.nextOffset === null) return null
+    const offset = previousPage?.nextOffset ?? pageIndex * PAGE_SIZE
+    const params = new URLSearchParams({
+      limit: String(PAGE_SIZE),
+      offset: String(offset),
+      orderBy: ordering,
+    })
+    if (searchTerm.trim().length > 0) params.set('search', searchTerm.trim())
+    if (tagsFilter) params.set('tag', tagsFilter)
+    return `/api/me/assistants/search?${params.toString()}`
+  }
   const {
-    data: assistants,
+    data: assistantPages,
     isLoading,
     error,
-  } = useSWRJson<dto.UserAssistant[]>(`/api/me/assistants/explore`)
+    size,
+    setSize,
+    isValidating,
+  } = useSWRInfinite<dto.AssistantSearchResponse>(getAssistantSearchKey, fetchJson)
 
   const isAssistantAvailable = (assistant: dto.UserAssistant) => {
     if (assistant.name === EMPTY_ASSISTANT_NAME) return false
@@ -50,40 +80,18 @@ const SelectAssistantPage = () => {
     return isSharedWithAllOrAnyWorkspace(assistant.sharing, workspaceIds)
   }
 
-  const availableAssistants = (assistants ?? [])
+  const availableAssistants = (assistantPages ?? [])
+    .flatMap((page) => page.items)
     .filter(isAssistantAvailable)
-    .sort(
-      ordering === 'lastused'
-        ? (a, b) => (b.lastUsed ?? '1970-01-01').localeCompare(a.lastUsed ?? '1970-01-01')
-        : (a, b) => a.name.localeCompare(b.name)
-    )
-  const tagEntries = new Map<string, string>()
-  for (const assistant of availableAssistants) {
-    for (const tag of assistant.tags) {
-      const key = tag.toLocaleLowerCase()
-      if (!tagEntries.has(key)) tagEntries.set(key, tag)
-    }
-  }
   const tags = [
     null,
-    ...Array.from(tagEntries.entries())
-      .sort((a, b) => a[1].localeCompare(b[1], undefined, { sensitivity: 'base' }))
-      .map(([key, label]) => ({ key, label })),
+    ...(availableTags ?? []).map((tag) => ({
+      key: tag.toLocaleLowerCase(),
+      label: tag,
+    })),
   ]
-
-  const searchTermLowerCase = searchTerm.toLocaleLowerCase()
-  const filterWithSearch = (assistant: dto.UserAssistant) => {
-    return (
-      searchTerm.trim().length === 0 ||
-      assistant.name.toLocaleLowerCase().includes(searchTermLowerCase) ||
-      assistant.description.toLocaleLowerCase().includes(searchTermLowerCase) ||
-      !!assistant.tags.find((s) => s.toLocaleLowerCase().includes(searchTermLowerCase))
-    )
-  }
-
-  const filterWithTags = (assistant: dto.UserAssistant) => {
-    return tagsFilter == null || assistant.tags.some((t) => t.toLocaleLowerCase() === tagsFilter)
-  }
+  const lastPage = assistantPages?.[assistantPages.length - 1]
+  const hasMore = lastPage !== undefined && lastPage.nextOffset !== null
 
   // just simulate a lot of assistants
   //for(let a = 0; a < 5; a++) { assistants = [...assistants, ...assistants] }
@@ -118,12 +126,12 @@ const SelectAssistantPage = () => {
                 <RovingFocus.Root orientation="vertical" loop>
                   <ul>
                     {tags.map((tag) => (
-                    <li
-                      key={tag?.key ?? ''}
-                      className={`flex items-center py-1 px-1 gap-2 rounded hover:bg-gray-100 ${
-                        tagsFilter === tag?.key ? 'bg-secondary-hover' : ''
-                      }`}
-                    >
+                      <li
+                        key={tag?.key ?? ''}
+                        className={`flex items-center py-1 px-1 gap-2 rounded hover:bg-gray-100 ${
+                          tagsFilter === tag?.key ? 'bg-secondary-hover' : ''
+                        }`}
+                      >
                         <RovingFocus.Item asChild>
                           <button
                             type="button"
@@ -177,45 +185,43 @@ const SelectAssistantPage = () => {
                   //     grid-template-columns: repeat(auto-fill, minmax(max(var(--max-item-width), calc((100% - var(--gap) * (var(--rows) - 1)) / var(--rows))), 1fr));
                 }
                 <div className="grid grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(max(300px,calc((100%-1rem*2)/3)),1fr))] m-auto">
-                  {availableAssistants
-                    .filter(filterWithSearch)
-                    .filter(filterWithTags)
-                    .sort(
-                      ordering === 'lastused'
-                        ? (a, b) =>
-                            (b.lastUsed ?? '1970-01-01').localeCompare(a.lastUsed ?? '1970-01-01')
-                        : (a, b) => a.name.localeCompare(b.name)
-                    )
-                    .map((assistant) => {
-                      return (
-                        <button
-                          type="button"
-                          key={assistant.id}
-                          className="flex gap-3 py-2 px-4 border text-left w-full overflow-hidden h-18 group"
-                          onClick={() => handleSelect(assistant)}
-                        >
-                          <AssistantAvatar
-                            className="shrink-0 self-center"
-                            size="big"
-                            assistant={assistant}
-                          />
-                          <span className="flex flex-col flex-1 h-full overflow-hidden">
-                            <span className="font-bold truncate">{assistant.name}</span>
-                            <span className="opacity-50 overflow-hidden text-ellipsis line-clamp-2 leading-[1.2rem] h-[2.4rem]">
-                              {assistant.description}
-                            </span>
-                            <span className="flex flex-row flex-wrap gap-1 pt-1">
-                              {assistant.tags.map((tag) => (
-                                <Badge key={tag ?? ''} variant="outline">
-                                  {tag}
-                                </Badge>
-                              ))}
-                            </span>
+                  {availableAssistants.map((assistant) => {
+                    return (
+                      <button
+                        type="button"
+                        key={assistant.id}
+                        className="flex gap-3 py-2 px-4 border text-left w-full overflow-hidden h-18 group"
+                        onClick={() => handleSelect(assistant)}
+                      >
+                        <AssistantAvatar
+                          className="shrink-0 self-center"
+                          size="big"
+                          assistant={assistant}
+                        />
+                        <span className="flex flex-col flex-1 h-full overflow-hidden">
+                          <span className="font-bold truncate">{assistant.name}</span>
+                          <span className="opacity-50 overflow-hidden text-ellipsis line-clamp-2 leading-[1.2rem] h-[2.4rem]">
+                            {assistant.description}
                           </span>
-                        </button>
-                      )
-                    })}
+                          <span className="flex flex-row flex-wrap gap-1 pt-1">
+                            {assistant.tags.map((tag) => (
+                              <Badge key={tag ?? ''} variant="outline">
+                                {tag}
+                              </Badge>
+                            ))}
+                          </span>
+                        </span>
+                      </button>
+                    )
+                  })}
                 </div>
+                {hasMore && (
+                  <div className="flex justify-center py-4">
+                    <Button disabled={isValidating} onClick={() => setSize(size + 1)}>
+                      {t('load_more')}
+                    </Button>
+                  </div>
+                )}
               </ScrollArea>
             </div>
           </div>

--- a/apps/frontend/locales/en/logicle.json
+++ b/apps/frontend/locales/en/logicle.json
@@ -321,6 +321,7 @@
   "label": "Label",
   "knowledge": "Knowledge",
   "language": "Language",
+  "load_more": "Load more",
   "last-12-months": "Last 12 months",
   "last-30-days": "Last 30 days",
   "last-7-days": "Last 7 days",

--- a/apps/frontend/locales/it/logicle.json
+++ b/apps/frontend/locales/it/logicle.json
@@ -321,6 +321,7 @@
   "label": "Etichetta",
   "knowledge": "Conoscenza",
   "language": "Lingua",
+  "load_more": "Carica altro",
   "last-12-months": "Ultimi 12 mesi",
   "last-30-days": "Ultimi 30 giorni",
   "last-7-days": "Ultimi 7 giorni",

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -1833,6 +1833,20 @@ paths:
                   $ref: "#/components/schemas/AssistantWithOwner"
       security:
         - bearerAuth: []
+  /api/me/assistants/search:
+    get:
+      summary: Search published assistants
+      description: Search published assistants visible to the current user with
+        cursor-style pagination.
+      responses:
+        "200":
+          description: Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssistantSearchResponse"
+      security:
+        - bearerAuth: []
   /api/me/folders/{folderId}/conversations:
     get:
       summary: List folder conversations
@@ -5147,6 +5161,28 @@ components:
         - provisioned
       additionalProperties: false
       id: AssistantWithOwner
+    AssistantSearchResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/UserAssistant"
+        limit:
+          type: number
+        offset:
+          type: number
+        nextOffset:
+          anyOf:
+            - type: number
+            - type: "null"
+      required:
+        - items
+        - limit
+        - offset
+        - nextOffset
+      additionalProperties: false
+      id: AssistantSearchResponse
     ConversationFolder:
       type: object
       properties:

--- a/packages/core/src/types/dto/assistant.ts
+++ b/packages/core/src/types/dto/assistant.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod'
-import { Sharing } from './sharing'
 import { iso8601UtcDateTimeSchema } from './common'
 
 export const assistantFileSchema = z.object({
@@ -237,3 +236,12 @@ export const userAssistantWithMediaSchema = userAssistantSchema.extend({
 }).meta({ id: 'UserAssistantWithMedia' })
 
 export type UserAssistantWithSupportedMedia = z.infer<typeof userAssistantWithMediaSchema>
+
+export const assistantSearchResponseSchema = z.object({
+  items: z.array(userAssistantSchema),
+  limit: z.number(),
+  offset: z.number(),
+  nextOffset: z.number().nullable(),
+}).meta({ id: 'AssistantSearchResponse' })
+
+export type AssistantSearchResponse = z.infer<typeof assistantSearchResponseSchema>


### PR DESCRIPTION
## Summary
Adds a paginated assistant search API and updates the high-cardinality assistant picker flows to use server-side search with incremental loading, so large assistant catalogs do not have to be fetched and filtered entirely on the client.

## Details
- Adds `/api/me/assistants/search` with `search`, `tag`, `orderBy`, `limit`, `offset`, `ids`, and `excludeIds` query support.
- Reuses existing assistant access rules and returns the same `UserAssistant` shape inside a paginated response.
- Updates the main assistant picker to request pages via `useSWRInfinite`, server-side search/tag/order, and a `Load more` control.
- Updates sub-assistant selection to search/load candidates lazily and resolve currently selected assistants by ID instead of loading every assistant.
- Regenerates backend route manifest and OpenAPI spec.

## Tests
- `npm run generate:backend-route-manifest`
- `npm run generate:openapi`
- `npx biome check apps/backend/api/me/assistants/search/route.ts apps/backend/models/assistant.ts apps/frontend/app/chat/assistants/select/page.tsx apps/frontend/app/assistants/components/AddAssistantDialog.tsx apps/frontend/app/assistants/components/ToolsTabPanel.tsx packages/core/src/types/dto/assistant.ts apps/frontend/locales/en/logicle.json apps/frontend/locales/it/logicle.json`
- `npm run check-types` currently fails on pre-existing AI SDK provider-tool type errors in `__tests__/prepareTools.test.ts` and `apps/backend/lib/chat/litellm/litellm-prepare-tools.ts`.
