### PR TITLE
fix: remove image edit from gallery; click navigates to source chat

### DIFF
--- a/apps/backend/api/files/images/route.ts
+++ b/apps/backend/api/files/images/route.ts
@@ -8,6 +8,7 @@ const userImageSchema = z.object({
   type: z.string(),
   size: z.number(),
   createdAt: z.string(),
+  conversationId: z.string().nullable(),
 })
 
 export const GET = operation({
@@ -20,7 +21,7 @@ export const GET = operation({
       .selectFrom('File as F')
       .innerJoin('FileBlob as FB', 'FB.id', 'F.fileBlobId')
       .leftJoin('Conversation as C', 'C.id', 'F.ownerId')
-      .select(['F.id', 'F.name', 'F.type', 'FB.size as size', 'F.createdAt'])
+      .select(['F.id', 'F.name', 'F.type', 'FB.size as size', 'F.createdAt', 'C.id as conversationId'])
       .where('F.fileBlobId', 'is not', null)
       .where('F.type', 'like', 'image/%')
       .where((eb) =>

--- a/apps/frontend/app/chat/components/Attachment.tsx
+++ b/apps/frontend/app/chat/components/Attachment.tsx
@@ -24,6 +24,7 @@ export const Attachment = ({ file, className, conversationId }: AttachmentProps)
 
   return (
     <div
+      id={file.fileId ? `file-${file.fileId}` : undefined}
       className={cn(
         'border p-2 m-2 flex flex-row items-center relative shadow rounded relative group/attachment',
         className

--- a/apps/frontend/app/chat/components/Chat.tsx
+++ b/apps/frontend/app/chat/components/Chat.tsx
@@ -75,7 +75,7 @@ export const Chat = ({
   }
 
   const scrollDown = () => {
-    if (autoScrollEnabled) {
+    if (autoScrollEnabled && !scrolledToFragmentRef.current) {
       messagesEndRef.current?.scrollIntoView()
     }
   }

--- a/apps/frontend/app/chat/components/Chat.tsx
+++ b/apps/frontend/app/chat/components/Chat.tsx
@@ -96,7 +96,7 @@ export const Chat = ({
     setAutoScrollEnabled(false)
     const elTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop
     container.scrollTo({ top: elTop - (container.clientHeight - el.offsetHeight) / 2, behavior: 'smooth' })
-  }, [selectedConversation?.messages])
+  }, [selectedConversation])
 
   useEffect(() => {
     throttledScrollDown()

--- a/apps/frontend/app/chat/components/Chat.tsx
+++ b/apps/frontend/app/chat/components/Chat.tsx
@@ -90,10 +90,12 @@ export const Chat = ({
     const hash = window.location.hash
     if (!hash) return
     const el = document.getElementById(hash.slice(1))
-    if (!el) return
+    const container = chatContainerRef.current
+    if (!el || !container) return
     scrolledToFragmentRef.current = true
     setAutoScrollEnabled(false)
-    el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    const elTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop
+    container.scrollTo({ top: elTop - (container.clientHeight - el.offsetHeight) / 2, behavior: 'smooth' })
   }, [selectedConversation?.messages])
 
   useEffect(() => {

--- a/apps/frontend/app/chat/components/Chat.tsx
+++ b/apps/frontend/app/chat/components/Chat.tsx
@@ -48,6 +48,7 @@ export const Chat = ({
 
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const chatContainerRef = useRef<HTMLDivElement>(null)
+  const scrolledToFragmentRef = useRef(false)
 
   useEffect(() => {
     setSideBarContent?.(undefined)
@@ -79,6 +80,21 @@ export const Chat = ({
     }
   }
   const throttledScrollDown = throttle(scrollDown, 250)
+
+  useEffect(() => {
+    scrolledToFragmentRef.current = false
+  }, [selectedConversation?.id])
+
+  useEffect(() => {
+    if (scrolledToFragmentRef.current) return
+    const hash = window.location.hash
+    if (!hash) return
+    const el = document.getElementById(hash.slice(1))
+    if (!el) return
+    scrolledToFragmentRef.current = true
+    setAutoScrollEnabled(false)
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }, [selectedConversation?.messages])
 
   useEffect(() => {
     throttledScrollDown()

--- a/apps/frontend/app/images/page.tsx
+++ b/apps/frontend/app/images/page.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import type { UserImage } from '@/services/files'
 import { IconCopy, IconDownload } from '@tabler/icons-react'
 import { copyImageUrlToClipboard } from '@/frontend/lib/clipboard'
+import { cn } from '@/frontend/lib/utils'
 
 export default function ImagesPage() {
   const { t } = useTranslation()
@@ -24,7 +25,7 @@ export default function ImagesPage() {
                 <img
                   alt={image.name}
                   src={`/api/files/${image.id}/content`}
-                  className={`w-full h-full object-contain bg-foreground/5 ${image.conversationId ? 'cursor-pointer' : ''}`}
+                  className={cn('w-full h-full object-contain bg-foreground/5', image.conversationId && 'cursor-pointer')}
                   onClick={() => image.conversationId && router.push(`/chat/${image.conversationId}#file-${image.id}`)}
                 />
                 <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors pointer-events-none" />

--- a/apps/frontend/app/images/page.tsx
+++ b/apps/frontend/app/images/page.tsx
@@ -1,15 +1,14 @@
 'use client'
-import { useContext } from 'react'
-import ChatPageContext from '@/app/chat/components/context'
+import { useRouter } from 'next/navigation'
 import { useSWRJson } from '@/hooks/swr'
 import { useTranslation } from 'react-i18next'
 import type { UserImage } from '@/services/files'
-import { IconCopy, IconDownload, IconEdit } from '@tabler/icons-react'
+import { IconCopy, IconDownload } from '@tabler/icons-react'
 import { copyImageUrlToClipboard } from '@/frontend/lib/clipboard'
 
 export default function ImagesPage() {
   const { t } = useTranslation()
-  const { openImageEditor } = useContext(ChatPageContext)
+  const router = useRouter()
   const { data: images } = useSWRJson<UserImage[]>(`/api/files/images`)
 
   return (
@@ -25,28 +24,11 @@ export default function ImagesPage() {
                 <img
                   alt={image.name}
                   src={`/api/files/${image.id}/content`}
-                  className="w-full h-full object-contain bg-foreground/5"
+                  className={`w-full h-full object-contain bg-foreground/5 ${image.conversationId ? 'cursor-pointer' : ''}`}
+                  onClick={() => image.conversationId && router.push(`/chat/${image.conversationId}#file-${image.id}`)}
                 />
-                <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors" />
+                <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors pointer-events-none" />
                 <div className="flex flex-horz m-2 gap-1 absolute top-0 right-0 invisible group-hover:visible">
-                  <button
-                    type="button"
-                    title={t('edit_image')}
-                    className="bg-black bg-opacity-30 rounded-md"
-                    onClick={() =>
-                      openImageEditor?.(
-                        {
-                          id: image.id,
-                          mimetype: image.type,
-                          name: image.name,
-                          size: image.size,
-                        },
-                        { startNewChat: true }
-                      )
-                    }
-                  >
-                    <IconEdit className="m-2" size={20} color="white" />
-                  </button>
                   <button
                     type="button"
                     title={t('copy_to_clipboard')}

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -1644,12 +1644,17 @@ paths:
                       type: number
                     createdAt:
                       type: string
+                    conversationId:
+                      anyOf:
+                        - type: string
+                        - type: "null"
                   required:
                     - id
                     - name
                     - type
                     - size
                     - createdAt
+                    - conversationId
                   additionalProperties: false
       security:
         - bearerAuth: []
@@ -3852,7 +3857,7 @@ components:
           properties:
             providerType:
               type: string
-              const: gemini
+              const: google-ai-studio
             name:
               type: string
               minLength: 2
@@ -3968,7 +3973,7 @@ components:
           properties:
             providerType:
               type: string
-              const: gemini
+              const: google-ai-studio
             name:
               type: string
               minLength: 2
@@ -4152,7 +4157,7 @@ components:
           properties:
             providerType:
               type: string
-              const: gemini
+              const: google-ai-studio
             name:
               type: string
               minLength: 2

--- a/apps/frontend/services/files.ts
+++ b/apps/frontend/services/files.ts
@@ -12,6 +12,7 @@ export interface UserImage {
   type: string
   size: number
   createdAt: string
+  conversationId: string | null
 }
 
 export const getUserImages = async () => {


### PR DESCRIPTION
## Summary

Removes the broken "Image edit" button from the image gallery and replaces it with a simpler, more useful interaction: clicking an image navigates to the chat that created it, scrolling the attachment into view. Addresses issue logicleai/logicle-issues#246.

## Details

- `GET /api/files/images` now returns `conversationId` (nullable) — populated for images generated inside a chat, `null` for user uploads
- Gallery images with a `conversationId` show a pointer cursor and navigate to `/chat/{conversationId}#file-{fileId}` on click
- `Attachment` wrapper gains `id="file-{fileId}"` so the fragment has a target
- `Chat` component scrolls the matched attachment into view (smooth, centered) once messages are rendered, and suppresses auto-scroll-to-bottom when a fragment is active
- OpenAPI spec regenerated

## Tests

- `npm run check-types` — no new errors
- `npm run generate:openapi` — spec updated cleanly