### PR TITLE
fix: return error-text instead of throwing on MCP and OpenAPI tool failures

### DIFF
--- a/apps/backend/lib/tools/mcp/implementation.ts
+++ b/apps/backend/lib/tools/mcp/implementation.ts
@@ -189,10 +189,17 @@ async function convertMcpSpecToToolFunctions(
           }
           clientToUse = await getClient(toolParams, resolution.accessToken, userId)
         }
-        const result = await clientToUse.callTool({
-          name: tool.name,
-          arguments: params,
-        })
+        let result
+        try {
+          result = await clientToUse.callTool({
+            name: tool.name,
+            arguments: params,
+          })
+        } catch (e) {
+          logger.error(`MCP tool '${tool.name}' invocation failed`, e)
+          const errorMessage = e instanceof Error ? e.message : 'MCP tool invocation failed'
+          return { type: 'error-text' as const, value: errorMessage }
+        }
         return await normalizeMcpToolResult(result, invokeParams)
       },
     }

--- a/apps/backend/lib/tools/openapi/implementation.ts
+++ b/apps/backend/lib/tools/openapi/implementation.ts
@@ -251,9 +251,9 @@ function convertOpenAPIOperationToToolFunction(
         return result
       }
       if (response.status < 200 || response.status >= 300) {
-        throw new Error(
-          `Http request failed with status ${response.status} body ${await response.text()}`
-        )
+        const errorBody = await response.text()
+        logger.error(`OpenAPI tool HTTP error ${response.status} from ${urlString}: ${errorBody}`)
+        return { type: 'error-text' as const, value: `Http request failed with status ${response.status}: ${errorBody}` }
       }
       if (contentDisposition.type === 'attachment') {
         const contentTypeOrDefault = contentType ?? 'application/binary'


### PR DESCRIPTION
## Summary

MCP and OpenAPI tool invocations now return a structured `error-text` response instead of throwing on failure. This prevents unhandled exceptions from bubbling up and surfaces the error message back to the conversation, while logging the failure server-side.

## Details

- MCP `callTool` errors are caught, logged via `logger.error`, and returned as `{ type: 'error-text', value: message }`.
- OpenAPI non-2xx responses no longer throw; the response body is logged and returned as `{ type: 'error-text', value: ... }`.