### PR TITLE
feat: prompt caching for Anthropic and OpenAI

### DIFF
--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -450,9 +450,7 @@ export class ChatAssistant {
                   assistantParams.reasoning_effort ?? this.llmModel.defaultReasoning ?? null,
               }
             : {}),
-          ...(this.llmModelCapabilities.prompt_cache_retention
-            ? { promptCacheRetention: this.llmModelCapabilities.prompt_cache_retention }
-            : {}),
+          ...(this.llmModelCapabilities.promptCaching ? { promptCacheRetention: '24h' } : {}),
         } satisfies openai.OpenAIResponsesProviderOptions,
       }
     } else if (vercelProviderType === 'openai.chat') {
@@ -485,6 +483,7 @@ export class ChatAssistant {
                 },
               }
             : {}),
+          ...(this.llmModelCapabilities.promptCaching ? { cacheControl: { type: 'ephemeral' } } : {}),
         } satisfies anthropic.AnthropicProviderOptions,
       }
     }
@@ -539,14 +538,52 @@ export class ChatAssistant {
     return segments.map((segment) => segment.message)
   }
 
+  private applyAnthropicCacheBreakpoint(message: ai.ModelMessage): void {
+    const cacheControl = { type: 'ephemeral' } as const
+    if (message.role === 'system') {
+      message.providerOptions = {
+        ...message.providerOptions,
+        anthropic: { ...(message.providerOptions?.anthropic as object | undefined), cacheControl },
+      }
+    } else if (message.role === 'user' || message.role === 'assistant') {
+      const parts = Array.isArray(message.content) ? message.content : undefined
+      if (parts && parts.length > 0) {
+        const last = parts[parts.length - 1]! as { providerOptions?: Record<string, unknown> }
+        last.providerOptions = {
+          ...last.providerOptions,
+          anthropic: { ...(last.providerOptions?.['anthropic'] as object | undefined), cacheControl },
+        }
+      }
+    }
+  }
+
   async invokeLlm(messages: dto.Message[]) {
     this.throwIfAborted()
     const truncatedChat = await this.truncateChat(messages)
-    const llmMessages = await this.computeLlmMessages(truncatedChat)
+
+    const preambleSegments = await buildPreambleSegments({
+      assistantParams: this.assistantParams,
+      llmModel: this.llmModel,
+      tools: this.tools,
+      parameters: this.parameters,
+      knowledge: this.knowledge,
+    })
+    const historySegments = await buildHistorySegments(
+      truncatedChat,
+      this.llmModel,
+      this.languageModel
+    )
+
+    const isAnthropic = this.languageModel.provider === 'anthropic.messages'
+    if (isAnthropic && this.llmModelCapabilities.promptCaching && preambleSegments.length > 0) {
+      this.applyAnthropicCacheBreakpoint(preambleSegments[preambleSegments.length - 1]!.message)
+    }
+
+    const llmMessages = [...preambleSegments, ...historySegments].map((s) => s.message)
     const tools = await this.createAiTools()
     const providerOptions = this.providerOptions(llmMessages)
     let maxOutputTokens = minOptional(this.llmModel.maxOutputTokens, env.chat.maxOutputTokens)
-    if (maxOutputTokens && this.languageModel.provider === 'anthropic.messages') {
+    if (maxOutputTokens && isAnthropic) {
       const anthropicProviderOptions = providerOptions?.anthropic as
         | anthropic.AnthropicProviderOptions
         | undefined

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -426,9 +426,7 @@ export class ChatAssistant {
     )
   }
 
-  private providerOptions(
-    _messages: ai.ModelMessage[]
-  ): Record<string, any> | undefined {
+  private providerOptions(_messages: ai.ModelMessage[]): Record<string, any> | undefined {
     const assistantParams = this.assistantParams
     const options = this.options
     const vercelProviderType = this.languageModel.provider
@@ -451,6 +449,9 @@ export class ChatAssistant {
                 reasoningEffort:
                   assistantParams.reasoning_effort ?? this.llmModel.defaultReasoning ?? null,
               }
+            : {}),
+          ...(this.llmModelCapabilities.prompt_cache_retention
+            ? { promptCacheRetention: this.llmModelCapabilities.prompt_cache_retention }
             : {}),
         } satisfies openai.OpenAIResponsesProviderOptions,
       }

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -450,7 +450,9 @@ export class ChatAssistant {
                   assistantParams.reasoning_effort ?? this.llmModel.defaultReasoning ?? null,
               }
             : {}),
