### PR TITLE
Refactor preamble cost planning and optimal truncation (#839)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
 
+      - name: Run chat projection parity tests
+        run: |
+          pnpm exec vitest run apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
+
       - name: Run unit tests with coverage
         run: |
           pnpm test:coverage

--- a/__tests__/chatTruncation.test.ts
+++ b/__tests__/chatTruncation.test.ts
@@ -6,14 +6,12 @@ import * as ai from 'ai'
 const {
   mockDtoMessageToLlmMessage,
   mockSanitizeOrphanToolCalls,
-  mockCountPromptSegmentsTokens,
-  mockEstimateConversationWindowTokens,
+  mockPrepareConversationCostPlan,
 } =
   vi.hoisted(() => ({
     mockDtoMessageToLlmMessage: vi.fn(),
     mockSanitizeOrphanToolCalls: vi.fn((msgs: ai.ModelMessage[]) => msgs),
-    mockCountPromptSegmentsTokens: vi.fn(),
-    mockEstimateConversationWindowTokens: vi.fn(),
+    mockPrepareConversationCostPlan: vi.fn(),
   }))
 
 vi.mock('@/backend/lib/chat/conversion', () => ({
@@ -21,12 +19,42 @@ vi.mock('@/backend/lib/chat/conversion', () => ({
   sanitizeOrphanToolCalls: mockSanitizeOrphanToolCalls,
 }))
 
-vi.mock('@/backend/lib/chat/prompt-token-counter', () => ({
-  countPromptSegmentsTokens: mockCountPromptSegmentsTokens,
-}))
-
 vi.mock('@/backend/lib/chat/token-estimator', () => ({
-  estimateConversationWindowTokens: mockEstimateConversationWindowTokens,
+  prepareConversationCostPlan: mockPrepareConversationCostPlan,
+  selectOptimalHistoryStartIndex: (
+    history: dto.Message[],
+    historyMessageCosts: Array<{ index: number; tokens: number; role: dto.Message['role'] }>,
+    assistantTokens: number,
+    draftTokens: number,
+    tokenLimit: number
+  ) => {
+    const suffixTotals = new Array(historyMessageCosts.length + 1).fill(0)
+    for (let i = historyMessageCosts.length - 1; i >= 0; i--) {
+      suffixTotals[i] = suffixTotals[i + 1] + historyMessageCosts[i].tokens
+    }
+    const candidates = [0, ...history.flatMap((m, i) => (m.role === 'user' && i > 0 ? [i] : []))]
+    for (const startIndex of candidates) {
+      if (assistantTokens + draftTokens + suffixTotals[startIndex] <= tokenLimit) return startIndex
+    }
+    for (let i = history.length - 1; i >= 0; i--) if (history[i].role === 'user') return i
+    return 0
+  },
+  computeConversationPlanTotalCost: ({
+    assistantTokens,
+    draftTokens,
+    historyMessageCosts,
+  }: {
+    assistantTokens: number
+    draftTokens: number
+    historyMessageCosts: Array<{ tokens: number }>
+  }) => assistantTokens + draftTokens + historyMessageCosts.reduce((s, c) => s + c.tokens, 0),
+  computeConversationTotalCostFromStartIndex: (
+    plan: { assistantTokens: number; draftTokens: number; historyMessageCosts: Array<{ index: number; tokens: number }> },
+    startIndex: number
+  ) =>
+    plan.assistantTokens +
+    plan.draftTokens +
+    plan.historyMessageCosts.reduce((sum, entry) => sum + (entry.index >= startIndex ? entry.tokens : 0), 0),
 }))
 
 vi.mock('@/db/database', () => ({ db: {} }))
@@ -45,7 +73,7 @@ vi.mock('@/lib/env', () => ({
 vi.mock('@/lib/satellite', () => ({ satelliteHub: { connections: [] } }))
 vi.mock('@/backend/lib/tools/retrieve-file/implementation', () => ({}))
 
-import { ChatAssistant, PromptSegment } from '@/backend/lib/chat'
+import { ChatAssistant } from '@/backend/lib/chat'
 import * as dto from '@/types/dto'
 import { LlmModel } from '@/lib/chat/models'
 import type { LanguageModelV3 } from '@ai-sdk/provider'
@@ -188,32 +216,23 @@ const makeChatAssistant = (tokenLimit: number) => {
 describe('truncateChat', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.spyOn(ChatAssistant, 'buildPreambleSegments')
-    mockEstimateConversationWindowTokens.mockImplementation(async ({ history }: { history: dto.Message[] }) => {
-      const assistant = 10
-      const historyTokens = history.length * 10
+    mockPrepareConversationCostPlan.mockImplementation(async ({ history }: { history: dto.Message[] }) => {
       return {
-        estimate: {
-          assistant,
-          history: historyTokens,
-          draft: 0,
-          total: assistant + historyTokens,
+        plan: {
+          assistantTokens: 10,
+          draftTokens: 0,
+          historyMessageCosts: history.map((m, i) => ({
+            index: i,
+            messageId: m.id,
+            role: m.role,
+            tokens: 10,
+          })),
         },
         cache: {
           textTokensCache: { hits: 0, misses: 0 },
           fileTokenCache: { hits: 0, misses: 0 },
         },
       }
-    })
-    mockCountPromptSegmentsTokens.mockImplementation(async (_model, segments: PromptSegment[]) => {
-      // Each segment counts as 10 tokens in its respective scope
-      const counts = { assistant: 0, history: 0, draft: 0 }
-      for (const s of segments) {
-        if (s.scope === 'prompt') counts.assistant += 10
-        else if (s.scope === 'history') counts.history += 10
-        else counts.draft += 10
-      }
-      return counts
     })
     mockDtoMessageToLlmMessage.mockImplementation(async (m: dto.Message) => makeLlmMessage(m.id))
   })
@@ -222,7 +241,7 @@ describe('truncateChat', () => {
     const assistant = makeChatAssistant(100)
     const result = await assistant.truncateChat([])
     expect(result).toEqual([])
-    expect(mockEstimateConversationWindowTokens).not.toHaveBeenCalled()
+    expect(mockPrepareConversationCostPlan).not.toHaveBeenCalled()
   })
 
   test('returns all messages when within token limit', async () => {
@@ -234,50 +253,46 @@ describe('truncateChat', () => {
     expect(result).toEqual(messages)
   })
 
-  test('buildPreambleSegments is called exactly once regardless of candidates tried', async () => {
-    // preamble = 10 tokens; each history message = 10 tokens
-    // limit = 25 → need to drop messages until only 1 or 2 history remain
+  test('cost plan is built exactly once', async () => {
     const assistant = makeChatAssistant(25)
     const messages = [
-      makeMessage('m1'), // user — candidate start
+      makeMessage('m1'),
       makeMessage('m2', 'assistant'),
-      makeMessage('m3'), // user — candidate start
+      makeMessage('m3'),
       makeMessage('m4', 'assistant'),
-      makeMessage('m5'), // user — candidate start
+      makeMessage('m5'),
     ]
 
     await assistant.truncateChat(messages)
 
-    expect(mockEstimateConversationWindowTokens).toHaveBeenCalledTimes(3)
+    expect(mockPrepareConversationCostPlan).toHaveBeenCalledTimes(1)
   })
 
   test('drops earliest messages when full history exceeds limit', async () => {
-    // preamble=10, limit=30 → fits preamble + 2 history messages (10+10+10=30)
     const assistant = makeChatAssistant(30)
     const messages = [
-      makeMessage('m1'), // user turn 1
+      makeMessage('m1'),
       makeMessage('m2', 'assistant'),
-      makeMessage('m3'), // user turn 2 — dropping m1+m2 gives 2 history msgs = 30 total ✓
+      makeMessage('m3'),
       makeMessage('m4', 'assistant'),
     ]
 
     const result = await assistant.truncateChat(messages)
 
-    expect(result).toEqual(messages.slice(2)) // [m3, m4]
+    expect(result).toEqual(messages.slice(2))
   })
 
   test('falls back to last user turn when even the shortest candidate exceeds limit', async () => {
-    // preamble=10, limit=15 → no candidate fits; fallback to last user turn
     const assistant = makeChatAssistant(15)
     const messages = [
-      makeMessage('m1'), // user
+      makeMessage('m1'),
       makeMessage('m2', 'assistant'),
-      makeMessage('m3'), // user — last user turn
+      makeMessage('m3'),
       makeMessage('m4', 'assistant'),
     ]
 
     const result = await assistant.truncateChat(messages)
 
-    expect(result).toEqual(messages.slice(2)) // [m3, m4]
+    expect(result).toEqual(messages.slice(2))
   })
 })

--- a/__tests__/chatTruncation.test.ts
+++ b/__tests__/chatTruncation.test.ts
@@ -19,43 +19,13 @@ vi.mock('@/backend/lib/chat/conversion', () => ({
   sanitizeOrphanToolCalls: mockSanitizeOrphanToolCalls,
 }))
 
-vi.mock('@/backend/lib/chat/token-estimator', () => ({
-  prepareConversationCostPlan: mockPrepareConversationCostPlan,
-  selectOptimalHistoryStartIndex: (
-    history: dto.Message[],
-    historyMessageCosts: Array<{ index: number; tokens: number; role: dto.Message['role'] }>,
-    assistantTokens: number,
-    draftTokens: number,
-    tokenLimit: number
-  ) => {
-    const suffixTotals = new Array(historyMessageCosts.length + 1).fill(0)
-    for (let i = historyMessageCosts.length - 1; i >= 0; i--) {
-      suffixTotals[i] = suffixTotals[i + 1] + historyMessageCosts[i].tokens
-    }
-    const candidates = [0, ...history.flatMap((m, i) => (m.role === 'user' && i > 0 ? [i] : []))]
-    for (const startIndex of candidates) {
-      if (assistantTokens + draftTokens + suffixTotals[startIndex] <= tokenLimit) return startIndex
-    }
-    for (let i = history.length - 1; i >= 0; i--) if (history[i].role === 'user') return i
-    return 0
-  },
-  computeConversationPlanTotalCost: ({
-    assistantTokens,
-    draftTokens,
-    historyMessageCosts,
-  }: {
-    assistantTokens: number
-    draftTokens: number
-    historyMessageCosts: Array<{ tokens: number }>
-  }) => assistantTokens + draftTokens + historyMessageCosts.reduce((s, c) => s + c.tokens, 0),
-  computeConversationTotalCostFromStartIndex: (
-    plan: { assistantTokens: number; draftTokens: number; historyMessageCosts: Array<{ index: number; tokens: number }> },
-    startIndex: number
-  ) =>
-    plan.assistantTokens +
-    plan.draftTokens +
-    plan.historyMessageCosts.reduce((sum, entry) => sum + (entry.index >= startIndex ? entry.tokens : 0), 0),
-}))
+vi.mock('@/backend/lib/chat/token-estimator', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/backend/lib/chat/token-estimator')>()
+  return {
+    ...actual,
+    prepareConversationCostPlan: mockPrepareConversationCostPlan,
+  }
+})
 
 vi.mock('@/db/database', () => ({ db: {} }))
 vi.mock('@/db/dialect', () => ({ createDialect: () => null }))
@@ -221,8 +191,7 @@ describe('truncateChat', () => {
         plan: {
           assistantTokens: 10,
           draftTokens: 0,
-          historyMessageCosts: history.map((m, i) => ({
-            index: i,
+          historyMessageCosts: history.map((m) => ({
             messageId: m.id,
             role: m.role,
             tokens: 10,

--- a/__tests__/chatTruncation.test.ts
+++ b/__tests__/chatTruncation.test.ts
@@ -7,11 +7,13 @@ const {
   mockDtoMessageToLlmMessage,
   mockSanitizeOrphanToolCalls,
   mockPrepareConversationCostPlan,
+  mockLoggerInfo,
 } =
   vi.hoisted(() => ({
     mockDtoMessageToLlmMessage: vi.fn(),
     mockSanitizeOrphanToolCalls: vi.fn((msgs: ai.ModelMessage[]) => msgs),
     mockPrepareConversationCostPlan: vi.fn(),
+    mockLoggerInfo: vi.fn(),
   }))
 
 vi.mock('@/backend/lib/chat/conversion', () => ({
@@ -30,7 +32,7 @@ vi.mock('@/backend/lib/chat/token-estimator', async (importOriginal) => {
 vi.mock('@/db/database', () => ({ db: {} }))
 vi.mock('@/db/dialect', () => ({ createDialect: () => null }))
 vi.mock('@/lib/logging', () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() },
+  logger: { info: mockLoggerInfo, warn: vi.fn(), error: vi.fn(), log: vi.fn() },
 }))
 vi.mock('@/lib/env', () => ({
   default: {
@@ -263,5 +265,21 @@ describe('truncateChat', () => {
     const result = await assistant.truncateChat(messages)
 
     expect(result).toEqual(messages.slice(2))
+  })
+
+  test('logs fallback accurately when latest user turn still exceeds the limit', async () => {
+    const assistant = makeChatAssistant(15)
+    const messages = [
+      makeMessage('m1'),
+      makeMessage('m2', 'assistant'),
+      makeMessage('m3'),
+      makeMessage('m4', 'assistant'),
+    ]
+
+    await assistant.truncateChat(messages)
+
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      'Truncating chat: latest user turn still exceeds limit of 15'
+    )
   })
 })

--- a/__tests__/conversion.test.ts
+++ b/__tests__/conversion.test.ts
@@ -602,3 +602,116 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
     expect(ensureFileAnalysis).not.toHaveBeenCalled()
   })
 })
+
+describe('dtoMessageToLlmMessage contract', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  test('simple user message remains plain string content', async () => {
+    const { dtoMessageToLlmMessage } = await import('@/backend/lib/chat/conversion')
+    const message = await dtoMessageToLlmMessage(
+      {
+        id: 'u-contract-1',
+        conversationId: 'c1',
+        parent: null,
+        sentAt: new Date().toISOString(),
+        citations: [],
+        role: 'user',
+        content: 'hello',
+        attachments: [],
+      },
+      { vision: false, function_calling: true, reasoning: false, supportedMedia: [] },
+      openaiLanguageModel.provider
+    )
+
+    expect(message).toEqual({ role: 'user', content: 'hello' })
+  })
+
+  test('user message with metadata/attachments materializes text parts + file parts', async () => {
+    const imageFile = {
+      ...pdfFile,
+      id: 'img-contract-1',
+      name: 'image.png',
+      path: 'files/image.png',
+      type: 'image/png',
+      size: 10,
+    }
+    getFileWithId.mockResolvedValue(imageFile)
+    readBuffer.mockResolvedValue(Buffer.from('img-bytes'))
+
+    const { dtoMessageToLlmMessage } = await import('@/backend/lib/chat/conversion')
+    const message = await dtoMessageToLlmMessage(
+      {
+        id: 'u-contract-2',
+        conversationId: 'c1',
+        parent: null,
+        sentAt: new Date().toISOString(),
+        citations: [],
+        role: 'user',
+        content: 'hello',
+        metadata: { locale: 'en-US' },
+        attachments: [{ id: imageFile.id, name: imageFile.name, mimetype: imageFile.type, size: imageFile.size }],
+      },
+      { vision: true, function_calling: true, reasoning: false, supportedMedia: ['image/png'] },
+      openaiLanguageModel.provider
+    )
+
+    expect(message).toEqual({
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Message metadata (system-use): {"locale":"en-US"}' },
+        { type: 'text', text: 'hello' },
+        {
+          type: 'text',
+          text: `The user has attached the following files to this chat: \n${JSON.stringify([
+            { id: imageFile.id, name: imageFile.name, mimetype: imageFile.type, size: imageFile.size },
+          ])}`,
+        },
+        {
+          type: 'image',
+          image: `data:${imageFile.type};base64,${Buffer.from('img-bytes').toString('base64')}`,
+        },
+      ],
+    })
+  })
+
+  test('assistant reasoning is included only when reasoning_signature is present', async () => {
+    const { dtoMessageToLlmMessage } = await import('@/backend/lib/chat/conversion')
+    const message = await dtoMessageToLlmMessage(
+      {
+        id: 'a-contract-1',
+        conversationId: 'c1',
+        parent: null,
+        sentAt: new Date().toISOString(),
+        citations: [],
+        role: 'assistant',
+        parts: [
+          { type: 'reasoning', reasoning: 'drop-me' },
+          { type: 'reasoning', reasoning: 'keep-me', reasoning_signature: 'sig-1' },
+          { type: 'tool-call', toolCallId: 'call-1', toolName: 'search', args: { q: 'cats' } },
+        ],
+      },
+      { vision: false, function_calling: true, reasoning: true, supportedMedia: [] },
+      openaiLanguageModel.provider
+    )
+
+    expect(message).toEqual({
+      role: 'assistant',
+      content: [
+        {
+          type: 'reasoning',
+          text: 'keep-me',
+          providerOptions: { anthropic: { signature: 'sig-1' } },
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'search',
+          input: { q: 'cats' },
+        },
+      ],
+    })
+  })
+})

--- a/__tests__/preamblePlanning.test.ts
+++ b/__tests__/preamblePlanning.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { LlmModel } from '@/lib/chat/models'
+
+const { mockKnowledgeToInputPart } = vi.hoisted(() => ({
+  mockKnowledgeToInputPart: vi.fn(),
+}))
+
+vi.mock('@/lib/env', () => ({
+  default: {
+    knowledge: { sendInPrompt: true },
+  },
+}))
+
+vi.mock('@/backend/lib/tools/knowledge/implementation', () => ({
+  KnowledgePlugin: class KnowledgePlugin {
+    toolParams = { id: 'knowledge', provisioned: false, promptFragment: '', name: 'knowledge' }
+    params: unknown = {}
+    constructor(toolParams: unknown, params: unknown) {
+      this.toolParams = toolParams as typeof this.toolParams
+      this.params = params
+    }
+    async knowledgeToInputPart(...args: unknown[]) {
+      return mockKnowledgeToInputPart(...args)
+    }
+  },
+}))
+
+vi.mock('@/backend/lib/chat/conversion', () => ({
+  dtoMessageToLlmMessage: vi.fn(),
+  sanitizeOrphanToolCalls: (messages: unknown[]) => messages,
+}))
+
+describe('preamble planning and rendering', () => {
+  const llmModel = {
+    id: 'gpt-4.1-mini',
+    capabilities: { knowledge: true, vision: true, supportedMedia: ['image/png'] },
+  } as unknown as LlmModel
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockKnowledgeToInputPart.mockResolvedValue({ type: 'text', text: 'knowledge content' })
+  })
+
+  test('preparePreamblePlan stays lightweight and does not materialize knowledge parts', async () => {
+    const { preparePreamblePlan } = await import('@/backend/lib/chat/preamble')
+    const plan = await preparePreamblePlan({
+      assistantParams: { systemPrompt: 'system prompt' },
+      llmModel,
+      tools: [],
+      parameters: {},
+      knowledge: [{ id: 'k1', name: 'k1.png', type: 'image/png', size: 1 }],
+    })
+
+    expect(plan.knowledgeFileEntries).toEqual([{ fileId: 'k1', fileName: 'k1.png', partIndex: 0 }])
+    expect(mockKnowledgeToInputPart).not.toHaveBeenCalled()
+  })
+
+  test('buildEstimatedPreambleSegments stays lightweight without materialization', async () => {
+    const { preparePreamblePlan, buildEstimatedPreambleSegments } = await import('@/backend/lib/chat/preamble')
+    const plan = await preparePreamblePlan({
+      assistantParams: { systemPrompt: 'system prompt' },
+      llmModel,
+      tools: [],
+      parameters: {},
+      knowledge: [{ id: 'k1', name: 'k1.png', type: 'image/png', size: 1 }],
+    })
+
+    const segments = buildEstimatedPreambleSegments(plan)
+
+    expect(segments).toHaveLength(2)
+    expect(segments[1]?.message).toEqual({ role: 'user', content: [] })
+    expect(segments[1]?.knowledgeFileEntries).toEqual([{ fileId: 'k1', fileName: 'k1.png', partIndex: 0 }])
+    expect(mockKnowledgeToInputPart).not.toHaveBeenCalled()
+  })
+
+  test('renderPreamblePlan materializes knowledge parts for real model rendering', async () => {
+    const { preparePreamblePlan, renderPreamblePlan } = await import('@/backend/lib/chat/preamble')
+    const plan = await preparePreamblePlan({
+      assistantParams: { systemPrompt: 'system prompt' },
+      llmModel,
+      tools: [],
+      parameters: {},
+      knowledge: [{ id: 'k1', name: 'k1.png', type: 'image/png', size: 1 }],
+    })
+
+    const segments = await renderPreamblePlan(plan)
+
+    expect(segments).toHaveLength(2)
+    expect(mockKnowledgeToInputPart).toHaveBeenCalledTimes(1)
+    expect(segments[1]?.message).toEqual({
+      role: 'user',
+      content: [{ type: 'text', text: 'knowledge content' }],
+    })
+  })
+
+  test('lightweight path stays non-materializing with many knowledge files', async () => {
+    const { preparePreamblePlan, buildEstimatedPreambleSegments } = await import('@/backend/lib/chat/preamble')
+    const knowledgeFiles = Array.from({ length: 200 }, (_, i) => ({
+      id: `k${i + 1}`,
+      name: `k${i + 1}.png`,
+      type: 'image/png',
+      size: i + 1,
+    }))
+    const plan = await preparePreamblePlan({
+      assistantParams: { systemPrompt: 'system prompt' },
+      llmModel,
+      tools: [],
+      parameters: {},
+      knowledge: knowledgeFiles,
+    })
+
+    const segments = buildEstimatedPreambleSegments(plan)
+
+    expect(segments).toHaveLength(2)
+    expect(segments[1]?.message).toEqual({ role: 'user', content: [] })
+    expect(segments[1]?.knowledgeFileEntries).toHaveLength(200)
+    expect(mockKnowledgeToInputPart).not.toHaveBeenCalled()
+  })
+
+})

--- a/__tests__/preamblePlanning.test.ts
+++ b/__tests__/preamblePlanning.test.ts
@@ -51,7 +51,9 @@ describe('preamble planning and rendering', () => {
       knowledge: [{ id: 'k1', name: 'k1.png', type: 'image/png', size: 1 }],
     })
 
-    expect(plan.knowledgeFileEntries).toEqual([{ fileId: 'k1', fileName: 'k1.png', partIndex: 0 }])
+    expect(plan.knowledgeFileEntries).toEqual([
+      { fileId: 'k1', fileName: 'k1.png', mimetype: 'image/png', partIndex: 0 },
+    ])
     expect(mockKnowledgeToInputPart).not.toHaveBeenCalled()
   })
 
@@ -69,7 +71,9 @@ describe('preamble planning and rendering', () => {
 
     expect(segments).toHaveLength(2)
     expect(segments[1]?.message).toEqual({ role: 'user', content: [] })
-    expect(segments[1]?.knowledgeFileEntries).toEqual([{ fileId: 'k1', fileName: 'k1.png', partIndex: 0 }])
+    expect(segments[1]?.knowledgeFileEntries).toEqual([
+      { fileId: 'k1', fileName: 'k1.png', mimetype: 'image/png', partIndex: 0 },
+    ])
     expect(mockKnowledgeToInputPart).not.toHaveBeenCalled()
   })
 

--- a/__tests__/subassistantTool.test.ts
+++ b/__tests__/subassistantTool.test.ts
@@ -34,13 +34,19 @@ vi.mock('@/backend/lib/chat/prompt-token-counter', () => ({
 }))
 
 vi.mock('@/backend/lib/chat/token-estimator', () => ({
-  estimateConversationWindowTokens: vi.fn().mockResolvedValue({
-    estimate: { assistant: 0, history: 0, draft: 0, total: 0 },
+  prepareConversationCostPlan: vi.fn().mockResolvedValue({
+    plan: {
+      assistantTokens: 0,
+      historyMessageCosts: [],
+      draftTokens: 0,
+    },
     cache: {
       textTokensCache: { hits: 0, misses: 0 },
       fileTokenCache: { hits: 0, misses: 0 },
     },
   }),
+  selectOptimalHistoryStartIndex: vi.fn().mockReturnValue(0),
+  computeConversationPlanTotalCost: vi.fn().mockReturnValue(0),
 }))
 
 vi.mock('db/database', () => ({

--- a/__tests__/tokenEstimator.test.ts
+++ b/__tests__/tokenEstimator.test.ts
@@ -5,6 +5,7 @@ import { gpt35Model, gpt41Model, gpt41MiniModel } from '@/lib/chat/models/openai
 import { countTextForModel, countTextWithTokenizer } from '@/lib/chat/tokenizer'
 import { normalizeExtractedText } from '@/backend/lib/chat/pdf-token-estimator'
 import { estimateNativeImageTokensFromDimensions } from '@/backend/lib/chat/image-token-estimator'
+import { projectedToolResultAttachedFilesDescriptor } from '@/backend/lib/chat/message-projection'
 
 // Regression helpers — intentionally NOT delegating to the implementation so that bugs in
 // resolvePdfEstimatorModel() or predictPdfTokenCount() are caught by the tests.
@@ -91,6 +92,17 @@ const makeImageFile = (id: string) => ({
   createdAt: new Date().toISOString(),
   encrypted: 0 as const,
 })
+
+const countUserAttachmentDescriptorTokens = (model: Parameters<typeof countTextForModel>[0], attachments: dto.Attachment[]) =>
+  countTextForModel(
+    model,
+    `The user has attached the following files to this chat: \n${JSON.stringify(attachments)}`
+  )
+
+const countToolResultAttachedFilesDescriptorTokens = (
+  model: Parameters<typeof countTextForModel>[0],
+  files: Array<{ id: string; name: string; mimetype: string; size: number }>
+) => countTextForModel(model, JSON.stringify(projectedToolResultAttachedFilesDescriptor(files)))
 
 describe('estimateInputTokens', () => {
   beforeEach(async () => {
@@ -269,8 +281,12 @@ describe('estimateInputTokens', () => {
     expect(result.estimate).toEqual({
       assistant: 0,
       history: 0,
-      draft: 0,
-      total: 0,
+      draft: countUserAttachmentDescriptorTokens(claude35SonnetModel, [
+        { id: fileId, name: `${fileId}.pdf`, mimetype: 'application/pdf', size: 123 },
+      ]),
+      total: countUserAttachmentDescriptorTokens(claude35SonnetModel, [
+        { id: fileId, name: `${fileId}.pdf`, mimetype: 'application/pdf', size: 123 },
+      ]),
     })
     expect(readExtractedTextFromAnalysis).not.toHaveBeenCalled()
     expect(readBuffer).not.toHaveBeenCalled()
@@ -320,8 +336,16 @@ describe('estimateInputTokens', () => {
     expect(result.estimate).toEqual({
       assistant: 0,
       history: 0,
-      draft: expectedImageTokens,
-      total: expectedImageTokens,
+      draft:
+        expectedImageTokens +
+        countUserAttachmentDescriptorTokens(gpt41MiniModel, [
+          { id: fileId, name: `${fileId}.png`, mimetype: 'image/png', size: 456 },
+        ]),
+      total:
+        expectedImageTokens +
+        countUserAttachmentDescriptorTokens(gpt41MiniModel, [
+          { id: fileId, name: `${fileId}.png`, mimetype: 'image/png', size: 456 },
+        ]),
     })
     expect(readExtractedTextFromAnalysis).not.toHaveBeenCalled()
     expect(readBuffer).not.toHaveBeenCalled()
@@ -401,12 +425,18 @@ describe('estimateInputTokens', () => {
       JSON.stringify({ toolCallId: 'call_1', toolName: 'GenerateImage' })
     )
     const expectedDescription = countTextForModel(gpt41MiniModel, 'The tool displayed 1 images.')
+    const expectedAttachedFilesDescriptor = countToolResultAttachedFilesDescriptorTokens(
+      gpt41MiniModel,
+      [{ id: fileId, name: 'generated.png', mimetype: 'image/png', size: 456 }]
+    )
 
     expect(result.estimate).toEqual({
       assistant: 0,
-      history: expectedToolResultPrefix + expectedDescription + expectedImageTokens,
+      history:
+        expectedToolResultPrefix + expectedAttachedFilesDescriptor + expectedDescription + expectedImageTokens,
       draft: 0,
-      total: expectedToolResultPrefix + expectedDescription + expectedImageTokens,
+      total:
+        expectedToolResultPrefix + expectedAttachedFilesDescriptor + expectedDescription + expectedImageTokens,
     })
     expect(readExtractedTextFromAnalysis).not.toHaveBeenCalled()
     expect(readBuffer).not.toHaveBeenCalled()
@@ -467,12 +497,15 @@ describe('estimateInputTokens', () => {
       gpt35Model,
       `Here is the text content of the file "${file.name}" with id ${file.id}\ntool pdf fallback text`
     )
+    const expectedAttachedFilesDescriptor = countToolResultAttachedFilesDescriptorTokens(gpt35Model, [
+      { id: fileId, name: file.name, mimetype: 'application/pdf', size: file.size },
+    ])
 
     expect(result.estimate).toEqual({
       assistant: 0,
-      history: expectedToolCallPrefix + expectedFallback,
+      history: expectedToolCallPrefix + expectedAttachedFilesDescriptor + expectedFallback,
       draft: 0,
-      total: expectedToolCallPrefix + expectedFallback,
+      total: expectedToolCallPrefix + expectedAttachedFilesDescriptor + expectedFallback,
     })
     expect(extractFromFile).toHaveBeenCalledWith(file)
     expect(ensureFileAnalysis).not.toHaveBeenCalled()
@@ -519,7 +552,12 @@ describe('estimateInputTokens', () => {
 
     const { getPdfAttachmentPageLimitText } = await import('@/backend/lib/chat/file-attachment-policy')
     const courtesyText = getPdfAttachmentPageLimitText(file, 101, claude35SonnetModel)!
-    expect(result.estimate.draft).toBe(countTextForModel(claude35SonnetModel, courtesyText))
+    expect(result.estimate.draft).toBe(
+      countTextForModel(claude35SonnetModel, courtesyText) +
+        countUserAttachmentDescriptorTokens(claude35SonnetModel, [
+          { id: fileId, name: file.name, mimetype: 'application/pdf', size: file.size },
+        ])
+    )
     expect(readExtractedTextFromAnalysis).not.toHaveBeenCalled()
   })
 
@@ -568,7 +606,10 @@ describe('estimateInputTokens', () => {
         1,
         2,
         countTextForModel(claude35SonnetModel, normalizeExtractedText('hello world'))
-      )
+      ) +
+        countUserAttachmentDescriptorTokens(claude35SonnetModel, [
+          { id: fileId, name: file.name, mimetype: 'application/pdf', size: file.size },
+        ])
     )
   })
 
@@ -616,8 +657,16 @@ describe('estimateInputTokens', () => {
     expect(result.estimate).toEqual({
       assistant: 0,
       history: 0,
-      draft: expectedPdfTokens,
-      total: expectedPdfTokens,
+      draft:
+        expectedPdfTokens +
+        countUserAttachmentDescriptorTokens(gpt41MiniModel, [
+          { id: fileId, name: file.name, mimetype: 'application/pdf', size: file.size },
+        ]),
+      total:
+        expectedPdfTokens +
+        countUserAttachmentDescriptorTokens(gpt41MiniModel, [
+          { id: fileId, name: file.name, mimetype: 'application/pdf', size: file.size },
+        ]),
     })
   })
 
@@ -670,7 +719,11 @@ describe('estimateInputTokens', () => {
       attachmentFileIds: [fileId],
     })
 
-    expect(result.estimate.draft).toBe(0)
+    expect(result.estimate.draft).toBe(
+      countUserAttachmentDescriptorTokens(claude35SonnetModel, [
+        { id: fileId, name: file.name, mimetype: 'application/pdf', size: file.size },
+      ])
+    )
     vi.doUnmock('@/backend/lib/chat/file-attachment-policy')
   })
 
@@ -817,7 +870,12 @@ describe('estimateInputTokens', () => {
       attachmentFileIds: [],
     })
 
-    expect(result.estimate.history).toBe(0)
+    expect(result.estimate.history).toBe(
+      countUserAttachmentDescriptorTokens(claude35SonnetModel, [
+        { id: badTypeId, name: 'bad-type.pdf', mimetype: 'application/pdf', size: 123 },
+        { id: badPayloadId, name: 'bad-payload.pdf', mimetype: 'application/pdf', size: 123 },
+      ])
+    )
   })
 
   test('counts extracted-text fallback for PDF attachments when the model does not support native PDFs', async () => {
@@ -853,7 +911,10 @@ describe('estimateInputTokens', () => {
       countTextForModel(
         gpt35Model,
         `Here is the text content of the file "${file.name}" with id ${file.id}\nplain pdf text`
-      )
+      ) +
+        countUserAttachmentDescriptorTokens(gpt35Model, [
+          { id: 'plain-pdf', name: 'plain.pdf', mimetype: 'application/pdf', size: 10 },
+        ])
     )
     expect(getFileWithId).toHaveBeenCalledWith(file.id)
     expect(extractFromFile).toHaveBeenCalledWith(file)
@@ -890,7 +951,10 @@ describe('estimateInputTokens', () => {
       countTextForModel(
         claude35SonnetModel,
         JSON.stringify({ filename: file.name, mediaType: file.type })
-      )
+      ) +
+        countUserAttachmentDescriptorTokens(claude35SonnetModel, [
+          { id: fileId, name: file.name, mimetype: file.type, size: file.size },
+        ])
     )
   })
 
@@ -1111,7 +1175,10 @@ describe('estimateInputTokens', () => {
     })
 
     expect(result.estimate.draft).toBe(
-      openAiPdfTokens(8, 10, countTextForModel(gpt41Model, normalizeExtractedText('brief caption text')))
+      openAiPdfTokens(8, 10, countTextForModel(gpt41Model, normalizeExtractedText('brief caption text'))) +
+        countUserAttachmentDescriptorTokens(gpt41Model, [
+          { id: fileId, name: file.name, mimetype: file.type, size: file.size },
+        ])
     )
   })
 
@@ -1156,7 +1223,10 @@ describe('estimateInputTokens', () => {
     })
 
     expect(result.estimate.draft).toBe(
-      anthropicPdfTokens(8, 10, countTextForModel(claude46SonnetModel, normalizeExtractedText('brief caption text')))
+      anthropicPdfTokens(8, 10, countTextForModel(claude46SonnetModel, normalizeExtractedText('brief caption text'))) +
+        countUserAttachmentDescriptorTokens(claude46SonnetModel, [
+          { id: fileId, name: file.name, mimetype: file.type, size: file.size },
+        ])
     )
   })
 
@@ -1201,7 +1271,12 @@ describe('estimateInputTokens', () => {
     })
 
     // OpenAI has no native PDF page limit — full regression model applies regardless of length
-    expect(result.estimate.draft).toBe(openAiPdfTokens(180, 200, 0))
+    expect(result.estimate.draft).toBe(
+      openAiPdfTokens(180, 200, 0) +
+        countUserAttachmentDescriptorTokens(gpt41Model, [
+          { id: fileId, name: file.name, mimetype: file.type, size: file.size },
+        ])
+    )
   })
 
   test('estimates very long visual PDF cost as a draft attachment for Anthropic flagship (claude46Sonnet)', async () => {
@@ -1245,8 +1320,13 @@ describe('estimateInputTokens', () => {
 
     // 200 pages exceeds Anthropic's 100-page native limit → courtesy text, not regression
     const { getPdfAttachmentPageLimitText } = await import('@/backend/lib/chat/file-attachment-policy')
-    const courtesyText = getPdfAttachmentPageLimitText(file, 200, claude46SonnetModel)!
-    expect(result.estimate.draft).toBe(countTextForModel(claude46SonnetModel, courtesyText))
+    const courtesyText = getPdfAttachmentPageLimitText(file, 200, claude46SonnetModel)
+    expect(result.estimate.draft).toBe(
+      (courtesyText ? countTextForModel(claude46SonnetModel, courtesyText) : 0) +
+        countUserAttachmentDescriptorTokens(claude46SonnetModel, [
+          { id: fileId, name: file.name, mimetype: file.type, size: file.size },
+        ])
+    )
     expect(readExtractedTextFromAnalysis).not.toHaveBeenCalled()
   })
 
@@ -1292,7 +1372,10 @@ describe('estimateInputTokens', () => {
     })
 
     expect(result.estimate.draft).toBe(
-      openAiPdfTokens(0, 30, countTextForModel(gpt41Model, normalizeExtractedText(extractedText)))
+      openAiPdfTokens(0, 30, countTextForModel(gpt41Model, normalizeExtractedText(extractedText))) +
+        countUserAttachmentDescriptorTokens(gpt41Model, [
+          { id: fileId, name: file.name, mimetype: file.type, size: file.size },
+        ])
     )
   })
 
@@ -1338,7 +1421,10 @@ describe('estimateInputTokens', () => {
     })
 
     expect(result.estimate.draft).toBe(
-      anthropicPdfTokens(0, 30, countTextForModel(claude46SonnetModel, normalizeExtractedText(extractedText)))
+      anthropicPdfTokens(0, 30, countTextForModel(claude46SonnetModel, normalizeExtractedText(extractedText))) +
+        countUserAttachmentDescriptorTokens(claude46SonnetModel, [
+          { id: fileId, name: file.name, mimetype: file.type, size: file.size },
+        ])
     )
   })
 
@@ -1362,7 +1448,12 @@ describe('estimateInputTokens', () => {
     })
 
     const expectedText = `Here is the text content of the file "${file.name}" with id ${file.id}\nextracted pdf content`
-    expect(result.estimate.draft).toBe(countTextForModel(gpt35Model, expectedText))
+    expect(result.estimate.draft).toBe(
+      countTextForModel(gpt35Model, expectedText) +
+        countUserAttachmentDescriptorTokens(gpt35Model, [
+          { id: fileId, name: file.name, mimetype: file.type, size: file.size },
+        ])
+    )
     expect(ensureFileAnalysis).not.toHaveBeenCalled()
     expect(extractFromFile).toHaveBeenCalledWith(file)
   })
@@ -1387,7 +1478,12 @@ describe('estimateInputTokens', () => {
     })
 
     const expectedText = `Here is the text content of the file "${file.name}" with id ${file.id}\nextracted pdf content`
-    expect(result.estimate.draft).toBe(countTextForModel(claude3HaikuModel, expectedText))
+    expect(result.estimate.draft).toBe(
+      countTextForModel(claude3HaikuModel, expectedText) +
+        countUserAttachmentDescriptorTokens(claude3HaikuModel, [
+          { id: fileId, name: file.name, mimetype: file.type, size: file.size },
+        ])
+    )
     expect(ensureFileAnalysis).not.toHaveBeenCalled()
     expect(extractFromFile).toHaveBeenCalledWith(file)
   })

--- a/__tests__/tokenEstimator.test.ts
+++ b/__tests__/tokenEstimator.test.ts
@@ -64,7 +64,10 @@ const assistantParams = {
 
 const mockBuildPreambleSegments = async (segments: any[]) => {
   const preambleModule = await import('@/backend/lib/chat/preamble')
-  vi.spyOn(preambleModule, 'buildPreambleSegments').mockResolvedValue(segments as never)
+  vi.spyOn(preambleModule, 'preparePreamblePlan').mockResolvedValue({
+    systemPromptMessage: { role: 'system', content: '' },
+  })
+  vi.spyOn(preambleModule, 'buildEstimatedPreambleSegments').mockReturnValue(segments)
 }
 
 const makePdfFile = (id: string) => ({
@@ -1501,5 +1504,28 @@ describe('estimateInputTokens', () => {
       countTextForModel(gpt41MiniModel, 'system') +
         Math.ceil(estimateNativeImageTokensFromDimensions(gpt41MiniModel, 512, 512))
     )
+  })
+
+  test('estimatePreambleTokens uses plan + estimated segments without materialization', async () => {
+    const preambleModule = await import('@/backend/lib/chat/preamble')
+    const buildPlanSpy = vi.spyOn(preambleModule, 'preparePreamblePlan').mockResolvedValue({
+      systemPromptMessage: { role: 'system', content: 'system' },
+      knowledgeFileEntries: [{ fileId: 'k1', fileName: 'k1.png', partIndex: 0 }],
+    })
+    const buildEstimatedSpy = vi.spyOn(preambleModule, 'buildEstimatedPreambleSegments')
+    const renderSpy = vi.spyOn(preambleModule, 'renderPreamblePlan')
+
+    const { estimatePreambleTokens } = await import('@/backend/lib/chat/token-estimator')
+    await estimatePreambleTokens({
+      assistantParams: { ...assistantParams, model: gpt41MiniModel.id },
+      model: gpt41MiniModel,
+      tools: [],
+      parameters: {},
+      knowledgeFiles: [{ id: 'k1', name: 'k1.png', type: 'image/png', size: 1 }],
+    })
+
+    expect(buildPlanSpy).toHaveBeenCalledTimes(1)
+    expect(buildEstimatedSpy).toHaveBeenCalledTimes(1)
+    expect(renderSpy).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/tokenEstimator.test.ts
+++ b/__tests__/tokenEstimator.test.ts
@@ -1510,7 +1510,7 @@ describe('estimateInputTokens', () => {
     const preambleModule = await import('@/backend/lib/chat/preamble')
     const buildPlanSpy = vi.spyOn(preambleModule, 'preparePreamblePlan').mockResolvedValue({
       systemPromptMessage: { role: 'system', content: 'system' },
-      knowledgeFileEntries: [{ fileId: 'k1', fileName: 'k1.png', partIndex: 0 }],
+      knowledgeFileEntries: [{ fileId: 'k1', fileName: 'k1.png', mimetype: 'image/png', partIndex: 0 }],
     })
     const buildEstimatedSpy = vi.spyOn(preambleModule, 'buildEstimatedPreambleSegments')
     const renderSpy = vi.spyOn(preambleModule, 'renderPreamblePlan')
@@ -1527,5 +1527,47 @@ describe('estimateInputTokens', () => {
     expect(buildPlanSpy).toHaveBeenCalledTimes(1)
     expect(buildEstimatedSpy).toHaveBeenCalledTimes(1)
     expect(renderSpy).not.toHaveBeenCalled()
+  })
+
+  test('estimatePreambleTokens counts non-native knowledge fallback text without rendering the preamble', async () => {
+    const fileId = 'knowledge-text-fallback'
+    const file = {
+      ...makePdfFile(fileId),
+      name: `${fileId}.txt`,
+      type: 'text/plain',
+    }
+    getFileWithId.mockResolvedValue(file)
+    ensureFileAnalysis.mockResolvedValue({
+      fileId,
+      kind: 'unknown',
+      status: 'failed',
+      analyzerVersion: 1,
+      payload: null,
+      error: 'unsupported',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as dto.FileAnalysis)
+    extractFromFile.mockResolvedValue('knowledge text fallback content')
+
+    const preambleModule = await import('@/backend/lib/chat/preamble')
+    vi.spyOn(preambleModule, 'preparePreamblePlan').mockResolvedValue({
+      systemPromptMessage: { role: 'system', content: 'system' },
+      knowledgeFileEntries: [{ fileId, fileName: file.name, mimetype: file.type, partIndex: 0 }],
+    })
+    vi.spyOn(preambleModule, 'renderPreamblePlan')
+
+    const { estimatePreambleTokens } = await import('@/backend/lib/chat/token-estimator')
+    const result = await estimatePreambleTokens({
+      assistantParams: { ...assistantParams, model: gpt35Model.id },
+      model: gpt35Model,
+      tools: [],
+      parameters: {},
+      knowledgeFiles: [{ id: fileId, name: file.name, type: file.type, size: file.size }],
+    })
+
+    const expectedText = `Here is the text content of the file "${file.name}" with id ${file.id}\nknowledge text fallback content`
+    expect(result).toBe(countTextForModel(gpt35Model, 'system') + countTextForModel(gpt35Model, expectedText))
+    expect(preambleModule.renderPreamblePlan).not.toHaveBeenCalled()
+    expect(readBuffer).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
+++ b/apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from 'vitest'
+import * as dto from '@/types/dto'
+import { stockModels } from '@/lib/chat/models'
+import { dtoMessageToLlmMessage } from '@/backend/lib/chat/conversion'
+import { projectMessageForEstimation } from '@/backend/lib/chat/message-projection'
+import { countModelMessageTokens } from '@/backend/lib/chat/prompt-token-counter'
+import { estimateConversationWindowTokens } from '@/backend/lib/chat/token-estimator'
+
+const base = {
+  conversationId: 'conv-1',
+  parent: null,
+  sentAt: '2026-05-07T00:00:00.000Z',
+} as const
+
+const approxModel =
+  stockModels.find((model) => model.tokenizer === 'approx_4chars') ?? stockModels[0]
+
+if (!approxModel) {
+  throw new Error('No stock model available for tests')
+}
+
+describe('message projection parity', () => {
+  test('projects user metadata and attachment descriptor text', () => {
+    const message: dto.UserMessage = {
+      ...base,
+      id: 'u-1',
+      role: 'user',
+      content: 'hello',
+      metadata: { locale: 'en-US' },
+      attachments: [{ id: 'f-1', name: 'a.pdf', mimetype: 'application/pdf', size: 42 }],
+    }
+
+    const projected = projectMessageForEstimation(message)
+    expect(projected.role).toBe('user')
+    if (projected.role !== 'user') return
+    expect(projected.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'text', source: 'metadata' }),
+        expect.objectContaining({ kind: 'text', source: 'content', text: 'hello' }),
+        expect.objectContaining({ kind: 'text', source: 'attachment_descriptor' }),
+        expect.objectContaining({ kind: 'attachment' }),
+      ])
+    )
+  })
+
+  test('projects assistant reasoning only when signature exists and keeps tool call payload', () => {
+    const message: dto.AssistantMessage = {
+      ...base,
+      id: 'a-1',
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'Answer' },
+        { type: 'reasoning', reasoning: 'hidden-no-signature' },
+        { type: 'reasoning', reasoning: 'hidden-with-signature', reasoning_signature: 'sig-1' },
+        { type: 'tool-call', toolCallId: 'tc-1', toolName: 'search', args: { q: 'x' } },
+      ],
+    }
+
+    const projected = projectMessageForEstimation(message)
+    expect(projected.role).toBe('assistant')
+    if (projected.role !== 'assistant') return
+    expect(projected.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'text', source: 'assistant_text', text: 'Answer' }),
+        expect.objectContaining({
+          kind: 'text',
+          source: 'assistant_reasoning',
+          text: 'hidden-with-signature',
+          reasoningSignature: 'sig-1',
+        }),
+        expect.objectContaining({
+          kind: 'tool_call',
+          toolCallId: 'tc-1',
+          toolName: 'search',
+          payload: { toolCallId: 'tc-1', toolName: 'search', input: { q: 'x' } },
+        }),
+      ])
+    )
+    expect(
+      projected.items.find(
+        (item) =>
+          item.kind === 'text' &&
+          item.source === 'assistant_reasoning' &&
+          item.text === 'hidden-no-signature'
+      )
+    ).toBeUndefined()
+  })
+
+  test('runtime conversion keeps signed reasoning and tool/result projections aligned', async () => {
+    const assistantMessage: dto.AssistantMessage = {
+      ...base,
+      id: 'a-2',
+      role: 'assistant',
+      parts: [
+        { type: 'reasoning', reasoning: 'reasoning', reasoning_signature: 'sig-2' },
+        { type: 'tool-call', toolCallId: 'tc-2', toolName: 'math', args: { x: 1 } },
+      ],
+    }
+    const toolMessage: dto.ToolMessage = {
+      ...base,
+      id: 't-1',
+      role: 'tool',
+      parts: [
+        {
+          type: 'tool-result',
+          toolCallId: 'tc-2',
+          toolName: 'math',
+          result: { type: 'text', value: '1' },
+        },
+      ],
+    }
+
+    const assistantLlm = await dtoMessageToLlmMessage(
+      assistantMessage,
+      approxModel.capabilities,
+      approxModel.provider
+    )
+    const toolLlm = await dtoMessageToLlmMessage(toolMessage, approxModel.capabilities, approxModel.provider)
+
+    expect(assistantLlm?.role).toBe('assistant')
+    expect(toolLlm?.role).toBe('tool')
+    if (!assistantLlm || !toolLlm || assistantLlm.role !== 'assistant' || toolLlm.role !== 'tool') return
+    expect(assistantLlm.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'reasoning', text: 'reasoning' }),
+        expect.objectContaining({ type: 'tool-call', toolCallId: 'tc-2', toolName: 'math' }),
+      ])
+    )
+    expect(toolLlm.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'tool-result', toolCallId: 'tc-2', toolName: 'math' }),
+      ])
+    )
+  })
+})
+
+describe('token invariant for non-file history', () => {
+  test('estimated history tokens equal runtime-projected message token sum', async () => {
+    const history: dto.Message[] = [
+      {
+        ...base,
+        id: 'u-2',
+        role: 'user',
+        content: 'Question?',
+        metadata: { ui: 'chat' },
+        attachments: [],
+      },
+      {
+        ...base,
+        id: 'a-3',
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'Answer.' },
+          { type: 'reasoning', reasoning: 'private', reasoning_signature: 'sig-3' },
+          { type: 'tool-call', toolCallId: 'tc-3', toolName: 'search', args: { q: 'abc' } },
+        ],
+      },
+      {
+        ...base,
+        id: 't-2',
+        role: 'tool',
+        parts: [
+          {
+            type: 'tool-result',
+            toolCallId: 'tc-3',
+            toolName: 'search',
+            result: { type: 'json', value: { ok: true } },
+          },
+        ],
+      },
+    ]
+
+    const estimate = await estimateConversationWindowTokens({
+      assistantParams: {
+        assistantId: 'asst-1',
+        model: approxModel.id,
+        systemPrompt: '',
+        temperature: 0,
+        tokenLimit: 100000,
+        reasoning_effort: null,
+      },
+      model: approxModel,
+      tools: [],
+      parameters: {},
+      knowledgeFiles: [],
+      history,
+      draft: null,
+    })
+
+    const llmMessages = (
+      await Promise.all(
+        history.map((message) =>
+          dtoMessageToLlmMessage(message, approxModel.capabilities, approxModel.provider)
+        )
+      )
+    ).filter((m): m is NonNullable<typeof m> => Boolean(m))
+
+    let runtimeHistoryTokens = 0
+    for (const llmMessage of llmMessages) {
+      runtimeHistoryTokens += await countModelMessageTokens(approxModel, llmMessage)
+    }
+
+    expect(estimate.estimate.history).toBe(runtimeHistoryTokens)
+  })
+})

