### PR TITLE
feat: add soft and hard chat message length limits

### DIFF
--- a/apps/frontend/app/chat/components/AssistantMessageGroup.tsx
+++ b/apps/frontend/app/chat/components/AssistantMessageGroup.tsx
@@ -29,6 +29,7 @@ import { computeMarkdown } from './markdown/process'
 import { useUserProfile } from '@/components/providers/userProfileContext'
 import { Button } from '@/components/ui/button'
 import { downloadAsFile } from '@/lib/savefile'
+import { useHardMessageLimitReached } from './useHardMessageLimitReached'
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -147,6 +148,7 @@ export const AssistantMessageGroup: FC<Props> = ({ assistant, group, isLast, sha
   } = useContext(ChatPageContext)
 
   const { setSideBarContent } = useContext(ChatPageContext)
+  const hardLimitReached = useHardMessageLimitReached()
 
   const mainMessage = group.messages[0]
   const conversationId = mainMessage.conversationId
@@ -467,7 +469,7 @@ export const AssistantMessageGroup: FC<Props> = ({ assistant, group, isLast, sha
                   />
                 </Button>
               )}
-              {isLast && sendMessage && (
+              {isLast && sendMessage && !hardLimitReached && (
                 <Button
                   variant="ghost"
                   size="icon"

--- a/apps/frontend/app/chat/components/ChatInput.tsx
+++ b/apps/frontend/app/chat/components/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { IconPaperclip, IconPlayerStopFilled, IconSend2 } from '@tabler/icons-react'
+import { IconAlertTriangle, IconBan, IconPaperclip, IconPlayerStopFilled, IconSend2 } from '@tabler/icons-react'
 import {
   ChangeEvent,
   DragEvent,
@@ -43,6 +43,7 @@ interface Props {
   onSend: (params: { content: string; attachments: dto.Attachment[] }) => void
   disabled?: boolean
   disabledMsg?: string
+  locked?: boolean
   autoFocus?: boolean
   textAreaRef?: MutableRefObject<HTMLTextAreaElement | null>
   chatInput: string
@@ -63,6 +64,7 @@ export const ChatInput = ({
   onSend,
   disabled,
   disabledMsg,
+  locked,
   autoFocus,
   textAreaRef,
   chatInput,
@@ -92,6 +94,12 @@ export const ChatInput = ({
   }
   const environment = useEnvironment()
   const model = environment.models.find((candidate) => candidate.id === modelId)
+  const userMessageCount = draftMessagesForEstimate?.filter((m) => m.role === 'user').length ?? 0
+  const softLimitReached =
+    environment.softMessageLimit !== undefined && userMessageCount >= environment.softMessageLimit
+  const hardLimitReached =
+    (environment.hardMessageLimit !== undefined && userMessageCount >= environment.hardMessageLimit) ||
+    !!locked
   const [isTyping, setIsTyping] = useState<boolean>(false)
   // using useState to keep the state of the uploads does not work, as xhr callbacks will not "pick up"
   // the state change, as they're bound to the state at xhr creation
@@ -292,7 +300,7 @@ export const ChatInput = ({
   }
 
   const handleSend = () => {
-    if (chatStatus.state !== 'idle' || anyUploadRunning) {
+    if (chatStatus.state !== 'idle' || anyUploadRunning || hardLimitReached) {
       return
     }
 
@@ -475,7 +483,7 @@ export const ChatInput = ({
         <div className="relative flex flex-col rounded-md border">
           <UploadList files={uploadedFiles.current} onDelete={handleDelete} modelId={modelId} />
           <textarea
-            disabled={disabled}
+            disabled={disabled || hardLimitReached}
             ref={textareaRefInt}
             className="m-0 w-full resize-none border-0 p-0 py-2 pr-8 pl-10 md:py-3 md:pl-10 bg-background text-body1 focus:ring-0 focus:ring-offset-0"
             style={{
@@ -499,7 +507,7 @@ export const ChatInput = ({
               className="absolute right-2 bottom-2 opacity-60"
               size="icon"
               variant="secondary"
-              disabled={disabled || (chatStatus.state === 'receiving' && !!chatStatus.stopRequested)}
+              disabled={disabled || hardLimitReached || (chatStatus.state === 'receiving' && !!chatStatus.stopRequested)}
               onClick={() => handleStopConversation()}
             >
               <IconPlayerStopFilled size={18} />
@@ -509,7 +517,7 @@ export const ChatInput = ({
               <Button
                 className="absolute right-2 bottom-2"
                 size="icon"
-                disabled={disabled || msgEmpty || anyUploadRunning}
+                disabled={disabled || hardLimitReached || msgEmpty || anyUploadRunning}
                 variant="primary"
                 onClick={() => handleSend()}
               >
@@ -532,6 +540,30 @@ export const ChatInput = ({
             </>
           )}
         </div>
+        {(softLimitReached || hardLimitReached) && (
+          <div
+            className={`mt-2 flex items-center gap-2.5 rounded-xl border px-4 py-2.5 text-sm font-medium ${
+              hardLimitReached
+                ? 'border-destructive/40 bg-destructive/10 text-destructive'
+                : 'border-amber-400 bg-amber-50 text-amber-800 dark:border-amber-600 dark:bg-amber-950 dark:text-amber-300'
+            }`}
+          >
+            {hardLimitReached ? (
+              <IconBan size={16} className="shrink-0" />
+            ) : (
+              <IconAlertTriangle size={16} className="shrink-0" />
+            )}
+            <span>
+              {hardLimitReached
+                ? t('chat_hard_message_limit_reached', {
+                    count: environment.hardMessageLimit ?? userMessageCount,
+                  })
+                : t('chat_soft_message_limit_warning', {
+                    count: environment.softMessageLimit ?? userMessageCount,
+                  })}
+            </span>
+          </div>
+        )}
         <ChatDisclaimer
           rightSlot={
             <ContextLengthIndicator

--- a/apps/frontend/app/chat/components/ChatInputOrApiKey.tsx
+++ b/apps/frontend/app/chat/components/ChatInputOrApiKey.tsx
@@ -22,6 +22,7 @@ interface Props {
   tokenLimit?: number
   disabled?: boolean
   disabledMsg?: string
+  locked?: boolean
   autoFocus?: boolean
   onSend: (params: { content: string; attachments: dto.Attachment[] }) => void
   textAreaRef?: MutableRefObject<HTMLTextAreaElement | null>
@@ -42,6 +43,7 @@ export const ChatInputOrApiKey = ({
   tokenLimit,
   disabled,
   disabledMsg,
+  locked,
   autoFocus,
   onSend,
   textAreaRef,
@@ -71,6 +73,7 @@ export const ChatInputOrApiKey = ({
       tokenLimit={tokenLimit}
       disabled={disabled}
       disabledMsg={disabledMsg}
+      locked={locked}
       autoFocus={autoFocus}
       onSend={onSend}
       textAreaRef={textAreaRef}

--- a/apps/frontend/app/chat/components/ChatMessageError.tsx
+++ b/apps/frontend/app/chat/components/ChatMessageError.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import ChatPageContext from './context'
 import { useTranslation } from 'react-i18next'
 import { Alert, AlertDescription } from '@/components/ui/alert'
+import { useHardMessageLimitReached } from './useHardMessageLimitReached'
 
 const findAncestorUserMessage = (
   messages: dto.Message[],
@@ -24,12 +25,13 @@ const findAncestorUserMessage = (
 export const MessageError = ({ msgId, error }: { msgId: string; error: string }) => {
   const { t } = useTranslation()
   const { sendMessage, state } = useContext(ChatPageContext)
+  const hardLimitReached = useHardMessageLimitReached()
   return (
     <Alert variant="destructive" className="mt-2">
       <AlertDescription>
         <div className="flex items-center">
           <div className="flex-1">{t(error)} </div>
-          {sendMessage && (
+          {sendMessage && !hardLimitReached && (
             <Button
               size="small"
               className="shrink-0"

--- a/apps/frontend/app/chat/components/UserMessage.tsx
+++ b/apps/frontend/app/chat/components/UserMessage.tsx
@@ -12,6 +12,7 @@ import { useConfirmationContext } from '@/components/providers/confirmationConte
 import { getMessageAndDescendants } from '@/lib/chat/conversationUtils'
 import { useUserProfile } from '@/components/providers/userProfileContext'
 import { MessageEdit, MessageEditHandle } from './MessageEdit'
+import { useHardMessageLimitReached } from './useHardMessageLimitReached'
 
 interface UserMessageProps {
   message: dto.UserMessage
@@ -41,6 +42,7 @@ export const UserMessage: FC<UserMessageProps> = ({
     ...dto.userPreferencesDefaults,
     ...(useUserProfile()?.preferences ?? {}),
   }
+  const hardLimitReached = useHardMessageLimitReached()
   const messageEditRef = useRef<MessageEditHandle | null>(null)
   const messageViewRef = useRef<HTMLDivElement | null>(null)
   const [editHeight, setEditHeight] = useState<number | undefined>(undefined)
@@ -185,7 +187,7 @@ export const UserMessage: FC<UserMessageProps> = ({
                 title={t('edit_and_send_message')}
                 className="invisible group-hover:visible"
                 onClick={() => setEditMode('branch')}
-                disabled={chatStatus.state !== 'idle'}
+                disabled={chatStatus.state !== 'idle' || hardLimitReached}
               >
                 {enableUserMessageEdit ? (
                   <IconGitBranch size={20} className="opacity-50 hover:opacity-100" />

--- a/apps/frontend/app/chat/components/useHardMessageLimitReached.ts
+++ b/apps/frontend/app/chat/components/useHardMessageLimitReached.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react'
+import { useEnvironment } from '@/app/context/environmentProvider'
+import ChatPageContext from './context'
+
+export const useHardMessageLimitReached = (): boolean => {
+  const { hardMessageLimit } = useEnvironment()
+  const { state } = useContext(ChatPageContext)
+  if (hardMessageLimit === undefined) return false
+  const userMessageCount =
+    state.selectedConversation?.messages.filter((m) => m.role === 'user').length ?? 0
+  return userMessageCount >= hardMessageLimit
+}

--- a/apps/frontend/app/context/environmentProvider.tsx
+++ b/apps/frontend/app/context/environmentProvider.tsx
@@ -23,6 +23,8 @@ export type Environment = {
   maxAttachmentSize: number
   sessionRefreshIntervalMinutes: number
   sessionRefreshThrottleMinutes: number
+  softMessageLimit?: number
+  hardMessageLimit?: number
   models: LlmModel[]
   parameters: dto.Parameter[]
   faviconPath?: string

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -88,6 +88,8 @@ export default async function RootLayout({
     logoPath: env.icons.logo,
     sessionRefreshIntervalMinutes: env.session.refreshIntervalMinutes,
     sessionRefreshThrottleMinutes: env.session.refreshThrottleMinutes,
+    softMessageLimit: env.chat.softMessageLimit,
+    hardMessageLimit: env.chat.hardMessageLimit,
   }
 
   const styles = env.provision.brand ? await loadProvisionedStyles(env.provision.brand) : []

--- a/apps/frontend/locales/en/logicle.json
+++ b/apps/frontend/locales/en/logicle.json
@@ -110,6 +110,8 @@
   "hidden_assistant_description": "Hide this assistant from the main assistant picker while keeping it available in My Assistants, admin, direct chats, and sub-assistant selection.",
   "chat_is_already_shared": "Chat is shared",
   "chat_response_failure": "An error happened while reading the server response",
+  "chat_soft_message_limit_warning": "This conversation is getting long ({{count}} messages sent). Consider starting a new conversation for better results.",
+  "chat_hard_message_limit_reached": "This conversation has reached its limit of {{count}} messages. Please start a new conversation to continue.",
   "choose-new-provider-type": "Choose the provider type",
   "choose-new-provider-type-description": "Choose the type of LLM provider for the new backend",
   "choose-workspace": "Choose your workspace",

--- a/apps/frontend/locales/it/logicle.json
+++ b/apps/frontend/locales/it/logicle.json
@@ -110,6 +110,8 @@
   "hidden_assistant_description": "Nasconde questo assistente dal selettore principale, mantenendolo disponibile in I miei assistenti, amministrazione, chat dirette e selezione dei sotto-assistenti.",
   "chat_is_already_shared": "La conversazione è condivisa",
   "chat_response_failure": "Si è verificato un errore durante la ricezione della risposta",
+  "chat_soft_message_limit_warning": "Questa conversazione sta diventando lunga ({{count}} messaggi inviati). Considera di iniziare una nuova conversazione per risultati migliori.",
+  "chat_hard_message_limit_reached": "Questa conversazione ha raggiunto il limite di {{count}} messaggi. Inizia una nuova conversazione per continuare.",
   "choose-new-provider-type": "Scegli il tipo di provider",
   "choose-new-provider-type-description": "Scegli il tipo di provider LLM per il nuovo backend",
   "choose-workspace": "Scegli il tuo workspace",

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -144,6 +144,8 @@ const env = {
       maxSize: parseInt(process.env.CHAT_ATTACHMENTS_MAX_SIZE ?? '50000000', 10),
     },
     maxOutputTokens: parseOptionalInt(process.env.CHAT_MAX_OUTPUT_TOKENS),
+    softMessageLimit: parseOptionalInt(process.env.CHAT_SOFT_MESSAGE_LIMIT),
+    hardMessageLimit: parseOptionalInt(process.env.CHAT_HARD_MESSAGE_LIMIT),
   },
   assistants: {
     enableInfo: process.env.ENABLE_ASSISTANT_INFO === '1',


### PR DESCRIPTION
## Summary

Adds operator-configurable message-count limits to the chat UI. Two new env vars (`CHAT_SOFT_MESSAGE_LIMIT`, `CHAT_HARD_MESSAGE_LIMIT`) control thresholds based on the number of user messages in a conversation. When a soft limit is reached a prominent amber warning banner appears above the input; when the hard limit is reached a red banner replaces it and the textarea + send button are disabled. No DB changes are required.

## Details

- `CHAT_SOFT_MESSAGE_LIMIT` — amber banner with icon, input still usable
- `CHAT_HARD_MESSAGE_LIMIT` — red banner with icon, textarea visible but disabled (grayed), send blocked
- Both limits are optional; omitting them leaves behavior unchanged
- User message count is derived client-side from `selectedConversation.messages` filtered by `role === 'user'`
- A new `locked` prop on `ChatInput` / `ChatInputOrApiKey` renders the full input UI in a disabled state without hiding it (distinct from the existing `disabled` prop which replaces the input with a text message)
- Translations provided for `en` and `it`

## Tests

- `npm run check-types` — passes with no errors