### PR TITLE
fix(chat): show blinking cursor when assistant message has no parts yet

### DIFF
--- a/apps/frontend/app/chat/components/Chat.tsx
+++ b/apps/frontend/app/chat/components/Chat.tsx
@@ -106,19 +106,17 @@ export const Chat = ({
   if (!selectedConversation) {
     return null
   }
-  let streamingPart: dto.MessagePart | undefined
+  let streamingMessageId: string | undefined
   if (chatStatus.state !== 'idle' && selectedConversation.messages.length) {
     const lastMessage = selectedConversation.messages[selectedConversation.messages.length - 1]
     if (lastMessage.role === 'assistant' || lastMessage.role === 'tool') {
-      if (lastMessage.parts.length) {
-        streamingPart = lastMessage.parts[lastMessage.parts.length - 1]
-      }
+      streamingMessageId = lastMessage.id
     }
   }
   const groupList = groupMessages(
     selectedConversation.messages,
     selectedConversation.targetLeaf,
-    streamingPart
+    streamingMessageId
   )
   const userMessageCount = groupList.filter((g) => g.actor === 'user').length
 

--- a/apps/frontend/app/chat/components/ChatPageContextProvider.tsx
+++ b/apps/frontend/app/chat/components/ChatPageContextProvider.tsx
@@ -389,7 +389,7 @@ export const ChatPageContextProvider: FC<Props> = ({ children }) => {
     const thinkingPlaceholder: dto.AssistantMessage = {
       id: THINKING_PLACEHOLDER_ID,
       role: 'assistant',
-      parts: [{ type: 'text', text: '' }],
+      parts: [],
       conversationId: conversation.id,
       parent: userMessage.id,
       sentAt: new Date().toISOString(),

--- a/apps/frontend/app/chat/components/ReasoningGroup.tsx
+++ b/apps/frontend/app/chat/components/ReasoningGroup.tsx
@@ -6,7 +6,7 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion'
 import { UIReasoningGroup, UIReasoningLikePart, UIReasoningPart } from '@/lib/chat/types'
-import { FC, useState, useEffect } from 'react'
+import { FC, useState } from 'react'
 import { RotatingLines } from 'react-loader-spinner'
 import * as dto from '@/types/dto'
 import { useTranslation } from 'react-i18next'
@@ -49,13 +49,7 @@ export const ReasoningGroup: FC<{
   const { t } = useTranslation()
   const { parts, running, title } = group
 
-  const [open, setOpen] = useState(running ? 'item-1' : '')
-
-  // Auto-expand while streaming, auto-collapse when done.
-  // User can still toggle manually during streaming.
-  useEffect(() => {
-    if (!running) setOpen('')
-  }, [running])
+  const [open, setOpen] = useState('')
 
   if (!running && parts.length === 0) return null
 

--- a/apps/frontend/app/chat/components/ReasoningGroup.tsx
+++ b/apps/frontend/app/chat/components/ReasoningGroup.tsx
@@ -6,7 +6,7 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion'
 import { UIReasoningGroup, UIReasoningLikePart, UIReasoningPart } from '@/lib/chat/types'
-import { FC, useState } from 'react'
+import { FC, useState, useEffect } from 'react'
 import { RotatingLines } from 'react-loader-spinner'
 import * as dto from '@/types/dto'
 import { useTranslation } from 'react-i18next'
@@ -49,7 +49,13 @@ export const ReasoningGroup: FC<{
   const { t } = useTranslation()
   const { parts, running, title } = group
 
-  const [open, setOpen] = useState('')
+  const [open, setOpen] = useState(running ? 'item-1' : '')
+
+  // Auto-expand while streaming, auto-collapse when done.
+  // User can still toggle manually during streaming.
+  useEffect(() => {
+    if (!running) setOpen('')
+  }, [running])
 
   if (!running && parts.length === 0) return null
 

--- a/apps/frontend/app/chat/components/TextPart.tsx
+++ b/apps/frontend/app/chat/components/TextPart.tsx
@@ -38,8 +38,8 @@ export const TextPart: FC<{
     }
   }
   const processedMarkdown = useMemo(
-    () => computeMarkdown(part.text, message.citations) || (part.running ? ' ' : ''),
-    [part.text, message.citations, part.running]
+    () => computeMarkdown(part.text, message.citations),
+    [part.text, message.citations]
   )
   return (
     <>
@@ -51,10 +51,16 @@ export const TextPart: FC<{
           part={part}
           height={editHeight}
         />
-      ) : (
+      ) : processedMarkdown ? (
         <MemoizedMarkdown ref={messageViewRef} className={className}>
           {processedMarkdown}
         </MemoizedMarkdown>
+      ) : (
+        // ReactMarkdown renders nothing for empty/whitespace strings, so the CSS
+        // ::after cursor has no child element to attach to. Render a real element.
+        <div ref={messageViewRef} className={className}>
+          {part.running && <p />}
+        </div>
       )}
     </>
   )

--- a/apps/frontend/app/chat/components/chatRunConversationState.ts
+++ b/apps/frontend/app/chat/components/chatRunConversationState.ts
@@ -37,16 +37,9 @@ export const applyChatRunEventToConversation = (
     const messages = conversation.messages
     const lastMsg = messages[messages.length - 1]
     if (lastMsg?.id === THINKING_PLACEHOLDER_ID) {
-      // Keep an empty text part so the streaming cursor (▍) stays visible until
-      // the first real content part arrives and replaces it.
-      const assistantMsg = event.msg as dto.AssistantMessage
-      const msg: dto.AssistantMessage =
-        assistantMsg.parts.length === 0
-          ? { ...assistantMsg, parts: [{ type: 'text', text: '' }] }
-          : assistantMsg
       return {
         ...conversation,
-        messages: [...messages.slice(0, -1), msg],
+        messages: [...messages.slice(0, -1), event.msg],
       }
     }
   }

--- a/packages/core/src/chat/conversationUtils.ts
+++ b/packages/core/src/chat/conversationUtils.ts
@@ -154,10 +154,12 @@ export const groupForReasoning = (
   return result
 }
 
+const DUMMY_TEXT_PART: UIAssistantMessagePart = { type: 'text', text: '', running: true }
+
 const makeAssistantGroup = (
   messages: MessageWithError[],
   allMessages: MessageWithError[],
-  streamingPart?: dto.MessagePart
+  streamingMessageId?: string
 ): IMessageGroup => {
   const UIMessages: UIMessage[] = []
   const pendingToolCalls = new Map<string, UIToolCallPart>()
@@ -165,21 +167,29 @@ const makeAssistantGroup = (
   for (const msg of messages) {
     let msgExt: UIMessage
     if (msg.role === 'assistant') {
+      const isStreaming = msg.id === streamingMessageId
+      const lastPartIndex = msg.parts.length - 1
+      const uiParts: UIAssistantMessagePart[] = msg.parts.flatMap((part, i): UIAssistantMessagePart[] => {
+        const partIsRunning = isStreaming && i === lastPartIndex
+        if (part.type === 'tool-call') {
+          return [{ ...part, status: 'running' } satisfies UIToolCallPart]
+        } else if (part.type === 'text') {
+          return [{ ...part, running: partIsRunning }]
+        } else if (part.type === 'reasoning') {
+          return splitReasoningPart(part, partIsRunning)
+        } else if (part.type === 'builtin-tool-call') {
+          return [{ ...part, status: 'running', type: 'tool-call' } satisfies UIToolCallPart]
+        } else {
+          return [part]
+        }
+      })
+      // When nothing has arrived yet, show a blinking cursor placeholder.
+      if (isStreaming && uiParts.length === 0) {
+        uiParts.push(DUMMY_TEXT_PART)
+      }
       const uiAssistantMessage = {
         ...msg,
-        parts: msg.parts.flatMap((part): UIAssistantMessagePart[] => {
-          if (part.type === 'tool-call') {
-            return [{ ...part, status: 'running' } satisfies UIToolCallPart]
-          } else if (part.type === 'text') {
-            return [{ ...part, running: streamingPart === part }]
-          } else if (part.type === 'reasoning') {
-            return splitReasoningPart(part, streamingPart === part)
-          } else if (part.type === 'builtin-tool-call') {
-            return [{ ...part, status: 'running', type: 'tool-call' } satisfies UIToolCallPart]
-          } else {
-            return [part]
-          }
-        }),
+        parts: uiParts,
       } satisfies UIAssistantMessage
       const toolCalls = uiAssistantMessage.parts.filter((b) => b.type === 'tool-call')
       toolCalls.forEach((toolCall) => {
@@ -258,7 +268,7 @@ const makeAssistantGroup = (
 export const groupMessages = (
   messages_: MessageWithError[],
   targetLeaf?: string,
-  streamingPart?: dto.MessagePart
+  streamingMessageId?: string
 ): IMessageGroup[] => {
   const flattened = flatten(messages_, targetLeaf)
   const groups: IMessageGroup[] = []
@@ -266,7 +276,7 @@ export const groupMessages = (
   for (const message of flattened) {
     if (message.role === 'user') {
       if (currentAssistantMessages) {
-        groups.push(makeAssistantGroup(currentAssistantMessages, messages_, streamingPart))
+        groups.push(makeAssistantGroup(currentAssistantMessages, messages_, streamingMessageId))
       }
       currentAssistantMessages = undefined
       groups.push(makeUserGroup(message, messages_))
@@ -276,7 +286,7 @@ export const groupMessages = (
     }
   }
   if (currentAssistantMessages) {
-    groups.push(makeAssistantGroup(currentAssistantMessages, messages_, streamingPart))
+    groups.push(makeAssistantGroup(currentAssistantMessages, messages_, streamingMessageId))
   }
   return groups
 }

--- a/packages/core/src/chat/streamApply.ts
+++ b/packages/core/src/chat/streamApply.ts
@@ -25,12 +25,6 @@ export function applyStreamPartToMessage(
       if (!isAssistantMessagePart(streamPart.part)) {
         throw new Error(`Invalid assistant part type: ${streamPart.part.type}`)
       }
-      // If the only existing part is an empty text placeholder (the streaming cursor
-      // sentinel), replace it with the first real part rather than appending.
-      const existing = message.parts
-      if (existing.length === 1 && existing[0].type === 'text' && existing[0].text === '') {
-        return { ...message, parts: [streamPart.part] }
-      }
       return {
         ...message,
         parts: [...message.parts, streamPart.part],


### PR DESCRIPTION
## Summary

Fixes the silent wait between sending a message and the first token arriving. When a provider takes time before emitting any content, the UI showed nothing — no cursor, no spinner.

## Details

- **Root cause:** streaming state was detected via object-identity on `streamingPart` (last part of last message), which is `undefined` when `parts: []`. The DTO-level empty-text sentinel injected by PR #929 worked around this, but `ReactMarkdown` renders nothing for an empty string, leaving the CSS `::after` cursor with no element to attach to.
- **Fix:** replace `streamingPart` with `streamingMessageId` (the ID of the last assistant/tool message when not idle). In `makeAssistantGroup`, when the streaming message has zero real parts, inject a synthetic `UITextPart { text: '', running: true }` into the UI model only — it disappears automatically as soon as the first real part arrives.
- **TextPart:** when text is empty, bypass `ReactMarkdown` and render a plain `<div><p/></div>` so the CSS `::after` cursor has an element to attach to.
- **Cleanup:** remove the DTO-level empty-text sentinel from `chatRunConversationState.ts`, the sentinel-replacement guard from `streamApply.ts`, the broken `|| (running ? ' ' : '')` fallback from `TextPart.tsx`, and the unnecessary `parts: [...]` on the thinking placeholder.

## Tests

- `npm run check-types` — clean