--- a/apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
+++ b/apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
@@ -4,7 +4,11 @@ import { stockModels } from '@/lib/chat/models'
 import { dtoMessageToLlmMessage } from '@/backend/lib/chat/conversion'
 import { projectMessageForEstimation } from '@/backend/lib/chat/message-projection'
 import { countModelMessageTokens } from '@/backend/lib/chat/prompt-token-counter'
-import { estimateConversationWindowTokens } from '@/backend/lib/chat/token-estimator'
+import {
+  estimateConversationWindowTokens,
+  prepareConversationCostPlan,
+  selectOptimalHistoryStartIndex,
+} from '@/backend/lib/chat/token-estimator'
 
 const ONE_BY_ONE_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/a7cAAAAASUVORK5CYII='
@@ -522,5 +526,70 @@ describe('token invariant for non-file history', () => {
     expect(llm?.role).toBe('user')
     const runtimeTokens = llm ? await countModelMessageTokens(parityMediaModel as any, llm) : 0
     expect(estimate.estimate.history).toBe(runtimeTokens)
+  })
+})
+
+describe('truncation correctness', () => {
+  const buildTurns = (turns: number): dto.Message[] => {
+    const messages: dto.Message[] = []
+    for (let i = 1; i <= turns; i++) {
+      messages.push({
+        ...base,
+        id: `u-turn-${i}`,
+        role: 'user',
+        content: `user turn ${i} question with some text`,
+        attachments: [],
+      })
+      messages.push({
+        ...base,
+        id: `a-turn-${i}`,
+        role: 'assistant',
+        parts: [{ type: 'text', text: `assistant turn ${i} answer with some text` }],
+      })
+    }
+    return messages
+  }
+
+  const buildBaseAssistantParams = (systemPrompt: string) => ({
+    assistantId: 'asst-truncate',
+    model: approxModel.id,
+    systemPrompt,
+    temperature: 0,
+    tokenLimit: 100000,
+    reasoning_effort: null,
+  })
+
+  const truncateLengthFor = async (systemPrompt: string, tokenLimit: number) => {
+    const history = buildTurns(10)
+    const planResult = await prepareConversationCostPlan({
+      assistantParams: {
+        ...buildBaseAssistantParams(systemPrompt),
+        tokenLimit,
+      },
+      model: approxModel,
+      tools: [],
+      parameters: {},
+      knowledgeFiles: [],
+      history,
+      draft: null,
+    })
+    const startIndex = selectOptimalHistoryStartIndex(
+      history,
+      planResult.plan.historyMessageCosts,
+      planResult.plan.assistantTokens,
+      planResult.plan.draftTokens,
+      tokenLimit
+    )
+    return history.slice(startIndex).length
+  }
+
+  test('without extra preamble can keep 10/20 messages', async () => {
+    const kept = await truncateLengthFor('', 180)
+    expect(kept).toBe(10)
+  })
+
+  test('with huge preamble can keep 2/20 messages under same budget', async () => {
+    const kept = await truncateLengthFor('HUGE PROMPT '.repeat(5000), 180)
+    expect(kept).toBe(2)
   })
 })

