### PR TITLE
feat: inject x-tenant-id header into MCP and OpenAPI tool calls

### DIFF
--- a/apps/backend/lib/tools/mcp/implementation.ts
+++ b/apps/backend/lib/tools/mcp/implementation.ts
@@ -70,7 +70,10 @@ const computeHeaders = (
 }
 
 const createTransport = ({ url, authentication }: McpPluginParams, accessToken?: string) => {
-  const headers = computeHeaders(authentication, accessToken)
+  const headers = {
+    ...computeHeaders(authentication, accessToken),
+    ...(env.tenantId ? { 'x-tenant-id': env.tenantId } : {}),
+  }
   if (url.endsWith('/sse')) {
     logger.info(`Create MCP SSE transport for url ${url}`)
     return new SSEClientTransport(new URL(url), {

--- a/apps/backend/lib/tools/openapi/implementation.ts
+++ b/apps/backend/lib/tools/openapi/implementation.ts
@@ -194,7 +194,11 @@ function convertOpenAPIOperationToToolFunction(
     }
 
     const urlString = url.toString()
-    const allHeaders = { ...headers, ...sensitiveHeaders }
+    const allHeaders = {
+      ...headers,
+      ...sensitiveHeaders,
+      ...(env.tenantId ? { 'x-tenant-id': env.tenantId } : {}),
+    }
 
     logger.info(`Invoking ${method} at ${urlString}`, {
       body: body,

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -184,6 +184,7 @@ const env = {
     },
     openai: parseOpenAiCacheMode(process.env.PROMPT_CACHE_OPENAI, '24h'),
   },
+  tenantId: process.env.TENANT_ID || undefined,
   dumpLlmConversation: process.env.DUMP_LLM_CONVERSATION === '1',
   allowMockProvider: process.env.ALLOW_MOCK_PROVIDER === '1',
   conversationLimit: parseOptionalInt(process.env.MAX_CONVERSATION_RESULTS),


### PR DESCRIPTION
## Summary

Adds support for a `TENANT_ID` environment variable. When set, a `x-tenant-id` header is injected into all outbound MCP transport connections and OpenAPI tool HTTP requests, enabling tenant-aware routing or filtering on downstream services.

## Details

- `packages/core/src/env.ts` — exposes `TENANT_ID` as `env.tenantId`
- `apps/backend/lib/tools/mcp/implementation.ts` — merges `x-tenant-id` into transport headers in `createTransport`
- `apps/backend/lib/tools/openapi/implementation.ts` — merges `x-tenant-id` into `allHeaders` before the fetch call

The header is only added when `TENANT_ID` is defined; no behaviour change otherwise.

## Tests

- `npm run check-types` — passed with no errors