### PR TITLE
Add API to get file details by fileId

### DIFF
--- a/apps/backend/api/files/[fileId]/route.ts
+++ b/apps/backend/api/files/[fileId]/route.ts
@@ -1,0 +1,84 @@
+import { db } from '@/db/database'
+import { canAccessFile } from '@/backend/lib/files/authorization'
+import { forbidden, notFound, operation, responseSpec, errorSpec, ok } from '@/lib/routes'
+import * as dto from '@/types/dto'
+
+export const GET = operation({
+  name: 'Get file details',
+  description: 'Get file metadata and ownership information by file id.',
+  authentication: 'user',
+  responses: [responseSpec(200, dto.fileDetailsSchema), errorSpec(403), errorSpec(404)] as const,
+  implementation: async ({ params, session }) => {
+    if (!(await canAccessFile({ userId: session.userId, userRole: session.userRole }, params.fileId))) {
+      return forbidden()
+    }
+
+    const file = await db
+      .selectFrom('File as F')
+      .leftJoin('FileBlob as FB', 'FB.id', 'F.fileBlobId')
+      .leftJoin('User as U', (join) =>
+        join.onRef('U.id', '=', 'F.ownerId').on('F.ownerType', '=', 'USER')
+      )
+      .leftJoin('Conversation as C', (join) =>
+        join.onRef('C.id', '=', 'F.ownerId').on('F.ownerType', '=', 'CHAT')
+      )
+      .leftJoin('Tool as T', (join) =>
+        join.onRef('T.id', '=', 'F.ownerId').on('F.ownerType', '=', 'TOOL')
+      )
+      .select([
+        'F.id',
+        'F.name',
+        'F.path',
+        'F.type',
+        'F.ownerType',
+        'F.ownerId',
+        'F.createdAt',
+        'FB.id as blobId',
+        'FB.size as blobSize',
+        'FB.encrypted as blobEncrypted',
+        'FB.contentHash as blobContentHash',
+        'FB.createdAt as blobCreatedAt',
+        'U.name as userOwnerName',
+        'C.name as chatOwnerName',
+        'T.name as toolOwnerName',
+      ])
+      .where('F.id', '=', params.fileId)
+      .executeTakeFirst()
+
+    if (!file) {
+      return notFound()
+    }
+
+    const ownerName =
+      file.ownerType === 'USER'
+        ? (file.userOwnerName ?? null)
+        : file.ownerType === 'CHAT'
+        ? (file.chatOwnerName ?? null)
+        : file.ownerType === 'TOOL'
+        ? (file.toolOwnerName ?? null)
+        : null
+
+    return ok({
+      id: file.id,
+      name: file.name,
+      path: file.path,
+      type: file.type,
+      createdAt: file.createdAt,
+      owner: {
+        ownerType: file.ownerType,
+        ownerId: file.ownerId,
+        ownerName,
+      },
+      blob:
+        file.blobId && file.blobSize !== null && file.blobEncrypted !== null && file.blobContentHash
+          ? {
+              id: file.blobId,
+              size: file.blobSize,
+              encrypted: file.blobEncrypted,
+              contentHash: file.blobContentHash,
+              createdAt: file.blobCreatedAt ?? file.createdAt,
+            }
+          : null,
+    })
+  },
+})

