### PR TITLE
fix: resolve OpenAPI secrets at runtime and clean up file persistence

### DIFF
--- a/__tests__/toolOutputNormalization.test.ts
+++ b/__tests__/toolOutputNormalization.test.ts
@@ -35,7 +35,7 @@ vi.mock('@/backend/lib/files/materialize', () => ({
 
 import {
   normalizeMcpToolResult,
-  persistFileLikePayload,
+  saveFile,
 } from '@/backend/lib/tools/file-output-normalization'
 
 describe('tool output normalization', () => {
@@ -66,74 +66,71 @@ describe('tool output normalization', () => {
   })
 
   test('openapi-like binary payload persists to stable file descriptor', async () => {
-    const payload = Buffer.from('binary-openapi').toString('base64')
-    const persisted = await persistFileLikePayload({
+    const persisted = await saveFile({
       assistantId: 'a1',
       userId: 'u1',
-      base64Data: payload,
+      content: Buffer.from('binary-openapi'),
       mimeType: 'application/pdf',
       nameHint: 'report.pdf',
       source: 'OpenAPI',
     })
-    expect(persisted.kind).toBe('file')
-    expect(persisted.value.type).toBe('file')
-    if (persisted.value.type === 'file') {
-      expect(persisted.value.name).toBe('report.pdf')
-      expect(persisted.value.mimetype).toBe('application/pdf')
+    expect(persisted.type).toBe('file')
+    if (persisted.type === 'file') {
+      expect(persisted.name).toBe('report.pdf')
+      expect(persisted.mimetype).toBe('application/pdf')
     }
   })
 
   test('file-like tool outputs in a chat are persisted with CHAT ownership', async () => {
-    const payload = Buffer.from('chat-owned-output').toString('base64')
-    const persisted = await persistFileLikePayload({
+    const persisted = await saveFile({
       assistantId: 'a1',
       userId: 'u1',
       conversationId: 'c1',
       rootOwner: { type: 'CHAT', id: 'c1' },
-      base64Data: payload,
+      content: Buffer.from('chat-owned-output'),
       mimeType: 'image/png',
       source: 'MCP',
     })
 
-    expect(persisted.kind).toBe('file')
+    expect(persisted.type).toBe('file')
     expect(materializeCalls).toHaveLength(1)
     expect(materializeCalls[0].owner).toEqual({ ownerType: 'CHAT', ownerId: 'c1' })
   })
 
   test('dedup regression: repeated identical payload resolves to same file id', async () => {
-    const payload = Buffer.from('same-bytes').toString('base64')
-    const first = await persistFileLikePayload({
+    const content = Buffer.from('same-bytes')
+    const first = await saveFile({
       assistantId: 'a1',
       userId: 'u1',
-      base64Data: payload,
+      content,
       mimeType: 'image/png',
       source: 'MCP',
     })
-    const second = await persistFileLikePayload({
+    const second = await saveFile({
       assistantId: 'a1',
       userId: 'u1',
-      base64Data: payload,
+      content,
       mimeType: 'image/png',
       source: 'MCP',
     })
-    expect(first.value.type).toBe('file')
-    expect(second.value.type).toBe('file')
-    if (first.value.type === 'file' && second.value.type === 'file') {
-      expect(first.value.id).toBe(second.value.id)
+    expect(first.type).toBe('file')
+    expect(second.type).toBe('file')
+    if (first.type === 'file' && second.type === 'file') {
+      expect(first.id).toBe(second.id)
     }
   })
 
-  test('unsupported mime types degrade to text fallback', async () => {
-    const payload = Buffer.from('fake').toString('base64')
-    const persisted = await persistFileLikePayload({
+  test('any mime type is persisted as-is', async () => {
+    const persisted = await saveFile({
       assistantId: 'a1',
       userId: 'u1',
-      base64Data: payload,
+      content: Buffer.from('fake'),
       mimeType: 'application/x-msdownload',
       source: 'MCP',
-      supportedMedia: ['image/png'],
     })
-    expect(persisted.kind).toBe('text')
-    expect(persisted.value.type).toBe('text')
+    expect(persisted.type).toBe('file')
+    if (persisted.type === 'file') {
+      expect(persisted.mimetype).toBe('application/x-msdownload')
+    }
   })
 })

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -31,7 +31,7 @@ import {
 } from '@/backend/lib/chat/token-estimator'
 import {
   normalizeMcpToolResult,
-  persistFileLikePayload,
+  saveFile,
 } from '@/backend/lib/tools/file-output-normalization'
 
 export { fillTemplate } from './preamble'
@@ -291,16 +291,16 @@ export class ChatAssistant {
               }
               for (const r of content) {
                 if (r.type === 'image' && typeof r.data === 'string') {
-                  const persisted = await persistFileLikePayload({
+                  const persisted = await saveFile({
                     rootOwner: context.rootOwner,
                     conversationId: undefined,
                     userId: context.userId,
                     assistantId: context.assistantId,
-                    base64Data: r.data,
+                    content: Buffer.from(r.data, 'base64'),
                     mimeType: r.mimeType ?? 'application/octet-stream',
                     source: 'Satellite',
                   })
-                  toolResult.value.push(persisted.value)
+                  toolResult.value.push(persisted)
                 } else if (r.type === 'resource') {
                   const normalized = await normalizeMcpToolResult(
                     { content: [r] },

--- a/apps/backend/lib/tools/file-output-normalization.ts
+++ b/apps/backend/lib/tools/file-output-normalization.ts
@@ -1,5 +1,4 @@
 import { resolveFileOwner } from '@/backend/lib/tools/ownership'
-import env from '@/lib/env'
 import { logger } from '@/lib/logging'
 import type { ToolInvokeParams } from '@/lib/chat/tools'
 import * as dto from '@/types/dto'
@@ -8,35 +7,13 @@ import { JSONValue } from 'ai'
 
 interface PersistFileLikeParams
   extends Pick<ToolInvokeParams, 'rootOwner' | 'conversationId' | 'userId' | 'assistantId'> {
-  base64Data: string
+  content: Buffer | Uint8Array
   mimeType: string
   nameHint?: string
   source: string
-  supportedMedia?: string[]
 }
 
 const defaultMimeType = 'application/octet-stream'
-
-const parseAllowedFromEnv = (): string[] => {
-  const raw = env.chat.attachments.allowedFormats
-  if (!raw) return []
-  return raw
-    .split(',')
-    .map((v) => v.trim().toLowerCase())
-    .filter(Boolean)
-}
-
-const mimeAllowed = (mimeType: string, allowlist: string[]): boolean => {
-  if (allowlist.length === 0) return true
-  const normalized = mimeType.toLowerCase()
-  return allowlist.some((allowed) => {
-    if (allowed.endsWith('/*')) {
-      const prefix = allowed.slice(0, allowed.length - 1)
-      return normalized.startsWith(prefix)
-    }
-    return normalized === allowed
-  })
-}
 
 const makeFileName = (mimeType: string, nameHint?: string): string => {
   if (nameHint && nameHint.length > 0) return nameHint
@@ -57,56 +34,11 @@ const toFilePart = (fileEntry: {
   size: fileEntry.size,
 })
 
-export const persistFileLikePayload = async (
+export const saveFile = async (
   params: PersistFileLikeParams
-): Promise<
-  | { kind: 'file'; value: Extract<dto.ToolCallResultOutput, { type: 'content' }>['value'][number] }
-  | { kind: 'text'; value: Extract<dto.ToolCallResultOutput, { type: 'content' }>['value'][number] }
-> => {
+): Promise<Extract<dto.ToolCallResultOutput, { type: 'content' }>['value'][number]> => {
   const mimeType = (params.mimeType || defaultMimeType).toLowerCase()
-  const allowlist = [
-    ...new Set([...(params.supportedMedia ?? []).map((m) => m.toLowerCase()), ...parseAllowedFromEnv()]),
-  ]
-  if (!mimeAllowed(mimeType, allowlist)) {
-    logger.warn(`[${params.source}] File-like output rejected by mime allowlist`, {
-      mimeType,
-      allowlist,
-    })
-    return {
-      kind: 'text',
-      value: {
-        type: 'text',
-        text: `Tool returned unsupported file payload (${mimeType}); keeping a text fallback instead.`,
-      },
-    }
-  }
-
-  const bytes = Buffer.from(params.base64Data, 'base64')
-  if (!bytes.length && params.base64Data.length > 0) {
-    logger.warn(`[${params.source}] File-like payload is not valid base64`, { mimeType })
-    return {
-      kind: 'text',
-      value: {
-        type: 'text',
-        text: `Tool returned an invalid base64 file payload (${mimeType}); keeping a text fallback instead.`,
-      },
-    }
-  }
-  if (bytes.byteLength > env.chat.attachments.maxSize) {
-    logger.warn(`[${params.source}] File-like payload exceeds max size`, {
-      mimeType,
-      size: bytes.byteLength,
-      maxSize: env.chat.attachments.maxSize,
-    })
-    return {
-      kind: 'text',
-      value: {
-        type: 'text',
-        text: `Tool returned a file payload too large to store (${bytes.byteLength} bytes, max ${env.chat.attachments.maxSize}).`,
-      },
-    }
-  }
-
+  const bytes = Buffer.from(params.content)
   const fileName = makeFileName(mimeType, params.nameHint)
   const { materializeFile } = await import('@/backend/lib/files/materialize')
   const dbFile = await materializeFile({
@@ -115,15 +47,13 @@ export const persistFileLikePayload = async (
     mimeType,
     owner: resolveFileOwner(params),
   })
-  return {
-    kind: 'file',
-    value: toFilePart({
-      id: dbFile.id,
-      type: dbFile.type,
-      name: dbFile.name,
-      size: dbFile.size ?? bytes.byteLength,
-    }),
-  }
+  logger.debug(`[${params.source}] Persisted file-like payload`, { mimeType, size: bytes.byteLength, name: fileName })
+  return toFilePart({
+    id: dbFile.id,
+    type: dbFile.type,
+    name: dbFile.name,
+    size: dbFile.size ?? bytes.byteLength,
+  })
 }
 
 export const normalizeMcpToolResult = async (
@@ -137,24 +67,24 @@ export const normalizeMcpToolResult = async (
       continue
     }
     if (item?.type === 'image' && typeof item.data === 'string') {
-      const persisted = await persistFileLikePayload({
+      const persisted = await saveFile({
         ...params,
-        base64Data: item.data,
+        content: Buffer.from(item.data, 'base64'),
         mimeType: item.mimeType ?? defaultMimeType,
         source: 'MCP',
       })
-      contentParts.push(persisted.value)
+      contentParts.push(persisted)
       continue
     }
     if (item?.type === 'resource' && typeof item.resource?.blob === 'string') {
-      const persisted = await persistFileLikePayload({
+      const persisted = await saveFile({
         ...params,
-        base64Data: item.resource.blob,
+        content: Buffer.from(item.resource.blob, 'base64'),
         mimeType: item.resource.mimeType ?? defaultMimeType,
         nameHint: item.resource.name,
         source: 'MCP',
       })
-      contentParts.push(persisted.value)
+      contentParts.push(persisted)
       continue
     }
     if (item?.type === 'resource' && typeof item.resource?.text === 'string') {

--- a/apps/backend/lib/tools/openapi/implementation.ts
+++ b/apps/backend/lib/tools/openapi/implementation.ts
@@ -26,7 +26,7 @@ import { JSONSchema7 } from 'json-schema'
 import { JSONValue } from 'ai'
 import * as dto from '@/types/dto'
 import { LlmModel } from '@/lib/chat/models'
-import { persistFileLikePayload } from '@/backend/lib/tools/file-output-normalization'
+import { saveFile } from '@/backend/lib/tools/file-output-normalization'
 
 export interface OpenApiPluginParams extends Record<string, unknown> {
   spec: string
@@ -48,11 +48,12 @@ function mergeOperationParamsIntoToolFunctionSchema(
   })
 }
 
-function computeSecurityHeaders(
+async function computeSecurityHeaders(
   securitySchemes: Record<string, OpenAPIV3.SecuritySchemeObject>,
   toolParams: Record<string, unknown>,
+  toolId: string,
   provisioned: boolean
-): Record<string, string> {
+): Promise<Record<string, string>> {
   const headers: Record<string, string> = {}
   for (const securitySchemeId in securitySchemes) {
     const securityScheme = securitySchemes[securitySchemeId]
@@ -60,8 +61,9 @@ function computeSecurityHeaders(
       if (!toolParams[securitySchemeId]) {
         throw new Error(`auth parameter ${securitySchemeId} not configured`)
       }
-      headers[securityScheme.name] = expandIfProvisioned(
+      headers[securityScheme.name] = await expandParam(
         `${toolParams[securitySchemeId]}`,
+        toolId,
         provisioned
       )
     } else if (securityScheme.type === 'http') {
@@ -69,7 +71,7 @@ function computeSecurityHeaders(
       if (!authParam) {
         throw new Error(`auth parameter ${securitySchemeId} not configured`)
       }
-      let expanded = expandIfProvisioned(`${authParam}`, provisioned)
+      let expanded = await expandParam(`${authParam}`, toolId, provisioned)
       if (securityScheme.scheme === 'bearer' && !expanded.startsWith('Bearer')) {
         expanded = `Bearer ${expanded}`
       }
@@ -79,9 +81,9 @@ function computeSecurityHeaders(
   return headers
 }
 
-function expandIfProvisioned(template: string, provisioned: boolean) {
-  if (!provisioned) return template
-  else return expandEnv(template)
+async function expandParam(template: string, toolId: string, provisioned: boolean) {
+  const { resolveToolSecretReference } = await import('templates')
+  return provisioned ? expandEnv(template) : resolveToolSecretReference(toolId, template)
 }
 
 function dumpTruncatedBodyContent(body: RequestInit['body']): string | undefined {
@@ -107,6 +109,7 @@ function convertOpenAPIOperationToToolFunction(
   method: string,
   operation: OpenAPIV3.OperationObject,
   toolParams: Record<string, unknown>,
+  toolId: string,
   provisioned: boolean
 ): ToolFunction | undefined {
   // Extracting parameters
@@ -146,12 +149,12 @@ function convertOpenAPIOperationToToolFunction(
     rootOwner,
   }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> => {
     const storeFile = async (data: Uint8Array, fileName: string, contentType: string) =>
-      await persistFileLikePayload({
+      await saveFile({
         rootOwner,
         conversationId,
         userId,
         assistantId,
-        base64Data: Buffer.from(data).toString('base64'),
+        content: data,
         mimeType: contentType,
         nameHint: fileName,
         source: 'OpenAPI',
@@ -186,9 +189,10 @@ function convertOpenAPIOperationToToolFunction(
     }
     let sensitiveHeaders: Record<string, string> = {}
     if (securitySchemes) {
-      sensitiveHeaders = computeSecurityHeaders(
+      sensitiveHeaders = await computeSecurityHeaders(
         securitySchemes as Record<string, OpenAPIV3.SecuritySchemeObject>,
         toolParams,
+        toolId,
         provisioned
       )
     }
@@ -237,7 +241,7 @@ function convertOpenAPIOperationToToolFunction(
             })
           } else {
             const persisted = await storeFile(await part.bytes(), fileName, mediaType)
-            result.value.push(persisted.value)
+            result.value.push(persisted)
           }
         }
         return result
@@ -259,17 +263,17 @@ function convertOpenAPIOperationToToolFunction(
               type: 'text',
               text: `File ${fileName} has been sent to the user and is plainly visible, so don't repeat the descriptions in detail. Do not list download links as they are available in the ChatGPT UI already. Do not mention anything about visualizing / downloading to the user`,
             },
-            persisted.value,
+            persisted,
           ],
         }
-      } else if (contentType && contentType === 'application/json') {
+      } else if (contentType && contentType.startsWith('application/json')) {
         return { type: 'json', value: (await response.json()) as JSONValue }
       } else if (contentType && !contentType.startsWith('text/')) {
         const body = await response.blob()
         const persisted = await storeFile(await body.bytes(), 'response.bin', contentType)
         return {
           type: 'content',
-          value: [persisted.value],
+          value: [persisted],
         }
       } else {
         return { type: 'text', value: await response.text() }
@@ -322,6 +326,7 @@ async function customFetch(
 function convertOpenAPIDocumentToToolFunctions(
   openAPISpec: OpenAPIV3.Document,
   toolParams: Record<string, unknown>,
+  toolId: string,
   provisioned: boolean
 ): ToolFunctions {
   const openAIFunctions: ToolFunctions = {}
@@ -344,6 +349,7 @@ function convertOpenAPIDocumentToToolFunctions(
             method,
             operation,
             toolParams,
+            toolId,
             provisioned
           )
           if (openAIFunction) {
@@ -360,12 +366,13 @@ function convertOpenAPIDocumentToToolFunctions(
 }
 async function convertOpenAPISpecToToolFunctions(
   toolParams: OpenApiPluginParams,
+  toolId: string,
   provisioned: boolean
 ): Promise<ToolFunctions> {
   try {
     const doc = parseDocument(toolParams.spec)
     const openAPISpec = (await OpenAPIParser.validate(doc.toJSON())) as OpenAPIV3.Document
-    return convertOpenAPIDocumentToToolFunctions(openAPISpec, toolParams, provisioned)
+    return convertOpenAPIDocumentToToolFunctions(openAPISpec, toolParams, toolId, provisioned)
   } catch (error) {
     logger.error(`Error parsing OpenAPI string: ${error}`)
     return {}
@@ -375,7 +382,11 @@ async function convertOpenAPISpecToToolFunctions(
 export class OpenApiPlugin extends OpenApiInterface implements ToolImplementation {
   static builder: ToolBuilder = async (toolParams: ToolParams, params: Record<string, unknown>) => {
     const config = params as OpenApiPluginParams
-    const functions = await convertOpenAPISpecToToolFunctions(config, toolParams.provisioned)
+    const functions = await convertOpenAPISpecToToolFunctions(
+      config,
+      toolParams.id,
+      toolParams.provisioned
+    )
     return new OpenApiPlugin(toolParams, functions, config.supportedMedia || []) // TODO: need a better validation
   }
 


### PR DESCRIPTION
## Summary

Fixes two runtime bugs in the OpenAPI tool and cleans up the file persistence layer. Non-provisioned OpenAPI tools now correctly resolve `${secret.xxx}` credentials at invocation time, and JSON responses with a charset suffix are no longer misrouted to the binary file handler. The `saveFile` helper (formerly `persistFileLikePayload`) is simplified to pure storage with no policy enforcement.

## Details

- **Secret resolution**: `computeSecurityHeaders` previously returned `${secret.xxx}` template strings as-is for non-provisioned tools. Now calls `resolveToolSecretReference` with the tool's ID so the actual credential is fetched from `ToolSecret` at runtime. `toolId` is threaded through the call chain from the plugin builder down to the header computation.
- **JSON content-type**: The check `contentType === 'application/json'` was strict equality, causing responses with `application/json; charset=utf-8` (and similar) to fall through to the binary file handler. Changed to `startsWith`.
- **`saveFile` cleanup**: Removed allowlist checking, size capping, and text-fallback returns — policy enforcement belongs at LLM transmission time, not at storage time. Changed the interface from `base64Data: string` to `content: Buffer | Uint8Array` to eliminate the unnecessary encode/decode round-trip in the OpenAPI path. MCP callers decode their base64 wire data before calling `saveFile`. Return type simplified from `{ kind, value }` to the file part directly.

## Tests

- `npm run check-types` — no errors