### PR TITLE
fix: pass sub-assistant generated files back to parent conversation

### DIFF
--- a/__tests__/chatAssistant.test.ts
+++ b/__tests__/chatAssistant.test.ts
@@ -133,7 +133,6 @@ const makeRealAssistant = () => {
   vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({
     functions: {},
     functionToolIdMap: new Map(),
-    groundingFallbackOptions: {},
   })
   return new ChatAssistant(
     { providerType: 'openai', apiKey: 'k', provisioned: false } as unknown as ProviderConfig,

--- a/__tests__/parallelToolCalls.test.ts
+++ b/__tests__/parallelToolCalls.test.ts
@@ -129,7 +129,6 @@ function makeAssistant(tools: Record<string, ToolFunction>) {
   vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({
     functions: tools,
     functionToolIdMap: new Map(),
-    groundingFallbackOptions: {},
   })
 
   const assistantParams: AssistantParams = {
@@ -403,7 +402,7 @@ describe('providerOptions: ENABLE_PARALLEL_TOOL_CALLS controls what is advertise
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'openai.responses',
     } as unknown as LanguageModelV3)
-    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map(), groundingFallbackOptions: {} })
+    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map() })
 
     const assistant = makeAssistant({})
     const testableAssistant = asTestableAssistant(assistant)
@@ -418,7 +417,7 @@ describe('providerOptions: ENABLE_PARALLEL_TOOL_CALLS controls what is advertise
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'openai.responses',
     } as unknown as LanguageModelV3)
-    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map(), groundingFallbackOptions: {} })
+    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map() })
 
     const assistant = makeAssistant({})
     const testableAssistant = asTestableAssistant(assistant)
@@ -433,7 +432,7 @@ describe('providerOptions: ENABLE_PARALLEL_TOOL_CALLS controls what is advertise
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'anthropic.messages',
     } as unknown as LanguageModelV3)
-    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map(), groundingFallbackOptions: {} })
+    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map() })
 
     const assistant = makeAssistant({})
     const testableAssistant = asTestableAssistant(assistant)
@@ -449,7 +448,7 @@ describe('providerOptions: ENABLE_PARALLEL_TOOL_CALLS controls what is advertise
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'anthropic.messages',
     } as unknown as LanguageModelV3)
-    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map(), groundingFallbackOptions: {} })
+    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map() })
 
     const assistant = makeAssistant({})
     const testableAssistant = asTestableAssistant(assistant)

--- a/apps/backend/api/assistants/evaluate/route.ts
+++ b/apps/backend/api/assistants/evaluate/route.ts
@@ -58,6 +58,7 @@ export const POST = operation({
         debug: true,
         user: session.userId,
         conversationId,
+        rootOwner: { type: 'USER', id: session.userId },
       }
     )
 

--- a/apps/backend/lib/tools/subassistant/__tests__/implementation.test.ts
+++ b/apps/backend/lib/tools/subassistant/__tests__/implementation.test.ts
@@ -111,8 +111,19 @@ function setupSubAssistantRun(
   })
 }
 
+type InvokeParamsOverrides = {
+  params?: Record<string, unknown>
+  userId?: string
+  conversationId?: string
+  rootOwner?: { type: 'CHAT' | 'USER' | 'ASSISTANT'; id: string }
+  toolCallId?: string
+  toolName?: string
+  assistantId?: string
+  debug?: boolean
+}
+
 /** Build a minimal ToolInvokeParams-compatible object. */