--- a/apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
+++ b/apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
@@ -6,16 +6,130 @@ import { projectMessageForEstimation } from '@/backend/lib/chat/message-projecti
 import { countModelMessageTokens } from '@/backend/lib/chat/prompt-token-counter'
 import { estimateConversationWindowTokens } from '@/backend/lib/chat/token-estimator'
 
+const ONE_BY_ONE_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/a7cAAAAASUVORK5CYII='
+
 vi.mock('@/models/file', () => ({
-  getFileWithId: async (id: string) => ({
-    id,
-    fileBlobId: `blob-${id}`,
-    name: `mock-${id}.txt`,
-    type: 'text/plain',
-    path: '/tmp/mock-file.txt',
-    encrypted: false,
-    size: 12,
-  }),
+  getFileWithId: async (id: string) => {
+    const isPdf = id.includes('pdf')
+    const isImage = id.includes('img')
+    return {
+      id,
+      fileBlobId: `blob-${id}`,
+      name: isPdf ? `mock-${id}.pdf` : isImage ? `mock-${id}.png` : `mock-${id}.txt`,
+      type: isPdf ? 'application/pdf' : isImage ? 'image/png' : 'text/plain',
+      path: '/tmp/mock-file.txt',
+      encrypted: false,
+      size: 12,
+    }
+  },
+}))
+
+vi.mock('@/lib/storage', () => ({
+  storage: {
+    readBuffer: async () => Buffer.from(ONE_BY_ONE_PNG_BASE64, 'base64'),
+  },
+}))
+
+vi.mock('@/lib/file-analysis', () => ({
+  ensureFileAnalysis: async (file: { id: string; type: string }) => {
+    if (file.type === 'application/pdf') {
+      const pageCount = file.id.includes('over-limit') ? 10 : 2
+      return {
+        fileId: file.id,
+        kind: 'pdf',
+        status: 'ready',
+        analyzerVersion: 1,
+        payload: {
+          kind: 'pdf',
+          mimeType: 'application/pdf',
+          sizeBytes: 100,
+          pageCount,
+          visionPageCount: 1,
+          textCharCount: 20,
+          hasExtractableText: true,
+          imagePageCount: 0,
+          contentMode: 'text',
+          extractedTextPath: null,
+        },
+        warnings: [],
+        error: null,
+        createdAt: '2026-05-07T00:00:00.000Z',
+        updatedAt: '2026-05-07T00:00:00.000Z',
+      }
+    }
+    return {
+      fileId: file.id,
+      kind: 'image',
+      status: 'ready',
+      analyzerVersion: 1,
+      payload: {
+        kind: 'image',
+        mimeType: file.type,
+        sizeBytes: 100,
+        width: 1,
+        height: 1,
+        frameCount: 1,
+        hasAlpha: false,
+        format: 'png',
+        extractedTextPath: null,
+      },
+      warnings: [],
+      error: null,
+      createdAt: '2026-05-07T00:00:00.000Z',
+      updatedAt: '2026-05-07T00:00:00.000Z',
+    }
+  },
+  ensureFileAnalysisForFile: async (file: { id: string; type: string }) => {
+    if (file.type === 'application/pdf') {
+      const pageCount = file.id.includes('over-limit') ? 10 : 2
+      return {
+        fileId: file.id,
+        kind: 'pdf',
+        status: 'ready',
+        analyzerVersion: 1,
+        payload: {
+          kind: 'pdf',
+          mimeType: 'application/pdf',
+          sizeBytes: 100,
+          pageCount,
+          visionPageCount: 1,
+          textCharCount: 20,
+          hasExtractableText: true,
+          imagePageCount: 0,
+          contentMode: 'text',
+          extractedTextPath: null,
+        },
+        warnings: [],
+        error: null,
+        createdAt: '2026-05-07T00:00:00.000Z',
+        updatedAt: '2026-05-07T00:00:00.000Z',
+      }
+    }
+    return {
+      fileId: file.id,
+      kind: 'image',
+      status: 'ready',
+      analyzerVersion: 1,
+      payload: {
+        kind: 'image',
+        mimeType: file.type,
+        sizeBytes: 100,
+        width: 1,
+        height: 1,
+        frameCount: 1,
+        hasAlpha: false,
+        format: 'png',
+        extractedTextPath: null,
+      },
+      warnings: [],
+      error: null,
+      createdAt: '2026-05-07T00:00:00.000Z',
+      updatedAt: '2026-05-07T00:00:00.000Z',
+    }
+  },
+  isReadyFileAnalysis: (analysis: { status: string }) => analysis.status === 'ready',
+  readExtractedTextFromAnalysis: async () => 'mock pdf extracted text',
 }))
 
 const base = {
@@ -29,6 +143,18 @@ const approxModel =
 
 if (!approxModel) {
   throw new Error('No stock model available for tests')
+}
+
+const parityMediaModel = {
+  ...approxModel,
+  owned_by: 'openai',
+  tokenizer: 'approx_4chars',
+  capabilities: {
+    ...approxModel.capabilities,
+    vision: true,
+    supportedMedia: ['application/pdf'],
+    nativePdfPageLimit: 3,
+  },
 }
 
 describe('message projection parity', () => {
@@ -270,5 +396,131 @@ describe('token invariant for non-file history', () => {
     }
 
     expect(estimate.estimate.history).toBe(runtimeHistoryTokens)
+  })
+
+  test('ignored user-request/user-response messages contribute zero in both projection and estimate', async () => {
+    const history: dto.Message[] = [
+      {
+        ...base,
+        id: 'r-1',
+        role: 'user-request',
+        request: {
+          type: 'tool-call-authorization',
+          toolCallId: 'tc-9',
+          toolName: 'x',
+          args: {},
+        },
+      },
+      {
+        ...base,
+        id: 'r-2',
+        role: 'user-response',
+        allow: true,
+      },
+      {
+        ...base,
+        id: 'u-9',
+        role: 'user',
+        content: 'only this counts',
+        attachments: [],
+      },
+    ]
+    const estimate = await estimateConversationWindowTokens({
+      assistantParams: {
+        assistantId: 'asst-1',
+        model: approxModel.id,
+        systemPrompt: '',
+        temperature: 0,
+        tokenLimit: 100000,
+        reasoning_effort: null,
+      },
+      model: approxModel,
+      tools: [],
+      parameters: {},
+      knowledgeFiles: [],
+      history,
+      draft: null,
+    })
+    const llmMessages = (
+      await Promise.all(
+        history.map((message) =>
+          dtoMessageToLlmMessage(message, approxModel.capabilities, approxModel.provider)
+        )
+      )
+    ).filter((m): m is NonNullable<typeof m> => Boolean(m))
+    expect(llmMessages).toHaveLength(1)
+    const runtimeTokens = await countModelMessageTokens(approxModel, llmMessages[0]!)
+    expect(estimate.estimate.history).toBe(runtimeTokens)
+  })
+
+  test('native image attachment path stays parity-aligned', async () => {
+    const history: dto.Message[] = [
+      {
+        ...base,
+        id: 'u-img',
+        role: 'user',
+        content: 'image',
+        attachments: [{ id: 'img-1', name: 'img.png', mimetype: 'image/png', size: 100 }],
+      },
+    ]
+    const estimate = await estimateConversationWindowTokens({
+      assistantParams: {
+        assistantId: 'asst-1',
+        model: parityMediaModel.id,
+        systemPrompt: '',
+        temperature: 0,
+        tokenLimit: 100000,
+        reasoning_effort: null,
+      },
+      model: parityMediaModel as any,
+      tools: [],
+      parameters: {},
+      knowledgeFiles: [],
+      history,
+      draft: null,
+    })
+    const llm = await dtoMessageToLlmMessage(history[0]!, parityMediaModel.capabilities as any, 'openai')
+    expect(llm?.role).toBe('user')
+    const runtimeTokens = llm ? await countModelMessageTokens(parityMediaModel as any, llm) : 0
+    expect(estimate.estimate.history).toBe(runtimeTokens)
+  })
+
+  test('pdf over native page limit uses text notice parity path', async () => {
+    const history: dto.Message[] = [
+      {
+        ...base,
+        id: 'u-pdf',
+        role: 'user',
+        content: 'pdf',
+        attachments: [
+          {
+            id: 'pdf-over-limit-1',
+            name: 'mock-pdf-over-limit-1.pdf',
+            mimetype: 'application/pdf',
+            size: 100,
+          },
+        ],
+      },
+    ]
+    const estimate = await estimateConversationWindowTokens({
+      assistantParams: {
+        assistantId: 'asst-1',
+        model: parityMediaModel.id,
+        systemPrompt: '',
+        temperature: 0,
+        tokenLimit: 100000,
+        reasoning_effort: null,
+      },
+      model: parityMediaModel as any,
+      tools: [],
+      parameters: {},
+      knowledgeFiles: [],
+      history,
+      draft: null,
+    })
+    const llm = await dtoMessageToLlmMessage(history[0]!, parityMediaModel.capabilities as any, 'openai')
+    expect(llm?.role).toBe('user')
+    const runtimeTokens = llm ? await countModelMessageTokens(parityMediaModel as any, llm) : 0
+    expect(estimate.estimate.history).toBe(runtimeTokens)
   })
 })

