### PR TITLE
Stamp CI build versions and reset package base version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,12 +152,20 @@ jobs:
           tags: |
             type=sha,format=long
 
+      - name: Set build version
+        id: buildver
+        run: |
+          DATE=$(date -u +%Y%m%d%H%M%S)
+          SHORT_SHA="${GITHUB_SHA::8}"
+          echo "version=${DATE}.${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
       - name: Build production image (local)
         uses: docker/build-push-action@v5
         with:
           context: .
           load: true
           tags: ${{ env.SMOKE_IMAGE }}
+          build-args: APP_VERSION=${{ steps.buildver.outputs.version }}
           cache-from: type=gha,scope=nextjs-build
           cache-to: type=gha,mode=max,scope=nextjs-build
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logicleai/logicle",
-  "version": "0.26-snapshot",
+  "version": "0.0.0",
   "pnpm": {
     "patchedDependencies": {
       "@libpdf/core@0.2.12": "patches/@libpdf__core@0.2.12.patch"


### PR DESCRIPTION
## Summary
Updates release/versioning behavior so CI builds produce timestamp+SHA-stamped versions while the repository base version is reset to .

## Details
- updates  to stamp build versions with datetime+commit SHA in CI
- resets  version to  as the repository baseline