-          ...(this.llmModelCapabilities.promptCaching ? { promptCacheRetention: '24h' } : {}),
+          ...(this.llmModelCapabilities.promptCaching && env.promptCaching.openai !== 'none'
+            ? { promptCacheRetention: env.promptCaching.openai }
+            : {}),
         } satisfies openai.OpenAIResponsesProviderOptions,
       }
     } else if (vercelProviderType === 'openai.chat') {
@@ -483,7 +485,10 @@ export class ChatAssistant {
                 },
               }
             : {}),
-          ...(this.llmModelCapabilities.promptCaching ? { cacheControl: { type: 'ephemeral' } } : {}),
+          ...(this.llmModelCapabilities.promptCaching &&
+          env.promptCaching.anthropic.automatic !== 'none'
+            ? { cacheControl: { type: 'ephemeral', ttl: env.promptCaching.anthropic.automatic } }
+            : {}),
         } satisfies anthropic.AnthropicProviderOptions,
       }
     }
@@ -539,7 +544,8 @@ export class ChatAssistant {
   }
 
   private applyAnthropicCacheBreakpoint(message: ai.ModelMessage): void {
-    const cacheControl = { type: 'ephemeral' } as const
+    const ttl = env.promptCaching.anthropic.preamble
+    const cacheControl = { type: 'ephemeral', ...(ttl !== 'none' ? { ttl } : {}) } as const
     if (message.role === 'system') {
       message.providerOptions = {
         ...message.providerOptions,
@@ -551,7 +557,10 @@ export class ChatAssistant {
         const last = parts[parts.length - 1]! as { providerOptions?: Record<string, unknown> }
         last.providerOptions = {
           ...last.providerOptions,
-          anthropic: { ...(last.providerOptions?.['anthropic'] as object | undefined), cacheControl },
+          anthropic: {
+            ...(last.providerOptions?.['anthropic'] as object | undefined),
+            cacheControl,
+          },
         }
       }
     }
@@ -575,7 +584,12 @@ export class ChatAssistant {
     )
 
     const isAnthropic = this.languageModel.provider === 'anthropic.messages'
-    if (isAnthropic && this.llmModelCapabilities.promptCaching && preambleSegments.length > 0) {
+    if (
+      isAnthropic &&
+      this.llmModelCapabilities.promptCaching &&
+      env.promptCaching.anthropic.preamble !== 'none' &&
+      preambleSegments.length > 0
+    ) {
       this.applyAnthropicCacheBreakpoint(preambleSegments[preambleSegments.length - 1]!.message)
     }
 

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -4061,11 +4061,8 @@ components:
           type: boolean
         knowledge:
           type: boolean
-        prompt_cache_retention:
-          type: string
-          enum:
-            - in_memory
-            - 24h
+        promptCaching:
+          type: boolean
       required:
         - vision
         - function_calling

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -4061,6 +4061,11 @@ components:
           type: boolean
         knowledge:
           type: boolean
+        prompt_cache_retention:
+          type: string
+          enum:
+            - in_memory
+            - 24h
       required:
         - vision
         - function_calling

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -9,6 +9,18 @@ function parseOptionalFloat(text?: string) {
   return Number.isNaN(value) ? undefined : value
 }
 
+function parseAnthropicCacheMode(raw: string | undefined, defaultValue: 'none' | '5m' | '1h'): 'none' | '5m' | '1h' {
+  if (raw === 'none' || raw === '0') return 'none'
+  if (raw === '5m' || raw === '1h') return raw
+  return defaultValue
+}
+
+function parseOpenAiCacheMode(raw: string | undefined, defaultValue: 'none' | 'in_memory' | '24h'): 'none' | 'in_memory' | '24h' {
+  if (raw === 'none' || raw === '0') return 'none'
+  if (raw === 'in_memory' || raw === '24h') return raw
+  return defaultValue
+}
+
 function parseCleanupMode(raw?: string): 'off' | 'dry-run' | 'delete' {
   if (raw === 'dry-run' || raw === 'delete' || raw === 'off') {
     return raw
@@ -164,6 +176,13 @@ const env = {
   apiKeys: {
     enable: process.env.ENABLE_APIKEYS === '1',
     enableUi: process.env.ENABLE_APIKEYS_UI === '1',
+  },
+  promptCaching: {
+    anthropic: {
+      preamble: parseAnthropicCacheMode(process.env.PROMPT_CACHE_ANTHROPIC_PREAMBLE, '1h'),
+      automatic: parseAnthropicCacheMode(process.env.PROMPT_CACHE_ANTHROPIC_AUTOMATIC, '5m'),
+    },
+    openai: parseOpenAiCacheMode(process.env.PROMPT_CACHE_OPENAI, '24h'),
   },
   dumpLlmConversation: process.env.DUMP_LLM_CONVERSATION === '1',
   allowMockProvider: process.env.ALLOW_MOCK_PROVIDER === '1',

--- a/packages/core/src/models/anthropic.ts
+++ b/packages/core/src/models/anthropic.ts
@@ -162,6 +162,7 @@ export const claude4OpusModel: LlmModel = {
     web_search: true,
     supportedMedia: ['application/pdf'],
     nativePdfPageLimit: 100,
+    promptCaching: true,
   },
   maxOutputTokens: 32000,
 }
@@ -182,6 +183,7 @@ export const claude41OpusModel: LlmModel = {
     web_search: true,
     supportedMedia: ['application/pdf'],
     nativePdfPageLimit: 100,
+    promptCaching: true,
   },
   maxOutputTokens: 32000,
 }
@@ -202,6 +204,7 @@ export const claude45SonnetModel: LlmModel = {
     web_search: true,
     supportedMedia: ['application/pdf'],
     nativePdfPageLimit: 100,
+    promptCaching: true,
   },
   maxOutputTokens: 64000,
 }
@@ -222,6 +225,7 @@ export const claude45HaikuModel: LlmModel = {
     web_search: true,
     supportedMedia: ['application/pdf'],
     nativePdfPageLimit: 100,
+    promptCaching: true,
   },
   maxOutputTokens: 64000,
 }
@@ -241,6 +245,7 @@ export const claude45OpusModel: LlmModel = {
     web_search: true,
     supportedMedia: ['application/pdf'],
     nativePdfPageLimit: 100,
+    promptCaching: true,
   },
   maxOutputTokens: 64000,
 }
@@ -261,6 +266,7 @@ export const claude46SonnetModel: LlmModel = {
     web_search: true,
     supportedMedia: ['application/pdf'],
     nativePdfPageLimit: 100,
+    promptCaching: true,
   },
   maxOutputTokens: 64000,
 }

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -18,7 +18,7 @@ export interface LlmModelCapabilities {
   web_search?: boolean
   knowledge?: boolean
   nativePdfPageLimit?: number
-  prompt_cache_retention?: 'in_memory' | '24h'
+  promptCaching?: boolean
 }
 
 export const tokenizerStrategies = ['cl100k_base', 'o200k_base', 'approx_4chars'] as const

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -18,6 +18,7 @@ export interface LlmModelCapabilities {
   web_search?: boolean
   knowledge?: boolean
   nativePdfPageLimit?: number
+  prompt_cache_retention?: 'in_memory' | '24h'
 }
 
 export const tokenizerStrategies = ['cl100k_base', 'o200k_base', 'approx_4chars'] as const

