### PR TITLE
fix: scrollbar covers message count in most-active analytics sections

### DIFF
--- a/apps/frontend/app/admin/analytics/most-active-assistants.tsx
+++ b/apps/frontend/app/admin/analytics/most-active-assistants.tsx
@@ -11,7 +11,7 @@ export function MostActiveAssistants({ className, items, colorMap }: Params) {
   const sorted = [...items].sort((a, b) => b.messages - a.messages)
   return (
     <ScrollArea className={`${className ?? ''} scroll-workaround`}>
-      <div className="space-y-8">
+      <div className="space-y-8 pr-4">
         {sorted.map((item) => {
           const id = item.assistantId ?? ''
           const color = colorMap.get(id) ?? '#000000'

--- a/apps/frontend/app/admin/analytics/most-active-users.tsx
+++ b/apps/frontend/app/admin/analytics/most-active-users.tsx
@@ -11,7 +11,7 @@ export function MostActiveUsers({ className, items, colorMap }: Params) {
   const sorted = [...items].sort((a, b) => b.messages - a.messages)
   return (
     <ScrollArea className={`${className ?? ''} scroll-workaround`}>
-      <div className="space-y-8">
+      <div className="space-y-8 pr-4">
         {sorted.map((item) => {
           const color = colorMap.get(item.userId) ?? '#000000'
           return (


### PR DESCRIPTION
## Summary

Added `pr-4` right padding to the content wrapper inside the `ScrollArea` in both `MostActiveAssistants` and `MostActiveUsers` components, so the vertical scrollbar no longer overlaps the message count numbers on the right edge.

## Tests

- Visual fix; no automated tests required for a layout padding change.
