### PR TITLE
Duplicate files when cloning assistants and shared chats

### DIFF
--- a/__tests__/cloneRoutes.test.ts
+++ b/__tests__/cloneRoutes.test.ts
@@ -1,0 +1,271 @@
+import { beforeAll, beforeEach, describe, expect, test } from 'vitest'
+import { Kysely, Migrator, type Migration, PostgresAdapter, SqliteAdapter, sql } from 'kysely'
+import { db } from '@/db/database'
+import { migrationModules } from '@/db/migrations.generated'
+import { SESSION_COOKIE_NAME } from '@/lib/auth/session'
+import { createSession } from '@/models/session'
+import { createUser } from '@/models/user'
+import { createAssistant } from '@/models/assistant'
+import { createConversation } from '@/models/conversation'
+import { saveMessage } from '@/models/message'
+import * as dto from '@/types/dto'
+import * as assistantCloneRoute from '@/api/assistants/[assistantId]/clone/route'
+import * as sharedConversationCloneRoute from '@/api/share/[shareId]/clone/route'
+
+function getDialectName(client: Kysely<any>) {
+  if (client.getExecutor().adapter instanceof SqliteAdapter) return 'sqlite'
+  if (client.getExecutor().adapter instanceof PostgresAdapter) return 'postgresql'
+  return undefined
+}
+
+async function migrateTestDb() {
+  const dialectName = getDialectName(db)
+  const migrator = new Migrator({
+    db,
+    provider: {
+      getMigrations: async () =>
+        Object.fromEntries(
+          Object.entries(migrationModules).map(([name, migration]) => [
+            name,
+            {
+              up: async (client: Kysely<any>) => {
+                await (
+                  migration as { up: (db: Kysely<any>, dialect?: string) => Promise<void> }
+                ).up(client, dialectName)
+              },
+            } satisfies Migration,
+          ])
+        ),
+    },
+  })
+  const { error } = await migrator.migrateToLatest()
+  if (error) throw error
+}
+
+async function resetTables() {
+  await db.deleteFrom('ConversationSharing').execute()
+  await db.deleteFrom('Message').execute()
+  await db.deleteFrom('Conversation').execute()
+  await db.deleteFrom('AssistantVersionFile').execute()
+  await db.deleteFrom('AssistantVersionToolAssociation').execute()
+  await db.deleteFrom('AssistantVersion').execute()
+  await db.deleteFrom('AssistantSharing').execute()
+  await db.deleteFrom('Assistant').execute()
+  await db.deleteFrom('File').execute()
+  await db.deleteFrom('FileBlob').execute()
+  await db.deleteFrom('Backend').execute()
+  await db.deleteFrom('Session').execute()
+  await db.deleteFrom('User').execute()
+}
+
+async function insertBackend(id: string) {
+  await db
+    .insertInto('Backend')
+    .values({
+      id,
+      name: `Backend ${id}`,
+      providerType: 'openai',
+      configuration: '{}',
+      provisioned: 0,
+    })
+    .execute()
+}
+
+async function insertUploadedFile(params: {
+  id: string
+  ownerType: 'USER' | 'CHAT' | 'ASSISTANT' | 'TOOL'
+  ownerId: string
+  name?: string
+  type?: string
+}) {
+  const fileName = params.name ?? `${params.id}.txt`
+  const mimeType = params.type ?? 'text/plain'
+  await db
+    .insertInto('FileBlob')
+    .values({
+      id: params.id,
+      contentHash: `legacy:${params.id}`,
+      path: `files/${params.id}-${fileName}`,
+      type: mimeType,
+      size: 123,
+      encrypted: 0,
+      createdAt: new Date().toISOString(),
+    })
+    .execute()
+
+  await sql`
+    INSERT INTO "File" ("id", "name", "path", "type", "size", "uploaded", "createdAt", "encrypted", "fileBlobId", "ownerType", "ownerId")
+    VALUES (${params.id}, ${fileName}, ${`files/${params.id}-${fileName}`}, ${mimeType}, ${123}, ${1}, ${new Date().toISOString()}, ${0}, ${params.id}, ${params.ownerType}, ${params.ownerId})
+  `.execute(db)
+}
+
+const makeDraft = (backendId: string, fileIds: string[]): dto.InsertableAssistantDraft => ({
+  backendId,
+  description: 'desc',
+  model: 'gpt-4o-mini',
+  name: 'assistant',
+  versionName: null,
+  systemPrompt: 'You are helpful',
+  temperature: 0,
+  tokenLimit: 4096,
+  reasoning_effort: null,
+  tags: [],
+  prompts: [],
+  tools: [],
+  files: fileIds.map((id) => ({ id, name: `${id}.txt`, type: 'text/plain', size: 123 })),
+  iconUri: null,
+  subAssistants: [],
+})
+
+let userId: string
+let sessionCookie: string
+
+beforeAll(async () => {
+  await migrateTestDb()
+})
+
+beforeEach(async () => {
+  await resetTables()
+  await insertBackend('b1')
+
+  const user = await createUser({ name: 'Test User', email: 'clone-tests@example.com', ssoUser: 0 })
+  userId = user.id
+  const session = await createSession(user.id, new Date(Date.now() + 60_000), 'password', null)
+  sessionCookie = `${SESSION_COOKIE_NAME}=${session.id}`
+})
+
+describe('clone routes duplicate files', () => {
+  test('assistant clone duplicates assistant files into new file ids', async () => {
+    await insertUploadedFile({ id: 'f-source-assistant', ownerType: 'USER', ownerId: userId })
+    const sourceAssistant = await createAssistant(makeDraft('b1', ['f-source-assistant']), userId)
+
+    const response = await assistantCloneRoute.POST(
+      new Request(`http://localhost/api/assistants/${sourceAssistant.assistantId}/clone`, {
+        method: 'POST',
+        headers: { cookie: sessionCookie },
+      }),
+      { params: Promise.resolve({ assistantId: sourceAssistant.assistantId }) }
+    )
+
+    expect(response.status).toBe(201)
+
+    const assistants = await db
+      .selectFrom('Assistant')
+      .select(['id', 'owner'])
+      .where('owner', '=', userId)
+      .execute()
+    expect(assistants).toHaveLength(2)
+    const clonedAssistantId = assistants.find((assistant) => assistant.id !== sourceAssistant.assistantId)?.id
+    expect(clonedAssistantId).toBeTruthy()
+
+    const clonedAssistant = await db
+      .selectFrom('Assistant')
+      .select(['id', 'publishedVersionId'])
+      .where('id', '=', clonedAssistantId!)
+      .executeTakeFirstOrThrow()
+
+    const clonedFiles = await db
+      .selectFrom('AssistantVersionFile')
+      .innerJoin('File', 'File.id', 'AssistantVersionFile.fileId')
+      .select([
+        'AssistantVersionFile.fileId as fileId',
+        'File.ownerType as ownerType',
+        'File.ownerId as ownerId',
+      ])
+      .where('AssistantVersionFile.assistantVersionId', '=', clonedAssistant.publishedVersionId!)
+      .execute()
+
+    expect(clonedFiles).toHaveLength(1)
+    expect(clonedFiles[0].fileId).not.toBe('f-source-assistant')
+    expect(clonedFiles[0].ownerType).toBe('ASSISTANT')
+    expect(clonedFiles[0].ownerId).toBe(clonedAssistant.id)
+  })
+
+  test('shared chat clone duplicates attachment files for new conversation owner', async () => {
+    const sourceOwner = await createUser({
+      name: 'Source User',
+      email: 'clone-source@example.com',
+      ssoUser: 0,
+    })
+    const targetUser = await createUser({
+      name: 'Target User',
+      email: 'clone-target@example.com',
+      ssoUser: 0,
+    })
+    const targetSession = await createSession(
+      targetUser.id,
+      new Date(Date.now() + 60_000),
+      'password',
+      null
+    )
+    const targetCookie = `${SESSION_COOKIE_NAME}=${targetSession.id}`
+
+    const assistant = await createAssistant(makeDraft('b1', []), targetUser.id)
+    const sourceConversation = await createConversation(sourceOwner.id, {
+      assistantId: assistant.assistantId,
+      name: 'Shared conversation',
+    })
+
+    await insertUploadedFile({
+      id: 'f-source-chat',
+      ownerType: 'CHAT',
+      ownerId: sourceConversation.id,
+      name: 'note.txt',
+    })
+
+    const sourceMessage: dto.UserMessage = {
+      id: 'm-source-user',
+      conversationId: sourceConversation.id,
+      parent: null,
+      sentAt: new Date().toISOString(),
+      role: 'user',
+      content: 'hello',
+      attachments: [
+        {
+          id: 'f-source-chat',
+          mimetype: 'text/plain',
+          name: 'note.txt',
+          size: 123,
+        },
+      ],
+    }
+    await saveMessage(sourceMessage)
+
+    await db
+      .insertInto('ConversationSharing')
+      .values({ id: 'share-1', lastMessageId: sourceMessage.id })
+      .execute()
+
+    const response = await sharedConversationCloneRoute.POST(
+      new Request('http://localhost/api/share/share-1/clone', {
+        method: 'POST',
+        headers: { cookie: targetCookie },
+      }),
+      { params: Promise.resolve({ shareId: 'share-1' }) }
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as dto.ConversationWithMessages
+    const clonedConversationId = body.conversation.id
+    const clonedUserMessage = body.messages.find((message) => message.role === 'user') as dto.UserMessage
+    expect(clonedUserMessage).toBeTruthy()
+    expect(clonedUserMessage.attachments).toHaveLength(1)
+    const clonedFileId = clonedUserMessage.attachments[0].id
+    expect(clonedFileId).not.toBe('f-source-chat')
+
+    const clonedFile = await db
+      .selectFrom('File')
+      .select(['id', 'ownerType', 'ownerId', 'fileBlobId'])
+      .where('id', '=', clonedFileId)
+      .executeTakeFirstOrThrow()
+    const sourceFile = await db
+      .selectFrom('File')
+      .select(['id', 'fileBlobId'])
+      .where('id', '=', 'f-source-chat')
+      .executeTakeFirstOrThrow()
+
+    expect(clonedFile.ownerType).toBe('CHAT')
+    expect(clonedFile.ownerId).toBe(clonedConversationId)
+    expect(clonedFile.fileBlobId).toBe(sourceFile.fileBlobId)
+  })
+})

--- a/apps/backend/api/assistants/[assistantId]/clone/route.ts
+++ b/apps/backend/api/assistants/[assistantId]/clone/route.ts
@@ -11,6 +11,7 @@ import {
 import { getImageAsDataUri } from '@/models/images'
 import { getUserWorkspaceMemberships } from '@/models/user'
 import { isSharedWithAllOrAnyWorkspace } from '@/types/dto'
+import { cloneFilesForOwner } from '@/models/file'
 
 export const dynamic = 'force-dynamic'
 
@@ -43,12 +44,22 @@ export const POST = operation({
       return forbidden(`Assistant is not published`)
     }
 
+    const originalFiles = await assistantVersionFiles(assistantVersion.id)
+    const clonedFileIds = await cloneFilesForOwner({
+      fileIds: originalFiles.map((file) => file.id),
+      owner: { ownerType: 'USER', ownerId: session.userId },
+    })
+    const clonedFiles = originalFiles.map((file) => ({
+      ...file,
+      id: clonedFileIds.get(file.id) ?? file.id,
+    }))
+
     const assistantDraft: dto.InsertableAssistantDraft = {
       ...assistantVersion,
       name: `Copy of ${assistantVersion.name}`,
       iconUri: assistantVersion.imageId ? await getImageAsDataUri(assistantVersion.imageId) : null,
       tools: await assistantVersionEnabledTools(assistantVersion.id),
-      files: await assistantVersionFiles(assistantVersion.id),
+      files: clonedFiles,
       prompts: JSON.parse(assistantVersion.prompts),
       tags: JSON.parse(assistantVersion.tags),
       subAssistants: assistantVersion.subAssistants

--- a/apps/backend/api/share/[shareId]/clone/route.ts
+++ b/apps/backend/api/share/[shareId]/clone/route.ts
@@ -6,6 +6,64 @@ import { nanoid } from 'nanoid'
 import { dtoMessageToDbMessage } from '@/models/message'
 import * as dto from '@/types/dto'
 import { getUserAssistants } from '@/models/assistant'
+import { cloneFilesForOwner } from '@/models/file'
+
+const collectFileIdsFromMessage = (message: dto.Message): string[] => {
+  const ids: string[] = []
+  if (message.role === 'user') {
+    ids.push(...message.attachments.map((attachment) => attachment.id))
+    return ids
+  }
+
+  if (message.role === 'tool') {
+    for (const part of message.parts) {
+      if (part.type !== 'tool-result') continue
+      if (part.result.type !== 'content') continue
+      for (const contentPart of part.result.value) {
+        if (contentPart.type === 'file') {
+          ids.push(contentPart.id)
+        }
+      }
+    }
+  }
+
+  return ids
+}
+
+const remapMessageFileIds = (message: dto.Message, fileIdMap: Map<string, string>): dto.Message => {
+  if (message.role === 'user') {
+    return {
+      ...message,
+      attachments: message.attachments.map((attachment) => ({
+        ...attachment,
+        id: fileIdMap.get(attachment.id) ?? attachment.id,
+      })),
+    }
+  }
+
+  if (message.role === 'tool') {
+    return {
+      ...message,
+      parts: message.parts.map((part) => {
+        if (part.type !== 'tool-result') return part
+        if (part.result.type !== 'content') return part
+        return {
+          ...part,
+          result: {
+            ...part.result,
+            value: part.result.value.map((contentPart) =>
+              contentPart.type === 'file'
+                ? { ...contentPart, id: fileIdMap.get(contentPart.id) ?? contentPart.id }
+                : contentPart
+            ),
+          },
+        }
+      }),
+    }
+  }
+
+  return message
+}
 
 export const POST = operation({
   name: 'Clone shared conversation',
@@ -57,8 +115,13 @@ export const POST = operation({
       messages,
       messages.find((m) => m.id === conversation.lastMessageId)!
     )
+    const clonedFileIds = await cloneFilesForOwner({
+      fileIds: linear.flatMap((message) => collectFileIdsFromMessage(message)),
+      owner: { ownerType: 'CHAT', ownerId: newConversation.id },
+    })
+    const linearWithClonedFiles = linear.map((message) => remapMessageFileIds(message, clonedFileIds))
     const idMap = new Map(linear.map((m) => [m.id, nanoid()]))
-    const newMessages = linear
+    const newMessages = linearWithClonedFiles
       .map((m) => {
         return {
           ...m,

--- a/apps/backend/models/file.ts
+++ b/apps/backend/models/file.ts
@@ -82,3 +82,61 @@ export const reassignUserOwnedFilesToConversation = async ({
     .where('ownerId', '=', userId)
     .execute()
 }
+
+export const cloneFilesForOwner = async ({
+  fileIds,
+  owner,
+}: {
+  fileIds: string[]
+  owner: dto.FileOwner
+}): Promise<Map<string, string>> => {
+  const uniqueIds = [...new Set(fileIds)]
+  if (uniqueIds.length === 0) {
+    return new Map()
+  }
+
+  const sourceRows = await db
+    .selectFrom('File')
+    .leftJoin('FileBlob', 'FileBlob.id', 'File.fileBlobId')
+    .select([
+      'File.id as id',
+      'File.name as name',
+      'File.path as path',
+      'File.type as type',
+      'File.createdAt as createdAt',
+      'File.fileBlobId as fileBlobId',
+      'FileBlob.size as blobSize',
+      'FileBlob.encrypted as blobEncrypted',
+    ])
+    .where('File.id', 'in', uniqueIds)
+    .execute()
+
+  const sourceById = new Map(sourceRows.map((row) => [row.id, row]))
+  const now = new Date().toISOString()
+  const idMap = new Map<string, string>()
+
+  for (const sourceId of uniqueIds) {
+    const source = sourceById.get(sourceId)
+    if (!source) continue
+    const clonedId = nanoid()
+    idMap.set(sourceId, clonedId)
+    await db
+      .insertInto('File')
+      .values({
+        id: clonedId,
+        name: source.name,
+        path: source.path,
+        type: source.type,
+        uploaded: source.fileBlobId ? 1 : 0,
+        createdAt: now,
+        encrypted: source.blobEncrypted ?? 0,
+        size: source.blobSize ?? 0,
+        fileBlobId: source.fileBlobId,
+        ownerType: owner.ownerType,
+        ownerId: owner.ownerId,
+      } as any)
+      .execute()
+  }
+
+  return idMap
+}


### PR DESCRIPTION
## Summary
Ensure assistant and shared-chat cloning create new logical file records for the clone instead of reusing original file IDs, so cloned artifacts have independent ownership.

## Details
- Add `cloneFilesForOwner(...)` in `apps/backend/models/file.ts` to clone `File` rows with new IDs while reusing the same `FileBlob` backing content.
- Update assistant clone route to clone knowledge files and map cloned IDs into the new assistant draft before creation.
- Update shared chat clone route to clone referenced file attachments and rewrite cloned message attachment IDs accordingly.
- Add route-level tests in `__tests__/cloneRoutes.test.ts` covering both assistant duplication and shared-chat duplication ownership/id behavior.

## Tests
- `pnpm vitest run __tests__/cloneRoutes.test.ts` (passed)
- `pnpm run check-types` (passed)