### PR TITLE
fix: do not offer to discard draft when publishing without effective changes

### DIFF
--- a/apps/frontend/app/assistants/[id]/page.tsx
+++ b/apps/frontend/app/assistants/[id]/page.tsx
@@ -44,6 +44,7 @@ interface LocalConfirmationDialogState {
   message: string | JSX.Element
   confirmMsg: string
   destructive?: boolean
+  cancelHidden?: boolean
 }
 const AssistantPage = () => {
   const { id } = useParams() as { id: string }
@@ -195,7 +196,7 @@ const AssistantPage = () => {
     const changedLabels = changedKeys.map((field) => changedFieldLabel(field))
 
     if (changedKeys.length === 0) {
-      const discardConfirmed = await askConfirmation({
+      await askConfirmation({
         title: t('publish_no_effective_changes_title'),
         message: (
           <div className="space-y-2">
@@ -205,11 +206,9 @@ const AssistantPage = () => {
             </div>
           </div>
         ),
-        confirmMsg: t('discard_changes'),
+        confirmMsg: t('ok'),
+        cancelHidden: true,
       })
-      if (discardConfirmed) {
-        await discardCurrentDraft()
-      }
       return
     }
 
@@ -542,15 +541,21 @@ const AssistantPage = () => {
       )}
       {confirmationDialog && (
         <AlertDialog open={true}>
-          <AlertDialogContent>
+          <AlertDialogContent
+          onEscapeKeyDown={
+            confirmationDialog.cancelHidden ? () => resolveConfirmation(true) : undefined
+          }
+        >
             <AlertDialogHeader>
               <AlertDialogTitle>{confirmationDialog.title}</AlertDialogTitle>
             </AlertDialogHeader>
             <div className="text-center text-muted-foreground">{confirmationDialog.message}</div>
             <AlertDialogFooter>
-              <AlertDialogCancel onClick={() => resolveConfirmation(false)}>
-                {t('cancel')}
-              </AlertDialogCancel>
+              {!confirmationDialog.cancelHidden && (
+                <AlertDialogCancel onClick={() => resolveConfirmation(false)}>
+                  {t('cancel')}
+                </AlertDialogCancel>
+              )}
               <AlertDialogAction
                 variant={confirmationDialog.destructive ? 'destructive' : undefined}
                 onClick={() => resolveConfirmation(true)}

--- a/apps/frontend/locales/en/logicle.json
+++ b/apps/frontend/locales/en/logicle.json
@@ -451,7 +451,7 @@
   "publish_changes_message": "The following changes will be published:",
   "publish_no_effective_changes_title": "No changes to publish",
   "publish_no_effective_changes_message": "This draft has no changes compared to the published version.",
-  "publish_no_effective_changes_hint": "You can discard this draft or go back and keep editing it.",
+  "publish_no_effective_changes_hint": "To discard this draft, use the options menu.",
   "reasoning": "Reasoning",
   "reasoning_effort": "Reasoning effort",
   "recover": "Recover",

--- a/apps/frontend/locales/it/logicle.json
+++ b/apps/frontend/locales/it/logicle.json
@@ -451,7 +451,7 @@
   "publish_changes_message": "Verranno pubblicate le seguenti modifiche:",
   "publish_no_effective_changes_title": "Nessuna modifica da pubblicare",
   "publish_no_effective_changes_message": "Questa bozza non contiene modifiche rispetto alla versione pubblicata.",
-  "publish_no_effective_changes_hint": "Puoi annullare questa bozza oppure tornare a modificarla.",
+  "publish_no_effective_changes_hint": "Per eliminare questa bozza, usa il menu delle opzioni.",
   "reasoning": "Ragionamento",
   "reasoning_effort": "Livello di ragionamento",
   "recover": "Recupera",


### PR DESCRIPTION
## Summary

When a user clicks Publish on an assistant draft that has no effective changes compared to the published version, the UI previously showed a confirmation dialog with a "Discard changes" button. This dialog is now replaced with a read-only informational notice: a single **Ok** button (also dismissable via Esc), with hint text pointing the user to the options menu if they want to discard the draft.

## Details

- Removed the `discardCurrentDraft()` call from the no-effective-changes publish path
- Changed the confirm button from `discard_changes` to `ok`
- Added `cancelHidden` flag to `LocalConfirmationDialogState` so the Cancel button is conditionally hidden
- Wired `onEscapeKeyDown` on `AlertDialogContent` to resolve the dialog when Cancel is hidden
- Updated hint text in EN and IT locales: "To discard this draft, use the options menu."

## Tests

- `npm run check-types` — no new errors