### PR TITLE
fix: add provider-aware image size and aspect ratio controls

### DIFF
--- a/__tests__/imagegenToolEditing.test.ts
+++ b/__tests__/imagegenToolEditing.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest'
 import { ImageGeneratorPlugin } from '@/backend/lib/tools/imagegenerator/implementation'
+import {
+  GoogleImageGeneratorPlugin,
+  OpenAiImageGeneratorPlugin,
+  ReplicateImageGeneratorPlugin,
+  TogetherImageGeneratorPlugin,
+} from '@/backend/lib/tools/imagegenerator/direct-implementation'
 import { shouldExposeImageEditingTool } from '@/backend/lib/imagegen/models'
 import type { ToolParams } from '@/lib/chat/tools'
 import type { LlmModel } from '@/lib/chat/models'
@@ -45,6 +51,24 @@ describe('image generator editing exposure', () => {
     expect(functions.EditImage).toBeDefined()
   })
 
+  test('legacy proxy-backed tool does not expose size controls', async () => {
+    const tool = new ImageGeneratorPlugin(toolParams, {
+      apiKey: 'secret',
+      model: 'gpt-image-2',
+    })
+
+    const functions = await tool.functions(fakeModel, { userId: 'user-1' })
+    const generateSizeSchema = (functions.GenerateImage as any).parameters?.properties?.size as
+      | { enum?: string[] }
+      | undefined
+    const editSizeSchema = (functions.EditImage as any)?.parameters?.properties?.size as
+      | { enum?: string[] }
+      | undefined
+
+    expect(generateSizeSchema).toBeUndefined()
+    expect(editSizeSchema).toBeUndefined()
+  })
+
   test('legacy proxy-backed tool does not expose editing for unsupported models', async () => {
     const tool = new ImageGeneratorPlugin(toolParams, {
       apiKey: 'secret',
@@ -61,5 +85,103 @@ describe('image generator editing exposure', () => {
     expect(shouldExposeImageEditingTool('gpt-image-2')).toBe(true)
     expect(shouldExposeImageEditingTool('gemini-3-pro-image-preview')).toBe(true)
     expect(shouldExposeImageEditingTool('dall-e-2')).toBe(false)
+  })
+
+  test('direct OpenAI image tool exposes size controls for generation and editing', async () => {
+    const tool = new OpenAiImageGeneratorPlugin(toolParams, {
+      apiKey: 'secret',
+      model: 'gpt-image-2',
+    })
+
+    const functions = await tool.functions(fakeModel, { userId: 'user-1' })
+    const generateSizeSchema = (functions.GenerateImage as any).parameters?.properties?.size as
+      | { enum?: string[] }
+      | undefined
+    const editSizeSchema = (functions.EditImage as any)?.parameters?.properties?.size as
+      | { enum?: string[] }
+      | undefined
+
+    expect(generateSizeSchema?.enum).toEqual(['auto', '1024x1024', '1024x1536', '1536x1024'])
+    expect(editSizeSchema?.enum).toEqual(['auto', '1024x1024', '1024x1536', '1536x1024'])
+  })
+
+  test('direct Together image tool exposes size controls for generation and editing', async () => {
+    const tool = new TogetherImageGeneratorPlugin(toolParams, {
+      apiKey: 'secret',
+      model: 'FLUX.1-kontext-pro',
+    })
+
+    const functions = await tool.functions(fakeModel, { userId: 'user-1' })
+    const generateSizeSchema = (functions.GenerateImage as any).parameters?.properties?.size as
+      | { enum?: string[] }
+      | undefined
+    const editSizeSchema = (functions.EditImage as any)?.parameters?.properties?.size as
+      | { enum?: string[] }
+      | undefined
+
+    expect(generateSizeSchema?.enum).toEqual(['auto', '1024x1024', '1024x1536', '1536x1024'])
+    expect(editSizeSchema?.enum).toEqual(['auto', '1024x1024', '1024x1536', '1536x1024'])
+  })
+
+  test('direct Google image tool exposes aspect ratio controls', async () => {
+    const tool = new GoogleImageGeneratorPlugin(toolParams, {
+      apiKey: 'secret',
+      model: 'gemini-3-pro-image-preview',
+    })
+
+    const functions = await tool.functions(fakeModel, { userId: 'user-1' })
+    const generateSizeSchema = (functions.GenerateImage as any).parameters?.properties?.size as
+      | { enum?: string[] }
+      | undefined
+    const editSizeSchema = (functions.EditImage as any)?.parameters?.properties?.size as
+      | { enum?: string[] }
+      | undefined
+    const generateAspectRatioSchema = (functions.GenerateImage as any).parameters?.properties
+      ?.aspectRatio as { enum?: string[] } | undefined
+    const editAspectRatioSchema = (functions.EditImage as any)?.parameters?.properties
+      ?.aspectRatio as { enum?: string[] } | undefined
+
+    expect(generateSizeSchema).toBeUndefined()
+    expect(editSizeSchema).toBeUndefined()
+    expect(generateAspectRatioSchema?.enum).toEqual([
+      '1:1',
+      '2:3',
+      '3:2',
+      '3:4',
+      '4:3',
+      '4:5',
+      '5:4',
+      '9:16',
+      '16:9',
+      '21:9',
+    ])
+    expect(editAspectRatioSchema?.enum).toEqual([
+      '1:1',
+      '2:3',
+      '3:2',
+      '3:4',
+      '4:3',
+      '4:5',
+      '5:4',
+      '9:16',
+      '16:9',
+      '21:9',
+    ])
+  })
+
+  test('direct Replicate image tool does not expose size controls when unsupported', async () => {
+    const tool = new ReplicateImageGeneratorPlugin(toolParams, {
+      apiKey: 'secret',
+      model: 'owner/model:version',
+      input: {},
+    })
+
+    const functions = await tool.functions(fakeModel, { userId: 'user-1' })
+    const generateSizeSchema = (functions.GenerateImage as any).parameters?.properties?.size as
+      | { enum?: string[] }
+      | undefined
+
+    expect(generateSizeSchema).toBeUndefined()
+    expect(functions.EditImage).toBeUndefined()
   })
 })

--- a/apps/backend/lib/imagegen/providers/gemini.ts
+++ b/apps/backend/lib/imagegen/providers/gemini.ts
@@ -17,6 +17,7 @@ export const generateWithGemini = async ({
   apiKey,
   model,
   prompt,
+  aspectRatio,
 }: ImageGenerationRequest): Promise<GeneratedImagesResponse> => {
   const client = createGeminiClient(apiKey)
   const geminiModel = client.getGenerativeModel({ model })
@@ -24,6 +25,13 @@ export const generateWithGemini = async ({
     contents: [{ role: 'user', parts: [{ text: prompt }] }],
     generationConfig: {
       responseModalities: ['IMAGE', 'TEXT'],
+      ...(aspectRatio
+        ? ({
+            imageConfig: {
+              aspectRatio,
+            },
+          } as const)
+        : {}),
     } as never,
   } as never)
 
@@ -53,6 +61,7 @@ export const editWithGemini = async ({
   model,
   prompt,
   images,
+  aspectRatio,
 }: ImageEditRequest): Promise<GeneratedImagesResponse> => {
   const client = createGeminiClient(apiKey)
   const geminiModel = client.getGenerativeModel({ model })
@@ -70,6 +79,13 @@ export const editWithGemini = async ({
     contents: [{ role: 'user', parts }],
     generationConfig: {
       responseModalities: ['IMAGE', 'TEXT'],
+      ...(aspectRatio
+        ? ({
+            imageConfig: {
+              aspectRatio,
+            },
+          } as const)
+        : {}),
     } as never,
   } as never)
 

--- a/apps/backend/lib/imagegen/providers/imagen.ts
+++ b/apps/backend/lib/imagegen/providers/imagen.ts
@@ -7,6 +7,7 @@ export const generateWithImagen = async ({
   model,
   prompt,
   n,
+  aspectRatio,
 }: ImageGenerationRequest): Promise<GeneratedImagesResponse> => {
   const client = new GoogleGenAI({ apiKey })
   const response = await client.models.generateImages({
@@ -14,6 +15,7 @@ export const generateWithImagen = async ({
     prompt,
     config: {
       numberOfImages: n ?? 1,
+      ...(aspectRatio ? { aspectRatio } : {}),
     },
   })
 

--- a/apps/backend/lib/imagegen/types.ts
+++ b/apps/backend/lib/imagegen/types.ts
@@ -14,6 +14,7 @@ export interface ImageGenerationRequest {
   prompt: string
   n?: number
   size?: string
+  aspectRatio?: string
   input?: Record<string, unknown>
 }
 

--- a/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
@@ -46,6 +46,39 @@ import {
 
 const IMAGE_TOOL_TEXT =
   "The tool displayed generated images. The images are already plainly visible, so don't repeat the descriptions in detail. Do not list download links as they are available in the ChatGPT UI already. Do not mention anything about visualizing / downloading to the user."
+const SUPPORTED_IMAGE_SIZES = ['auto', '1024x1024', '1024x1536', '1536x1024'] as const
+const SUPPORTED_IMAGE_ASPECT_RATIOS = [
+  '1:1',
+  '2:3',
+  '3:2',
+  '3:4',
+  '4:3',
+  '4:5',
+  '5:4',
+  '9:16',
+  '16:9',
+  '21:9',
+] as const
+
+type SupportedImageSize = (typeof SUPPORTED_IMAGE_SIZES)[number]
+type SupportedImageAspectRatio = (typeof SUPPORTED_IMAGE_ASPECT_RATIOS)[number]
+
+const normalizeRequestedSize = (value: unknown): SupportedImageSize => {
+  if (typeof value === 'string' && SUPPORTED_IMAGE_SIZES.includes(value as SupportedImageSize)) {
+    return value as SupportedImageSize
+  }
+  return '1024x1024'
+}
+
+const normalizeRequestedAspectRatio = (value: unknown): SupportedImageAspectRatio | undefined => {
+  if (
+    typeof value === 'string' &&
+    SUPPORTED_IMAGE_ASPECT_RATIOS.includes(value as SupportedImageAspectRatio)
+  ) {
+    return value as SupportedImageAspectRatio
+  }
+  return undefined
+}
 
 type DirectImageToolParams = {
   apiKey: string
@@ -74,6 +107,8 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
               type: 'string',
               description: 'textual description of the image(s) to generate',
             },
+            ...this.buildSizeProperty(),
+            ...this.buildAspectRatioProperty(),
           },
           additionalProperties: false,
           required: ['prompt'],
@@ -93,6 +128,8 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
               type: 'string',
               description: 'textual description of the modification to apport to the image(s)',
             },
+            ...this.buildSizeProperty(),
+            ...this.buildAspectRatioProperty(),
             fileId: {
               type: 'array',
               description: 'Array of image IDs to edit',
@@ -114,6 +151,8 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
   functions = async (_model: LlmModel, _context: ToolFunctionContext) => this.functions_
 
   protected abstract supportsModel(model: string): boolean
+  protected abstract supportsSizeControl(model: string): boolean
+  protected abstract supportsAspectRatioControl(model: string): boolean
   protected abstract providerName(): string
   protected abstract generateDirect(request: ImageGenerationRequest): Promise<GeneratedImagesResponse>
   protected abstract editDirect(request: ImageEditRequest): Promise<GeneratedImagesResponse>
@@ -121,6 +160,33 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
   private assertSupportedModel() {
     if (!this.supportsModel(this.model)) {
       throw new Error(`Model "${this.model}" is not supported by tool "${this.toolParams.name}"`)
+    }
+  }
+
+  private buildSizeProperty(): Record<string, unknown> {
+    if (!this.supportsSizeControl(this.model)) {
+      return {}
+    }
+    return {
+      size: {
+        type: 'string',
+        enum: [...SUPPORTED_IMAGE_SIZES],
+        description:
+          'Optional output size. Use portrait (`1024x1536`) or landscape (`1536x1024`) to control aspect ratio.',
+      },
+    }
+  }
+
+  private buildAspectRatioProperty(): Record<string, unknown> {
+    if (!this.supportsAspectRatioControl(this.model)) {
+      return {}
+    }
+    return {
+      aspectRatio: {
+        type: 'string',
+        enum: [...SUPPORTED_IMAGE_ASPECT_RATIOS],
+        description: 'Optional output aspect ratio.',
+      },
     }
   }
 
@@ -139,13 +205,20 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
     rootOwner,
   }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> {
     const apiKey = await expandToolParameter(this.toolParams, this.params.apiKey)
+    const size = this.supportsSizeControl(this.model)
+      ? normalizeRequestedSize(invocationParams.size)
+      : undefined
+    const aspectRatio = this.supportsAspectRatioControl(this.model)
+      ? normalizeRequestedAspectRatio(invocationParams.aspectRatio)
+      : undefined
     const aiResponse = this.assertImageResponse(
       await this.generateDirect({
         apiKey,
         model: this.model,
         prompt: `${invocationParams.prompt}`,
         n: 1,
-        size: '1024x1024',
+        size,
+        aspectRatio,
       })
     )
     await recordImageGenerationEvent({
@@ -191,6 +264,12 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
       throw new Error(`Image editing is not supported for model: ${this.model}`)
     }
     const apiKey = await expandToolParameter(this.toolParams, this.params.apiKey)
+    const size = this.supportsSizeControl(this.model)
+      ? normalizeRequestedSize(invocationParams.size)
+      : undefined
+    const aspectRatio = this.supportsAspectRatioControl(this.model)
+      ? normalizeRequestedAspectRatio(invocationParams.aspectRatio)
+      : undefined
     const fileIds = invocationParams.fileId as string[]
     const files = await Promise.all(fileIds.map((fileId) => this.loadImage(fileId, userId)))
     const aiResponse = this.assertImageResponse(
@@ -200,7 +279,8 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
         prompt: `${invocationParams.prompt}`,
         images: files,
         n: 1,
-        size: '1024x1024',
+        size,
+        aspectRatio,
       })
     )
     await recordImageGenerationEvent({
@@ -281,6 +361,14 @@ export class OpenAiImageGeneratorPlugin extends DirectImageGeneratorPlugin {
     return isOpenAiImageModel(model)
   }
 
+  protected supportsSizeControl() {
+    return true
+  }
+
+  protected supportsAspectRatioControl() {
+    return false
+  }
+
   protected generateDirect(request: ImageGenerationRequest) {
     return generateWithOpenAI(request)
   }
@@ -305,6 +393,14 @@ export class GoogleImageGeneratorPlugin extends DirectImageGeneratorPlugin {
 
   protected supportsModel(model: string) {
     return isGeminiImageModel(model) || isImagenImageModel(model)
+  }
+
+  protected supportsSizeControl() {
+    return false
+  }
+
+  protected supportsAspectRatioControl() {
+    return true
   }
 
   protected generateDirect(request: ImageGenerationRequest) {
@@ -342,6 +438,14 @@ export class TogetherImageGeneratorPlugin extends DirectImageGeneratorPlugin {
     return isTogetherImageModel(model)
   }
 
+  protected supportsSizeControl() {
+    return true
+  }
+
+  protected supportsAspectRatioControl() {
+    return false
+  }
+
   protected generateDirect(request: ImageGenerationRequest) {
     return generateWithTogether(request)
   }
@@ -369,6 +473,14 @@ export class ReplicateImageGeneratorPlugin extends DirectImageGeneratorPlugin {
 
   protected supportsModel(_model: string) {
     return true
+  }
+
+  protected supportsSizeControl() {
+    return false
+  }
+
+  protected supportsAspectRatioControl() {
+    return false
   }
 
   protected generateDirect(request: ImageGenerationRequest) {


### PR DESCRIPTION
## Summary
Adds provider-aware image tool controls so `size` is exposed only for models that support it, while Google image models expose `aspectRatio`, and both values are normalized and passed through to provider calls.

## Details
- Adds optional `aspectRatio` to shared image generation request typing.
- Exposes dynamic tool parameters for `size` and `aspectRatio` based on provider/model capabilities.
- Normalizes and forwards supported `size`/`aspectRatio` inputs in direct generate/edit flows.
- Wires Gemini and Imagen providers to pass aspect-ratio configuration to Google APIs.
- Expands image tool tests to cover legacy and direct providers for size/aspect-ratio schema exposure.

## Tests
- `npm run test -- __tests__/imagegenToolEditing.test.ts` (passed)