--- a/apps/backend/lib/router/routes.generated.ts
+++ b/apps/backend/lib/router/routes.generated.ts
@@ -50,6 +50,7 @@ export const backendRouteModules = [
   { pathname: '/api/feedbacks', load: () => import('@/backend/api/feedbacks/route') },
   { pathname: '/api/files/[fileId]/analysis', load: () => import('@/backend/api/files/[fileId]/analysis/route') },
   { pathname: '/api/files/[fileId]/content', load: () => import('@/backend/api/files/[fileId]/content/route') },
+  { pathname: '/api/files/[fileId]', load: () => import('@/backend/api/files/[fileId]/route') },
   { pathname: '/api/files/images', load: () => import('@/backend/api/files/images/route') },
   { pathname: '/api/files', load: () => import('@/backend/api/files/route') },
   { pathname: '/api/health', load: () => import('@/backend/api/health/route') },

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -1597,6 +1597,29 @@ paths:
             type: string
       security:
         - bearerAuth: []
+  /api/files/{fileId}:
+    get:
+      summary: Get file details
+      description: Get file metadata and ownership information by file id.
+      responses:
+        "200":
+          description: Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FileDetails"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+      parameters:
+        - name: fileId
+          in: path
+          required: true
+          schema:
+            type: string
+      security:
+        - bearerAuth: []
   /api/files/images:
     get:
       summary: List user images
@@ -4691,6 +4714,80 @@ components:
         - updatedAt
       additionalProperties: false
       id: FileAnalysis
+    FileDetails:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        path:
+          type: string
+        type:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        owner:
+          type: object
+          properties:
+            ownerType:
+              type: string
+              enum:
+                - USER
+                - CHAT
+                - ASSISTANT
+                - TOOL
+            ownerId:
+              type: string
+            ownerName:
+              anyOf:
+                - type: string
+                - type: "null"
+          required:
+            - ownerType
+            - ownerId
+            - ownerName
+          additionalProperties: false
+        blob:
+          anyOf:
+            - type: object
+              properties:
+                id:
+                  type: string
+                size:
+                  type: number
+                encrypted:
+                  anyOf:
+                    - type: number
+                      const: 0
+                    - type: number
+                      const: 1
+                contentHash:
+                  type: string
+                createdAt:
+                  type: string
+                  format: date-time
+                  pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+              required:
+                - id
+                - size
+                - encrypted
+                - contentHash
+                - createdAt
+              additionalProperties: false
+            - type: "null"
+      required:
+        - id
+        - name
+        - path
+        - type
+        - createdAt
+        - owner
+        - blob
+      additionalProperties: false
+      id: FileDetails
     FileOwner:
       type: object
       properties:

--- a/packages/core/src/types/dto/file.ts
+++ b/packages/core/src/types/dto/file.ts
@@ -16,6 +16,26 @@ export const fileSchema = z.object({
   encrypted: z.union([z.literal(0), z.literal(1)]),
 }).meta({ id: 'File' })
 
+export const fileDetailsSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  path: z.string(),
+  type: z.string(),
+  createdAt: iso8601UtcDateTimeSchema,
+  owner: fileOwnerSchema.extend({
+    ownerName: z.string().nullable(),
+  }),
+  blob: z
+    .object({
+      id: z.string(),
+      size: z.number(),
+      encrypted: z.union([z.literal(0), z.literal(1)]),
+      contentHash: z.string(),
+      createdAt: iso8601UtcDateTimeSchema,
+    })
+    .nullable(),
+}).meta({ id: 'FileDetails' })
+
 export const insertableFileSchema = fileSchema
   .omit({
     id: true,
@@ -30,4 +50,5 @@ export const insertableFileSchema = fileSchema
 
 export type FileOwner = z.infer<typeof fileOwnerSchema>
 export type File = z.infer<typeof fileSchema>
+export type FileDetails = z.infer<typeof fileDetailsSchema>
 export type InsertableFile = z.infer<typeof insertableFileSchema>


### PR DESCRIPTION
## Summary
Adds a new authenticated endpoint to retrieve file metadata by `fileId`, including file name, MIME type, ownership context, and blob metadata, with typed response schemas and OpenAPI coverage.

## Details
- Adds `GET /api/files/{fileId}` in `apps/backend/api/files/[fileId]/route.ts`.
- Enforces access control with `canAccessFile(...)` and returns typed `403`/`404` errors.
- Returns file-level metadata (`id`, `name`, `path`, `type`, `createdAt`) and ownership (`ownerType`, `ownerId`, `ownerName`).
- Includes blob metadata when available (`id`, `size`, `encrypted`, `contentHash`, `createdAt`).
- Adds shared DTO schema/type `fileDetailsSchema` / `FileDetails` in `packages/core/src/types/dto/file.ts`.
- Regenerates backend route manifest and OpenAPI spec.
- References issue: `logicleai/logicle-issues#240`.

## Tests
- `npm run generate:backend-route-manifest` (pass)
- `npm run generate:openapi` (pass)
- `npm run check-types` (pass)