--- a/packages/core/src/models/openai.ts
+++ b/packages/core/src/models/openai.ts
@@ -100,6 +100,7 @@ export const gpt41Model: LlmModel = {
     reasoning: false,
     web_search: true,
     supportedMedia: ['application/pdf'],
+    prompt_cache_retention: '24h',
   },
 }
 
@@ -275,6 +276,7 @@ export const gpt5Model: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
+    prompt_cache_retention: '24h',
   },
   defaultReasoning: 'low',
 }
@@ -345,6 +347,7 @@ export const gpt51Model: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
+    prompt_cache_retention: '24h',
   },
   defaultReasoning: 'low',
 }
@@ -379,6 +382,7 @@ export const gpt52Model: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
+    prompt_cache_retention: '24h',
   },
   defaultReasoning: 'low',
 }
@@ -417,6 +421,42 @@ export const gpt52ChatModel: LlmModel = {
   defaultReasoning: 'medium',
 }
 
+export const gpt55Model: LlmModel = {
+  id: 'gpt-5.5',
+  model: 'gpt-5.5',
+  name: 'GPT-5.5',
+  description: 'GPT-5.5, available via Chat Completions and Responses APIs',
+  provider: 'openai',
+  owned_by: 'openai',
+  context_length: 400000,
+  capabilities: {
+    vision: true,
+    function_calling: true,
+    reasoning: true,
+    supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
+    prompt_cache_retention: '24h',
+  },
+  defaultReasoning: 'low',
+}
+
+export const gpt55ProModel: LlmModel = {
+  id: 'gpt-5.5-pro',
+  model: 'gpt-5.5-pro',
+  name: 'GPT-5.5 Pro',
+  description: 'GPT-5.5 Pro, available via Responses API only; supports Batch API',
+  provider: 'openai',
+  owned_by: 'openai',
+  context_length: 400000,
+  capabilities: {
+    vision: true,
+    function_calling: true,
+    reasoning: true,
+    supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
+    prompt_cache_retention: '24h',
+  },
+  defaultReasoning: 'low',
+}
+
 export const gpt54Model: LlmModel = {
   id: 'gpt-5.4',
   model: 'gpt-5.4',
@@ -430,6 +470,7 @@ export const gpt54Model: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
+    prompt_cache_retention: '24h',
   },
   defaultReasoning: 'low',
 }
