### PR TITLE
Add MessageAudit tokenDetails and capture token usage detail payloads

### DIFF
--- a/apps/backend/db/migrations.generated.ts
+++ b/apps/backend/db/migrations.generated.ts
@@ -41,6 +41,7 @@ import * as m202605052AssistantVersionName from './migrations/20260505.2-assista
 import * as m202605053AssistantVersionFileOrder from './migrations/20260505.3-assistant_version_file_order'
 import * as m20260506AssistantHidden from './migrations/20260506-assistant_hidden'
 import * as m20260508RenameGeminiProvider from './migrations/20260508-rename-gemini-provider'
+import * as m20260519MessageAuditTokenDetails from './migrations/20260519-message_audit_token_details'
 
 import type { MigrationWithDialect } from './migrations'
 
@@ -86,4 +87,5 @@ export const migrationModules: Record<string, MigrationWithDialect> = {
   '20260505.3-assistant_version_file_order': m202605053AssistantVersionFileOrder,
   '20260506-assistant_hidden': m20260506AssistantHidden,
   '20260508-rename-gemini-provider': m20260508RenameGeminiProvider,
+  '20260519-message_audit_token_details': m20260519MessageAuditTokenDetails,
 }

--- a/apps/backend/db/migrations/20260519-message_audit_token_details.ts
+++ b/apps/backend/db/migrations/20260519-message_audit_token_details.ts
@@ -1,0 +1,8 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('MessageAudit')
+    .addColumn('tokenDetails', 'jsonb', (col) => col.defaultTo(null))
+    .execute()
+}

--- a/apps/backend/db/schema.ts
+++ b/apps/backend/db/schema.ts
@@ -311,6 +311,7 @@ export interface MessageAudit {
     | 'user-response'
   model: string
   tokens: number
+  tokenDetails: string | null
   errors: string | null
   sentAt: string
 }

--- a/apps/backend/lib/MessageAuditor.ts
+++ b/apps/backend/lib/MessageAuditor.ts
@@ -49,7 +49,7 @@ export class MessageAuditor {
         logger.error('Expected a pending message')
       }
       auditEntry.tokens = usage.outputTokens
