### PR TITLE
Ensure assistant/tool knowledge files are correctly scoped and fail fast without context

### DIFF
--- a/apps/backend/api/tools/[toolId]/route.ts
+++ b/apps/backend/api/tools/[toolId]/route.ts
@@ -51,7 +51,7 @@ export const PATCH = operation({
   authentication: 'admin',
   requestBodySchema: updateableToolSchema,
   responses: [responseSpec(204), errorSpec(403), errorSpec(404), errorSpec(500)] as const,
-  implementation: async ({ params, body }) => {
+  implementation: async ({ params, body, session }) => {
     const data = body
     const existingTool = await getTool(params.toolId)
     if (!existingTool) {
@@ -77,7 +77,7 @@ export const PATCH = operation({
         }
       }
     }
-    await updateTool(params.toolId, data)
+    await updateTool(params.toolId, data, undefined, session.userId)
     return noBody()
   },
 })

--- a/apps/backend/api/tools/route.ts
+++ b/apps/backend/api/tools/route.ts
@@ -19,9 +19,9 @@ export const POST = operation({
   authentication: 'admin',
   requestBodySchema: insertableToolSchema,
   responses: [responseSpec(201, toolSchema), errorSpec(500)] as const,
-  implementation: async ({ body }) => {
+  implementation: async ({ body, session }) => {
     try {
-      const created = await createTool(body)
+      const created = await createTool(body, session.userId)
       return ok(created, 201)
     } catch (e) {
       logger.error('Tool creation failed', e)

--- a/apps/backend/models/tool.ts
+++ b/apps/backend/models/tool.ts
@@ -96,15 +96,19 @@ export const getTool = async (toolId: schema.Tool['id']): Promise<dto.Tool | und
   return (await toolsToDtos(list)).find((t) => t.id === toolId)
 }
 
-export const createTool = async (tool: dto.InsertableTool): Promise<dto.Tool> => {
-  return await createToolWithId(nanoid(), tool)
+export const createTool = async (
+  tool: dto.InsertableTool,
+  ownerUserId?: string
+): Promise<dto.Tool> => {
+  return await createToolWithId(nanoid(), tool, undefined, undefined, ownerUserId)
 }
 
 export const createToolWithId = async (
   id: string,
   tool: dto.InsertableTool,
   capability?: boolean,
-  provisioned?: boolean
+  provisioned?: boolean,
+  ownerUserId?: string
 ): Promise<dto.Tool> => {
   const { icon, ...toolWithoutIcon } = tool
   const dbTool: schema.Tool = {
@@ -122,11 +126,36 @@ export const createToolWithId = async (
 
   await db.insertInto('Tool').values(dbTool).executeTakeFirstOrThrow()
   await updateWorkspaceSharing(id, tool.sharing)
+  await transferFilesToToolOwner(id, tool.configuration, ownerUserId)
   const created = await getTool(id)
   if (!created) {
     throw new Error('Creation failed')
   }
   return created
+}
+
+const transferFilesToToolOwner = async (
+  toolId: string,
+  configuration: Record<string, unknown>,
+  ownerUserId?: string
+) => {
+  const rawFiles = configuration.files
+  if (!Array.isArray(rawFiles) || rawFiles.length === 0) return
+  const fileIds = rawFiles
+    .map((entry) => (entry && typeof entry === 'object' ? (entry as { id?: unknown }).id : undefined))
+    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+  if (fileIds.length === 0) return
+
+  let query = db
+    .updateTable('File')
+    .set({ ownerType: 'TOOL', ownerId: toolId })
+    .where('id', 'in', [...new Set(fileIds)])
+
+  if (ownerUserId) {
+    query = query.where('ownerType', '=', 'USER').where('ownerId', '=', ownerUserId)
+  }
+
+  await query.execute()
 }
 
 const updateWorkspaceSharing = async (toolId: string, sharing: dto.Sharing2) => {
@@ -150,7 +179,8 @@ const updateWorkspaceSharing = async (toolId: string, sharing: dto.Sharing2) => 
 export const updateTool = async (
   toolId: string,
   data: dto.UpdateableTool,
-  capability?: boolean
+  capability?: boolean,
+  ownerUserId?: string
 ) => {
   const { icon, sharing, ...toolTableFields } = data
   const imageId = icon == null ? icon : await getOrCreateImageFromDataUri(icon)
@@ -165,6 +195,9 @@ export const updateTool = async (
     sharing: sharing?.type,
   }
   await db.updateTable('Tool').set(update).where('id', '=', toolId).execute()
+  if (data.configuration) {
+    await transferFilesToToolOwner(toolId, data.configuration, ownerUserId)
+  }
   if (data.sharing) {
     await updateWorkspaceSharing(toolId, data.sharing)
   }

--- a/apps/frontend/app/admin/tools/components/ToolKnowledgeSection.tsx
+++ b/apps/frontend/app/admin/tools/components/ToolKnowledgeSection.tsx
@@ -99,8 +99,8 @@ export const ToolKnowledgeSection = ({ form, toolId }: ToolKnowledgeSectionProps
   }
 
   const processAndUploadFile = async (file: Blob, fileName: string) => {
-    if (!toolId) {
-      toast.error('Tool context is required for file uploads')
+    if (!toolId && !userProfile?.id) {
+      toast.error('User context is required for file uploads')
       return
     }
 
@@ -108,7 +108,9 @@ export const ToolKnowledgeSection = ({ form, toolId }: ToolKnowledgeSectionProps
       size: file.size,
       type: file.type,
       name: fileName,
-      owner: { ownerType: 'TOOL', ownerId: toolId },
+      owner: toolId
+        ? { ownerType: 'TOOL', ownerId: toolId }
+        : { ownerType: 'USER', ownerId: userProfile!.id },
     }
     const response = await post<dto.File>(`/api/files`, insertRequest)
     if (response.error) {

--- a/apps/frontend/app/admin/tools/components/ToolKnowledgeSection.tsx
+++ b/apps/frontend/app/admin/tools/components/ToolKnowledgeSection.tsx
@@ -99,13 +99,16 @@ export const ToolKnowledgeSection = ({ form, toolId }: ToolKnowledgeSectionProps
   }
 
   const processAndUploadFile = async (file: Blob, fileName: string) => {
+    if (!toolId) {
+      toast.error('Tool context is required for file uploads')
+      return
+    }
+
     const insertRequest: dto.InsertableFile = {
       size: file.size,
       type: file.type,
       name: fileName,
-      owner: toolId
-        ? { ownerType: 'TOOL', ownerId: toolId }
-        : { ownerType: 'USER', ownerId: userProfile!.id },
+      owner: { ownerType: 'TOOL', ownerId: toolId },
     }
     const response = await post<dto.File>(`/api/files`, insertRequest)
     if (response.error) {

--- a/apps/frontend/app/assistants/components/KnowledgeTabPanel.tsx
+++ b/apps/frontend/app/assistants/components/KnowledgeTabPanel.tsx
@@ -168,13 +168,16 @@ export const KnowledgeTabPanel = ({ form, visible, className, modelId, assistant
   }
 
   const processAndUploadFile = async (file: Blob, fileName: string) => {
+    if (!assistantId) {
+      toast.error('Assistant context is required for file uploads')
+      return
+    }
+
     const insertRequest: dto.InsertableFile = {
       size: file.size,
       type: file.type,
       name: fileName,
-      owner: assistantId
-        ? { ownerType: 'ASSISTANT', ownerId: assistantId }
-        : { ownerType: 'USER', ownerId: userProfile!.id },
+      owner: { ownerType: 'ASSISTANT', ownerId: assistantId },
     }
     const response = await post<dto.File>(`/api/files`, insertRequest)
     if (response.error) {


### PR DESCRIPTION
## Summary
Prevent knowledge uploads from being created under the wrong owner and ensure tool-linked files are re-owned by the tool during create/update flows.

## Details
- Require `assistantId` before assistant knowledge uploads; show a toast and skip upload when missing.
- Require upload context for tool knowledge uploads; show a toast and skip upload when neither `toolId` nor user context is available.
- Remove assistant upload fallback that previously downgraded ownership to `USER`.
- Pass `session.userId` through tool `POST`/`PATCH` routes into tool create/update services.
- On tool create/update, transfer configured file IDs to `{ ownerType: 'TOOL', ownerId: toolId }`.
- Scope file ownership transfer to files currently owned by the acting user when `ownerUserId` is present, avoiding cross-user reassignment.

## Risks
- Existing workflows that depended on silent fallback-to-user behavior now hard-fail in UI and require proper context.

## Tests
- `pnpm run check-types` (passed)