### PR TITLE
Add admin feedback export API

### DIFF
--- a/apps/backend/api/feedbacks/route.ts
+++ b/apps/backend/api/feedbacks/route.ts
@@ -1,0 +1,125 @@
+import { db } from '@/db/database'
+import { errorSpec, ok, operation, responseSpec } from '@/lib/routes'
+import { z } from 'zod'
+
+export const dynamic = 'force-dynamic'
+
+const feedbackQuerySchema = z.object({
+  feedback: z.enum(['like', 'dislike']).optional(),
+  assistantIds: z.string().optional(),
+  conversationIds: z.string().optional(),
+  userIds: z.string().optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+})
+
+const feedbackRecordSchema = z.object({
+  messageId: z.string(),
+  conversationId: z.string(),
+  assistantId: z.string(),
+  assistantName: z.string().nullable(),
+  userId: z.string(),
+  feedback: z.enum(['like', 'dislike']),
+  comment: z.string().nullable(),
+  messageRole: z.string(),
+  messageContent: z.string(),
+  messageSentAt: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+const feedbackSearchResponseSchema = z.object({
+  items: feedbackRecordSchema.array(),
+  limit: z.number(),
+  offset: z.number(),
+  nextOffset: z.number().nullable(),
+})
+
+const parseIds = (value: string | undefined): string[] =>
+  value
+    ?.split(',')
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0) ?? []
+
+export const GET = operation({
+  name: 'List message feedbacks',
+  description: 'List and filter thumbs up/down feedback left on assistant messages for reporting.',
+  authentication: 'admin',
+  querySchema: feedbackQuerySchema,
+  responses: [responseSpec(200, feedbackSearchResponseSchema), errorSpec(400)] as const,
+  implementation: async ({ query }) => {
+    const limit = query.limit ?? 100
+    const offset = query.offset ?? 0
+    const assistantIds = parseIds(query.assistantIds)
+    const conversationIds = parseIds(query.conversationIds)
+    const userIds = parseIds(query.userIds)
+
+    let feedbackQuery = db
+      .selectFrom('MessageFeedback')
+      .innerJoin('Message', 'Message.id', 'MessageFeedback.messageId')
+      .innerJoin('Conversation', 'Conversation.id', 'Message.conversationId')
+      .leftJoin('Assistant', 'Assistant.id', 'Conversation.assistantId')
+      .leftJoin('AssistantVersion', 'AssistantVersion.id', 'Assistant.publishedVersionId')
+      .select([
+        'MessageFeedback.messageId',
+        'MessageFeedback.userId',
+        'MessageFeedback.positive',
+        'MessageFeedback.comment',
+        'MessageFeedback.createdAt',
+        'MessageFeedback.updatedAt',
+        'Message.conversationId',
+        'Message.role as messageRole',
+        'Message.content as messageContent',
+        'Message.sentAt as messageSentAt',
+        'Conversation.assistantId',
+        'AssistantVersion.name as assistantName',
+      ])
+      .orderBy('MessageFeedback.updatedAt', 'desc')
+      .offset(offset)
+      .limit(limit + 1)
+
+    if (query.feedback) {
+      feedbackQuery = feedbackQuery.where('MessageFeedback.positive', '=', query.feedback === 'like' ? 1 : 0)
+    }
+    if (assistantIds.length > 0) {
+      feedbackQuery = feedbackQuery.where('Conversation.assistantId', 'in', assistantIds)
+    }
+    if (conversationIds.length > 0) {
+      feedbackQuery = feedbackQuery.where('Message.conversationId', 'in', conversationIds)
+    }
+    if (userIds.length > 0) {
+      feedbackQuery = feedbackQuery.where('MessageFeedback.userId', 'in', userIds)
+    }
+    if (query.from) {
+      feedbackQuery = feedbackQuery.where('MessageFeedback.createdAt', '>=', query.from)
+    }
+    if (query.to) {
+      feedbackQuery = feedbackQuery.where('MessageFeedback.createdAt', '<', query.to)
+    }
+
+    const rows = await feedbackQuery.execute()
+    const items = rows.slice(0, limit).map((row) => ({
+      messageId: row.messageId,
+      conversationId: row.conversationId,
+      assistantId: row.assistantId,
+      assistantName: row.assistantName ?? null,
+      userId: row.userId,
+      feedback: (row.positive ? 'like' : 'dislike') as 'like' | 'dislike',
+      comment: row.comment,
+      messageRole: row.messageRole,
+      messageContent: row.messageContent,
+      messageSentAt: row.messageSentAt,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    }))
+
+    return ok({
+      items,
+      limit,
+      offset,
+      nextOffset: rows.length > limit ? offset + limit : null,
+    })
+  },
+})

--- a/apps/backend/lib/router/routes.generated.ts
+++ b/apps/backend/lib/router/routes.generated.ts
@@ -46,6 +46,7 @@ export const backendRouteModules = [
   { pathname: '/api/conversations/[conversationId]/share', load: () => import('@/backend/api/conversations/[conversationId]/share/route') },
   { pathname: '/api/conversations', load: () => import('@/backend/api/conversations/route') },
   { pathname: '/api/conversations/search', load: () => import('@/backend/api/conversations/search/route') },
+  { pathname: '/api/feedbacks', load: () => import('@/backend/api/feedbacks/route') },
   { pathname: '/api/files/[fileId]/analysis', load: () => import('@/backend/api/files/[fileId]/analysis/route') },
   { pathname: '/api/files/[fileId]/content', load: () => import('@/backend/api/files/[fileId]/content/route') },
   { pathname: '/api/files/images', load: () => import('@/backend/api/files/images/route') },

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -1444,6 +1444,87 @@ paths:
           $ref: "#/components/responses/Error"
       security:
         - bearerAuth: []
+  /api/feedbacks:
+    get:
+      summary: List message feedbacks
+      description: List and filter thumbs up/down feedback left on assistant messages
+        for reporting.
+      responses:
+        "200":
+          description: Response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        messageId:
+                          type: string
+                        conversationId:
+                          type: string
+                        assistantId:
+                          type: string
+                        assistantName:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        userId:
+                          type: string
+                        feedback:
+                          type: string
+                          enum:
+                            - like
+                            - dislike
+                        comment:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        messageRole:
+                          type: string
+                        messageContent:
+                          type: string
+                        messageSentAt:
+                          type: string
+                        createdAt:
+                          type: string
+                        updatedAt:
+                          type: string
+                      required:
+                        - messageId
+                        - conversationId
+                        - assistantId
+                        - assistantName
+                        - userId
+                        - feedback
+                        - comment
+                        - messageRole
+                        - messageContent
+                        - messageSentAt
+                        - createdAt
+                        - updatedAt
+                      additionalProperties: false
+                  limit:
+                    type: number
+                  offset:
+                    type: number
+                  nextOffset:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                required:
+                  - items
+                  - limit
+                  - offset
+                  - nextOffset
+                additionalProperties: false
+        "400":
+          $ref: "#/components/responses/Error"
+      security:
+        - bearerAuth: []
   /api/files/{fileId}/analysis:
     get:
       summary: Get file analysis


### PR DESCRIPTION
## Summary
Adds an admin-only API endpoint for extracting thumbs up/down message feedback for reporting and assistant response evaluation workflows.

## Details
- Adds `GET /api/feedbacks` with filters for `feedback`, `assistantIds`, `conversationIds`, `userIds`, `from`, and `to`.
- Supports paginated extraction via `limit`, `offset`, and `nextOffset`.
- Returns message, conversation, assistant, user, feedback, comment, and timestamp context so downstream systems can evaluate the response that received feedback.
- Regenerates backend route manifest and OpenAPI spec.

## Tests
- `npm run generate:backend-route-manifest`
- `npm run generate:openapi`
- `npx biome check apps/backend/api/feedbacks/route.ts`
- `npm run check-types` currently fails on pre-existing AI SDK provider-tool type errors in `__tests__/prepareTools.test.ts` and `apps/backend/lib/chat/litellm/litellm-prepare-tools.ts`.