-      auditEntry.tokenDetails = stringifyTokenDetails(usage.outputTokensDetails)
+      auditEntry.tokenDetails = stringifyTokenDetails(usage.outputTokenDetails)
     }
     if (auditEntry.type === 'user' || auditEntry.type === 'tool') {
       this.pendingLlmInvocation = auditEntry

--- a/apps/backend/lib/MessageAuditor.ts
+++ b/apps/backend/lib/MessageAuditor.ts
@@ -10,6 +10,13 @@ function doAuditMessage(value: schema.MessageAudit) {
   return db.insertInto('MessageAudit').values(value).execute()
 }
 
+function stringifyTokenDetails(value: unknown): string | null {
+  if (value == null) {
+    return null
+  }
+  return JSON.stringify(value)
+}
+
 export class MessageAuditor {
   pendingLlmInvocation: schema.MessageAudit | undefined
   constructor(
@@ -35,12 +42,14 @@ export class MessageAuditor {
     if (usage) {
       if (this.pendingLlmInvocation) {
         this.pendingLlmInvocation.tokens = usage.inputTokens
+        this.pendingLlmInvocation.tokenDetails = stringifyTokenDetails(usage.inputTokensDetails)
         await doAuditMessage(this.pendingLlmInvocation)
         this.pendingLlmInvocation = undefined
       } else {
         logger.error('Expected a pending message')
       }
       auditEntry.tokens = usage.outputTokens
+      auditEntry.tokenDetails = stringifyTokenDetails(usage.outputTokensDetails)
     }
     if (auditEntry.type === 'user' || auditEntry.type === 'tool') {
       this.pendingLlmInvocation = auditEntry
@@ -58,6 +67,7 @@ export class MessageAuditor {
       type: message.role,
       model: this.conversation.assistant.model,
       tokens: 0,
+      tokenDetails: null,
       sentAt: message.sentAt,
       errors: null,
     }

--- a/apps/backend/lib/MessageAuditor.ts
+++ b/apps/backend/lib/MessageAuditor.ts
@@ -42,7 +42,7 @@ export class MessageAuditor {
     if (usage) {
       if (this.pendingLlmInvocation) {
         this.pendingLlmInvocation.tokens = usage.inputTokens
-        this.pendingLlmInvocation.tokenDetails = stringifyTokenDetails(usage.inputTokensDetails)
+        this.pendingLlmInvocation.tokenDetails = stringifyTokenDetails(usage.inputTokenDetails)
         await doAuditMessage(this.pendingLlmInvocation)
         this.pendingLlmInvocation = undefined
       } else {

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -965,10 +965,6 @@ export class ChatAssistant {
           clientSink.enqueue({ type: 'reasoning', reasoning: delta })
         } else if (chunk.type === 'finish') {
           const totalUsageWithDetails = chunk.totalUsage
-          const usageWithAliases = totalUsageWithDetails as typeof totalUsageWithDetails & {
-            inputTokenDetails?: unknown
-            outputTokenDetails?: unknown
-          }
           const totalTokens = totalUsageWithDetails.totalTokens ?? 0
           const inputTokens = totalUsageWithDetails.inputTokens ?? 0
           const outputTokens =
@@ -977,8 +973,8 @@ export class ChatAssistant {
             totalTokens,
             inputTokens,
             outputTokens,
-            inputTokenDetails: usageWithAliases.inputTokenDetails,
-            outputTokenDetails: usageWithAliases.outputTokenDetails,
+            inputTokenDetails: totalUsageWithDetails.inputTokenDetails,
+            outputTokenDetails: totalUsageWithDetails.outputTokenDetails,
           }
           if (chunk.finishReason === 'error') {
             throw new ai.AISDKError({

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -29,10 +29,7 @@ import {
   prepareConversationCostPlan,
   selectOptimalHistoryStartIndex,
 } from '@/backend/lib/chat/token-estimator'
-import {
-  normalizeMcpToolResult,
-  saveFile,
-} from '@/backend/lib/tools/file-output-normalization'
+import { normalizeMcpToolResult, saveFile } from '@/backend/lib/tools/file-output-normalization'
 
 export { fillTemplate } from './preamble'
 export type { PromptSegment } from './preamble'
@@ -967,14 +964,23 @@ export class ChatAssistant {
           }
           clientSink.enqueue({ type: 'reasoning', reasoning: delta })
         } else if (chunk.type === 'finish') {
-          const totalTokens = chunk.totalUsage.totalTokens ?? 0
-          const inputTokens = chunk.totalUsage.inputTokens ?? 0
+          const totalUsageWithDetails = chunk.totalUsage
+          const usageWithAliases = totalUsageWithDetails as typeof totalUsageWithDetails & {
+            inputTokensDetails?: unknown
+            outputTokensDetails?: unknown
+          }
+          const totalTokens = totalUsageWithDetails.totalTokens ?? 0
+          const inputTokens = totalUsageWithDetails.inputTokens ?? 0
           const outputTokens =
-            chunk.totalUsage.outputTokens ?? Math.max(totalTokens - inputTokens, 0)
+            totalUsageWithDetails.outputTokens ?? Math.max(totalTokens - inputTokens, 0)
           usage = {
             totalTokens,
             inputTokens,
             outputTokens,
+            inputTokensDetails:
+              usageWithAliases.inputTokensDetails ?? totalUsageWithDetails.inputTokenDetails,
+            outputTokensDetails:
+              usageWithAliases.outputTokensDetails ?? totalUsageWithDetails.outputTokenDetails,
           }
           if (chunk.finishReason === 'error') {
             throw new ai.AISDKError({

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -967,7 +967,7 @@ export class ChatAssistant {
           const totalUsageWithDetails = chunk.totalUsage
           const usageWithAliases = totalUsageWithDetails as typeof totalUsageWithDetails & {
             inputTokensDetails?: unknown
-            outputTokensDetails?: unknown
+            outputTokenDetails?: unknown
           }
           const totalTokens = totalUsageWithDetails.totalTokens ?? 0
           const inputTokens = totalUsageWithDetails.inputTokens ?? 0
@@ -977,10 +977,8 @@ export class ChatAssistant {
             totalTokens,
             inputTokens,
             outputTokens,
-            inputTokensDetails:
-              usageWithAliases.inputTokensDetails ?? totalUsageWithDetails.inputTokenDetails,
-            outputTokensDetails:
-              usageWithAliases.outputTokensDetails ?? totalUsageWithDetails.outputTokenDetails,
+            inputTokensDetails: usageWithAliases.inputTokensDetails,
+            outputTokenDetails: usageWithAliases.outputTokenDetails,
           }
           if (chunk.finishReason === 'error') {
             throw new ai.AISDKError({

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -966,7 +966,7 @@ export class ChatAssistant {
         } else if (chunk.type === 'finish') {
           const totalUsageWithDetails = chunk.totalUsage
           const usageWithAliases = totalUsageWithDetails as typeof totalUsageWithDetails & {
-            inputTokensDetails?: unknown
+            inputTokenDetails?: unknown
             outputTokenDetails?: unknown
           }
           const totalTokens = totalUsageWithDetails.totalTokens ?? 0
@@ -977,7 +977,7 @@ export class ChatAssistant {
             totalTokens,
             inputTokens,
             outputTokens,
-            inputTokensDetails: usageWithAliases.inputTokensDetails,
+            inputTokenDetails: usageWithAliases.inputTokenDetails,
             outputTokenDetails: usageWithAliases.outputTokenDetails,
           }
           if (chunk.finishReason === 'error') {

--- a/apps/backend/lib/chat/usage.ts
+++ b/apps/backend/lib/chat/usage.ts
@@ -2,6 +2,6 @@ export interface Usage {
   inputTokens: number
   inputTokensDetails?: unknown
   outputTokens: number
-  outputTokensDetails?: unknown
+  outputTokenDetails?: unknown
   totalTokens: number
 }

--- a/apps/backend/lib/chat/usage.ts
+++ b/apps/backend/lib/chat/usage.ts
@@ -1,6 +1,6 @@
 export interface Usage {
   inputTokens: number
-  inputTokensDetails?: unknown
+  inputTokenDetails?: unknown
   outputTokens: number
   outputTokenDetails?: unknown
   totalTokens: number

--- a/apps/backend/lib/chat/usage.ts
+++ b/apps/backend/lib/chat/usage.ts
@@ -1,5 +1,7 @@
 export interface Usage {
-  totalTokens: number
   inputTokens: number
+  inputTokensDetails?: unknown
   outputTokens: number
+  outputTokensDetails?: unknown
+  totalTokens: number
 }


### PR DESCRIPTION
## Summary
Adds nullable `tokenDetails` on `MessageAudit` and stores stringified token detail payloads from AI SDK usage so input and output token breakdowns are persisted with each audited invocation.

## Details
- Add migration `20260519-message_audit_token_details` to add `MessageAudit.tokenDetails` as `jsonb` with default `NULL`.
- Extend DB schema typing for `MessageAudit` with `tokenDetails: string | null`.
- Update chat usage handling to carry token detail payloads from finish chunks using `chunk.totalUsage.inputTokensDetails` and `chunk.totalUsage.outputTokenDetails`.
- Persist input token detail payload on pending invocation audit rows and output token detail payload on assistant audit rows via `MessageAuditor`.
- Regenerate `apps/backend/db/migrations.generated.ts`.

## Risks
- `tokenDetails` stores provider-specific structures as JSON strings; consumers should treat this field as optional and schema-flexible.

## Tests
- `npm run generate:migration-manifest` (pass)
- `npm run check-types` (pass)