-function invokeParams(overrides: Partial<Parameters<typeof invokeAssistant>[0]> = {}) {
+function invokeParams(overrides: InvokeParamsOverrides = {}) {
   return {
     params: { assistantId: 'sub-assistant-id', input: 'do something' },
     userId: 'user-1',
@@ -143,7 +154,9 @@ beforeEach(async () => {
     [{ id: 'sub-assistant-id', name: 'ImageBot', description: 'generates images' }]
   )
   const fns = await tool.functions({} as any, {} as any)
-  invokeAssistant = (p) => fns['invoke_assistant'].invoke(p as any)
+  const fn = fns['invoke_assistant']
+  if (!fn || fn.type === 'provider') throw new Error('invoke_assistant not found or not a function tool')
+  invokeAssistant = (p) => fn.invoke(p as any)
 })
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/apps/backend/lib/tools/subassistant/__tests__/implementation.test.ts
+++ b/apps/backend/lib/tools/subassistant/__tests__/implementation.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import * as dto from '@/types/dto'
+import { nanoid } from 'nanoid'
+import { ChatState } from '@/backend/lib/chat/ChatState'
+
+// ── Heavy dependency mocks ────────────────────────────────────────────────────
+
+vi.mock('@/models/assistant', () => ({
+  canUserAccessAssistant: vi.fn().mockResolvedValue(true),
+  getPublishedAssistantVersion: vi.fn().mockResolvedValue({
+    id: 'av-1',
+    backendId: 'backend-1',
+    model: 'gpt-4o',
+    systemPrompt: '',
+    temperature: 0.7,
+    tokenLimit: null,
+    reasoning_effort: null,
+  }),
+  assistantVersionFiles: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('db/database', () => ({
+  db: {
+    selectFrom: () => ({
+      selectAll: () => ({
+        where: () => ({
+          executeTakeFirst: vi.fn().mockResolvedValue({
+            id: 'backend-1',
+            providerType: 'openai.chat',
+            provisioned: false,
+            configuration: JSON.stringify({ apiKey: 'test-key' }),
+          }),
+        }),
+      }),
+    }),
+  },
+}))
+
+vi.mock('@/backend/lib/tools/enumerate', () => ({
+  availableToolsForAssistantVersion: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('@/lib/parameters', () => ({
+  getUserParameters: vi.fn().mockResolvedValue({}),
+}))
+
+const mockInvokeLlm = vi.fn()
+const mockBuild = vi.fn().mockResolvedValue({ invokeLlmAndProcessResponse: mockInvokeLlm })
+
+vi.mock('@/backend/lib/chat', () => ({
+  ChatAssistant: { build: mockBuild },
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Populate chatState to simulate a sub-assistant that optionally calls a tool
+ * producing files, then responds with a text message.
+ */
+function setupSubAssistantRun(
+  files: Array<{ id: string; mimetype: string; name: string; size: number }>,
+  replyText: string
+) {
+  mockInvokeLlm.mockImplementation(async (chatState: ChatState) => {
+    const convId = chatState.conversationId
+
+    if (files.length > 0) {
+      const assistantCallMsg: dto.AssistantMessage = {
+        id: nanoid(),
+        role: 'assistant',
+        conversationId: convId,
+        parent: chatState.chatHistory[chatState.chatHistory.length - 1].id,
+        sentAt: new Date().toISOString(),
+        parts: [{ type: 'tool-call', toolCallId: 'call-img', toolName: 'GenerateImage', args: {} }],
+      }
+      chatState.appendMessage(assistantCallMsg)
+
+      const toolMsg: dto.ToolMessage = {
+        id: nanoid(),
+        role: 'tool',
+        conversationId: convId,
+        parent: assistantCallMsg.id,
+        sentAt: new Date().toISOString(),
+        parts: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-img',
+            toolName: 'GenerateImage',
+            result: {
+              type: 'content',
+              value: [
+                { type: 'text', text: 'Image displayed.' },
+                ...files.map((f) => ({ ...f, type: 'file' as const })),
+              ],
+            },
+          },
+        ],
+      }
+      chatState.appendMessage(toolMsg)
+    }
+
+    const assistantReplyMsg: dto.AssistantMessage = {
+      id: nanoid(),
+      role: 'assistant',
+      conversationId: convId,
+      parent: chatState.chatHistory[chatState.chatHistory.length - 1].id,
+      sentAt: new Date().toISOString(),
+      parts: [{ type: 'text', text: replyText }],
+    }
+    chatState.appendMessage(assistantReplyMsg)
+  })
+}
+
+/** Build a minimal ToolInvokeParams-compatible object. */
+function invokeParams(overrides: Partial<Parameters<typeof invokeAssistant>[0]> = {}) {
+  return {
+    params: { assistantId: 'sub-assistant-id', input: 'do something' },
+    userId: 'user-1',
+    conversationId: 'parent-conv-id',
+    rootOwner: { type: 'CHAT' as const, id: 'parent-conv-id' },
+    toolCallId: 'tc-1',
+    toolName: 'invoke_assistant',
+    llmModel: {} as any,
+    messages: [],
+    assistantId: 'parent-assistant-id',
+    uiLink: {} as any,
+    debug: false,
+    ...overrides,
+  }
+}
+
+// ── Lazy import to give mocks time to register ────────────────────────────────
+
+let invokeAssistant: (params: ReturnType<typeof invokeParams>) => Promise<dto.ToolCallResultOutput>
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  mockBuild.mockResolvedValue({ invokeLlmAndProcessResponse: mockInvokeLlm })
+
+  const { SubAssistantTool } = await import('../implementation')
+  const tool = new SubAssistantTool(
+    { name: 'invoke_assistant', id: 'tool-1' } as any,
+    [{ id: 'sub-assistant-id', name: 'ImageBot', description: 'generates images' }]
+  )
+  const fns = await tool.functions({} as any, {} as any)
+  invokeAssistant = (p) => fns['invoke_assistant'].invoke(p as any)
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('invoke_assistant — file passthrough', () => {
+  test('returns plain text when the sub-assistant produces no files', async () => {
+    setupSubAssistantRun([], 'Sure, here is the answer.')
+
+    const result = await invokeAssistant(invokeParams())
+
+    expect(result).toEqual({ type: 'text', value: 'Sure, here is the answer.' })
+  })
+
+  test('returns content result with files when the sub-assistant tool produces images', async () => {
+    setupSubAssistantRun(
+      [{ id: 'img-001', mimetype: 'image/png', name: 'cat.png', size: 2048 }],
+      'Here is the generated image.'
+    )
+
+    const result = await invokeAssistant(invokeParams())
+
+    expect(result).toEqual({
+      type: 'content',
+      value: [
+        { type: 'text', text: 'Here is the generated image.' },
+        { type: 'file', id: 'img-001', mimetype: 'image/png', name: 'cat.png', size: 2048 },
+      ],
+    })
+  })
+
+  test('includes multiple files when the sub-assistant tool produces several images', async () => {
+    setupSubAssistantRun(
+      [
+        { id: 'img-001', mimetype: 'image/png', name: 'a.png', size: 100 },
+        { id: 'img-002', mimetype: 'image/png', name: 'b.png', size: 200 },
+      ],
+      'Two images generated.'
+    )
+
+    const result = await invokeAssistant(invokeParams())
+
+    expect(result.type).toBe('content')
+    if (result.type !== 'content') return
+    expect(result.value.filter((v) => v.type === 'file')).toHaveLength(2)
+  })
+})
+
+describe('invoke_assistant — ownership', () => {
+  test('forwards the parent rootOwner to ChatAssistant.build so sub-assistant files are owned by the parent chat', async () => {
+    setupSubAssistantRun([], 'done')
+    const parentRootOwner = { type: 'CHAT' as const, id: 'parent-conv-id' }
+
+    await invokeAssistant(invokeParams({ rootOwner: parentRootOwner }))
+
+    const buildOptions = mockBuild.mock.calls[0][5]
+    expect(buildOptions.rootOwner).toEqual(parentRootOwner)
+  })
+
+  test('forwards the parent conversationId to ChatAssistant.build', async () => {
+    setupSubAssistantRun([], 'done')
+
+    await invokeAssistant(invokeParams({ conversationId: 'parent-conv-id' }))
+
+    const buildOptions = mockBuild.mock.calls[0][5]
+    expect(buildOptions.conversationId).toBe('parent-conv-id')
+  })
+})

--- a/apps/backend/lib/tools/subassistant/implementation.ts
+++ b/apps/backend/lib/tools/subassistant/implementation.ts
@@ -19,6 +19,7 @@ import { ChatState } from '@/backend/lib/chat/ChatState'
 import { ClientSink } from '@/backend/lib/chat/ClientSink'
 import * as dto from '@/types/dto'
 import { nanoid } from 'nanoid'
+import { getFileWithId } from '@/models/file'
 
 export interface SubAssistantEntry {
   id: string
@@ -53,6 +54,18 @@ export class SubAssistantTool implements ToolImplementation {
               type: 'string',
               description: 'The input message to send to the assistant',
             },
+            attachments: {
+              type: 'array',
+              description: 'Optional file attachments to send along with the input message',
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string', description: 'File ID' },
+                },
+                required: ['id'],
+                additionalProperties: false,
+              },
+            },
           },
           required: ['assistantId', 'input'],
           additionalProperties: false,
@@ -61,6 +74,7 @@ export class SubAssistantTool implements ToolImplementation {
         invoke: async ({ params, userId, conversationId, rootOwner }) => {
           const assistantId = params.assistantId as string
           const input = params.input as string
+          const attachmentIds = (params.attachments as Array<{ id: string }> | undefined) ?? []
           const entry = assistants.find((a) => a.id === assistantId)
           const label = entry?.name ?? assistantId
           try {
@@ -118,6 +132,12 @@ export class SubAssistantTool implements ToolImplementation {
               rootOwner,
             })
 
+            const attachments: dto.Attachment[] = (
+              await Promise.all(attachmentIds.map(({ id }) => getFileWithId(id)))
+            )
+              .filter((f): f is NonNullable<typeof f> => f != null)
+              .map((f) => ({ id: f.id, mimetype: f.type, name: f.name, size: f.size ?? 0 }))
+
             const subConversationId = nanoid()
             const userMsg: dto.UserMessage = {
               id: nanoid(),
@@ -126,7 +146,7 @@ export class SubAssistantTool implements ToolImplementation {
               sentAt: new Date().toISOString(),
               role: 'user',
               content: input,
-              attachments: [],
+              attachments,
             }
 
             const chatState = new ChatState([userMsg])

--- a/apps/backend/lib/tools/subassistant/implementation.ts
+++ b/apps/backend/lib/tools/subassistant/implementation.ts
@@ -108,6 +108,10 @@ export class SubAssistantTool implements ToolImplementation {
                 | null,
             }
 
+            // Pass the parent conversationId and rootOwner so that any files
+            // created by the sub-assistant's tools (e.g. generated images) are
+            // stored as owned by the parent chat, not by the ephemeral
+            // sub-conversation.
             const assistant = await ChatAssistant.build(providerConfig, assistantParams, parameters, tools, files, {
               user: userId,
               conversationId,

--- a/apps/backend/lib/tools/subassistant/implementation.ts
+++ b/apps/backend/lib/tools/subassistant/implementation.ts
@@ -139,11 +139,30 @@ export class SubAssistantTool implements ToolImplementation {
             if (errorPart) {
               return { type: 'error-text', value: errorPart.error }
             }
-            const text = assistantMsg.parts
+            const textContent = assistantMsg.parts
               .filter((p): p is dto.TextPart => p.type === 'text')
               .map((p) => p.text)
               .join('')
-            return { type: 'text', value: text }
+            type ContentFile = { type: 'file'; id: string; mimetype: string; name: string; size: number }
+            const generatedFiles = chatState.chatHistory
+              .filter((m): m is dto.ToolMessage => m.role === 'tool')
+              .flatMap((m) => m.parts)
+              .filter((p): p is dto.ToolCallResultPart => p.type === 'tool-result')
+              .flatMap((p) =>
+                p.result.type === 'content'
+                  ? (p.result.value.filter((v) => v.type === 'file') as ContentFile[])
+                  : []
+              )
+            if (generatedFiles.length > 0) {
+              return {
+                type: 'content',
+                value: [
+                  ...(textContent ? [{ type: 'text' as const, text: textContent }] : []),
+                  ...generatedFiles,
+                ],
+              }
+            }
+            return { type: 'text', value: textContent }
           } catch (e) {
             logger.error(`SubAssistantTool: error invoking "${label}"`, e)
             return { type: 'error-text', value: (e as Error).message ?? 'Sub-assistant invocation failed' }


### PR DESCRIPTION
## Summary

Fixes file handling for sub-assistants on two fronts: generated files from sub-assistant tool calls (e.g. image generation) are now passed back to the parent conversation, and the parent assistant can now forward file attachments into a sub-assistant invocation. A third fix corrects file ownership when \`invoke_assistant\` is used during an evaluate (playground) request.

## Details

- \`invoke_assistant\` scans the sub-assistant's \`ToolMessage\` history for \`tool-result\` parts containing files and includes them in the result returned to the parent LLM and UI
- \`invoke_assistant\` now accepts an optional \`attachments\` parameter — an array of \`{ id }\` objects; each ID is resolved to its full metadata so the sub-assistant receives proper \`UserMessage.attachments\`
- The evaluate endpoint now sets \`rootOwner: { type: 'USER', id: userId }\` instead of falling back to \`CHAT\` with a fake conversation ID, so files created during playground runs are attributed to the user rather than a non-existent chat

## Tests

- \`npm run check-types\` — no errors in modified files
- Reproduced the image passthrough scenario: parent assistant calling a sub-assistant configured with image generation; the image now propagates back correctly