### PR TITLE
Track file origin for uploads and generated assets

### DIFF
--- a/__tests__/conversion.test.ts
+++ b/__tests__/conversion.test.ts
@@ -53,6 +53,7 @@ const pdfFile = {
   fileBlobId: 'blob-1',
   id: 'pdf-1',
   name: 'example.pdf',
+  origin: null,
   ownerType: 'USER' as const,
   ownerId: 'u1',
   path: 'files/example.pdf',

--- a/__tests__/textExtractionCache.test.ts
+++ b/__tests__/textExtractionCache.test.ts
@@ -38,6 +38,7 @@ describe('cachingExtractor', () => {
       encrypted: 0 as const,
       ownerType: 'USER' as const,
       ownerId: 'u1',
+      origin: null,
     }
 
     ensureFileAnalysisForFile.mockResolvedValue({
@@ -87,6 +88,7 @@ describe('cachingExtractor', () => {
       encrypted: 0 as const,
       ownerType: 'USER' as const,
       ownerId: 'u1',
+      origin: null,
     }
 
     ensureFileAnalysisForFile.mockResolvedValue(undefined)
@@ -116,6 +118,7 @@ describe('cachingExtractor', () => {
       encrypted: 0 as const,
       ownerType: 'USER' as const,
       ownerId: 'u1',
+      origin: null,
     }
 
     ensureFileAnalysisForFile.mockResolvedValue({

--- a/apps/backend/api/files/[fileId]/content/route.ts
+++ b/apps/backend/api/files/[fileId]/content/route.ts
@@ -130,6 +130,7 @@ export const PUT = operation({
       .select([
         'File.id as id',
         'File.name as name',
+        'File.origin as origin',
         'File.ownerType as ownerType',
         'File.ownerId as ownerId',
         'File.path as path',

--- a/apps/backend/api/files/images/route.ts
+++ b/apps/backend/api/files/images/route.ts
@@ -33,6 +33,7 @@ export const GET = operation({
       )
       .distinct()
       .orderBy('F.createdAt', 'desc')
+      .orderBy('F.id', 'desc')
       .execute()
 
     return ok(rows)

--- a/apps/backend/api/files/images/route.ts
+++ b/apps/backend/api/files/images/route.ts
@@ -24,6 +24,7 @@ export const GET = operation({
       .select(['F.id', 'F.name', 'F.type', 'FB.size as size', 'F.createdAt', 'C.id as conversationId'])
       .where('F.fileBlobId', 'is not', null)
       .where('F.type', 'like', 'image/%')
+      .where('F.origin', '=', 'generated')
       .where((eb) =>
         eb.or([
           eb.and([eb('F.ownerType', '=', 'USER'), eb('F.ownerId', '=', session.userId)]),

--- a/apps/backend/db/migrations.generated.ts
+++ b/apps/backend/db/migrations.generated.ts
@@ -42,6 +42,7 @@ import * as m202605053AssistantVersionFileOrder from './migrations/20260505.3-as
 import * as m20260506AssistantHidden from './migrations/20260506-assistant_hidden'
 import * as m20260508RenameGeminiProvider from './migrations/20260508-rename-gemini-provider'
 import * as m20260519MessageAuditTokenDetails from './migrations/20260519-message_audit_token_details'
+import * as m202605192FileOrigin from './migrations/20260519.2-file_origin'
 
 import type { MigrationWithDialect } from './migrations'
 
@@ -88,4 +89,5 @@ export const migrationModules: Record<string, MigrationWithDialect> = {
   '20260506-assistant_hidden': m20260506AssistantHidden,
   '20260508-rename-gemini-provider': m20260508RenameGeminiProvider,
   '20260519-message_audit_token_details': m20260519MessageAuditTokenDetails,
+  '20260519.2-file_origin': m202605192FileOrigin,
 }

--- a/apps/backend/db/migrations/20260519.2-file_origin.ts
+++ b/apps/backend/db/migrations/20260519.2-file_origin.ts
@@ -1,0 +1,19 @@
+import { Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<any>, dialect: 'sqlite' | 'postgresql'): Promise<void> {
+  if (dialect === 'postgresql') {
+    await db.schema.createType('FileOrigin').asEnum(['uploaded', 'generated']).execute()
+
+    await db.schema
+      .alterTable('File')
+      .addColumn('origin', sql`"FileOrigin"`, (col) => col.defaultTo(sql`NULL`))
+      .execute()
+  } else {
+    await db.schema
+      .alterTable('File')
+      .addColumn('origin', 'text', (col) => col.defaultTo(sql`NULL`))
+      .execute()
+  }
+
+  await db.schema.createIndex('idx_File_origin').on('File').column('origin').execute()
+}

--- a/apps/backend/db/schema.ts
+++ b/apps/backend/db/schema.ts
@@ -112,6 +112,7 @@ export interface File {
   fileBlobId: string | null
   id: string
   name: string
+  origin: FileOrigin | null
   ownerType: FileOwnerType
   ownerId: string
   path: string
@@ -141,6 +142,7 @@ export interface FileAnalysis {
 }
 
 export type FileOwnerType = 'USER' | 'CHAT' | 'ASSISTANT' | 'TOOL'
+export type FileOrigin = 'uploaded' | 'generated'
 
 export interface Image {
   id: string

--- a/apps/backend/lib/files/materialize.ts
+++ b/apps/backend/lib/files/materialize.ts
@@ -97,6 +97,7 @@ export const materializeFile = async (params: MaterializeFileParams): Promise<Fi
         name: params.name,
         path: fileBlob.path,
         type: fileBlob.type,
+        origin: 'generated',
         size: fileBlob.size,
         uploaded: 1,
         createdAt: timestamp,

--- a/apps/backend/lib/files/upload-dedup.ts
+++ b/apps/backend/lib/files/upload-dedup.ts
@@ -46,6 +46,7 @@ export const finalizeUploadedFile = async (params: {
   await db
     .updateTable('File')
     .set({
+      origin: 'uploaded',
       uploaded: 1,
       fileBlobId: blob.id,
       path: blob.path,

--- a/apps/backend/models/file.ts
+++ b/apps/backend/models/file.ts
@@ -5,6 +5,7 @@ import { nanoid } from 'nanoid'
 export interface FileDbRow {
   id: string
   name: string
+  origin: 'uploaded' | 'generated' | null
   ownerType: 'USER' | 'CHAT' | 'ASSISTANT' | 'TOOL'
   ownerId: string
   path: string
@@ -41,6 +42,7 @@ export const addFile = async (
       name: file.name,
       path,
       type: file.type,
+      origin: 'uploaded',
       size: file.size,
       uploaded: 0,
       createdAt: new Date().toISOString(),
@@ -101,6 +103,7 @@ export const cloneFilesForOwner = async ({
     .select([
       'File.id as id',
       'File.name as name',
+      'File.origin as origin',
       'File.path as path',
       'File.type as type',
       'File.createdAt as createdAt',
@@ -127,6 +130,7 @@ export const cloneFilesForOwner = async ({
         name: source.name,
         path: source.path,
         type: source.type,
+        origin: source.origin,
         uploaded: source.fileBlobId ? 1 : 0,
         createdAt: now,
         encrypted: source.blobEncrypted ?? 0,


### PR DESCRIPTION
## Summary
This change adds a nullable `origin` field on `File` and consistently sets it to distinguish uploaded files from generated files, enabling safer filtering and propagation of file provenance.

## Details
- Added migration `20260519.2-file_origin` and regenerated the migration manifest.
- Extended backend DB schema/model typings with `FileOrigin` and `File.origin`.
- Set `origin` to `uploaded` in upload flows and to `generated` in materialization flows.
- Included `origin` in file clone/content selection paths.
- Filtered the images API to return generated images only.
- Updated tests to include the new nullable `origin` field.

## Tests
- `npm run check-types` (pass)