--- a/apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
+++ b/apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
@@ -1,10 +1,22 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import * as dto from '@/types/dto'
 import { stockModels } from '@/lib/chat/models'
 import { dtoMessageToLlmMessage } from '@/backend/lib/chat/conversion'
 import { projectMessageForEstimation } from '@/backend/lib/chat/message-projection'
 import { countModelMessageTokens } from '@/backend/lib/chat/prompt-token-counter'
 import { estimateConversationWindowTokens } from '@/backend/lib/chat/token-estimator'
+
+vi.mock('@/models/file', () => ({
+  getFileWithId: async (id: string) => ({
+    id,
+    fileBlobId: `blob-${id}`,
+    name: `mock-${id}.txt`,
+    type: 'text/plain',
+    path: '/tmp/mock-file.txt',
+    encrypted: false,
+    size: 12,
+  }),
+}))
 
 const base = {
   conversationId: 'conv-1',
@@ -131,6 +143,63 @@ describe('message projection parity', () => {
         expect.objectContaining({ type: 'tool-result', toolCallId: 'tc-2', toolName: 'math' }),
       ])
     )
+  })
+
+  test('tool result content with files includes attached_files descriptor and remains estimable', async () => {
+    const toolMessage: dto.ToolMessage = {
+      ...base,
+      id: 't-3',
+      role: 'tool',
+      parts: [
+        {
+          type: 'tool-result',
+          toolCallId: 'tc-4',
+          toolName: 'knowledge',
+          result: {
+            type: 'content',
+            value: [
+              { type: 'text', text: 'summary' },
+              { type: 'file', id: 'file-1', mimetype: 'text/plain', name: 'doc.txt', size: 100 },
+            ],
+          },
+        },
+      ],
+    }
+
+    const projected = projectMessageForEstimation(toolMessage)
+    expect(projected.role).toBe('tool')
+    if (projected.role !== 'tool') return
+    expect(projected.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'tool_result',
+          toolCallId: 'tc-4',
+          toolName: 'knowledge',
+        }),
+      ])
+    )
+
+    const llm = await dtoMessageToLlmMessage(toolMessage, approxModel.capabilities, 'litellm')
+    expect(llm?.role).toBe('tool')
+    if (!llm || llm.role !== 'tool') return
+    const content = llm.content
+    expect(content[0]).toEqual(
+      expect.objectContaining({
+        type: 'tool-result',
+        toolCallId: 'tc-4',
+        toolName: 'knowledge',
+      })
+    )
+    const toolResultPart = content.find((part) => part.type === 'tool-result')
+    const output = toolResultPart?.output
+    expect(output && typeof output === 'object' ? (output as any).type : undefined).toBe('content')
+    const outputParts = output && typeof output === 'object' && 'value' in output ? (output as any).value : []
+    expect(outputParts[0]).toEqual(
+      expect.objectContaining({
+        type: 'text',
+      })
+    )
+    expect(String(outputParts[0]?.text ?? '')).toContain('"attached_files"')
   })
 })
 

