### PR TITLE
feat(chat): split Gemini reasoning text into per-step blocks client-side

### DIFF
--- a/apps/frontend/app/chat/components/AssistantMessage.tsx
+++ b/apps/frontend/app/chat/components/AssistantMessage.tsx
@@ -1,11 +1,12 @@
 'use client'
 import { FC, MutableRefObject } from 'react'
 import React from 'react'
-import { UIAssistantMessagePart, UIAssistantMessage } from '@/lib/chat/types'
+import { UIAssistantMessagePart, UIAssistantMessage, UIReasoningGroup } from '@/lib/chat/types'
+import { groupForReasoning } from '@/lib/chat/conversationUtils'
 import * as dto from '@/types/dto'
 import { ToolCall } from './ChatMessage'
 import { MessageError } from './ChatMessageError'
-import { ReasoningGroup, UIReasoningGroup, UIReasoningLikePart } from './ReasoningGroup'
+import { ReasoningGroup } from './ReasoningGroup'
 import { TextPart } from './TextPart'
 
 interface Props {
@@ -47,10 +48,10 @@ export const AssistantMessagePart: FC<{
   } else if (part.type === 'reasoning-group') {
     return (
       <ReasoningGroup
-        parts={part.parts}
+        group={part}
         subAssistants={subAssistants}
         assistantTools={assistantTools}
-      ></ReasoningGroup>
+      />
     )
   } else {
     // No reasoning here, as all reasoning parts go into ReasoningGroup
@@ -58,37 +59,6 @@ export const AssistantMessagePart: FC<{
   }
 }
 
-const canGroupInReasoning = (p: UIAssistantMessagePart) =>
-  p.type === 'builtin-tool-result' || p.type === 'tool-call'
-
-/**
- * Groups consecutive reasoning-like parts into a single bucket.
- */
-function groupForReasoning(parts: UIAssistantMessagePart[]) {
-  const grouped: Array<UIAssistantMessagePart | UIReasoningGroup> = []
-
-  let buffer: UIReasoningLikePart[] = []
-
-  for (const p of parts) {
-    if (p.type === 'reasoning') {
-      buffer.push(p)
-    } else if (buffer.length !== 0 && canGroupInReasoning(p)) {
-      buffer.push(p)
-    } else {
-      if (buffer.length) {
-        grouped.push({ type: 'reasoning-group', parts: buffer })
-        buffer = []
-      }
-      grouped.push(p)
-    }
-  }
-
-  if (buffer.length) {
-    grouped.push({ type: 'reasoning-group', parts: buffer })
-  }
-
-  return grouped
-}
 
 export const AssistantMessage: FC<Props> = ({ fireEdit, message, subAssistants, assistantTools }) => {
   const groupedParts = groupForReasoning(message.parts)

--- a/apps/frontend/app/chat/components/Reasoning.tsx
+++ b/apps/frontend/app/chat/components/Reasoning.tsx
@@ -1,9 +1,64 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
+const BOLD_HEADER = /^\*\*(.+?)\*\*$/
+
+interface Section {
+  title?: string
+  body: string
+}
+
+function splitIntoSections(text: string): Section[] {
+  const lines = text.split(/\r?\n/)
+  const sections: Section[] = []
+  let currentTitle: string | undefined
+  let currentLines: string[] = []
+
+  for (const line of lines) {
+    const m = line.trim().match(BOLD_HEADER)
+    if (m) {
+      const body = currentLines.join('\n').trim()
+      if (body || currentTitle !== undefined) {
+        sections.push({ title: currentTitle, body })
+      }
+      currentTitle = m[1].trim()
+      currentLines = []
+    } else {
+      currentLines.push(line)
+    }
+  }
+
+  const body = currentLines.join('\n').trim()
+  if (body || currentTitle !== undefined) {
+    sections.push({ title: currentTitle, body })
+  }
+
+  return sections
+}
+
 export const Reasoning: FC<{ text: string }> = ({ text }) => {
   const { t } = useTranslation()
+  if (text.length === 0) {
+    return <div className="text-sm">{t('reasoning')}</div>
+  }
+
+  const sections = splitIntoSections(text)
+
+  // No bold headers — plain text fallback
+  if (sections.length === 1 && sections[0].title === undefined) {
+    return <div className="text-sm whitespace-pre-wrap">{text}</div>
+  }
+
   return (
-    <div className="text-sm whitespace-pre-wrap">{text.length === 0 ? t('reasoning') : text}</div>
+    <div className="flex flex-col gap-2">
+      {sections.map((section, i) => (
+        <div key={i}>
+          {section.title && <div className="text-sm font-semibold">{section.title}</div>}
+          {section.body && (
+            <div className="text-sm whitespace-pre-wrap text-muted-foreground">{section.body}</div>
+          )}
+        </div>
+      ))}
+    </div>
   )
 }

--- a/apps/frontend/app/chat/components/ReasoningGroup.tsx
+++ b/apps/frontend/app/chat/components/ReasoningGroup.tsx
@@ -65,7 +65,13 @@ export const ReasoningGroup: FC<Props> = ({ parts, subAssistants, assistantTools
   const running = lastPartWithMeta?.running
   const title = (running && lastPartWithMeta?.title) ? lastPartWithMeta.title : t('thinking')
 
+  const hasContent = parts.some(
+    (p) => p.type !== 'reasoning' || (p as UIReasoningPart).reasoning || (p as UIReasoningPart).title
+  )
+
   const [open, setOpen] = useState('')
+
+  if (!running && !hasContent) return null
 
   return (
     <Accordion type="single" collapsible value={open} onValueChange={setOpen}>

--- a/apps/frontend/app/chat/components/ReasoningGroup.tsx
+++ b/apps/frontend/app/chat/components/ReasoningGroup.tsx
@@ -5,7 +5,7 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion'
 import { UIReasoningPart, UIToolCallPart } from '@/lib/chat/types'
-import { FC, useState, useEffect } from 'react'
+import { FC, useState } from 'react'
 import { RotatingLines } from 'react-loader-spinner'
 import * as dto from '@/types/dto'
 import { useTranslation } from 'react-i18next'
@@ -63,13 +63,9 @@ export const ReasoningGroup: FC<Props> = ({ parts, subAssistants, assistantTools
   const lastPartWithMeta = lastPart as PartWithMeta | undefined
 
   const running = lastPartWithMeta?.running
-  const lastTitle = running ? lastPartWithMeta?.title : undefined
-  const title = lastTitle ?? t('reasoning')
+  const title = (running && lastPartWithMeta?.title) ? lastPartWithMeta.title : t('thinking')
 
-  const [open, setOpen] = useState('item-1')
-  useEffect(() => {
-    if (running) setOpen('item-1')
-  }, [running])
+  const [open, setOpen] = useState('')
 
   return (
     <Accordion type="single" collapsible value={open} onValueChange={setOpen}>

--- a/apps/frontend/app/chat/components/ReasoningGroup.tsx
+++ b/apps/frontend/app/chat/components/ReasoningGroup.tsx
@@ -45,7 +45,12 @@ export const ReasoningGroupPart: FC<{
       />
     )
   } else if (part.type === 'reasoning') {
-    return <Reasoning text={part.reasoning} />
+    return (
+      <div>
+        {part.title && <div className="text-sm font-semibold">{part.title}</div>}
+        {part.reasoning && <Reasoning text={part.reasoning} />}
+      </div>
+    )
   } else {
     return null
   }

--- a/apps/frontend/app/chat/components/ReasoningGroup.tsx
+++ b/apps/frontend/app/chat/components/ReasoningGroup.tsx
@@ -1,33 +1,17 @@
+'use client'
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/accordion'
-import { UIReasoningPart, UIToolCallPart } from '@/lib/chat/types'
+import { UIReasoningGroup, UIReasoningLikePart, UIReasoningPart } from '@/lib/chat/types'
 import { FC, useState } from 'react'
 import { RotatingLines } from 'react-loader-spinner'
 import * as dto from '@/types/dto'
 import { useTranslation } from 'react-i18next'
 import { ToolCall } from './ChatMessage'
 import { Reasoning } from './Reasoning'
-
-interface Props {
-  parts: UIReasoningLikePart[]
-  subAssistants?: dto.UserAssistant['subAssistants']
-  assistantTools?: dto.UserAssistant['tools']
-}
-
-export type UIReasoningLikePart =
-  | UIReasoningPart
-  | UIToolCallPart
-  | dto.BuiltinToolCallResultPart
-  | dto.ToolCallResultPart
-
-export type UIReasoningGroup = {
-  type: 'reasoning-group'
-  parts: UIReasoningLikePart[]
-}
 
 export const ReasoningGroupPart: FC<{
   part: UIReasoningLikePart
@@ -45,10 +29,11 @@ export const ReasoningGroupPart: FC<{
       />
     )
   } else if (part.type === 'reasoning') {
+    const rp = part as UIReasoningPart
     return (
       <div>
-        {part.title && <div className="text-sm font-semibold">{part.title}</div>}
-        {part.reasoning && <Reasoning text={part.reasoning} />}
+        {rp.title && <div className="text-sm font-semibold">{rp.title}</div>}
+        {rp.reasoning && <Reasoning text={rp.reasoning} />}
       </div>
     )
   } else {
@@ -56,53 +41,45 @@ export const ReasoningGroupPart: FC<{
   }
 }
 
-export const ReasoningGroup: FC<Props> = ({ parts, subAssistants, assistantTools }) => {
+export const ReasoningGroup: FC<{
+  group: UIReasoningGroup
+  subAssistants?: dto.UserAssistant['subAssistants']
+  assistantTools?: dto.UserAssistant['tools']
+}> = ({ group, subAssistants, assistantTools }) => {
   const { t } = useTranslation()
-  const lastPart = parts.length !== 0 ? parts[parts.length - 1] : undefined
-  type PartWithMeta = { running?: boolean; title?: string }
-  const lastPartWithMeta = lastPart as PartWithMeta | undefined
-
-  const running = lastPartWithMeta?.running
-  const title = (running && lastPartWithMeta?.title) ? lastPartWithMeta.title : t('thinking')
-
-  const hasContent = parts.some(
-    (p) => p.type !== 'reasoning' || (p as UIReasoningPart).reasoning || (p as UIReasoningPart).title
-  )
+  const { parts, running, title } = group
 
   const [open, setOpen] = useState('')
 
-  if (!running && !hasContent) return null
+  if (!running && parts.length === 0) return null
 
   return (
     <Accordion type="single" collapsible value={open} onValueChange={setOpen}>
       <AccordionItem value="item-1" style={{ border: 'none' }}>
         <AccordionTrigger className="py-1" showChevron={false}>
           <div className="flex flex-horz items-center gap-2">
-            <div className="text-sm">{title}</div>
+            <div className="text-sm">{title ?? t('thinking')}</div>
             {running && <RotatingLines width="16" height="16" strokeColor="gray" />}
           </div>
         </AccordionTrigger>
         <AccordionContent className="l-2 flex flex-col gap-2">
           {parts
             .filter((p) => p.type === 'reasoning' || p.type === 'tool-call')
-            .map((part, index) => {
-              return (
-                <div key={index} className="flex gap-2">
-                  <div className="flex flex-col items-center gap-2">
-                    <span className="mt-2 w-2 h-2 rounded-full bg-gray-500 shrink-0" />
-                    <div className="mt-2 h-full w-[1px] bg-black"></div>
-                  </div>
-                  <div className="flex-1">
-                    <ReasoningGroupPart
-                      key={index}
-                      part={part}
-                      subAssistants={subAssistants}
-                      assistantTools={assistantTools}
-                    />
-                  </div>
+            .map((part, index) => (
+              <div key={index} className="flex gap-2">
+                <div className="flex flex-col items-center gap-2">
+                  <span className="mt-2 w-2 h-2 rounded-full bg-gray-500 shrink-0" />
+                  <div className="mt-2 h-full w-[1px] bg-black" />
                 </div>
-              )
-            })}
+                <div className="flex-1">
+                  <ReasoningGroupPart
+                    part={part}
+                    subAssistants={subAssistants}
+                    assistantTools={assistantTools}
+                  />
+                </div>
+              </div>
+            ))}
         </AccordionContent>
       </AccordionItem>
     </Accordion>

--- a/apps/frontend/locales/en/logicle.json
+++ b/apps/frontend/locales/en/logicle.json
@@ -455,6 +455,7 @@
   "publish_no_effective_changes_message": "This draft has no changes compared to the published version.",
   "publish_no_effective_changes_hint": "To discard this draft, use the options menu.",
   "reasoning": "Reasoning",
+  "thinking": "Thinking",
   "reasoning_effort": "Reasoning effort",
   "reasoning_effort_not_supported": "Reasoning effort not supported by this model",
   "minimal": "Minimal",

--- a/apps/frontend/locales/it/logicle.json
+++ b/apps/frontend/locales/it/logicle.json
@@ -455,6 +455,7 @@
   "publish_no_effective_changes_message": "Questa bozza non contiene modifiche rispetto alla versione pubblicata.",
   "publish_no_effective_changes_hint": "Per eliminare questa bozza, usa il menu delle opzioni.",
   "reasoning": "Ragionamento",
+  "thinking": "Ragionamento",
   "reasoning_effort": "Livello di ragionamento",
   "reasoning_effort_not_supported": "Livello di ragionamento non supportato da questo modello",
   "minimal": "Minimo",

--- a/packages/core/src/chat/conversationUtils.ts
+++ b/packages/core/src/chat/conversationUtils.ts
@@ -1,5 +1,6 @@
 import {
   UIAssistantMessage,
+  UIAssistantMessagePart,
   IMessageGroup,
   IUserMessageGroup,
   MessageWithError,
@@ -78,34 +79,39 @@ const makeUserGroup = (
   }
 }
 
-const extractReasoningTitle = (text: string) => {
-  const raw = text ?? ''
+const splitReasoningPart = (part: dto.ReasoningPart, running: boolean): UIReasoningPart[] => {
+  const raw = part.reasoning ?? ''
   const lines = raw.split(/\r?\n/)
-  const first = (lines[0] ?? '').trim()
 
-  // Case A: full-line bold => ** Title **
-  const fullBoldMatch = first.match(/^\*\*(.+?)\*\*$/)
-  if (fullBoldMatch) {
-    return {
-      title: fullBoldMatch[1].trim(),
-      body: lines.slice(1).join('\n').trimStart(),
+  const sections: { title?: string; bodyLines: string[] }[] = []
+  let current: { title?: string; bodyLines: string[] } = { bodyLines: [] }
+
+  for (const line of lines) {
+    const m = line.trim().match(/^\*\*(.+?)\*\*$/)
+    if (m) {
+      sections.push(current)
+      current = { title: m[1].trim(), bodyLines: [] }
+    } else {
+      // Stop before an incomplete bold header still being streamed
+      const trimmed = line.trim()
+      if (/^\*\*/.test(trimmed) && !trimmed.slice(2).includes('**')) break
+      current.bodyLines.push(line)
     }
   }
+  sections.push(current)
 
-  // Case B: starts with ** but no closing ** yet (incomplete header)
-  const startsBold = /^\*\*/.test(first)
-  const hasClosingAfterStart = first.slice(2).includes('**')
-  if (startsBold && !hasClosingAfterStart) {
-    // Keep default title ("Reasoning"), clear body while streaming that first line
-    return {
-      body: '',
-    }
+  const filtered = sections.filter((s) => s.title !== undefined || s.bodyLines.join('').trim())
+
+  if (filtered.length === 0) {
+    return [{ ...part, reasoning: '', title: undefined, running }]
   }
 
-  // Fallback: default title + full body
-  return {
-    body: raw,
-  }
+  return filtered.map((s, i) => ({
+    ...part,
+    reasoning: s.bodyLines.join('\n').trim(),
+    title: s.title,
+    running: running && i === filtered.length - 1,
+  }))
 }
 
 const makeAssistantGroup = (
@@ -121,33 +127,17 @@ const makeAssistantGroup = (
     if (msg.role === 'assistant') {
       const uiAssistantMessage = {
         ...msg,
-        parts: msg.parts.map((part) => {
+        parts: msg.parts.flatMap((part): UIAssistantMessagePart[] => {
           if (part.type === 'tool-call') {
-            return {
-              ...part,
-              status: 'running',
-            } satisfies UIToolCallPart
+            return [{ ...part, status: 'running' } satisfies UIToolCallPart]
           } else if (part.type === 'text') {
-            return {
-              ...part,
-              running: streamingPart === part,
-            }
+            return [{ ...part, running: streamingPart === part }]
           } else if (part.type === 'reasoning') {
-            const { body, title } = extractReasoningTitle(part.reasoning)
-            return {
-              ...part,
-              reasoning: body,
-              title,
-              running: streamingPart === part,
-            } satisfies UIReasoningPart
+            return splitReasoningPart(part, streamingPart === part)
           } else if (part.type === 'builtin-tool-call') {
-            return {
-              ...part,
-              status: 'running',
-              type: 'tool-call',
-            } satisfies UIToolCallPart
+            return [{ ...part, status: 'running', type: 'tool-call' } satisfies UIToolCallPart]
           } else {
-            return part
+            return [part]
           }
         }),
       } satisfies UIAssistantMessage

--- a/packages/core/src/chat/conversationUtils.ts
+++ b/packages/core/src/chat/conversationUtils.ts
@@ -1,6 +1,8 @@
 import {
   UIAssistantMessage,
   UIAssistantMessagePart,
+  UIReasoningGroup,
+  UIReasoningLikePart,
   IMessageGroup,
   IUserMessageGroup,
   MessageWithError,
@@ -112,6 +114,44 @@ const splitReasoningPart = (part: dto.ReasoningPart, running: boolean): UIReason
     title: s.title,
     running: running && i === filtered.length - 1,
   }))
+}
+
+const canGroupInReasoning = (p: UIAssistantMessagePart) =>
+  p.type === 'builtin-tool-result' || p.type === 'tool-call'
+
+const isEmptyReasoningPart = (p: UIReasoningLikePart) =>
+  p.type === 'reasoning' && !p.reasoning && !p.title
+
+export const groupForReasoning = (
+  parts: UIAssistantMessagePart[]
+): Array<UIAssistantMessagePart | UIReasoningGroup> => {
+  const result: Array<UIAssistantMessagePart | UIReasoningGroup> = []
+  let buffer: UIReasoningLikePart[] = []
+
+  const flushBuffer = () => {
+    if (buffer.length === 0) return
+    const running = buffer.some((p) => 'running' in p && (p as UIReasoningPart).running)
+    const title = buffer
+      .filter((p): p is UIReasoningPart => p.type === 'reasoning' && !!(p as UIReasoningPart).running && !!(p as UIReasoningPart).title)
+      .at(-1)?.title
+    const displayParts = buffer.filter((p) => !isEmptyReasoningPart(p))
+    result.push({ type: 'reasoning-group', parts: displayParts, running, title })
+    buffer = []
+  }
+
+  for (const p of parts) {
+    if (p.type === 'reasoning') {
+      buffer.push(p)
+    } else if (buffer.length !== 0 && canGroupInReasoning(p)) {
+      buffer.push(p as UIReasoningLikePart)
+    } else {
+      flushBuffer()
+      result.push(p)
+    }
+  }
+  flushBuffer()
+
+  return result
 }
 
 const makeAssistantGroup = (

--- a/packages/core/src/chat/types.ts
+++ b/packages/core/src/chat/types.ts
@@ -23,6 +23,21 @@ export type UITextPart = dto.TextPart & {
   running: boolean
 }
 
+export type UIReasoningLikePart =
+  | UIReasoningPart
+  | UIToolCallPart
+  | dto.BuiltinToolCallResultPart
+  | dto.ToolCallResultPart
+
+export type UIReasoningGroup = {
+  type: 'reasoning-group'
+  /** Filtered parts: empty reasoning parts (no title, no body) are excluded. */
+  parts: UIReasoningLikePart[]
+  running: boolean
+  /** Title of the last running reasoning part, if any. */
+  title?: string
+}
+
 export type UIAssistantMessagePart =
   | UIReasoningPart
   | UITextPart


### PR DESCRIPTION
## Summary

Gemini sends all reasoning as a single part whose text uses `**bold**` lines as step headers, while OpenAI sends one part per step. This aligns the UI behaviour: both providers now produce one `UIReasoningPart` per section, each with its own accordion-trigger label and body, without any backend changes.

## Details

- `splitReasoningPart` in `conversationUtils.ts` replaces `extractReasoningTitle`. It `flatMap`s each raw `ReasoningPart` into multiple `UIReasoningPart`s — one per `**Title**` section — with the section body as `reasoning` and the title as the live step label shown in the accordion trigger.
- While a bold header is still being streamed (no closing `**` yet), it is held back so no partial `**Ti` flash appears in the body.
- Conversion is purely client-side, in the pure-TS `conversationUtils.ts`, keeping presentation logic out of the data layer.
- `Reasoning.tsx` is simplified: it renders a single section body as plain text. Sectioning is now a data concern, not a presentation concern.

## Tests

- `npm run check-types` — passes with no errors.