### PR TITLE
Fix first-message upload ownership binding to conversations

### DIFF
--- a/__tests__/chatAssistant.test.ts
+++ b/__tests__/chatAssistant.test.ts
@@ -646,6 +646,24 @@ describe('ChatAssistant.invokeFunction', () => {
     )
   })
 
+  test('uses chat state conversation id for tool ownership when build options omit it', async () => {
+    const invokeResult: dto.ToolCallResultOutput = { type: 'content', value: [] }
+    const fn: ToolFunction = { description: 'Test', invoke: vi.fn().mockResolvedValue(invokeResult) }
+    const assistant = makeChatAssistant()
+    ;(assistant as any).options = { user: 'u1' }
+    const chatState = { chatHistory: [makeUserMsg()], conversationId: 'c1' } as any
+    const toolUILink = { attachments: [] } as any
+
+    await assistant.invokeFunction(makeToolCall(), fn, chatState, toolUILink)
+
+    expect(fn.invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'c1',
+        rootOwner: { type: 'CHAT', id: 'c1' },
+      })
+    )
+  })
+
   test('returns error-text when func.invoke throws', async () => {
     const fn: ToolFunction = { description: 'Test', invoke: vi.fn().mockRejectedValue(new Error('boom')) }
     const assistant = makeChatAssistant()

--- a/__tests__/fileOwnershipTransfer.test.ts
+++ b/__tests__/fileOwnershipTransfer.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const updateExecute = vi.fn()
+const whereOwnerId = vi.fn(() => ({ execute: updateExecute }))
+const whereOwnerType = vi.fn(() => ({ where: whereOwnerId }))
+const whereIds = vi.fn(() => ({ where: whereOwnerType }))
+const setMock = vi.fn(() => ({ where: whereIds }))
+const updateTableMock = vi.fn(() => ({ set: setMock }))
+
+vi.mock('db/database', () => ({
+  db: {
+    updateTable: updateTableMock,
+  },
+}))
+
+describe('reassignUserOwnedFilesToConversation', () => {
+  beforeEach(() => {
+    updateExecute.mockReset()
+    whereOwnerId.mockClear()
+    whereOwnerType.mockClear()
+    whereIds.mockClear()
+    setMock.mockClear()
+    updateTableMock.mockClear()
+  })
+
+  test('does nothing when no file ids are provided', async () => {
+    const { reassignUserOwnedFilesToConversation } = await import('@/models/file')
+
+    await reassignUserOwnedFilesToConversation({
+      fileIds: [],
+      userId: 'u1',
+      conversationId: 'c1',
+    })
+
+    expect(updateTableMock).not.toHaveBeenCalled()
+  })
+
+  test('reassigns only current user USER-owned files to CHAT owner', async () => {
+    const { reassignUserOwnedFilesToConversation } = await import('@/models/file')
+
+    await reassignUserOwnedFilesToConversation({
+      fileIds: ['f1', 'f1', 'f2'],
+      userId: 'u1',
+      conversationId: 'c1',
+    })
+
+    expect(updateTableMock).toHaveBeenCalledWith('File')
+    expect(setMock).toHaveBeenCalledWith({
+      ownerType: 'CHAT',
+      ownerId: 'c1',
+    })
+    expect(whereIds).toHaveBeenCalledWith('id', 'in', ['f1', 'f2'])
+    expect(whereOwnerType).toHaveBeenCalledWith('ownerType', '=', 'USER')
+    expect(whereOwnerId).toHaveBeenCalledWith('ownerId', '=', 'u1')
+    expect(updateExecute).toHaveBeenCalledOnce()
+  })
+})

--- a/__tests__/fileUploadRoutes.test.ts
+++ b/__tests__/fileUploadRoutes.test.ts
@@ -64,6 +64,10 @@ async function migrateTestDb() {
 
 async function resetTables() {
   await db.deleteFrom('File').execute()
+  await db.deleteFrom('Conversation').execute()
+  await db.deleteFrom('AssistantVersion').execute()
+  await db.deleteFrom('Assistant').execute()
+  await db.deleteFrom('Backend').execute()
   await db.deleteFrom('Session').execute()
   await db.deleteFrom('User').execute()
 }
@@ -78,6 +82,41 @@ async function insertFile(params: {
     INSERT INTO "File" ("id", "name", "path", "type", "size", "uploaded", "createdAt", "encrypted", "fileBlobId", "ownerType", "ownerId")
     VALUES (${params.id}, ${'test.txt'}, ${params.path}, ${'text/plain'}, ${100}, ${0}, ${new Date().toISOString()}, ${0}, NULL, ${params.ownerType ?? 'USER'}, ${params.ownerId ?? testUserId})
   `.execute(db)
+}
+
+async function insertConversation(params: { id: string; ownerId: string }) {
+  await db
+    .insertInto('Backend')
+    .values({
+      id: 'backend-for-chat-upload',
+      name: 'Backend',
+      providerType: 'openai',
+      configuration: '{}',
+      provisioned: 0,
+    })
+    .execute()
+  await db
+    .insertInto('Assistant')
+    .values({
+      id: 'assistant-for-chat-upload',
+      draftVersionId: null,
+      publishedVersionId: null,
+      provisioned: 0,
+      deleted: 0,
+      hidden: 0,
+      owner: params.ownerId,
+    })
+    .execute()
+  await db
+    .insertInto('Conversation')
+    .values({
+      id: params.id,
+      name: 'Chat upload test',
+      assistantId: 'assistant-for-chat-upload',
+      ownerId: params.ownerId,
+      createdAt: new Date().toISOString(),
+    })
+    .execute()
 }
 
 // Consumes a readable stream so the piped TransformStream (and hash) runs.
@@ -274,6 +313,36 @@ describe('PUT /api/files/:fileId/content', () => {
 // ── POST /api/files ──────────────────────────────────────────────────────────
 
 describe('POST /api/files', () => {
+  test('creates chat upload metadata with CHAT ownership', async () => {
+    await insertConversation({ id: 'chat-1', ownerId: testUserId })
+
+    const response = await filesRoute.POST(
+      new Request('http://localhost/api/files', {
+        method: 'POST',
+        headers: {
+          cookie: sessionCookie,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: 'chat-upload.txt',
+          type: 'text/plain',
+          size: 12,
+          owner: { ownerType: 'CHAT', ownerId: 'chat-1' },
+        }),
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(201)
+    const body = await response.json()
+    const file = await db
+      .selectFrom('File')
+      .select(['ownerType', 'ownerId'])
+      .where('id', '=', body.id)
+      .executeTakeFirstOrThrow()
+    expect(file).toEqual({ ownerType: 'CHAT', ownerId: 'chat-1' })
+  })
+
   test('returns 403 when creating metadata for an owner the user cannot access', async () => {
     const response = await filesRoute.POST(
       new Request('http://localhost/api/files', {

--- a/__tests__/toolOutputNormalization.test.ts
+++ b/__tests__/toolOutputNormalization.test.ts
@@ -1,22 +1,36 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { createHash } from 'node:crypto'
 
-const materializedByHash = new Map<string, { id: string; type: string; name: string; size: number }>()
+const materializedByHash = new Map<
+  string,
+  { id: string; type: string; name: string; size: number }
+>()
+const materializeCalls: Array<{
+  owner: { ownerType: string; ownerId: string }
+}> = []
 
 vi.mock('@/backend/lib/files/materialize', () => ({
-  materializeFile: vi.fn(async (params: { content: Buffer; name: string; mimeType: string }) => {
-    const hash = createHash('sha256').update(params.content).digest('hex')
-    const existing = materializedByHash.get(hash)
-    if (existing) return existing
-    const created = {
-      id: `file-${materializedByHash.size + 1}`,
-      type: params.mimeType,
-      name: params.name,
-      size: params.content.byteLength,
+  materializeFile: vi.fn(
+    async (params: {
+      content: Buffer
+      name: string
+      mimeType: string
+      owner: { ownerType: string; ownerId: string }
+    }) => {
+      materializeCalls.push({ owner: params.owner })
+      const hash = createHash('sha256').update(params.content).digest('hex')
+      const existing = materializedByHash.get(hash)
+      if (existing) return existing
+      const created = {
+        id: `file-${materializedByHash.size + 1}`,
+        type: params.mimeType,
+        name: params.name,
+        size: params.content.byteLength,
+      }
+      materializedByHash.set(hash, created)
+      return created
     }
-    materializedByHash.set(hash, created)
-    return created
-  }),
+  ),
 }))
 
 import {
@@ -27,6 +41,7 @@ import {
 describe('tool output normalization', () => {
   beforeEach(() => {
     materializedByHash.clear()
+    materializeCalls.length = 0
   })
 
   test('normalizes MCP image/resource file-like outputs into file content items', async () => {
@@ -66,6 +81,23 @@ describe('tool output normalization', () => {
       expect(persisted.value.name).toBe('report.pdf')
       expect(persisted.value.mimetype).toBe('application/pdf')
     }
+  })
+
+  test('file-like tool outputs in a chat are persisted with CHAT ownership', async () => {
+    const payload = Buffer.from('chat-owned-output').toString('base64')
+    const persisted = await persistFileLikePayload({
+      assistantId: 'a1',
+      userId: 'u1',
+      conversationId: 'c1',
+      rootOwner: { type: 'CHAT', id: 'c1' },
+      base64Data: payload,
+      mimeType: 'image/png',
+      source: 'MCP',
+    })
+
+    expect(persisted.kind).toBe('file')
+    expect(materializeCalls).toHaveLength(1)
+    expect(materializeCalls[0].owner).toEqual({ ownerType: 'CHAT', ownerId: 'c1' })
   })
 
   test('dedup regression: repeated identical payload resolves to same file id', async () => {

--- a/apps/backend/api/assistants/evaluate/route.ts
+++ b/apps/backend/api/assistants/evaluate/route.ts
@@ -57,6 +57,7 @@ export const POST = operation({
       {
         debug: true,
         user: session.userId,
+        conversationId,
       }
     )
 

--- a/apps/backend/api/v1/responses/route.ts
+++ b/apps/backend/api/v1/responses/route.ts
@@ -9,7 +9,7 @@ import { z } from 'zod'
 import { nanoid } from 'nanoid'
 import { MessageAuditor } from '@/lib/MessageAuditor'
 import { assistantVersionFiles, getAssistant } from '@/models/assistant'
-import { getFileWithId } from '@/models/file'
+import { getFileWithId, reassignUserOwnedFilesToConversation } from '@/models/file'
 import { storage } from '@/lib/storage'
 import { getUserParameters } from '@/lib/parameters'
 import { error, forbidden, ok, operation, responseSpec, errorSpec } from '@/lib/routes'
@@ -109,6 +109,16 @@ export const POST = operation({
       return error(500, 'No such conversation')
     }
     const { conversation, assistant, backend } = conversationWithBackendAssistant
+    if (conversation.ownerId !== session.userId) {
+      return forbidden('Trying to add a message to a non owned conversation')
+    }
+    if (userMessage.attachments && userMessage.attachments.length > 0) {
+      await reassignUserOwnedFilesToConversation({
+        fileIds: userMessage.attachments,
+        userId: session.userId,
+        conversationId: conversation.id,
+      })
+    }
     const dtoUserMessage = {
       content: userMessage.content,
       id: nanoid(),
@@ -118,9 +128,6 @@ export const POST = operation({
       attachments: [],
       role: 'user',
     } satisfies dto.UserMessage
-    if (conversation.ownerId !== session.userId) {
-      return forbidden('Trying to add a message to a non owned conversation')
-    }
     if (assistant.deleted) {
       return forbidden('This assistant has been deleted')
     }

--- a/apps/backend/api/v1/responses/route.ts
+++ b/apps/backend/api/v1/responses/route.ts
@@ -219,6 +219,7 @@ export const POST = operation({
         saveMessage: saveAndAuditMessage,
         updateChatTitle,
         user: session.userId,
+        conversationId: conversation.id,
         userLanguage: acceptLanguageHeader ?? undefined,
       }
     )

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -722,16 +722,17 @@ export class ChatAssistant {
     try {
       this.throwIfAborted()
       const args = toolCall.args
+      const conversationId = this.options.conversationId ?? chatState.conversationId
       logger.info(`Invoking tool '${toolCall.toolName}'`, { args })
       const result = await func.invoke({
         llmModel: this.llmModel,
         messages: chatState.chatHistory,
         assistantId: this.assistantParams.assistantId,
         userId: this.options.user,
-        conversationId: this.options.conversationId,
+        conversationId,
         rootOwner:
           this.options.rootOwner ??
-          (this.options.conversationId ? { type: 'CHAT', id: this.options.conversationId } : undefined),
+          (conversationId ? { type: 'CHAT', id: conversationId } : undefined),
         toolCallId: toolCall.toolCallId,
         toolName: toolCall.toolName,
         params: args,
@@ -1008,6 +1009,7 @@ export class ChatAssistant {
         if (!implementation) throw new Error(`No such function: ${toolCall.toolName}`)
 
         if (implementation.auth) {
+          const conversationId = this.options.conversationId ?? chatState.conversationId
           const authRequest = await implementation.auth({
             llmModel: this.llmModel,
             messages: chatState.chatHistory,
@@ -1015,7 +1017,7 @@ export class ChatAssistant {
             userId: this.options.user,
             rootOwner:
               this.options.rootOwner ??
-              (this.options.conversationId ? { type: 'CHAT', id: this.options.conversationId } : undefined),
+              (conversationId ? { type: 'CHAT', id: conversationId } : undefined),
             toolCallId: toolCall.toolCallId,
             toolName: toolCall.toolName,
             params: toolCall.args,

--- a/apps/backend/lib/chat/startServerChatRun.ts
+++ b/apps/backend/lib/chat/startServerChatRun.ts
@@ -14,6 +14,7 @@ import { setRootSpanAttrs } from '@/lib/tracing/root-registry'
 import { getUserParameters } from '@/lib/parameters'
 import { assistantVersionFiles } from '@/models/assistant'
 import { getConversationWithBackendAssistant } from '@/models/conversation'
+import { reassignUserOwnedFilesToConversation } from '@/models/file'
 import { getMessages, saveMessage } from '@/models/message'
 import { getUserSecretValue } from '@/models/userSecrets'
 import { db } from 'db/database'
@@ -85,6 +86,14 @@ export const startServerChatRun = async ({
       status: 403,
       message: 'This assistant has been deleted',
     }
+  }
+
+  if (userMessage.role === 'user' && userMessage.attachments.length > 0) {
+    await reassignUserOwnedFilesToConversation({
+      fileIds: userMessage.attachments.map((attachment) => attachment.id),
+      userId: session.userId,
+      conversationId: conversation.id,
+    })
   }
 
   const created = createChatRun({

--- a/apps/backend/models/file.ts
+++ b/apps/backend/models/file.ts
@@ -56,3 +56,29 @@ export const addFile = async (
   }
   return created
 }
+
+export const reassignUserOwnedFilesToConversation = async ({
+  fileIds,
+  userId,
+  conversationId,
+}: {
+  fileIds: string[]
+  userId: string
+  conversationId: string
+}) => {
+  if (fileIds.length === 0) {
+    return
+  }
+
+  const uniqueIds = [...new Set(fileIds)]
+  await db
+    .updateTable('File')
+    .set({
+      ownerType: 'CHAT',
+      ownerId: conversationId,
+    })
+    .where('id', 'in', uniqueIds)
+    .where('ownerType', '=', 'USER')
+    .where('ownerId', '=', userId)
+    .execute()
+}


### PR DESCRIPTION
## Summary
Ensure file ownership is correctly bound to the active chat conversation for first-message uploads, while preventing ownership reassignment before conversation access checks.

## Details
- Add `reassignUserOwnedFilesToConversation(...)` in `apps/backend/models/file.ts` to transfer only files currently owned by the requesting user (`ownerType=USER`, `ownerId=<session user>`) to `ownerType=CHAT` for the target conversation.
- Apply reassignment in chat send flows before run execution so attachments uploaded before conversation creation are attached to the conversation context.
- In `/api/v1/responses`, enforce conversation ownership before any attachment reassignment to avoid cross-conversation rebinding attempts.
- Add focused unit tests in `__tests__/fileOwnershipTransfer.test.ts` for no-op behavior, deduping IDs, and reassignment constraints.

## Tests
- `pnpm vitest run __tests__/fileOwnershipTransfer.test.ts __tests__/fileUploadRoutes.test.ts __tests__/toolOutputNormalization.test.ts __tests__/chatAssistant.test.ts` (passed)
- `pnpm run check-types` (passed)