@@ -468,6 +509,8 @@ export const openaiModels: LlmModel[] = [
   gpt52Model,
   gpt52ProModel, // too expensive
   gpt54Model,
+  gpt55Model,
+  gpt55ProModel,
   o1Model,
   o1MiniModel,
   o3Model,

--- a/packages/core/src/models/openai.ts
+++ b/packages/core/src/models/openai.ts
@@ -330,6 +330,7 @@ export const gpt5ChatModel: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
+    promptCaching: true,
   },
   defaultReasoning: 'medium',
 }
@@ -365,6 +366,7 @@ export const gpt51ChatModel: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
+    promptCaching: true,
   },
   defaultReasoning: 'medium',
 }
@@ -400,6 +402,7 @@ export const gpt52ProModel: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
+    promptCaching: true,
   },
   defaultReasoning: 'low',
 }
@@ -417,6 +420,7 @@ export const gpt52ChatModel: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
+    promptCaching: true,
   },
   defaultReasoning: 'medium',
 }

--- a/packages/core/src/models/openai.ts
+++ b/packages/core/src/models/openai.ts
@@ -438,7 +438,7 @@ export const gpt55Model: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
-    promptCaching: true,
+    promptCaching: false,
   },
   defaultReasoning: 'low',
 }
@@ -456,7 +456,7 @@ export const gpt55ProModel: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
-    promptCaching: true,
+    promptCaching: false,
   },
   defaultReasoning: 'low',
 }

--- a/packages/core/src/models/openai.ts
+++ b/packages/core/src/models/openai.ts
@@ -438,7 +438,7 @@ export const gpt55Model: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
-    promptCaching: false,
+    promptCaching: false, // caching is automatic and non-configurable on this model
   },
   defaultReasoning: 'low',
 }
@@ -456,7 +456,7 @@ export const gpt55ProModel: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
-    promptCaching: false,
+    promptCaching: false, // caching is automatic and non-configurable on this model
   },
   defaultReasoning: 'low',
 }

--- a/packages/core/src/models/openai.ts
+++ b/packages/core/src/models/openai.ts
@@ -100,7 +100,7 @@ export const gpt41Model: LlmModel = {
     reasoning: false,
     web_search: true,
     supportedMedia: ['application/pdf'],
-    prompt_cache_retention: '24h',
+    promptCaching: true,
   },
 }
 
