### PR TITLE
fix: remove spurious page breaks from DOCX export

### DIFF
--- a/apps/backend/lib/docx/export.ts
+++ b/apps/backend/lib/docx/export.ts
@@ -246,6 +246,7 @@ export async function renderDocxFromMarkdown(markdown: string): Promise<Uint8Arr
     .use(remarkMath)
     .use(remarkColoredSpans)
     .use(docx, {
+      thematicBreak: 'line',
       plugins: [
         coloredHtmlPlugin(),
         latexPlugin(),


### PR DESCRIPTION
## Summary

DOCX exports were inserting a page break after every section that contained a horizontal rule (`---`). This is because `remark-docx` defaults `thematicBreak` to `"page"`, converting any `---` in the AI's markdown (commonly used as section separators) into a Word page break. Setting `thematicBreak: 'line'` renders them as horizontal lines instead.

Fixes https://github.com/logicleai/logicle-issues/issues/252.

## Tests

- `npm run check-types` passes.