### PR TITLE
Fix chat truncation windowing and non-native attachment token estimation

### DIFF
--- a/__tests__/chatTruncation.test.ts
+++ b/__tests__/chatTruncation.test.ts
@@ -224,6 +224,19 @@ describe('truncateChat', () => {
     expect(result).toEqual(messages)
   })
 
+  test('keeps history starting at index 0 when first message is user and total is within budget', async () => {
+    const assistant = makeChatAssistant(40)
+    const messages = [
+      makeMessage('m1', 'user'),
+      makeMessage('m2', 'assistant'),
+      makeMessage('m3', 'user'),
+    ]
+
+    const result = await assistant.truncateChat(messages)
+
+    expect(result).toEqual(messages)
+  })
+
   test('cost plan is built exactly once', async () => {
     const assistant = makeChatAssistant(25)
     const messages = [
@@ -251,6 +264,21 @@ describe('truncateChat', () => {
     const result = await assistant.truncateChat(messages)
 
     expect(result).toEqual(messages.slice(2))
+  })
+
+  test('truncated history starts at a user message when history begins with assistant messages', async () => {
+    const assistant = makeChatAssistant(35)
+    const messages = [
+      makeMessage('m1', 'assistant'),
+      makeMessage('m2', 'assistant'),
+      makeMessage('m3', 'user'),
+      makeMessage('m4', 'assistant'),
+    ]
+
+    const result = await assistant.truncateChat(messages)
+
+    expect(result).toEqual(messages.slice(2))
+    expect(result[0]?.role).toBe('user')
   })
 
   test('falls back to last user turn when even the shortest candidate exceeds limit', async () => {
@@ -281,5 +309,14 @@ describe('truncateChat', () => {
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       'Truncating chat: latest user turn still exceeds limit of 15'
     )
+  })
+
+  test('falls back safely to index 0 when history has no user messages', async () => {
+    const assistant = makeChatAssistant(15)
+    const messages = [makeMessage('m1', 'assistant'), makeMessage('m2', 'assistant')]
+
+    const result = await assistant.truncateChat(messages)
+
+    expect(result).toEqual(messages)
   })
 })

--- a/__tests__/tokenEstimator.test.ts
+++ b/__tests__/tokenEstimator.test.ts
@@ -920,7 +920,7 @@ describe('estimateInputTokens', () => {
     expect(extractFromFile).toHaveBeenCalledWith(file)
   })
 
-  test('counts metadata for attachments without native analysis-backed handling', async () => {
+  test('counts extracted-text fallback for non-native attachments', async () => {
     const fileId = 'text-attachment'
     const file = {
       id: fileId,
@@ -933,6 +933,7 @@ describe('estimateInputTokens', () => {
       encrypted: 0 as const,
     }
     getFileWithId.mockResolvedValue(file)
+    extractFromFile.mockResolvedValue('notes attachment text')
     await mockBuildPreambleSegments([])
 
     const { estimateInputTokens } = await import('@/backend/lib/chat/token-estimator')
@@ -950,12 +951,13 @@ describe('estimateInputTokens', () => {
     expect(result.estimate.draft).toBe(
       countTextForModel(
         claude35SonnetModel,
-        JSON.stringify({ filename: file.name, mediaType: file.type })
+        `Here is the text content of the file "${file.name}" with id ${file.id}\nnotes attachment text`
       ) +
         countUserAttachmentDescriptorTokens(claude35SonnetModel, [
           { id: fileId, name: file.name, mimetype: file.type, size: file.size },
         ])
     )
+    expect(extractFromFile).toHaveBeenCalledWith(file)
   })
 
   test('counts assistant and tool history message parts', async () => {

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -359,13 +359,19 @@ const estimateAttachmentTokens = async (
     onDetail?.(entry.tokens, entry.algorithm, entry.params)
     return entry.tokens
   }
-  const tokens = await countTextTokensCached(
-    model,
-    JSON.stringify({ filename: attachment.name, mediaType: attachment.mimetype }),
-    stats
-  )
-  onDetail?.(tokens, algorithm)
-  return tokens
+  if (canSendAsNativeFile(attachment.mimetype, model.capabilities)) {
+    const tokens = await countTextTokensCached(
+      model,
+      JSON.stringify({ filename: attachment.name, mediaType: attachment.mimetype }),
+      stats
+    )
+    onDetail?.(tokens, algorithm)
+    return tokens
+  }
+
+  const fallbackTokens = await estimateTextFallbackAttachmentTokens(model, attachment.id, stats)
+  onDetail?.(fallbackTokens, 'text_fallback')
+  return fallbackTokens
 }
 
 const estimateDtoMessageTokens = async (

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -464,10 +464,12 @@ export const selectOptimalHistoryStartIndex = (
   for (let i = historyMessageCosts.length - 1; i >= 0; i--) {
     running[i] = running[i + 1]! + (historyMessageCosts[i]?.tokens ?? 0)
   }
+  // Truncation windows must start from a user message so the model receives
+  // a coherent user turn after the preamble.
   const userTurnStartIndexes = history.flatMap((message, index) =>
-    message.role === 'user' && index > 0 ? [index] : []
+    message.role === 'user' ? [index] : []
   )
-  const candidateStartIndexes = [0, ...userTurnStartIndexes]
+  const candidateStartIndexes = userTurnStartIndexes
   for (const startIndex of candidateStartIndexes) {
     const total = assistantTokens + draftTokens + (running[startIndex] ?? 0)
     if (total <= tokenLimit) return startIndex


### PR DESCRIPTION
## Summary
Chat truncation now starts history windows from `user` messages after preamble and preserves fallback to the last user turn when no candidate fits the configured token budget. The token estimator was also fixed to match runtime attachment handling for non-native files (for example `.xlsx`): it now counts extracted-text fallback content instead of metadata-only, preventing major underestimation versus provider-reported input tokens.

## Details
- Enforce user-start truncation candidates in history window selection.
- Keep safe fallback behavior when all candidates exceed budget.
- Align non-native attachment token estimation with runtime conversion by using extracted-text fallback.
- Keep metadata-only counting only for truly native file attachments.
- Add regression coverage for user-start truncation, no-user-history fallback, and non-native attachment extracted-text estimation.

## Risks
- Token estimates for text-like attachments are now intentionally higher and may cause earlier truncation in long chats.

## Tests
- `npx vitest run __tests__/chatTruncation.test.ts` (14 passed)
- `npx vitest run __tests__/tokenEstimator.test.ts` (32 passed)
- `npx vitest run apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts` (10 passed)
