### PR TITLE
fix(evaluate): disable auto-summary during assistant evaluation

### DIFF
--- a/apps/backend/api/assistants/evaluate/route.ts
+++ b/apps/backend/api/assistants/evaluate/route.ts
@@ -59,6 +59,7 @@ export const POST = operation({
         user: session.userId,
         conversationId,
         rootOwner: { type: 'USER', id: session.userId },
+        disableAutoSummary: true,
       }
     )
 

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -104,6 +104,7 @@ interface Options {
   }
   debug?: boolean
   abortSignal?: AbortSignal
+  disableAutoSummary?: boolean
 }
 
 export class ChatAbortedError extends Error {
@@ -873,7 +874,10 @@ export class ChatAssistant {
   }
 
   async invokeLlmAndProcessResponse(chatState: ChatState, clientSink: ClientSink) {
-    const generateSummary = env.chat.autoSummary.enable && chatState.chatHistory.length === 1
+    const generateSummary =
+      !this.options.disableAutoSummary &&
+      env.chat.autoSummary.enable &&
+      chatState.chatHistory.length === 1
     const receiveStreamIntoMessage = async (
       stream: ai.StreamTextResult<Record<string, ai.Tool>, any>
     ): Promise<Usage | undefined> => {


### PR DESCRIPTION
## Summary

The `/api/assistants/evaluate` endpoint was triggering the auto-summary flow after its first response, causing an unintended extra LLM call (typically `gpt-4o-mini`) to generate a chat title. Evaluation/preview should only return the assistant response.

## Details

- Added `disableAutoSummary?: boolean` to the `Options` interface in `ChatAssistant`
- Gated the `generateAndSendSummary` call in `invokeLlmAndProcessResponse` on `!this.options.disableAutoSummary`
- Set `disableAutoSummary: true` in the evaluate route options

Fixes logicleai/logicle-issues#254

## Tests

- `npm run check-types` — passed