--- a/apps/backend/lib/chat/conversion.ts
+++ b/apps/backend/lib/chat/conversion.ts
@@ -16,6 +16,7 @@ import {
 } from './file-attachment-policy'
 import {
   projectMessageForEstimation,
+  projectedToolResultAttachedFilesDescriptor,
   projectedAssistantToolCallPayload,
 } from './message-projection'
 
@@ -27,17 +28,6 @@ const supportsToolResultAttachments = (providerName: string) =>
 const toolResultAttachmentText = (fileEntry: FileDbRow) =>
   `The tool returned a file attachment "${fileEntry.name}" (${fileEntry.type}, id ${fileEntry.id}) that is available in the UI, but this provider cannot receive binary tool attachments.`
 type ToolCallResultOutput = ai.ToolResultPart['output']
-
-const describeAttachedFiles = (
-  files: Array<{ id: string; name: string; size: number; mimetype: string }>
-) => ({
-  attached_files: files.map((f) => ({
-    id: f.id,
-    name: f.name,
-    size: f.size,
-    mimetype: f.mimetype,
-  })),
-})
 
 export const loadImagePartFromFileEntry = async (fileEntry: FileDbRow): Promise<ai.ImagePart> => {
   let fileContent: Buffer
@@ -190,7 +180,7 @@ export const dtoMessageToLlmMessage = async (
             return output
           case 'content': {
             const files = output.value.filter((v) => v.type === 'file')
-            const description = describeAttachedFiles(files)
+            const description = projectedToolResultAttachedFilesDescriptor(files)
             const outputs = await Promise.all(
               output.value.map(async (v) => {
                 switch (v.type) {

--- a/apps/backend/lib/chat/conversion.ts
+++ b/apps/backend/lib/chat/conversion.ts
@@ -265,10 +265,13 @@ export const dtoMessageToLlmMessage = async (
       content: parts,
     }
   }
-  const message: ai.ModelMessage = {
-    role: 'user',
-    content: '',
+  if (m.role === 'user' && m.attachments.length === 0 && !m.metadata) {
+    return {
+      role: 'user',
+      content: m.content,
+    }
   }
+  const message: ai.ModelMessage = { role: 'user', content: '' }
   const attachments = projected.items.filter((item) => item.kind === 'attachment')
   if (attachments.length !== 0) {
     const messageParts: typeof message.content = []

--- a/apps/backend/lib/chat/conversion.ts
+++ b/apps/backend/lib/chat/conversion.ts
@@ -64,6 +64,7 @@ export type EstimationProjectionItem =
       kind: 'text'
       text: string
       source?: 'content' | 'metadata' | 'attachment_descriptor' | 'assistant_text' | 'assistant_reasoning'
+      reasoningSignature?: string
     }
   | {
       kind: 'attachment'
@@ -115,7 +116,12 @@ export const projectMessageForEstimation = (message: dto.Message): EstimationMes
       if (part.type === 'text') {
         items.push({ kind: 'text', text: part.text, source: 'assistant_text' })
       } else if (part.type === 'reasoning' && shouldIncludeAssistantReasoningPart(part)) {
-        items.push({ kind: 'text', text: part.reasoning, source: 'assistant_reasoning' })
+        items.push({
+          kind: 'text',
+          text: part.reasoning,
+          source: 'assistant_reasoning',
+          reasoningSignature: part.reasoning_signature,
+        })
       } else if (part.type === 'tool-call') {
         const payload = projectedAssistantToolCallPayload(part)
         items.push({
@@ -278,10 +284,10 @@ export const dtoMessageToLlmMessage = async (
   capabilities: LlmModelCapabilities,
   providerName: string
 ): Promise<ai.ModelMessage | undefined> => {
-  if (m.role === 'user-request') return undefined
-  if (m.role === 'user-response') return undefined
-  if (m.role === 'tool') {
-    const results = m.parts.filter((m) => m.type === 'tool-result')
+  const projected = projectMessageForEstimation(m)
+  if (projected.role === 'ignored') return undefined
+  if (projected.role === 'tool') {
+    const results = projected.items.filter((item) => item.kind === 'tool_result')
     if (results.length === 0) return undefined
     const convertOutput = async (output: dto.ToolCallResultOutput): Promise<ToolCallResultOutput> => {
       if ((output as dto.ToolCallResultOutput).type) {
@@ -339,40 +345,37 @@ export const dtoMessageToLlmMessage = async (
           return {
             toolCallId: result.toolCallId,
             toolName: result.toolName,
-            output: await convertOutput(result.result),
+            output: await convertOutput(result.output),
             type: 'tool-result',
           }
         })
       ),
     }
-  } else if (m.role === 'assistant') {
+  } else if (projected.role === 'assistant') {
     type ContentArrayElement = Extract<ai.AssistantContent, any[]>[number]
     const parts: ContentArrayElement[] = []
-    m.parts.forEach((part) => {
-      if (part.type === 'tool-call') {
-        const projected = projectedAssistantToolCallPayload(part)
+    projected.items.forEach((item) => {
+      if (item.kind === 'tool_call') {
         parts.push({
           type: 'tool-call',
-          toolCallId: projected.toolCallId,
-          toolName: projected.toolName,
-          input: projected.input,
+          toolCallId: item.toolCallId,
+          toolName: item.toolName,
+          input: item.payload.input,
         })
-      } else if (part.type === 'text') {
-        parts.push({
-          type: 'text',
-          text: part.text,
-        })
-      } else if (part.type === 'builtin-tool-result') {
-        // builtin tools are just... notifications
-      } else if (part.type === 'reasoning' && shouldIncludeAssistantReasoningPart(part)) {
+      } else if (item.kind === 'text' && item.source === 'assistant_reasoning' && item.reasoningSignature) {
         parts.push({
           type: 'reasoning',
-          text: part.reasoning,
+          text: item.text,
           providerOptions: {
             anthropic: {
-              signature: part.reasoning_signature,
+              signature: item.reasoningSignature,
             },
           },
+        })
+      } else if (item.kind === 'text') {
+        parts.push({
+          type: 'text',
+          text: item.text,
         })
       }
     })
@@ -381,57 +384,37 @@ export const dtoMessageToLlmMessage = async (
       content: parts,
     }
   }
-  const metadataText = m.role === 'user' ? userMessageMetadataText(m) : undefined
-  const attachmentDescriptorText = m.role === 'user' ? userAttachmentDescriptorText(m) : undefined
   const message: ai.ModelMessage = {
-    role: m.role,
-    content: m.content,
+    role: 'user',
+    content: '',
   }
-  if (m.attachments.length !== 0) {
+  const attachments = projected.items.filter((item) => item.kind === 'attachment')
+  if (attachments.length !== 0) {
     const messageParts: typeof message.content = []
-    if (metadataText) {
-      messageParts.push({
-        type: 'text',
-        text: metadataText,
-      })
+    for (const item of projected.items) {
+      if (item.kind !== 'text') continue
+      messageParts.push({ type: 'text', text: item.text })
     }
-    if (m.content.length !== 0)
-      messageParts.push({
-        type: 'text',
-        text: m.content,
-      })
     const fileParts = (
       await Promise.all(
-        m.attachments.map(async (a) => {
-          const fileEntry = await getFileWithId(a.id)
+        attachments.map(async (item) => {
+          const fileEntry = await getFileWithId(item.attachment.id)
           if (!fileEntry) {
-            logger.warn(`Can't find entry for attachment ${a.id}`)
+            logger.warn(`Can't find entry for attachment ${item.attachment.id}`)
             return undefined
           }
           return await dtoFileToLlmFilePart(fileEntry, capabilities)
         })
       )
     ).filter((a) => a !== undefined)
-    if (attachmentDescriptorText) {
-      messageParts.push({
-        type: 'text',
-        text: attachmentDescriptorText,
-      })
-    }
     message.content = [...messageParts, ...fileParts]
-  } else if (metadataText) {
+  } else {
+    const textItems = projected.items.filter((item) => item.kind === 'text')
     const messageParts: typeof message.content = []
-    messageParts.push({
-      type: 'text',
-      text: metadataText,
-    })
-    if (m.content.length !== 0) {
-      messageParts.push({
-        type: 'text',
-        text: m.content,
-      })
+    for (const item of textItems) {
+      messageParts.push({ type: 'text', text: item.text })
     }
-    message.content = messageParts
+    message.content = messageParts.length > 0 ? messageParts : ''
   }
   return message
 }

--- a/apps/backend/lib/chat/conversion.ts
+++ b/apps/backend/lib/chat/conversion.ts
@@ -59,6 +59,89 @@ export const projectedToolResultMetaPayload = (part: dto.ToolCallResultPart) => 
   toolName: part.toolName,
 })
 
+export type EstimationProjectionItem =
+  | {
+      kind: 'text'
+      text: string
+      source?: 'content' | 'metadata' | 'attachment_descriptor' | 'assistant_text' | 'assistant_reasoning'
+    }
+  | {
+      kind: 'attachment'
+      attachment: dto.Attachment
+    }
+  | {
+      kind: 'tool_call'
+      toolCallId: string
+      toolName: string
+      payload: ReturnType<typeof projectedAssistantToolCallPayload>
+    }
+  | {
+      kind: 'tool_result'
+      toolCallId: string
+      toolName: string
+      metaPayload: ReturnType<typeof projectedToolResultMetaPayload>
+      output: dto.ToolCallResultOutput
+    }
+
+export type EstimationMessageProjection =
+  | { role: 'user' | 'assistant' | 'tool'; items: EstimationProjectionItem[] }
+  | { role: 'ignored'; items: [] }
+
+export const projectMessageForEstimation = (message: dto.Message): EstimationMessageProjection => {
+  if (message.role === 'user-request' || message.role === 'user-response') {
+    return { role: 'ignored', items: [] }
+  }
+  if (message.role === 'user') {
+    const items: EstimationProjectionItem[] = []
+    const metadataText = userMessageMetadataText(message)
+    if (metadataText) items.push({ kind: 'text', text: metadataText, source: 'metadata' })
+    if (message.content.length !== 0) items.push({ kind: 'text', text: message.content, source: 'content' })
+    const attachmentDescriptorText = userAttachmentDescriptorText(message)
+    if (attachmentDescriptorText) {
+      items.push({
+        kind: 'text',
+        text: attachmentDescriptorText,
+        source: 'attachment_descriptor',
+      })
+    }
+    for (const attachment of message.attachments) {
+      items.push({ kind: 'attachment', attachment })
+    }
+    return { role: 'user', items }
+  }
+  if (message.role === 'assistant') {
+    const items: EstimationProjectionItem[] = []
+    for (const part of message.parts) {
+      if (part.type === 'text') {
+        items.push({ kind: 'text', text: part.text, source: 'assistant_text' })
+      } else if (part.type === 'reasoning' && shouldIncludeAssistantReasoningPart(part)) {
+        items.push({ kind: 'text', text: part.reasoning, source: 'assistant_reasoning' })
+      } else if (part.type === 'tool-call') {
+        const payload = projectedAssistantToolCallPayload(part)
+        items.push({
+          kind: 'tool_call',
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          payload,
+        })
+      }
+    }
+    return { role: 'assistant', items }
+  }
+  const items: EstimationProjectionItem[] = []
+  for (const part of message.parts) {
+    if (part.type !== 'tool-result') continue
+    items.push({
+      kind: 'tool_result',
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      metaPayload: projectedToolResultMetaPayload(part),
+      output: part.result,
+    })
+  }
+  return { role: 'tool', items }
+}
+
 export const loadImagePartFromFileEntry = async (fileEntry: FileDbRow): Promise<ai.ImagePart> => {
   let fileContent: Buffer
   try {

--- a/apps/backend/lib/chat/conversion.ts
+++ b/apps/backend/lib/chat/conversion.ts
@@ -14,6 +14,10 @@ import {
   canSendAsNativeImage,
   resolvePdfNativeAttachmentDecision,
 } from './file-attachment-policy'
+import {
+  projectMessageForEstimation,
+  projectedAssistantToolCallPayload,
+} from './message-projection'
 
 // LiteLLM does not support binary attachments inside tool results. Detect this by inspecting
 // the AI SDK provider string rather than storing the limitation in model capabilities.
@@ -34,119 +38,6 @@ const describeAttachedFiles = (
     mimetype: f.mimetype,
   })),
 })
-
-export const userMessageMetadataText = (message: dto.UserMessage): string | undefined =>
-  message.metadata
-    ? `Message metadata (system-use): ${JSON.stringify(message.metadata)}`
-    : undefined
-
-export const userAttachmentDescriptorText = (message: dto.UserMessage): string | undefined =>
-  message.attachments.length === 0
-    ? undefined
-    : `The user has attached the following files to this chat: \n${JSON.stringify(message.attachments)}`
-
-export const shouldIncludeAssistantReasoningPart = (part: dto.ReasoningPart): boolean =>
-  Boolean(part.reasoning_signature)
-
-export const projectedAssistantToolCallPayload = (part: dto.ToolCallPart) => ({
-  toolCallId: part.toolCallId,
-  toolName: part.toolName,
-  input: part.args,
-})
-
-export const projectedToolResultMetaPayload = (part: dto.ToolCallResultPart) => ({
-  toolCallId: part.toolCallId,
-  toolName: part.toolName,
-})
-
-export type EstimationProjectionItem =
-  | {
-      kind: 'text'
-      text: string
-      source?: 'content' | 'metadata' | 'attachment_descriptor' | 'assistant_text' | 'assistant_reasoning'
-      reasoningSignature?: string
-    }
-  | {
-      kind: 'attachment'
-      attachment: dto.Attachment
-    }
-  | {
-      kind: 'tool_call'
-      toolCallId: string
-      toolName: string
-      payload: ReturnType<typeof projectedAssistantToolCallPayload>
-    }
-  | {
-      kind: 'tool_result'
-      toolCallId: string
-      toolName: string
-      metaPayload: ReturnType<typeof projectedToolResultMetaPayload>
-      output: dto.ToolCallResultOutput
-    }
-
-export type EstimationMessageProjection =
-  | { role: 'user' | 'assistant' | 'tool'; items: EstimationProjectionItem[] }
-  | { role: 'ignored'; items: [] }
-
-export const projectMessageForEstimation = (message: dto.Message): EstimationMessageProjection => {
-  if (message.role === 'user-request' || message.role === 'user-response') {
-    return { role: 'ignored', items: [] }
-  }
-  if (message.role === 'user') {
-    const items: EstimationProjectionItem[] = []
-    const metadataText = userMessageMetadataText(message)
-    if (metadataText) items.push({ kind: 'text', text: metadataText, source: 'metadata' })
-    if (message.content.length !== 0) items.push({ kind: 'text', text: message.content, source: 'content' })
-    const attachmentDescriptorText = userAttachmentDescriptorText(message)
-    if (attachmentDescriptorText) {
-      items.push({
-        kind: 'text',
-        text: attachmentDescriptorText,
-        source: 'attachment_descriptor',
-      })
-    }
-    for (const attachment of message.attachments) {
-      items.push({ kind: 'attachment', attachment })
-    }
-    return { role: 'user', items }
-  }
-  if (message.role === 'assistant') {
-    const items: EstimationProjectionItem[] = []
-    for (const part of message.parts) {
-      if (part.type === 'text') {
-        items.push({ kind: 'text', text: part.text, source: 'assistant_text' })
-      } else if (part.type === 'reasoning' && shouldIncludeAssistantReasoningPart(part)) {
-        items.push({
-          kind: 'text',
-          text: part.reasoning,
-          source: 'assistant_reasoning',
-          reasoningSignature: part.reasoning_signature,
-        })
-      } else if (part.type === 'tool-call') {
-        const payload = projectedAssistantToolCallPayload(part)
-        items.push({
-          kind: 'tool_call',
-          toolCallId: part.toolCallId,
-          toolName: part.toolName,
-          payload,
-        })
-      }
-    }
-    return { role: 'assistant', items }
-  }
-  const items: EstimationProjectionItem[] = []
-  for (const part of message.parts) {
-    if (part.type !== 'tool-result') continue
-    items.push({
-      kind: 'tool_result',
-      toolCallId: part.toolCallId,
-      toolName: part.toolName,
-      metaPayload: projectedToolResultMetaPayload(part),
-      output: part.result,
-    })
-  }
-  return { role: 'tool', items }
-}
 
 export const loadImagePartFromFileEntry = async (fileEntry: FileDbRow): Promise<ai.ImagePart> => {
   let fileContent: Buffer

--- a/apps/backend/lib/chat/conversion.ts
+++ b/apps/backend/lib/chat/conversion.ts
@@ -35,6 +35,30 @@ const describeAttachedFiles = (
   })),
 })
 
+export const userMessageMetadataText = (message: dto.UserMessage): string | undefined =>
+  message.metadata
+    ? `Message metadata (system-use): ${JSON.stringify(message.metadata)}`
+    : undefined
+
+export const userAttachmentDescriptorText = (message: dto.UserMessage): string | undefined =>
+  message.attachments.length === 0
+    ? undefined
+    : `The user has attached the following files to this chat: \n${JSON.stringify(message.attachments)}`
+
+export const shouldIncludeAssistantReasoningPart = (part: dto.ReasoningPart): boolean =>
+  Boolean(part.reasoning_signature)
+
+export const projectedAssistantToolCallPayload = (part: dto.ToolCallPart) => ({
+  toolCallId: part.toolCallId,
+  toolName: part.toolName,
+  input: part.args,
+})
+
+export const projectedToolResultMetaPayload = (part: dto.ToolCallResultPart) => ({
+  toolCallId: part.toolCallId,
+  toolName: part.toolName,
+})
+
 export const loadImagePartFromFileEntry = async (fileEntry: FileDbRow): Promise<ai.ImagePart> => {
   let fileContent: Buffer
   try {
@@ -243,11 +267,12 @@ export const dtoMessageToLlmMessage = async (
     const parts: ContentArrayElement[] = []
     m.parts.forEach((part) => {
       if (part.type === 'tool-call') {
+        const projected = projectedAssistantToolCallPayload(part)
         parts.push({
           type: 'tool-call',
-          toolCallId: part.toolCallId,
-          toolName: part.toolName,
-          input: part.args,
+          toolCallId: projected.toolCallId,
+          toolName: projected.toolName,
+          input: projected.input,
         })
       } else if (part.type === 'text') {
         parts.push({
@@ -256,7 +281,7 @@ export const dtoMessageToLlmMessage = async (
         })
       } else if (part.type === 'builtin-tool-result') {
         // builtin tools are just... notifications
-      } else if (part.type === 'reasoning' && part.reasoning_signature) {
+      } else if (part.type === 'reasoning' && shouldIncludeAssistantReasoningPart(part)) {
         parts.push({
           type: 'reasoning',
           text: part.reasoning,
@@ -273,10 +298,8 @@ export const dtoMessageToLlmMessage = async (
       content: parts,
     }
   }
-  const metadataText =
-    m.role === 'user' && m.metadata
-      ? `Message metadata (system-use): ${JSON.stringify(m.metadata)}`
-      : undefined
+  const metadataText = m.role === 'user' ? userMessageMetadataText(m) : undefined
+  const attachmentDescriptorText = m.role === 'user' ? userAttachmentDescriptorText(m) : undefined
   const message: ai.ModelMessage = {
     role: m.role,
     content: m.content,
@@ -306,12 +329,10 @@ export const dtoMessageToLlmMessage = async (
         })
       )
     ).filter((a) => a !== undefined)
-    if (m.attachments.length) {
+    if (attachmentDescriptorText) {
       messageParts.push({
         type: 'text',
-        text: `The user has attached the following files to this chat: \n${JSON.stringify(
-          m.attachments
-        )}`,
+        text: attachmentDescriptorText,
       })
     }
     message.content = [...messageParts, ...fileParts]

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -504,9 +504,15 @@ export class ChatAssistant {
         plan.assistantTokens +
         plan.draftTokens +
         plan.historyMessageCosts.slice(startIndex).reduce((s, e) => s + e.tokens, 0)
-      logger.info(
-        `Truncating chat: estimated token count ${totalTokens} within limit of ${this.assistantParams.tokenLimit} after dropping ${startIndex} messages`
-      )
+      if (totalTokens <= this.assistantParams.tokenLimit) {
+        logger.info(
+          `Truncating chat: estimated token count ${totalTokens} within limit of ${this.assistantParams.tokenLimit} after dropping ${startIndex} messages`
+        )
+      } else {
+        logger.info(
+          `Truncating chat: latest user turn still exceeds limit of ${this.assistantParams.tokenLimit}`
+        )
+      }
     }
     return messages.slice(startIndex)
   }

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -28,7 +28,6 @@ import { nanoid } from 'nanoid'
 import {
   prepareConversationCostPlan,
   selectOptimalHistoryStartIndex,
-  computeConversationTotalCostFromStartIndex,
 } from '@/backend/lib/chat/token-estimator'
 import {
   normalizeMcpToolResult,
@@ -500,8 +499,11 @@ export class ChatAssistant {
       plan.draftTokens,
       this.assistantParams.tokenLimit
     )
-    const totalTokens = computeConversationTotalCostFromStartIndex(plan, startIndex)
     if (startIndex > 0) {
+      const totalTokens =
+        plan.assistantTokens +
+        plan.draftTokens +
+        plan.historyMessageCosts.slice(startIndex).reduce((s, e) => s + e.tokens, 0)
       logger.info(
         `Truncating chat: estimated token count ${totalTokens} within limit of ${this.assistantParams.tokenLimit} after dropping ${startIndex} messages`
       )

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -25,7 +25,11 @@ import { llmModels } from '@/lib/models'
 import { z } from 'zod/v4'
 import { ParameterValueAndDescription } from '@/models/user'
 import { nanoid } from 'nanoid'
-import { estimateConversationWindowTokens } from '@/backend/lib/chat/token-estimator'
+import {
+  prepareConversationCostPlan,
+  selectOptimalHistoryStartIndex,
+  computeConversationTotalCostFromStartIndex,
+} from '@/backend/lib/chat/token-estimator'
 import {
   normalizeMcpToolResult,
   persistFileLikePayload,
@@ -481,47 +485,28 @@ export class ChatAssistant {
 
   async truncateChat(messages: dto.Message[]) {
     if (messages.length === 0) return messages
-
-    const userTurnStartIndexes = messages.flatMap((message, index) =>
-      message.role === 'user' && index > 0 ? [index] : []
+    const { plan } = await prepareConversationCostPlan({
+      assistantParams: this.assistantParams,
+      model: this.llmModel,
+      tools: this.tools,
+      parameters: this.parameters,
+      knowledgeFiles: this.knowledge,
+      history: messages,
+    })
+    const startIndex = selectOptimalHistoryStartIndex(
+      messages,
+      plan.historyMessageCosts,
+      plan.assistantTokens,
+      plan.draftTokens,
+      this.assistantParams.tokenLimit
     )
-    const candidateStartIndexes = [0, ...userTurnStartIndexes]
-
-    for (const startIndex of candidateStartIndexes) {
-      const candidateMessages = messages.slice(startIndex)
-      const { estimate } = await estimateConversationWindowTokens({
-        assistantParams: this.assistantParams,
-        model: this.llmModel,
-        tools: this.tools,
-        parameters: this.parameters,
-        knowledgeFiles: this.knowledge,
-        history: candidateMessages,
-      })
-      const totalTokens = estimate.total
-      if (totalTokens <= this.assistantParams.tokenLimit) {
-        if (startIndex > 0) {
-          logger.info(
-            `Truncating chat: estimated token count ${totalTokens} within limit of ${this.assistantParams.tokenLimit} after dropping ${startIndex} messages`
-          )
-        }
-        return candidateMessages
-      }
-    }
-
-    let lastUserIndex = -1
-    for (let index = messages.length - 1; index >= 0; index--) {
-      if (messages[index].role === 'user') {
-        lastUserIndex = index
-        break
-      }
-    }
-    if (lastUserIndex > 0) {
+    const totalTokens = computeConversationTotalCostFromStartIndex(plan, startIndex)
+    if (startIndex > 0) {
       logger.info(
-        `Truncating chat: latest user turn still exceeds limit of ${this.assistantParams.tokenLimit}`
+        `Truncating chat: estimated token count ${totalTokens} within limit of ${this.assistantParams.tokenLimit} after dropping ${startIndex} messages`
       )
-      return messages.slice(lastUserIndex)
     }
-    return messages
+    return messages.slice(startIndex)
   }
 
   async computeLlmMessages(messages: dto.Message[]): Promise<ai.ModelMessage[]> {

--- a/apps/backend/lib/chat/message-projection.ts
+++ b/apps/backend/lib/chat/message-projection.ts
@@ -1,5 +1,16 @@
 import * as dto from '@/types/dto'
 
+export const projectedToolResultAttachedFilesDescriptor = (
+  files: Array<{ id: string; name: string; size: number; mimetype: string }>
+) => ({
+  attached_files: files.map((f) => ({
+    id: f.id,
+    name: f.name,
+    size: f.size,
+    mimetype: f.mimetype,
+  })),
+})
+
 export const userMessageMetadataText = (message: dto.UserMessage): string | undefined =>
   message.metadata
     ? `Message metadata (system-use): ${JSON.stringify(message.metadata)}`
@@ -24,7 +35,7 @@ export const projectedToolResultMetaPayload = (part: dto.ToolCallResultPart) => 
   toolName: part.toolName,
 })
 
-export type EstimationProjectionItem =
+export type MessageProjectionItem =
   | {
       kind: 'text'
       text: string
@@ -49,16 +60,16 @@ export type EstimationProjectionItem =
       output: dto.ToolCallResultOutput
     }
 
-export type EstimationMessageProjection =
-  | { role: 'user' | 'assistant' | 'tool'; items: EstimationProjectionItem[] }
+export type ProjectedMessageForEstimation =
+  | { role: 'user' | 'assistant' | 'tool'; items: MessageProjectionItem[] }
   | { role: 'ignored'; items: [] }
 
-export const projectMessageForEstimation = (message: dto.Message): EstimationMessageProjection => {
+export const projectMessageForEstimation = (message: dto.Message): ProjectedMessageForEstimation => {
   if (message.role === 'user-request' || message.role === 'user-response') {
     return { role: 'ignored', items: [] }
   }
   if (message.role === 'user') {
-    const items: EstimationProjectionItem[] = []
+    const items: MessageProjectionItem[] = []
     const metadataText = userMessageMetadataText(message)
     if (metadataText) items.push({ kind: 'text', text: metadataText, source: 'metadata' })
     if (message.content.length !== 0) items.push({ kind: 'text', text: message.content, source: 'content' })
@@ -76,7 +87,7 @@ export const projectMessageForEstimation = (message: dto.Message): EstimationMes
     return { role: 'user', items }
   }
   if (message.role === 'assistant') {
-    const items: EstimationProjectionItem[] = []
+    const items: MessageProjectionItem[] = []
     for (const part of message.parts) {
       if (part.type === 'text') {
         items.push({ kind: 'text', text: part.text, source: 'assistant_text' })
@@ -99,7 +110,7 @@ export const projectMessageForEstimation = (message: dto.Message): EstimationMes
     }
     return { role: 'assistant', items }
   }
-  const items: EstimationProjectionItem[] = []
+  const items: MessageProjectionItem[] = []
   for (const part of message.parts) {
     if (part.type !== 'tool-result') continue
     items.push({

--- a/apps/backend/lib/chat/message-projection.ts
+++ b/apps/backend/lib/chat/message-projection.ts
@@ -1,0 +1,114 @@
+import * as dto from '@/types/dto'
+
+export const userMessageMetadataText = (message: dto.UserMessage): string | undefined =>
+  message.metadata
+    ? `Message metadata (system-use): ${JSON.stringify(message.metadata)}`
+    : undefined
+
+export const userAttachmentDescriptorText = (message: dto.UserMessage): string | undefined =>
+  message.attachments.length === 0
+    ? undefined
+    : `The user has attached the following files to this chat: \n${JSON.stringify(message.attachments)}`
+
+export const shouldIncludeAssistantReasoningPart = (part: dto.ReasoningPart): boolean =>
+  Boolean(part.reasoning_signature)
+
+export const projectedAssistantToolCallPayload = (part: dto.ToolCallPart) => ({
+  toolCallId: part.toolCallId,
+  toolName: part.toolName,
+  input: part.args,
+})
+
+export const projectedToolResultMetaPayload = (part: dto.ToolCallResultPart) => ({
+  toolCallId: part.toolCallId,
+  toolName: part.toolName,
+})
+
+export type EstimationProjectionItem =
+  | {
+      kind: 'text'
+      text: string
+      source?: 'content' | 'metadata' | 'attachment_descriptor' | 'assistant_text' | 'assistant_reasoning'
+      reasoningSignature?: string
+    }
+  | {
+      kind: 'attachment'
+      attachment: dto.Attachment
+    }
+  | {
+      kind: 'tool_call'
+      toolCallId: string
+      toolName: string
+      payload: ReturnType<typeof projectedAssistantToolCallPayload>
+    }
+  | {
+      kind: 'tool_result'
+      toolCallId: string
+      toolName: string
+      metaPayload: ReturnType<typeof projectedToolResultMetaPayload>
+      output: dto.ToolCallResultOutput
+    }
+
+export type EstimationMessageProjection =
+  | { role: 'user' | 'assistant' | 'tool'; items: EstimationProjectionItem[] }
+  | { role: 'ignored'; items: [] }
+
+export const projectMessageForEstimation = (message: dto.Message): EstimationMessageProjection => {
+  if (message.role === 'user-request' || message.role === 'user-response') {
+    return { role: 'ignored', items: [] }
+  }
+  if (message.role === 'user') {
+    const items: EstimationProjectionItem[] = []
+    const metadataText = userMessageMetadataText(message)
+    if (metadataText) items.push({ kind: 'text', text: metadataText, source: 'metadata' })
+    if (message.content.length !== 0) items.push({ kind: 'text', text: message.content, source: 'content' })
+    const attachmentDescriptorText = userAttachmentDescriptorText(message)
+    if (attachmentDescriptorText) {
+      items.push({
+        kind: 'text',
+        text: attachmentDescriptorText,
+        source: 'attachment_descriptor',
+      })
+    }
+    for (const attachment of message.attachments) {
+      items.push({ kind: 'attachment', attachment })
+    }
+    return { role: 'user', items }
+  }
+  if (message.role === 'assistant') {
+    const items: EstimationProjectionItem[] = []
+    for (const part of message.parts) {
+      if (part.type === 'text') {
+        items.push({ kind: 'text', text: part.text, source: 'assistant_text' })
+      } else if (part.type === 'reasoning' && shouldIncludeAssistantReasoningPart(part)) {
+        items.push({
+          kind: 'text',
+          text: part.reasoning,
+          source: 'assistant_reasoning',
+          reasoningSignature: part.reasoning_signature,
+        })
+      } else if (part.type === 'tool-call') {
+        const payload = projectedAssistantToolCallPayload(part)
+        items.push({
+          kind: 'tool_call',
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          payload,
+        })
+      }
+    }
+    return { role: 'assistant', items }
+  }
+  const items: EstimationProjectionItem[] = []
+  for (const part of message.parts) {
+    if (part.type !== 'tool-result') continue
+    items.push({
+      kind: 'tool_result',
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      metaPayload: projectedToolResultMetaPayload(part),
+      output: part.result,
+    })
+  }
+  return { role: 'tool', items }
+}

--- a/apps/backend/lib/chat/preamble.ts
+++ b/apps/backend/lib/chat/preamble.ts
@@ -31,6 +31,7 @@ type AssistantParamsLike = {
 export type KnowledgeFileEntry = {
   fileId: string
   fileName: string
+  mimetype: string
   partIndex: number
 }
 
@@ -167,6 +168,7 @@ export async function preparePreamblePlan({
   const knowledgeFileEntries: KnowledgeFileEntry[] = knowledge.map((k, index) => ({
     fileId: k.id,
     fileName: k.name,
+    mimetype: k.type,
     partIndex: index,
   }))
   return {

--- a/apps/backend/lib/chat/preamble.ts
+++ b/apps/backend/lib/chat/preamble.ts
@@ -41,6 +41,16 @@ export type PromptSegment = {
   knowledgeFileEntries?: KnowledgeFileEntry[]
 }
 
+export type PreamblePlan = {
+  systemPromptMessage: ai.SystemModelMessage
+  knowledgePrompt?: string
+  knowledgeFileEntries?: KnowledgeFileEntry[]
+  materializeKnowledgeSegment?: () => Promise<{
+    message: ai.UserModelMessage
+    analysisFileIds: string[]
+  } | null>
+}
+
 export function fillTemplate(
   template: string,
   values: Record<string, ParameterValueAndDescription>
@@ -120,54 +130,109 @@ export async function buildPreambleSegments({
   parameters: Record<string, ParameterValueAndDescription>
   knowledge: dto.AssistantFile[]
 }): Promise<PromptSegment[]> {
-  const { KnowledgePlugin } = await import('@/backend/lib/tools/knowledge/implementation')
+  const plan = await preparePreamblePlan({ assistantParams, llmModel, tools, parameters, knowledge })
+  return renderPreamblePlan(plan)
+}
+
+export async function preparePreamblePlan({
+  assistantParams,
+  llmModel,
+  tools,
+  parameters,
+  knowledge,
+}: {
+  assistantParams: AssistantParamsLike
+  llmModel: LlmModel
+  tools: ToolImplementation[]
+  parameters: Record<string, ParameterValueAndDescription>
+  knowledge: dto.AssistantFile[]
+}): Promise<PreamblePlan> {
   const resolvedTools = await withBuiltinTools(tools, llmModel)
   const systemPromptMessage = await computeSystemPrompt(assistantParams, resolvedTools, parameters)
-  const segments: PromptSegment[] = [{ scope: 'prompt', message: systemPromptMessage }]
-
-  if (knowledge.length > 0 && env.knowledge.sendInPrompt) {
-    const knowledgePrompt = `
+  if (knowledge.length === 0 || !env.knowledge.sendInPrompt) {
+    return { systemPromptMessage }
+  }
+  const knowledgePrompt = `
       More files are available as assistant knowledge.
       These files can be retrieved or processed by function calls referring to their id.
       Here is the assistant knowledge:
       ${JSON.stringify(knowledge)}
       When the user requests to gather information from unspecified files, he's referring to files attached in the same message, so **do not mention / use the knowledge if it's not useful to answer the user question**.
       `
-    segments[0] = {
-      scope: 'prompt',
-      message: {
-        ...systemPromptMessage,
-        content: `${systemPromptMessage.content}${knowledgePrompt}`,
-      },
-    }
-    const knowledgePlugin = resolvedTools.find((t) => t instanceof KnowledgePlugin)
-    if (knowledgePlugin) {
-      // Limit concurrency to avoid saturating the libuv thread pool and
-      // the Node.js microtask queue when an assistant has many knowledge files.
-      // Unbounded Promise.all over hundreds of files causes multi-second
-      // health-check stalls and S3 socket pool exhaustion.
-      const parts = await mapWithConcurrency(
-        knowledge,
-        (k) => (knowledgePlugin as InstanceType<typeof KnowledgePlugin>).knowledgeToInputPart(k, llmModel),
-        8
-      )
-      const analysisFileIds = parts.flatMap((part, index) =>
-        part.type === 'file' ? [knowledge[index]?.id ?? ''] : []
-      ).filter((id) => id.length > 0)
-      const knowledgeFileEntries: KnowledgeFileEntry[] = knowledge.map((k, index) => ({
-        fileId: k.id,
-        fileName: k.name,
-        partIndex: index,
-      }))
-      segments.push({
-        scope: 'prompt',
-        message: { role: 'user', content: parts },
-        analysisFileIds,
-        knowledgeFileEntries,
-      })
-    }
+  const knowledgeFileEntries: KnowledgeFileEntry[] = knowledge.map((k, index) => ({
+    fileId: k.id,
+    fileName: k.name,
+    partIndex: index,
+  }))
+  const { KnowledgePlugin } = await import('@/backend/lib/tools/knowledge/implementation')
+  const knowledgePlugin = resolvedTools.find((t) => t instanceof KnowledgePlugin)
+  return {
+    systemPromptMessage,
+    knowledgePrompt,
+    knowledgeFileEntries,
+    materializeKnowledgeSegment: knowledgePlugin
+      ? async () => {
+          // Limit concurrency to avoid saturating the libuv thread pool and
+          // the Node.js microtask queue when an assistant has many knowledge files.
+          // Unbounded Promise.all over hundreds of files causes multi-second
+          // health-check stalls and S3 socket pool exhaustion.
+          const parts = await mapWithConcurrency(
+            knowledge,
+            (k) => (knowledgePlugin as InstanceType<typeof KnowledgePlugin>).knowledgeToInputPart(k, llmModel),
+            8
+          )
+          const analysisFileIds = parts
+            .flatMap((part, index) => (part.type === 'file' ? [knowledge[index]?.id ?? ''] : []))
+            .filter((id) => id.length > 0)
+          return {
+            message: { role: 'user', content: parts },
+            analysisFileIds,
+          }
+        }
+      : undefined,
   }
+}
 
+export function buildEstimatedPreambleSegments(plan: PreamblePlan): PromptSegment[] {
+  const segments: PromptSegment[] = [
+    {
+      scope: 'prompt',
+      message: plan.knowledgePrompt
+        ? {
+            ...plan.systemPromptMessage,
+            content: `${plan.systemPromptMessage.content}${plan.knowledgePrompt}`,
+          }
+        : plan.systemPromptMessage,
+    },
+  ]
+  if (plan.knowledgeFileEntries) {
+    segments.push({
+      scope: 'prompt',
+      message: { role: 'user', content: [] },
+      knowledgeFileEntries: plan.knowledgeFileEntries,
+    })
+  }
+  return segments
+}
+
+export async function renderPreamblePlan(
+  plan: PreamblePlan
+): Promise<PromptSegment[]> {
+  const segments = buildEstimatedPreambleSegments(plan)
+  if (!plan.knowledgeFileEntries) {
+    return segments
+  }
+  if (!plan.materializeKnowledgeSegment) {
+    return segments
+  }
+  const renderedKnowledge = await plan.materializeKnowledgeSegment()
+  if (!renderedKnowledge) return segments
+  segments[1] = {
+    scope: 'prompt',
+    message: renderedKnowledge.message,
+    analysisFileIds: renderedKnowledge.analysisFileIds,
+    knowledgeFileEntries: plan.knowledgeFileEntries,
+  }
   return segments
 }
 

--- a/apps/backend/lib/chat/preamble.ts
+++ b/apps/backend/lib/chat/preamble.ts
@@ -159,37 +159,38 @@ export async function preparePreamblePlan({
       ${JSON.stringify(knowledge)}
       When the user requests to gather information from unspecified files, he's referring to files attached in the same message, so **do not mention / use the knowledge if it's not useful to answer the user question**.
       `
+  const { KnowledgePlugin } = await import('@/backend/lib/tools/knowledge/implementation')
+  const knowledgePlugin = resolvedTools.find((t) => t instanceof KnowledgePlugin)
+  if (!knowledgePlugin) {
+    return { systemPromptMessage, knowledgePrompt }
+  }
   const knowledgeFileEntries: KnowledgeFileEntry[] = knowledge.map((k, index) => ({
     fileId: k.id,
     fileName: k.name,
     partIndex: index,
   }))
-  const { KnowledgePlugin } = await import('@/backend/lib/tools/knowledge/implementation')
-  const knowledgePlugin = resolvedTools.find((t) => t instanceof KnowledgePlugin)
   return {
     systemPromptMessage,
     knowledgePrompt,
     knowledgeFileEntries,
-    materializeKnowledgeSegment: knowledgePlugin
-      ? async () => {
-          // Limit concurrency to avoid saturating the libuv thread pool and
-          // the Node.js microtask queue when an assistant has many knowledge files.
-          // Unbounded Promise.all over hundreds of files causes multi-second
-          // health-check stalls and S3 socket pool exhaustion.
-          const parts = await mapWithConcurrency(
-            knowledge,
-            (k) => (knowledgePlugin as InstanceType<typeof KnowledgePlugin>).knowledgeToInputPart(k, llmModel),
-            8
-          )
-          const analysisFileIds = parts
-            .flatMap((part, index) => (part.type === 'file' ? [knowledge[index]?.id ?? ''] : []))
-            .filter((id) => id.length > 0)
-          return {
-            message: { role: 'user', content: parts },
-            analysisFileIds,
-          }
-        }
-      : undefined,
+    materializeKnowledgeSegment: async () => {
+      // Limit concurrency to avoid saturating the libuv thread pool and
+      // the Node.js microtask queue when an assistant has many knowledge files.
+      // Unbounded Promise.all over hundreds of files causes multi-second
+      // health-check stalls and S3 socket pool exhaustion.
+      const parts = await mapWithConcurrency(
+        knowledge,
+        (k) => (knowledgePlugin as InstanceType<typeof KnowledgePlugin>).knowledgeToInputPart(k, llmModel),
+        8
+      )
+      const analysisFileIds = parts
+        .flatMap((part, index) => (part.type === 'file' ? [knowledge[index]?.id ?? ''] : []))
+        .filter((id) => id.length > 0)
+      return {
+        message: { role: 'user', content: parts },
+        analysisFileIds,
+      }
+    },
   }
 }
 

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -143,7 +143,6 @@ export type TokenEstimateResult = {
 }
 
 export type HistoryMessageCost = {
-  index: number
   messageId: string
   role: dto.Message['role']
   tokens: number
@@ -432,21 +431,13 @@ export const estimateHistoryMessageCosts = async (
       stats,
       collector ? (part) => collector.addHistoryPart(message.id, message.role, part) : undefined
     )
-    costs.push({ index, messageId: message.id, role: message.role, tokens })
+    costs.push({ messageId: message.id, role: message.role, tokens })
   }
   return costs
 }
 
 export const computeConversationPlanTotalCost = (plan: ConversationCostPlan): number =>
   plan.assistantTokens + plan.draftTokens + plan.historyMessageCosts.reduce((sum, entry) => sum + entry.tokens, 0)
-
-export const computeConversationTotalCostFromStartIndex = (
-  plan: ConversationCostPlan,
-  startIndex: number
-): number =>
-  plan.assistantTokens +
-  plan.draftTokens +
-  plan.historyMessageCosts.reduce((sum, entry) => sum + (entry.index >= startIndex ? entry.tokens : 0), 0)
 
 export const selectOptimalHistoryStartIndex = (
   history: dto.Message[],

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -36,6 +36,7 @@ import type * as ai from 'ai'
 import { buildEstimatedPreambleSegments, preparePreamblePlan, PreamblePlan } from '@/backend/lib/chat/preamble'
 import { tokenizerForModel } from '@/lib/chat/tokenizer'
 import { projectMessageForEstimation } from '@/backend/lib/chat/message-projection'
+import { projectedToolResultAttachedFilesDescriptor } from '@/backend/lib/chat/message-projection'
 
 // --- File token cache -----------------------------------------------------------
 
@@ -292,6 +293,14 @@ const estimateToolResultOutputTokens = async (
       return countTextTokensCached(model, JSON.stringify(output.value), stats)
     case 'content': {
       let tokens = 0
+      const files = output.value.filter((item) => item.type === 'file')
+      if (files.length > 0) {
+        tokens += await countTextTokensCached(
+          model,
+          JSON.stringify(projectedToolResultAttachedFilesDescriptor(files)),
+          stats
+        )
+      }
       for (const item of output.value) {
         if (item.type === 'text') {
           tokens += await countTextTokensCached(model, item.text, stats)

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -35,6 +35,13 @@ import {
 import type * as ai from 'ai'
 import { buildEstimatedPreambleSegments, preparePreamblePlan, PreamblePlan } from '@/backend/lib/chat/preamble'
 import { tokenizerForModel } from '@/lib/chat/tokenizer'
+import {
+  projectedAssistantToolCallPayload,
+  projectedToolResultMetaPayload,
+  shouldIncludeAssistantReasoningPart,
+  userAttachmentDescriptorText,
+  userMessageMetadataText,
+} from '@/backend/lib/chat/conversion'
 
 // --- File token cache -----------------------------------------------------------
 
@@ -366,9 +373,33 @@ const estimateDtoMessageTokens = async (
 ): Promise<number> => {
   const algorithm = tokenizerForModel(model)
   if (message.role === 'user') {
-    const textTokens = await countTextTokensCached(model, message.content, stats)
-    onDetail?.({ type: 'text', tokens: textTokens, algorithm })
-    let tokens = textTokens
+    let tokens = 0
+    const metadataText = userMessageMetadataText(message)
+    if (metadataText) {
+      const metadataTokens = await countTextTokensCached(model, metadataText, stats)
+      onDetail?.({ type: 'text', tokens: metadataTokens, algorithm, params: { source: 'metadata' } })
+      tokens += metadataTokens
+    }
+    if (message.content.length !== 0) {
+      const textTokens = await countTextTokensCached(model, message.content, stats)
+      onDetail?.({ type: 'text', tokens: textTokens, algorithm, params: { source: 'content' } })
+      tokens += textTokens
+    }
+    const attachmentDescriptorText = userAttachmentDescriptorText(message)
+    if (attachmentDescriptorText) {
+      const attachmentDescriptorTokens = await countTextTokensCached(
+        model,
+        attachmentDescriptorText,
+        stats
+      )
+      onDetail?.({
+        type: 'text',
+        tokens: attachmentDescriptorTokens,
+        algorithm,
+        params: { source: 'attachment_descriptor' },
+      })
+      tokens += attachmentDescriptorTokens
+    }
     for (const attachment of message.attachments) {
       tokens += await estimateAttachmentTokens(model, attachment, stats, (aTokens, aAlgorithm, aParams) => {
         onDetail?.({
@@ -391,14 +422,14 @@ const estimateDtoMessageTokens = async (
         const t = await countTextTokensCached(model, part.text, stats)
         onDetail?.({ type: 'text', tokens: t, algorithm })
         tokens += t
-      } else if (part.type === 'reasoning') {
+      } else if (part.type === 'reasoning' && shouldIncludeAssistantReasoningPart(part)) {
         const t = await countTextTokensCached(model, part.reasoning, stats)
         onDetail?.({ type: 'reasoning', tokens: t, algorithm })
         tokens += t
       } else if (part.type === 'tool-call') {
         const t = await countTextTokensCached(
           model,
-          JSON.stringify({ toolCallId: part.toolCallId, toolName: part.toolName, input: part.args }),
+          JSON.stringify(projectedAssistantToolCallPayload(part)),
           stats
         )
         onDetail?.({ type: 'tool_call', toolCallId: part.toolCallId, toolName: part.toolName, tokens: t, algorithm })
@@ -413,7 +444,7 @@ const estimateDtoMessageTokens = async (
       if (part.type !== 'tool-result') continue
       const metaTokens = await countTextTokensCached(
         model,
-        JSON.stringify({ toolCallId: part.toolCallId, toolName: part.toolName }),
+        JSON.stringify(projectedToolResultMetaPayload(part)),
         stats
       )
       const resultTokens = await estimateToolResultOutputTokens(model, part.result, stats)

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -35,9 +35,7 @@ import {
 import type * as ai from 'ai'
 import { buildEstimatedPreambleSegments, preparePreamblePlan, PreamblePlan } from '@/backend/lib/chat/preamble'
 import { tokenizerForModel } from '@/lib/chat/tokenizer'
-import {
-  projectMessageForEstimation,
-} from '@/backend/lib/chat/conversion'
+import { projectMessageForEstimation } from '@/backend/lib/chat/message-projection'
 
 // --- File token cache -----------------------------------------------------------
 

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -36,11 +36,7 @@ import type * as ai from 'ai'
 import { buildEstimatedPreambleSegments, preparePreamblePlan, PreamblePlan } from '@/backend/lib/chat/preamble'
 import { tokenizerForModel } from '@/lib/chat/tokenizer'
 import {
-  projectedAssistantToolCallPayload,
-  projectedToolResultMetaPayload,
-  shouldIncludeAssistantReasoningPart,
-  userAttachmentDescriptorText,
-  userMessageMetadataText,
+  projectMessageForEstimation,
 } from '@/backend/lib/chat/conversion'
 
 // --- File token cache -----------------------------------------------------------
@@ -372,95 +368,58 @@ const estimateDtoMessageTokens = async (
   onDetail?: (part: dto.TokenDetailPart) => void
 ): Promise<number> => {
   const algorithm = tokenizerForModel(model)
-  if (message.role === 'user') {
-    let tokens = 0
-    const metadataText = userMessageMetadataText(message)
-    if (metadataText) {
-      const metadataTokens = await countTextTokensCached(model, metadataText, stats)
-      onDetail?.({ type: 'text', tokens: metadataTokens, algorithm, params: { source: 'metadata' } })
-      tokens += metadataTokens
-    }
-    if (message.content.length !== 0) {
-      const textTokens = await countTextTokensCached(model, message.content, stats)
-      onDetail?.({ type: 'text', tokens: textTokens, algorithm, params: { source: 'content' } })
-      tokens += textTokens
-    }
-    const attachmentDescriptorText = userAttachmentDescriptorText(message)
-    if (attachmentDescriptorText) {
-      const attachmentDescriptorTokens = await countTextTokensCached(
-        model,
-        attachmentDescriptorText,
-        stats
-      )
+  const projected = projectMessageForEstimation(message)
+  if (projected.role === 'ignored') return 0
+  let tokens = 0
+  for (const item of projected.items) {
+    if (item.kind === 'text') {
+      const t = await countTextTokensCached(model, item.text, stats)
       onDetail?.({
-        type: 'text',
-        tokens: attachmentDescriptorTokens,
+        type: item.source === 'assistant_reasoning' ? 'reasoning' : 'text',
+        tokens: t,
         algorithm,
-        params: { source: 'attachment_descriptor' },
+        params: item.source ? { source: item.source } : undefined,
       })
-      tokens += attachmentDescriptorTokens
+      tokens += t
+      continue
     }
-    for (const attachment of message.attachments) {
-      tokens += await estimateAttachmentTokens(model, attachment, stats, (aTokens, aAlgorithm, aParams) => {
+    if (item.kind === 'attachment') {
+      tokens += await estimateAttachmentTokens(model, item.attachment, stats, (aTokens, aAlgorithm, aParams) => {
         onDetail?.({
           type: 'attachment',
-          id: attachment.id,
-          name: attachment.name,
-          mimetype: attachment.mimetype,
+          id: item.attachment.id,
+          name: item.attachment.name,
+          mimetype: item.attachment.mimetype,
           tokens: aTokens,
           algorithm: aAlgorithm,
           params: aParams,
         })
       })
+      continue
     }
-    return tokens
-  }
-  if (message.role === 'assistant') {
-    let tokens = 0
-    for (const part of message.parts) {
-      if (part.type === 'text') {
-        const t = await countTextTokensCached(model, part.text, stats)
-        onDetail?.({ type: 'text', tokens: t, algorithm })
-        tokens += t
-      } else if (part.type === 'reasoning' && shouldIncludeAssistantReasoningPart(part)) {
-        const t = await countTextTokensCached(model, part.reasoning, stats)
-        onDetail?.({ type: 'reasoning', tokens: t, algorithm })
-        tokens += t
-      } else if (part.type === 'tool-call') {
-        const t = await countTextTokensCached(
-          model,
-          JSON.stringify(projectedAssistantToolCallPayload(part)),
-          stats
-        )
-        onDetail?.({ type: 'tool_call', toolCallId: part.toolCallId, toolName: part.toolName, tokens: t, algorithm })
-        tokens += t
-      }
+    if (item.kind === 'tool_call') {
+      const t = await countTextTokensCached(model, JSON.stringify(item.payload), stats)
+      onDetail?.({ type: 'tool_call', toolCallId: item.toolCallId, toolName: item.toolName, tokens: t, algorithm })
+      tokens += t
+      continue
     }
-    return tokens
+    const metaTokens = await countTextTokensCached(
+      model,
+      JSON.stringify(item.metaPayload),
+      stats
+    )
+    const resultTokens = await estimateToolResultOutputTokens(model, item.output, stats)
+    const partTokens = metaTokens + resultTokens
+    onDetail?.({
+      type: 'tool_result',
+      toolCallId: item.toolCallId,
+      toolName: item.toolName,
+      tokens: partTokens,
+      algorithm,
+    })
+    tokens += partTokens
   }
-  if (message.role === 'tool') {
-    let tokens = 0
-    for (const part of message.parts) {
-      if (part.type !== 'tool-result') continue
-      const metaTokens = await countTextTokensCached(
-        model,
-        JSON.stringify(projectedToolResultMetaPayload(part)),
-        stats
-      )
-      const resultTokens = await estimateToolResultOutputTokens(model, part.result, stats)
-      const partTokens = metaTokens + resultTokens
-      onDetail?.({
-        type: 'tool_result',
-        toolCallId: part.toolCallId,
-        toolName: part.toolName,
-        tokens: partTokens,
-        algorithm,
-      })
-      tokens += partTokens
-    }
-    return tokens
-  }
-  return 0
+  return tokens
 }
 
 export const estimateHistoryMessageCosts = async (

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -19,6 +19,8 @@ import {
 } from '@/backend/lib/chat/pdf-token-estimator'
 import {
   acceptableImageTypes,
+  canSendAsNativeFile,
+  canSendAsNativeImage,
   getPdfAttachmentPageLimitText,
 } from '@/backend/lib/chat/file-attachment-policy'
 import { estimateNativeImageTokensFromDimensions, nativeImageAlgorithmName } from '@/backend/lib/chat/image-token-estimator'
@@ -243,6 +245,7 @@ const estimateTextFallbackAttachmentTokens = async (
 const estimateKnowledgeFileTokens = async (
   fileId: string,
   fileName: string,
+  mimetype: string,
   partIndex: number,
   messageParts: unknown[],
   model: LlmModel,
@@ -258,7 +261,20 @@ const estimateKnowledgeFileTokens = async (
         stats
       )
     : 0
-  return { tokens, algorithm: tokenizerForModel(model) }
+  if (part) return { tokens, algorithm: tokenizerForModel(model) }
+  if (mimetype === 'application/pdf') {
+    const pdfTokens = await estimateAttachmentTokens(
+      model,
+      { id: fileId, name: fileName, mimetype, size: 0 },
+      stats
+    )
+    return { tokens: pdfTokens, algorithm: tokenizerForModel(model) }
+  }
+  if (canSendAsNativeImage(mimetype, model.capabilities) || canSendAsNativeFile(mimetype, model.capabilities)) {
+    return { tokens: 0, algorithm: 'none' }
+  }
+  const fallbackTokens = await estimateTextFallbackAttachmentTokens(model, fileId, stats)
+  return { tokens: fallbackTokens, algorithm: 'text_fallback' }
 }
 
 const estimateToolResultOutputTokens = async (
@@ -559,7 +575,7 @@ export const estimatePreambleTokensFromPlan = async ({
       : []
     for (const entry of (knowledgeSegment.knowledgeFileEntries ?? [])) {
       const fileEntry = await estimateKnowledgeFileTokens(
-        entry.fileId, entry.fileName, entry.partIndex, messageParts, model, stats
+        entry.fileId, entry.fileName, entry.mimetype, entry.partIndex, messageParts, model, stats
       )
       knowledgeTokens += fileEntry.tokens
       collector?.addPreamblePart({

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -31,7 +31,7 @@ import {
   TokenCountCacheStats,
 } from './prompt-token-counter'
 import type * as ai from 'ai'
-import { buildPreambleSegments } from '@/backend/lib/chat/preamble'
+import { buildEstimatedPreambleSegments, preparePreamblePlan, PreamblePlan } from '@/backend/lib/chat/preamble'
 import { tokenizerForModel } from '@/lib/chat/tokenizer'
 
 // --- File token cache -----------------------------------------------------------
@@ -140,6 +140,19 @@ export type TokenEstimateResult = {
   estimate: TokenEstimateBreakdown
   cache: CacheStats
   detail?: dto.TokenEstimateDetail
+}
+
+export type HistoryMessageCost = {
+  index: number
+  messageId: string
+  role: dto.Message['role']
+  tokens: number
+}
+
+export type ConversationCostPlan = {
+  assistantTokens: number
+  historyMessageCosts: HistoryMessageCost[]
+  draftTokens: number
 }
 
 type TokenEstimateInput = {
@@ -404,24 +417,99 @@ const estimateDtoMessageTokens = async (
   return 0
 }
 
-export const estimateHistoryTokens = async (
+export const estimateHistoryMessageCosts = async (
   model: LlmModel,
   history: dto.Message[],
   stats?: CacheStats,
   collector?: TokenDetailCollector
-): Promise<number> => {
-  let historyTokenCount = 0
-  for (const message of history) {
-    historyTokenCount += await estimateDtoMessageTokens(
+): Promise<HistoryMessageCost[]> => {
+  const costs: HistoryMessageCost[] = []
+  for (let index = 0; index < history.length; index++) {
+    const message = history[index]!
+    const tokens = await estimateDtoMessageTokens(
       model,
       message,
       stats,
-      collector
-        ? (part) => collector.addHistoryPart(message.id, message.role, part)
-        : undefined
+      collector ? (part) => collector.addHistoryPart(message.id, message.role, part) : undefined
     )
+    costs.push({ index, messageId: message.id, role: message.role, tokens })
   }
-  return historyTokenCount
+  return costs
+}
+
+export const computeConversationPlanTotalCost = (plan: ConversationCostPlan): number =>
+  plan.assistantTokens + plan.draftTokens + plan.historyMessageCosts.reduce((sum, entry) => sum + entry.tokens, 0)
+
+export const computeConversationTotalCostFromStartIndex = (
+  plan: ConversationCostPlan,
+  startIndex: number
+): number =>
+  plan.assistantTokens +
+  plan.draftTokens +
+  plan.historyMessageCosts.reduce((sum, entry) => sum + (entry.index >= startIndex ? entry.tokens : 0), 0)
+
+export const selectOptimalHistoryStartIndex = (
+  history: dto.Message[],
+  historyMessageCosts: HistoryMessageCost[],
+  assistantTokens: number,
+  draftTokens: number,
+  tokenLimit: number
+): number => {
+  if (history.length === 0) return 0
+  const running: number[] = new Array(historyMessageCosts.length + 1).fill(0)
+  for (let i = historyMessageCosts.length - 1; i >= 0; i--) {
+    running[i] = running[i + 1]! + (historyMessageCosts[i]?.tokens ?? 0)
+  }
+  const userTurnStartIndexes = history.flatMap((message, index) =>
+    message.role === 'user' && index > 0 ? [index] : []
+  )
+  const candidateStartIndexes = [0, ...userTurnStartIndexes]
+  for (const startIndex of candidateStartIndexes) {
+    const total = assistantTokens + draftTokens + (running[startIndex] ?? 0)
+    if (total <= tokenLimit) return startIndex
+  }
+  for (let index = history.length - 1; index >= 0; index--) {
+    if (history[index]?.role === 'user') return index
+  }
+  return 0
+}
+
+export const prepareConversationCostPlan = async (
+  input: ConversationWindowEstimateInput,
+  collector?: TokenDetailCollector
+): Promise<{ plan: ConversationCostPlan; cache: CacheStats }> => {
+  const stats: CacheStats = createTokenCountCacheStats()
+  const { assistantParams, model, tools, parameters, knowledgeFiles, history, draft } = input
+  const preamblePlan = await preparePreamblePlan({
+    assistantParams,
+    llmModel: model,
+    tools,
+    parameters,
+    knowledge: knowledgeFiles,
+  })
+  const assistantTokens = await estimatePreambleTokensFromPlan({
+    plan: preamblePlan,
+    model,
+    stats,
+    collector,
+  })
+  const historyMessageCosts = await estimateHistoryMessageCosts(model, history, stats, collector)
+  const draftTokens = draft
+    ? await estimateDtoMessageTokens(
+        model,
+        draft,
+        stats,
+        collector ? (part) => collector.addDraftPart(part) : undefined
+      )
+    : 0
+  return {
+    plan: {
+      assistantTokens,
+      historyMessageCosts,
+      draftTokens,
+    },
+    cache: stats,
+  }
 }
 
 export const estimatePreambleTokens = async ({
@@ -441,13 +529,28 @@ export const estimatePreambleTokens = async ({
   stats?: CacheStats
   collector?: TokenDetailCollector
 }): Promise<number> => {
-  const preambleSegments = await buildPreambleSegments({
+  const preamblePlan = await preparePreamblePlan({
     assistantParams,
     llmModel: model,
     tools,
     parameters,
     knowledge: knowledgeFiles,
   })
+  return estimatePreambleTokensFromPlan({ plan: preamblePlan, model, stats, collector })
+}
+
+export const estimatePreambleTokensFromPlan = async ({
+  plan,
+  model,
+  stats,
+  collector,
+}: {
+  plan: PreamblePlan
+  model: LlmModel
+  stats?: CacheStats
+  collector?: TokenDetailCollector
+}): Promise<number> => {
+  const preambleSegments = buildEstimatedPreambleSegments(plan)
   if (preambleSegments.length === 0) return 0
 
   const algorithm = tokenizerForModel(model)
@@ -537,39 +640,18 @@ export const estimateConversationWindowTokens = async (
   input: ConversationWindowEstimateInput,
   collector?: TokenDetailCollector
 ): Promise<TokenEstimateResult> => {
-  const stats: CacheStats = createTokenCountCacheStats()
-  const { assistantParams, model, tools, parameters, knowledgeFiles, history, draft } = input
-
-  const preambleTokenCount = await estimatePreambleTokens({
-    assistantParams,
-    model,
-    tools,
-    parameters,
-    knowledgeFiles,
-    stats,
-    collector,
-  })
-
-  const historyTokenCount = await estimateHistoryTokens(model, history, stats, collector)
-  const draftTokenCount = draft
-    ? await estimateDtoMessageTokens(
-        model,
-        draft,
-        stats,
-        collector ? (part) => collector.addDraftPart(part) : undefined
-      )
-    : 0
-
-  const total = preambleTokenCount + historyTokenCount + draftTokenCount
+  const { plan, cache } = await prepareConversationCostPlan(input, collector)
+  const historyTokenCount = plan.historyMessageCosts.reduce((sum, entry) => sum + entry.tokens, 0)
+  const total = computeConversationPlanTotalCost(plan)
 
   return {
     estimate: {
-      assistant: preambleTokenCount,
+      assistant: plan.assistantTokens,
       history: historyTokenCount,
-      draft: draftTokenCount,
+      draft: plan.draftTokens,
       total,
     },
-    cache: stats,
+    cache,
     detail: collector?.build(),
   }
 }


### PR DESCRIPTION
## Summary
Refactors chat preamble/token estimation into a shared projection-based path and hardens truncation/cost correctness with deterministic parity tests, including fixed-fixture truncation expectations under normal vs huge preamble conditions.

## Details
- Introduced a shared message projection module for estimation/runtime alignment in `apps/backend/lib/chat/message-projection.ts`.
- Reused shared projection helpers in runtime conversion (`apps/backend/lib/chat/conversion.ts`) and estimator (`apps/backend/lib/chat/token-estimator.ts`) to reduce drift risk.
- Aligned estimator behavior with runtime conversion for user metadata text, attachment descriptor text, assistant reasoning-signature gating, and tool/result payload projection.
- Added estimator parity for tool-result `content` file descriptors (`attached_files`) so estimate/runtime include the same descriptor text path.
- Added a focused projection/cost parity test suite in `apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts`.
- Added exact truncation fixture assertions:
- without extra preamble: `expect(truncate(chat_fixture)).length === 10`
- with huge preamble under same budget: `expect(truncate(prompt + chat_fixture)).length === 2`
- Added a focused CI guard in `.github/workflows/ci.yml` to run the parity suite before full coverage tests.

## Risks
- Truncation expected lengths are intentionally fixture-specific (`10` and `2`) and may require updates if prompt templates or tokenization defaults change.

## Tests
- `pnpm exec vitest run apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts`
- `npm run check-types`