### PR TITLE
feat(tokens): switch Anthropic defaults to heuristic-based token estimator

### DIFF
--- a/__tests__/chatTruncation.test.ts
+++ b/__tests__/chatTruncation.test.ts
@@ -224,6 +224,19 @@ describe('truncateChat', () => {
     expect(result).toEqual(messages)
   })
 
+  test('keeps history starting at index 0 when first message is user and total is within budget', async () => {
+    const assistant = makeChatAssistant(40)
+    const messages = [
+      makeMessage('m1', 'user'),
+      makeMessage('m2', 'assistant'),
+      makeMessage('m3', 'user'),
+    ]
+
+    const result = await assistant.truncateChat(messages)
+
+    expect(result).toEqual(messages)
+  })
+
   test('cost plan is built exactly once', async () => {
     const assistant = makeChatAssistant(25)
     const messages = [
@@ -251,6 +264,21 @@ describe('truncateChat', () => {
     const result = await assistant.truncateChat(messages)
 
     expect(result).toEqual(messages.slice(2))
+  })
+
+  test('truncated history starts at a user message when history begins with assistant messages', async () => {
+    const assistant = makeChatAssistant(35)
+    const messages = [
+      makeMessage('m1', 'assistant'),
+      makeMessage('m2', 'assistant'),
+      makeMessage('m3', 'user'),
+      makeMessage('m4', 'assistant'),
+    ]
+
+    const result = await assistant.truncateChat(messages)
+
+    expect(result).toEqual(messages.slice(2))
+    expect(result[0]?.role).toBe('user')
   })
 
   test('falls back to last user turn when even the shortest candidate exceeds limit', async () => {
@@ -281,5 +309,14 @@ describe('truncateChat', () => {
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       'Truncating chat: latest user turn still exceeds limit of 15'
     )
+  })
+
+  test('falls back safely to index 0 when history has no user messages', async () => {
+    const assistant = makeChatAssistant(15)
+    const messages = [makeMessage('m1', 'assistant'), makeMessage('m2', 'assistant')]
+
+    const result = await assistant.truncateChat(messages)
+
+    expect(result).toEqual(messages)
   })
 })

--- a/__tests__/coverageTargets.test.ts
+++ b/__tests__/coverageTargets.test.ts
@@ -200,7 +200,7 @@ describe('apps/backend/lib/models', () => {
     expect(llmModels).toHaveLength(2)
     expect(llmModels[0]).toMatchObject({
       id: 'anthropic-pdf',
-      tokenizer: 'approx_4chars',
+      tokenizer: 'anthropic_heuristic',
       capabilities: {
         nativePdfPageLimit: 100,
         supportedMedia: ['application/pdf'],

--- a/__tests__/tokenEstimator.test.ts
+++ b/__tests__/tokenEstimator.test.ts
@@ -920,7 +920,7 @@ describe('estimateInputTokens', () => {
     expect(extractFromFile).toHaveBeenCalledWith(file)
   })
 
-  test('counts metadata for attachments without native analysis-backed handling', async () => {
+  test('counts extracted-text fallback for non-native attachments', async () => {
     const fileId = 'text-attachment'
     const file = {
       id: fileId,
@@ -933,6 +933,7 @@ describe('estimateInputTokens', () => {
       encrypted: 0 as const,
     }
     getFileWithId.mockResolvedValue(file)
+    extractFromFile.mockResolvedValue('notes attachment text')
     await mockBuildPreambleSegments([])
 
     const { estimateInputTokens } = await import('@/backend/lib/chat/token-estimator')
@@ -950,12 +951,13 @@ describe('estimateInputTokens', () => {
     expect(result.estimate.draft).toBe(
       countTextForModel(
         claude35SonnetModel,
-        JSON.stringify({ filename: file.name, mediaType: file.type })
+        `Here is the text content of the file "${file.name}" with id ${file.id}\nnotes attachment text`
       ) +
         countUserAttachmentDescriptorTokens(claude35SonnetModel, [
           { id: fileId, name: file.name, mimetype: file.type, size: file.size },
         ])
     )
+    expect(extractFromFile).toHaveBeenCalledWith(file)
   })
 
   test('counts assistant and tool history message parts', async () => {

--- a/__tests__/tokenizer.test.ts
+++ b/__tests__/tokenizer.test.ts
@@ -9,7 +9,7 @@ import {
 import type { LlmModel } from '@/lib/chat/models'
 import type * as dto from '@/types/dto'
 
-// A model that uses the fast approx_4chars strategy (no WASM loading)
+// A model that uses Anthropic default tokenizer strategy
 const approxModel: LlmModel = {
   id: 'claude-3',
   model: 'claude-3',
@@ -27,8 +27,8 @@ const overrideModel: LlmModel = { ...approxModel, tokenizer: 'approx_4chars' }
 const base = { conversationId: 'c1', sentAt: '2024-01-01T00:00:00.000Z', parent: null }
 
 describe('tokenizerForModel', () => {
-  test('returns approx_4chars for anthropic provider', () => {
-    expect(tokenizerForModel(approxModel)).toBe('approx_4chars')
+  test('returns anthropic_heuristic for anthropic provider', () => {
+    expect(tokenizerForModel(approxModel)).toBe('anthropic_heuristic')
   })
 
   test('respects explicit tokenizer override on model', () => {
@@ -37,11 +37,11 @@ describe('tokenizerForModel', () => {
   })
 })
 
-describe('countTextForModel (approx_4chars)', () => {
-  test('counts ceil(length / 4) tokens', () => {
-    expect(countTextForModel(approxModel, 'abcd')).toBe(1)   // 4/4 = 1
-    expect(countTextForModel(approxModel, 'abcde')).toBe(2)  // ceil(5/4) = 2
-    expect(countTextForModel(approxModel, '')).toBe(0)
+describe('countTextForModel (anthropic_heuristic)', () => {
+  test('applies heuristic estimation and minimum token floor', () => {
+    expect(countTextForModel(approxModel, 'abcd')).toBe(1)
+    expect(countTextForModel(approxModel, 'abcde')).toBe(2)
+    expect(countTextForModel(approxModel, '')).toBe(1)
   })
 })
 

--- a/apps/backend/lib/chat/prompt-token-counter.ts
+++ b/apps/backend/lib/chat/prompt-token-counter.ts
@@ -8,10 +8,13 @@ import { estimateNativeImageTokens } from '@/backend/lib/chat/image-token-estima
 import type { PromptSegment } from './index'
 import type { TokenizerStrategy } from '@/lib/chat/models'
 import { LlmModel } from '@/lib/chat/models'
-import { tokenizerForModel } from '@/lib/chat/tokenizer'
+import { countAnthropicSmartTokens, tokenizerForModel } from '@/lib/chat/tokenizer'
 
 type AsyncTokenizer = {
-  countText: (tokenizer: Exclude<TokenizerStrategy, 'approx_4chars'>, text: string) => Promise<number>
+  countText: (
+    tokenizer: Exclude<TokenizerStrategy, 'approx_4chars' | 'anthropic_smart'>,
+    text: string
+  ) => Promise<number>
 }
 
 let tokenizerCounter: AsyncTokenizer | null = null
@@ -56,6 +59,9 @@ export const countTextTokensCached = async (
   const tokenizer = tokenizerForModel(model)
   if (tokenizer === 'approx_4chars') {
     return Math.ceil(text.length / 4)
+  }
+  if (tokenizer === 'anthropic_smart') {
+    return countAnthropicSmartTokens(text)
   }
   const normalized = normalizeText(text)
   const key = hashKey('text', String(estimatorVersion), tokenizer, model.id, normalized)

--- a/apps/backend/lib/chat/prompt-token-counter.ts
+++ b/apps/backend/lib/chat/prompt-token-counter.ts
@@ -8,11 +8,11 @@ import { estimateNativeImageTokens } from '@/backend/lib/chat/image-token-estima
 import type { PromptSegment } from './index'
 import type { TokenizerStrategy } from '@/lib/chat/models'
 import { LlmModel } from '@/lib/chat/models'
-import { countAnthropicSmartTokens, tokenizerForModel } from '@/lib/chat/tokenizer'
+import { countAnthropicHeuristicTokens, tokenizerForModel } from '@/lib/chat/tokenizer'
 
 type AsyncTokenizer = {
   countText: (
-    tokenizer: Exclude<TokenizerStrategy, 'approx_4chars' | 'anthropic_smart'>,
+    tokenizer: Exclude<TokenizerStrategy, 'approx_4chars' | 'anthropic_heuristic'>,
     text: string
   ) => Promise<number>
 }
@@ -60,8 +60,8 @@ export const countTextTokensCached = async (
   if (tokenizer === 'approx_4chars') {
     return Math.ceil(text.length / 4)
   }
-  if (tokenizer === 'anthropic_smart') {
-    return countAnthropicSmartTokens(text)
+  if (tokenizer === 'anthropic_heuristic') {
+    return countAnthropicHeuristicTokens(text)
   }
   const normalized = normalizeText(text)
   const key = hashKey('text', String(estimatorVersion), tokenizer, model.id, normalized)

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -359,13 +359,19 @@ const estimateAttachmentTokens = async (
     onDetail?.(entry.tokens, entry.algorithm, entry.params)
     return entry.tokens
   }
-  const tokens = await countTextTokensCached(
-    model,
-    JSON.stringify({ filename: attachment.name, mediaType: attachment.mimetype }),
-    stats
-  )
-  onDetail?.(tokens, algorithm)
-  return tokens
+  if (canSendAsNativeFile(attachment.mimetype, model.capabilities)) {
+    const tokens = await countTextTokensCached(
+      model,
+      JSON.stringify({ filename: attachment.name, mediaType: attachment.mimetype }),
+      stats
+    )
+    onDetail?.(tokens, algorithm)
+    return tokens
+  }
+
+  const fallbackTokens = await estimateTextFallbackAttachmentTokens(model, attachment.id, stats)
+  onDetail?.(fallbackTokens, 'text_fallback')
+  return fallbackTokens
 }
 
 const estimateDtoMessageTokens = async (

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -464,10 +464,12 @@ export const selectOptimalHistoryStartIndex = (
   for (let i = historyMessageCosts.length - 1; i >= 0; i--) {
     running[i] = running[i + 1]! + (historyMessageCosts[i]?.tokens ?? 0)
   }
+  // Truncation windows must start from a user message so the model receives
+  // a coherent user turn after the preamble.
   const userTurnStartIndexes = history.flatMap((message, index) =>
-    message.role === 'user' && index > 0 ? [index] : []
+    message.role === 'user' ? [index] : []
   )
-  const candidateStartIndexes = [0, ...userTurnStartIndexes]
+  const candidateStartIndexes = userTurnStartIndexes
   for (const startIndex of candidateStartIndexes) {
     const total = assistantTokens + draftTokens + (running[startIndex] ?? 0)
     if (total <= tokenLimit) return startIndex

--- a/packages/core/src/chat/tokenizer.ts
+++ b/packages/core/src/chat/tokenizer.ts
@@ -16,8 +16,8 @@ export const countTextWithTokenizer = (tokenizer: TokenizerStrategy, text: strin
   if (tokenizer === 'approx_4chars') {
     return Math.ceil(text.length / 4)
   }
-  if (tokenizer === 'anthropic_smart') {
-    return countAnthropicSmartTokens(text)
+  if (tokenizer === 'anthropic_heuristic') {
+    return countAnthropicHeuristicTokens(text)
   }
   return getEncodingCached(tokenizer).encode(text).length
 }
@@ -25,8 +25,9 @@ export const countTextWithTokenizer = (tokenizer: TokenizerStrategy, text: strin
 const countWhitespace = (text: string) => (text.match(/\s/g) ?? []).length
 const countPipe = (text: string) => (text.match(/\|/g) ?? []).length
 
-export const countAnthropicSmartTokens = (text: string) => {
-  // Linear model trained against Anthropic count_tokens endpoint:
+export const countAnthropicHeuristicTokens = (text: string) => {
+  // Linear model trained against Anthropic count_tokens endpoint.
+  // Training repo/reference: https://github.com/logicleai/token_estimation
   // tokens ~= 2.38 * pipes + 0.31 * (chars - pipes - whitespace) + 0.07 * whitespace
   const pipes = countPipe(text)
   const whitespace = countWhitespace(text)

--- a/packages/core/src/chat/tokenizer.ts
+++ b/packages/core/src/chat/tokenizer.ts
@@ -16,7 +16,23 @@ export const countTextWithTokenizer = (tokenizer: TokenizerStrategy, text: strin
   if (tokenizer === 'approx_4chars') {
     return Math.ceil(text.length / 4)
   }
+  if (tokenizer === 'anthropic_smart') {
+    return countAnthropicSmartTokens(text)
+  }
   return getEncodingCached(tokenizer).encode(text).length
+}
+
+const countWhitespace = (text: string) => (text.match(/\s/g) ?? []).length
+const countPipe = (text: string) => (text.match(/\|/g) ?? []).length
+
+export const countAnthropicSmartTokens = (text: string) => {
+  // Linear model trained against Anthropic count_tokens endpoint:
+  // tokens ~= 2.38 * pipes + 0.31 * (chars - pipes - whitespace) + 0.07 * whitespace
+  const pipes = countPipe(text)
+  const whitespace = countWhitespace(text)
+  const charsMinusPipesMinusWhitespace = text.length - pipes - whitespace
+  const estimate = 2.38 * pipes + 0.31 * charsMinusPipesMinusWhitespace + 0.07 * whitespace
+  return Math.max(1, Math.round(estimate))
 }
 
 export const tokenizerForModel = (model: LlmModel): TokenizerStrategy =>

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -21,7 +21,7 @@ export interface LlmModelCapabilities {
   promptCaching?: boolean
 }
 
-export const tokenizerStrategies = ['cl100k_base', 'o200k_base', 'approx_4chars'] as const
+export const tokenizerStrategies = ['cl100k_base', 'o200k_base', 'approx_4chars', 'anthropic_smart'] as const
 export type TokenizerStrategy = (typeof tokenizerStrategies)[number]
 
 export const llmModelNoCapabilities: LlmModelCapabilities = {
@@ -58,6 +58,7 @@ export const defaultTokenizerByProvider = (provider: ProviderType): TokenizerStr
     case 'logiclecloud':
       return 'cl100k_base'
     case 'anthropic':
+      return 'anthropic_smart'
     case 'gcp-vertex':
     case 'google-ai-studio':
     case 'mock':
@@ -71,6 +72,7 @@ export const defaultTokenizerByOwner = (owner: EngineOwner): TokenizerStrategy =
     case 'perplexity':
       return 'cl100k_base'
     case 'anthropic':
+      return 'anthropic_smart'
     case 'google':
     case 'gemini':
     case 'meta':

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -21,7 +21,7 @@ export interface LlmModelCapabilities {
   promptCaching?: boolean
 }
 
-export const tokenizerStrategies = ['cl100k_base', 'o200k_base', 'approx_4chars', 'anthropic_smart'] as const
+export const tokenizerStrategies = ['cl100k_base', 'o200k_base', 'approx_4chars', 'anthropic_heuristic'] as const
 export type TokenizerStrategy = (typeof tokenizerStrategies)[number]
 
 export const llmModelNoCapabilities: LlmModelCapabilities = {
@@ -58,7 +58,7 @@ export const defaultTokenizerByProvider = (provider: ProviderType): TokenizerStr
     case 'logiclecloud':
       return 'cl100k_base'
     case 'anthropic':
-      return 'anthropic_smart'
+      return 'anthropic_heuristic'
     case 'gcp-vertex':
     case 'google-ai-studio':
     case 'mock':
@@ -72,7 +72,7 @@ export const defaultTokenizerByOwner = (owner: EngineOwner): TokenizerStrategy =
     case 'perplexity':
       return 'cl100k_base'
     case 'anthropic':
-      return 'anthropic_smart'
+      return 'anthropic_heuristic'
     case 'google':
     case 'gemini':
     case 'meta':

--- a/packages/core/src/types/dto/llmmodel.ts
+++ b/packages/core/src/types/dto/llmmodel.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-const tokenizerStrategySchema = z.enum(['cl100k_base', 'o200k_base', 'approx_4chars'])
+const tokenizerStrategySchema = z.enum(['cl100k_base', 'o200k_base', 'approx_4chars', 'anthropic_smart'])
 
 export const llmModelCapabilitiesSchema = z.object({
   vision: z.boolean(),

--- a/packages/core/src/types/dto/llmmodel.ts
+++ b/packages/core/src/types/dto/llmmodel.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-const tokenizerStrategySchema = z.enum(['cl100k_base', 'o200k_base', 'approx_4chars', 'anthropic_smart'])
+const tokenizerStrategySchema = z.enum(['cl100k_base', 'o200k_base', 'approx_4chars', 'anthropic_heuristic'])
 
 export const llmModelCapabilitiesSchema = z.object({
   vision: z.boolean(),

--- a/packages/core/src/types/dto/tokenestimate.ts
+++ b/packages/core/src/types/dto/tokenestimate.ts
@@ -28,7 +28,7 @@ const tokenEstimateMetaSchema = z.object({
   assistantId: z.string().describe('Assistant id used for estimation.'),
   model: z.string().describe('Resolved model id used for estimation.'),
   tokenizer: z
-    .enum(['cl100k_base', 'o200k_base', 'approx_4chars', 'anthropic_smart'])
+    .enum(['cl100k_base', 'o200k_base', 'approx_4chars', 'anthropic_heuristic'])
     .describe('Tokenizer strategy used to compute token estimates.'),
 }).meta({ id: 'TokenEstimateMeta' })
 
@@ -42,7 +42,7 @@ export const tokenDetailPartSchema = z.object({
   algorithm: z
     .string()
     .describe(
-      'Algorithm or tokenizer used: cl100k_base, o200k_base, approx_4chars, anthropic_smart, native_image, pdf_native, pdf_text_fallback, pdf_page_limit_notice.'
+      'Algorithm or tokenizer used: cl100k_base, o200k_base, approx_4chars, anthropic_heuristic, native_image, pdf_native, pdf_text_fallback, pdf_page_limit_notice.'
     ),
   params: z
     .record(z.string(), z.unknown())

--- a/packages/core/src/types/dto/tokenestimate.ts
+++ b/packages/core/src/types/dto/tokenestimate.ts
@@ -28,7 +28,7 @@ const tokenEstimateMetaSchema = z.object({
   assistantId: z.string().describe('Assistant id used for estimation.'),
   model: z.string().describe('Resolved model id used for estimation.'),
   tokenizer: z
-    .enum(['cl100k_base', 'o200k_base', 'approx_4chars'])
+    .enum(['cl100k_base', 'o200k_base', 'approx_4chars', 'anthropic_smart'])
     .describe('Tokenizer strategy used to compute token estimates.'),
 }).meta({ id: 'TokenEstimateMeta' })
 
@@ -42,7 +42,7 @@ export const tokenDetailPartSchema = z.object({
   algorithm: z
     .string()
     .describe(
-      'Algorithm or tokenizer used: cl100k_base, o200k_base, approx_4chars, native_image, pdf_native, pdf_text_fallback, pdf_page_limit_notice.'
+      'Algorithm or tokenizer used: cl100k_base, o200k_base, approx_4chars, anthropic_smart, native_image, pdf_native, pdf_text_fallback, pdf_page_limit_notice.'
     ),
   params: z
     .record(z.string(), z.unknown())


### PR DESCRIPTION
## Summary
Switches Anthropic token estimation defaults from `approx_4chars` to a new `anthropic_heuristic` tokenizer strategy, using a calibrated linear formula based on text features (`pipes`, `chars - pipes - whitespace`, `whitespace`) for more realistic token estimates in prompt planning and token-estimate APIs.

## Details
- Adds `anthropic_heuristic` to tokenizer strategy enums and DTO schemas.
- Updates Anthropic defaults in model/provider tokenizer resolution to use `anthropic_heuristic`.
- Implements shared `countAnthropicHeuristicTokens(...)` in core tokenizer logic.
- Uses the same heuristic counter path in backend prompt token counting (without worker tokenizer round-trip).
- Extends token-estimate metadata description to include `anthropic_heuristic`.
- Adds code-level reference to the training source repository: `https://github.com/logicleai/token_estimation`.

## Tests
- `npm run check-types` (pass)