### PR TITLE
fix: prevent chat input from stealing focus while editing assistant description

### DIFF
--- a/apps/frontend/app/assistants/components/AssistantPreview.tsx
+++ b/apps/frontend/app/assistants/components/AssistantPreview.tsx
@@ -156,28 +156,22 @@ export const AssistantPreview = ({ assistant, className, sendDisabled }: Props) 
               textareaRef?.current?.focus()
             }}
           ></StartChatFromHere>
-          {sendDisabled ? (
-            <div className="pt-.5 px-4 text-body1">
-              <div className="relative max-w-[var(--thread-content-max-width)] mx-auto w-full flex flex-col rounded-md text-center">
-                {t('configure_assistant_before_sending_messages')}
-              </div>
-            </div>
-          ) : (
-            <ChatInputOrApiKey
-              assistant={userAssistant}
-              chatInput={chatInput}
-              setChatInput={setChatInput}
-              textAreaRef={textareaRef}
-              supportedMedia={['*/*']}
-              modelId={assistant.model}
-              tokenLimit={assistant.tokenLimit}
-              draftAssistantForEstimate={assistant}
-              draftMessagesForEstimate={conversation.messages}
-              initialServerContextTokens={cachedPreviewContextLength}
-              onServerContextTokensChange={setCachedPreviewContextLength}
-              onSend={(msg) => handleSend({ msg: { ...msg, role: 'user' } })}
-            />
-          )}
+          <ChatInputOrApiKey
+            assistant={userAssistant}
+            chatInput={chatInput}
+            setChatInput={setChatInput}
+            textAreaRef={textareaRef}
+            supportedMedia={['*/*']}
+            modelId={assistant.model}
+            tokenLimit={assistant.tokenLimit}
+            draftAssistantForEstimate={assistant}
+            draftMessagesForEstimate={conversation.messages}
+            initialServerContextTokens={cachedPreviewContextLength}
+            onServerContextTokensChange={setCachedPreviewContextLength}
+            disabled={sendDisabled}
+            disabledMsg={t('configure_assistant_before_sending_messages')}
+            onSend={(msg) => handleSend({ msg: { ...msg, role: 'user' } })}
+          />
           {sendDisabled && <ChatDisclaimer />}
         </div>
       ) : (

--- a/apps/frontend/app/chat/components/Chat.tsx
+++ b/apps/frontend/app/chat/components/Chat.tsx
@@ -148,6 +148,7 @@ export const Chat = ({
           conversationId={selectedConversation.id}
           targetMessageId={selectedConversation.targetLeaf ?? undefined}
           tokenLimit={assistant.tokenLimit}
+          autoFocus
           onSend={({ content, attachments }) => {
             setAutoScrollEnabled(true)
             messagesEndRef.current?.scrollIntoView()

--- a/apps/frontend/app/chat/components/ChatInput.tsx
+++ b/apps/frontend/app/chat/components/ChatInput.tsx
@@ -43,6 +43,7 @@ interface Props {
   onSend: (params: { content: string; attachments: dto.Attachment[] }) => void
   disabled?: boolean
   disabledMsg?: string
+  autoFocus?: boolean
   textAreaRef?: MutableRefObject<HTMLTextAreaElement | null>
   chatInput: string
   supportedMedia: string[]
@@ -62,6 +63,7 @@ export const ChatInput = ({
   onSend,
   disabled,
   disabledMsg,
+  autoFocus,
   textAreaRef,
   chatInput,
   setChatInput,
@@ -115,15 +117,15 @@ export const ChatInput = ({
 
   const fileInputId = `${useId()}-attach`
 
-  // Focus the textarea on mount and whenever the conversation changes.
   useEffect(() => {
+    if (!autoFocus) return
     const el = textareaRefInt.current
     if (el) {
       el.focus()
       const len = el.value.length
       el.setSelectionRange(len, len)
     }
-  }, [conversationId])
+  }, [autoFocus, conversationId])
 
   const completedAttachmentFileIds = uploadedFiles.current
     .filter((upload) => upload.done)

--- a/apps/frontend/app/chat/components/ChatInputOrApiKey.tsx
+++ b/apps/frontend/app/chat/components/ChatInputOrApiKey.tsx
@@ -20,6 +20,9 @@ interface Props {
   conversationId?: string
   targetMessageId?: string
   tokenLimit?: number
+  disabled?: boolean
+  disabledMsg?: string
+  autoFocus?: boolean
   onSend: (params: { content: string; attachments: dto.Attachment[] }) => void
   textAreaRef?: MutableRefObject<HTMLTextAreaElement | null>
 }
@@ -37,6 +40,9 @@ export const ChatInputOrApiKey = ({
   conversationId,
   targetMessageId,
   tokenLimit,
+  disabled,
+  disabledMsg,
+  autoFocus,
   onSend,
   textAreaRef,
 }: Props) => {
@@ -63,6 +69,9 @@ export const ChatInputOrApiKey = ({
       conversationId={conversationId}
       targetMessageId={targetMessageId}
       tokenLimit={tokenLimit}
+      disabled={disabled}
+      disabledMsg={disabledMsg}
+      autoFocus={autoFocus}
       onSend={onSend}
       textAreaRef={textAreaRef}
     />

--- a/apps/frontend/app/chat/page.tsx
+++ b/apps/frontend/app/chat/page.tsx
@@ -123,6 +123,7 @@ const StartChat = () => {
         supportedMedia={assistant.supportedMedia}
         modelId={assistant.model}
         tokenLimit={assistant.tokenLimit}
+        autoFocus
       />
     </div>
   )

--- a/apps/frontend/app/share/[shareId]/page.tsx
+++ b/apps/frontend/app/share/[shareId]/page.tsx
@@ -87,6 +87,7 @@ const SharePage = () => {
             setChatInput={setChatInput}
             textAreaRef={textareaRef}
             supportedMedia={['*/*']}
+            autoFocus
             onSend={handleSend}
           />
         ) : (
@@ -99,6 +100,7 @@ const SharePage = () => {
             setChatInput={setChatInput}
             textAreaRef={textareaRef}
             supportedMedia={['*/*']}
+            autoFocus
             onSend={handleSend}
           />
         )}


### PR DESCRIPTION
## Summary

While typing in the assistant description field, the chat input textarea was stealing keyboard focus, causing keystrokes to land in the wrong box. The root cause was an unconditional `el.focus()` in a `useEffect` inside `ChatInput` that fired on every mount — including spurious remounts triggered by form validation state changes (the description field requires ≥2 chars, so `valid` toggled on the second keystroke, which mounted/unmounted `ChatInputOrApiKey`).

## Details

- `autoFocus` is now an explicit opt-in prop on `ChatInput` and `ChatInputOrApiKey`; the focus effect only runs when the prop is set. Real chat pages (`chat/page.tsx`, `Chat.tsx`, share page) pass `autoFocus`; the assistant preview does not.
- `AssistantPreview` no longer conditionally mounts/unmounts `ChatInputOrApiKey` based on `sendDisabled`. It always renders the component and passes `disabled`/`disabledMsg` instead, avoiding the lifecycle churn that was the proximate trigger.

## Tests

- `npm run check-types` — no new errors