@@ -276,7 +276,7 @@ export const gpt5Model: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
-    prompt_cache_retention: '24h',
+    promptCaching: true,
   },
   defaultReasoning: 'low',
 }
@@ -347,7 +347,7 @@ export const gpt51Model: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
-    prompt_cache_retention: '24h',
+    promptCaching: true,
   },
   defaultReasoning: 'low',
 }
@@ -382,7 +382,7 @@ export const gpt52Model: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
-    prompt_cache_retention: '24h',
+    promptCaching: true,
   },
   defaultReasoning: 'low',
 }
@@ -434,7 +434,7 @@ export const gpt55Model: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
-    prompt_cache_retention: '24h',
+    promptCaching: true,
   },
   defaultReasoning: 'low',
 }
@@ -452,7 +452,7 @@ export const gpt55ProModel: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
-    prompt_cache_retention: '24h',
+    promptCaching: true,
   },
   defaultReasoning: 'low',
 }
@@ -470,7 +470,7 @@ export const gpt54Model: LlmModel = {
     function_calling: true,
     reasoning: true,
     supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
-    prompt_cache_retention: '24h',
+    promptCaching: true,
   },
   defaultReasoning: 'low',
 }

--- a/packages/core/src/types/dto/llmmodel.ts
+++ b/packages/core/src/types/dto/llmmodel.ts
@@ -9,7 +9,7 @@ export const llmModelCapabilitiesSchema = z.object({
   supportedMedia: z.array(z.string()).optional(),
   web_search: z.boolean().optional(),
   knowledge: z.boolean().optional(),
-  prompt_cache_retention: z.enum(['in_memory', '24h']).optional(),
+  promptCaching: z.boolean().optional(),
 }).meta({ id: 'LlmModelCapabilities' })
 
 export const llmModelSchema = z.object({

--- a/packages/core/src/types/dto/llmmodel.ts
+++ b/packages/core/src/types/dto/llmmodel.ts
@@ -9,6 +9,7 @@ export const llmModelCapabilitiesSchema = z.object({
   supportedMedia: z.array(z.string()).optional(),
   web_search: z.boolean().optional(),
   knowledge: z.boolean().optional(),
+  prompt_cache_retention: z.enum(['in_memory', '24h']).optional(),
 }).meta({ id: 'LlmModelCapabilities' })
 
 export const llmModelSchema = z.object({


### PR DESCRIPTION
## Summary

Adds prompt caching support for Anthropic and OpenAI providers. Models declare whether they support caching via a `promptCaching` capability flag; operators control the actual behavior (mode, TTL) through env vars. For Anthropic, an explicit cache breakpoint is placed at the end of the preamble (system prompt + knowledge), and automatic tail caching is enabled at the request level. For OpenAI's Responses API, `promptCacheRetention` is forwarded when the capability is set.

## Details

- New `promptCaching?: boolean` capability on `LlmModelCapabilities` (replaces the old `prompt_cache_retention` enum)
- `promptCaching: true` added to all active Anthropic models (Claude 4 Opus through 4.6 Sonnet) and OpenAI models that support configurable caching (gpt-4.1, gpt-5 family, gpt-5.1–5.4 and variants); gpt-5.5/5.5-pro marked `false` as their caching is implicit and non-configurable
- Anthropic caching uses two complementary mechanisms:
  - Explicit breakpoint on the last preamble segment (system prompt or knowledge `UserMessage`), with configurable TTL
  - Request-level `cacheControl` for automatic tail caching, with a separate TTL
- `invokeLlm` refactored to build preamble and history segments separately so the preamble boundary is known before sending
- Three env vars to tune behavior at runtime:

| Env var | Values | Default |
|---|---|---|
| `PROMPT_CACHE_ANTHROPIC_PREAMBLE` | `none` \| `5m` \| `1h` | `1h` |
| `PROMPT_CACHE_ANTHROPIC_AUTOMATIC` | `none` \| `5m` \| `1h` | `5m` |
| `PROMPT_CACHE_OPENAI` | `none` \| `in_memory` \| `24h` | `24h` |

## Tests

- `npm run check-types` — no errors
- `npm test` — 74 test files, 714 tests, all passing