### PR TITLE
refactor(chat): extract loadKnowledgeFilePart, remove KnowledgePlugin from prompt path

### DIFF
--- a/__tests__/chatAssistant.test.ts
+++ b/__tests__/chatAssistant.test.ts
@@ -315,21 +315,34 @@ describe('ChatAssistant.assistantParamsFrom', () => {
 // ============================================================
 
 describe('ChatAssistant.withBuiltinTools', () => {
-  test('appends KnowledgePlugin when knowledge capability is not false', async () => {
+  test('appends KnowledgePlugin when knowledge=true and sendInPrompt=false', async () => {
     const tools = [makeToolImpl()]
     const model = makeFakeLlmModel({ capabilities: { knowledge: true } } as unknown as Partial<LlmModel>)
     const result = await ChatAssistant.withBuiltinTools(tools, model)
     expect(result).toHaveLength(2)
   })
 
-  test('does not append KnowledgePlugin when knowledge=false', async () => {
+  test('does not append KnowledgePlugin when knowledge capability=false', async () => {
     const tools = [makeToolImpl()]
     const model = makeFakeLlmModel({ capabilities: { knowledge: false } } as unknown as Partial<LlmModel>)
     const result = await ChatAssistant.withBuiltinTools(tools, model)
     expect(result).toHaveLength(1)
   })
 
-  test('defaults to adding KnowledgePlugin when knowledge capability is undefined', async () => {
+  test('does not append KnowledgePlugin when sendInPrompt=true (files go directly into prompt)', async () => {
+    const { default: env } = await import('@/lib/env')
+    ;(env as any).knowledge.sendInPrompt = true
+    try {
+      const tools = [makeToolImpl()]
+      const model = makeFakeLlmModel({ capabilities: { knowledge: true } } as unknown as Partial<LlmModel>)
+      const result = await ChatAssistant.withBuiltinTools(tools, model)
+      expect(result).toHaveLength(1)
+    } finally {
+      ;(env as any).knowledge.sendInPrompt = false
+    }
+  })
+
+  test('defaults to adding KnowledgePlugin when knowledge capability is undefined and sendInPrompt=false', async () => {
     const tools: ToolImplementation[] = []
     const model = makeFakeLlmModel({ capabilities: {} } as unknown as Partial<LlmModel>)
     const result = await ChatAssistant.withBuiltinTools(tools, model)

--- a/__tests__/fileMetadataInterspersing.test.ts
+++ b/__tests__/fileMetadataInterspersing.test.ts
@@ -538,14 +538,13 @@ describe('preparePreamblePlan — interspersed knowledge mode', () => {
         knowledge: { sendInPrompt: true, intersperseFileMetadata: true, alwaysConvertToText: true },
       },
     }))
-    // Mock KnowledgePlugin import
-    const knowledgeToInputPart = vi.fn().mockResolvedValue({ type: 'text', text: 'extracted' })
+    const mockLoadKnowledgeFilePart = vi.fn().mockResolvedValue({ type: 'text', text: 'extracted' })
     vi.doMock('@/backend/lib/tools/knowledge/implementation', () => ({
+      loadKnowledgeFilePart: mockLoadKnowledgeFilePart,
       KnowledgePlugin: class {
         toolParams = { promptFragment: '' }
         supportedMedia = []
         functions = async () => ({})
-        knowledgeToInputPart = knowledgeToInputPart
       },
     }))
 
@@ -575,15 +574,15 @@ describe('preparePreamblePlan — interspersed knowledge mode', () => {
         knowledge: { sendInPrompt: true, intersperseFileMetadata: true, alwaysConvertToText: true },
       },
     }))
-    const knowledgeToInputPart = vi.fn()
+    const mockLoadKnowledgeFilePart = vi.fn()
       .mockResolvedValueOnce({ type: 'text', text: 'handbook text' })
       .mockResolvedValueOnce({ type: 'text', text: 'photo text' })
     vi.doMock('@/backend/lib/tools/knowledge/implementation', () => ({
+      loadKnowledgeFilePart: mockLoadKnowledgeFilePart,
       KnowledgePlugin: class {
         toolParams = { promptFragment: '' }
         supportedMedia = []
         functions = async () => ({})
-        knowledgeToInputPart = knowledgeToInputPart
       },
     }))
 
@@ -615,13 +614,13 @@ describe('preparePreamblePlan — interspersed knowledge mode', () => {
         knowledge: { sendInPrompt: true, intersperseFileMetadata: false, alwaysConvertToText: true },
       },
     }))
-    const knowledgeToInputPart = vi.fn().mockResolvedValue({ type: 'text', text: 'x' })
+    const mockLoadKnowledgeFilePart = vi.fn().mockResolvedValue({ type: 'text', text: 'x' })
     vi.doMock('@/backend/lib/tools/knowledge/implementation', () => ({
+      loadKnowledgeFilePart: mockLoadKnowledgeFilePart,
       KnowledgePlugin: class {
         toolParams = { promptFragment: '' }
         supportedMedia = []
         functions = async () => ({})
-        knowledgeToInputPart = knowledgeToInputPart
       },
     }))
 
@@ -644,15 +643,15 @@ describe('preparePreamblePlan — interspersed knowledge mode', () => {
         knowledge: { sendInPrompt: true, intersperseFileMetadata: false, alwaysConvertToText: true },
       },
     }))
-    const knowledgeToInputPart = vi.fn()
+    const mockLoadKnowledgeFilePart = vi.fn()
       .mockResolvedValueOnce({ type: 'text', text: 'handbook text' })
       .mockResolvedValueOnce({ type: 'text', text: 'photo text' })
     vi.doMock('@/backend/lib/tools/knowledge/implementation', () => ({
+      loadKnowledgeFilePart: mockLoadKnowledgeFilePart,
       KnowledgePlugin: class {
         toolParams = { promptFragment: '' }
         supportedMedia = []
         functions = async () => ({})
-        knowledgeToInputPart = knowledgeToInputPart
       },
     }))
 
@@ -680,11 +679,11 @@ describe('preparePreamblePlan — interspersed knowledge mode', () => {
       },
     }))
     vi.doMock('@/backend/lib/tools/knowledge/implementation', () => ({
+      loadKnowledgeFilePart: vi.fn(),
       KnowledgePlugin: class {
         toolParams = { promptFragment: '' }
         supportedMedia = []
         functions = async () => ({})
-        knowledgeToInputPart = vi.fn()
       },
     }))
 
@@ -707,13 +706,13 @@ describe('preparePreamblePlan — interspersed knowledge mode', () => {
         knowledge: { sendInPrompt: true, intersperseFileMetadata: true, alwaysConvertToText: true },
       },
     }))
-    const knowledgeToInputPart = vi.fn().mockResolvedValue({ type: 'text', text: '' })
+    const mockLoadKnowledgeFilePart = vi.fn().mockResolvedValue({ type: 'text', text: '' })
     vi.doMock('@/backend/lib/tools/knowledge/implementation', () => ({
+      loadKnowledgeFilePart: mockLoadKnowledgeFilePart,
       KnowledgePlugin: class {
         toolParams = { promptFragment: '' }
         supportedMedia = []
         functions = async () => ({})
-        knowledgeToInputPart = knowledgeToInputPart
       },
     }))
     const three: dto.AssistantFile[] = [

--- a/__tests__/preamblePlanning.test.ts
+++ b/__tests__/preamblePlanning.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { LlmModel } from '@/lib/chat/models'
 
-const { mockKnowledgeToInputPart } = vi.hoisted(() => ({
-  mockKnowledgeToInputPart: vi.fn(),
+const { mockLoadKnowledgeFilePart } = vi.hoisted(() => ({
+  mockLoadKnowledgeFilePart: vi.fn(),
 }))
 
 vi.mock('@/lib/env', () => ({
@@ -12,15 +12,13 @@ vi.mock('@/lib/env', () => ({
 }))
 
 vi.mock('@/backend/lib/tools/knowledge/implementation', () => ({
+  loadKnowledgeFilePart: mockLoadKnowledgeFilePart,
   KnowledgePlugin: class KnowledgePlugin {
     toolParams = { id: 'knowledge', provisioned: false, promptFragment: '', name: 'knowledge' }
     params: unknown = {}
     constructor(toolParams: unknown, params: unknown) {
       this.toolParams = toolParams as typeof this.toolParams
       this.params = params
-    }
-    async knowledgeToInputPart(...args: unknown[]) {
-      return mockKnowledgeToInputPart(...args)
     }
   },
 }))
@@ -38,7 +36,7 @@ describe('preamble planning and rendering', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mockKnowledgeToInputPart.mockResolvedValue({ type: 'text', text: 'knowledge content' })
+    mockLoadKnowledgeFilePart.mockResolvedValue({ type: 'text', text: 'knowledge content' })
   })
 
   test('preparePreamblePlan stays lightweight and does not materialize knowledge parts', async () => {
@@ -54,7 +52,7 @@ describe('preamble planning and rendering', () => {
     expect(plan.knowledgeFileEntries).toEqual([
       { fileId: 'k1', fileName: 'k1.png', mimetype: 'image/png', size: 1, partIndex: 0 },
     ])
-    expect(mockKnowledgeToInputPart).not.toHaveBeenCalled()
+    expect(mockLoadKnowledgeFilePart).not.toHaveBeenCalled()
   })
 
   test('buildEstimatedPreambleSegments stays lightweight without materialization', async () => {
@@ -74,7 +72,7 @@ describe('preamble planning and rendering', () => {
     expect(segments[1]?.knowledgeFileEntries).toEqual([
       { fileId: 'k1', fileName: 'k1.png', mimetype: 'image/png', size: 1, partIndex: 0 },
     ])
-    expect(mockKnowledgeToInputPart).not.toHaveBeenCalled()
+    expect(mockLoadKnowledgeFilePart).not.toHaveBeenCalled()
   })
 
   test('renderPreamblePlan materializes knowledge parts for real model rendering', async () => {
@@ -90,7 +88,7 @@ describe('preamble planning and rendering', () => {
     const segments = await renderPreamblePlan(plan)
 
     expect(segments).toHaveLength(2)
-    expect(mockKnowledgeToInputPart).toHaveBeenCalledTimes(1)
+    expect(mockLoadKnowledgeFilePart).toHaveBeenCalledTimes(1)
     expect(segments[1]?.message).toEqual({
       role: 'user',
       content: [{ type: 'text', text: 'knowledge content' }],
@@ -118,7 +116,7 @@ describe('preamble planning and rendering', () => {
     expect(segments).toHaveLength(2)
     expect(segments[1]?.message).toEqual({ role: 'user', content: [] })
     expect(segments[1]?.knowledgeFileEntries).toHaveLength(200)
-    expect(mockKnowledgeToInputPart).not.toHaveBeenCalled()
+    expect(mockLoadKnowledgeFilePart).not.toHaveBeenCalled()
   })
 
 })

--- a/apps/backend/lib/chat/preamble.ts
+++ b/apps/backend/lib/chat/preamble.ts
@@ -102,22 +102,21 @@ export async function computeSystemPrompt(
   }
 }
 
-export async function withBuiltinTools(tools: ToolImplementation[], llmModel: LlmModel) {
+export async function withBuiltinTools(tools: ToolImplementation[], llmModel: LlmModel): Promise<ToolImplementation[]> {
   if (!(llmModel.capabilities.knowledge ?? true)) {
     return tools
   }
   const { KnowledgePlugin } = await import('@/backend/lib/tools/knowledge/implementation')
+  // Only add the plugin when sendInPrompt is off — that is the only mode where
+  // the plugin exposes an active function (GetFile) to the LLM. When sendInPrompt
+  // is on, knowledge content is injected directly into the prompt; the plugin
+  // contributes nothing as a tool.
+  if (env.knowledge.sendInPrompt) {
+    return tools
+  }
   return [
     ...tools,
-    new KnowledgePlugin(
-      {
-        id: 'knowledge',
-        provisioned: false,
-        promptFragment: '',
-        name: 'knowledge',
-      },
-      {}
-    ),
+    new KnowledgePlugin({ id: 'knowledge', provisioned: false, promptFragment: '', name: 'knowledge' }, {}),
   ]
 }
 
@@ -138,6 +137,10 @@ export async function buildPreambleSegments({
   return renderPreamblePlan(plan)
 }
 
+const knowledgeFileSelectionNotice =
+  `When the user requests to gather information from unspecified files, ` +
+  `he's referring to files attached in the same message, so **do not mention / use the knowledge if it's not useful to answer the user question**.`
+
 export async function preparePreamblePlan({
   assistantParams,
   llmModel,
@@ -156,101 +159,50 @@ export async function preparePreamblePlan({
   if (knowledge.length === 0 || !env.knowledge.sendInPrompt) {
     return { systemPromptMessage }
   }
-  const { KnowledgePlugin } = await import('@/backend/lib/tools/knowledge/implementation')
-  const knowledgePlugin = resolvedTools.find((t) => t instanceof KnowledgePlugin)
+  const { loadKnowledgeFilePart } = await import('@/backend/lib/tools/knowledge/implementation')
 
-  if (env.knowledge.intersperseFileMetadata) {
-    const knowledgePrompt = `
-      Assistant knowledge files are embedded in this conversation, each preceded by a brief descriptor.
-      When the user requests to gather information from unspecified files, he's referring to files attached in the same message, so **do not mention / use the knowledge if it's not useful to answer the user question**.
-      `
-    const knowledgeFileEntries: KnowledgeFileEntry[] = knowledge.map((k, index) => ({
-      fileId: k.id,
-      fileName: k.name,
-      mimetype: k.type,
-      size: k.size,
-      partIndex: index * 2 + 1,
-    }))
-    if (!knowledgePlugin) {
-      return { systemPromptMessage, knowledgePrompt, knowledgeFileEntries, intersperseFileMetadata: true }
-    }
-    return {
-      systemPromptMessage,
-      knowledgePrompt,
-      knowledgeFileEntries,
-      intersperseFileMetadata: true,
-      materializeKnowledgeSegment: async () => {
-        // Limit concurrency to avoid saturating the libuv thread pool.
-        // mapWithConcurrency callback receives only the item; thread the index via indexed entries.
-        const indexedKnowledge = knowledge.map((k, i) => ({ k, i }))
-        const pairs = await mapWithConcurrency(
-          indexedKnowledge,
-          async ({ k, i }): Promise<[ai.TextPart, ai.TextPart | ai.ImagePart | ai.FilePart]> => {
-            const descriptor: ai.TextPart = {
-              type: 'text',
-              text: fileDescriptorText(k.name, k.id, k.type, k.size, i + 1, 'Knowledge'),
-            }
-            const content = await (knowledgePlugin as InstanceType<typeof KnowledgePlugin>).knowledgeToInputPart(k, llmModel)
-            return [descriptor, content]
-          },
-          8
-        )
-        const interleavedParts: (ai.TextPart | ai.ImagePart | ai.FilePart)[] = []
-        const analysisFileIds: string[] = []
-        for (let i = 0; i < pairs.length; i++) {
-          const [descriptor, content] = pairs[i]!
-          interleavedParts.push(descriptor, content)
-          if (content.type === 'file') {
-            const id = knowledge[i]?.id
-            if (id) analysisFileIds.push(id)
-          }
-        }
-        return {
-          message: { role: 'user', content: interleavedParts },
-          analysisFileIds,
-        }
-      },
-    }
-  }
+  const intersperse = env.knowledge.intersperseFileMetadata
 
-  const knowledgePrompt = `
-      More files are available as assistant knowledge.
-      These files can be retrieved or processed by function calls referring to their id.
-      Here is the assistant knowledge:
-      ${JSON.stringify(knowledge)}
-      When the user requests to gather information from unspecified files, he's referring to files attached in the same message, so **do not mention / use the knowledge if it's not useful to answer the user question**.
-      `
-  if (!knowledgePlugin) {
-    return { systemPromptMessage, knowledgePrompt }
-  }
+  const knowledgePrompt = intersperse
+    ? `Assistant knowledge files are embedded in this conversation, each preceded by a brief descriptor.\n${knowledgeFileSelectionNotice}`
+    : `More files are available as assistant knowledge. These files can be retrieved or processed by function calls referring to their id.\nHere is the assistant knowledge:\n${JSON.stringify(knowledge)}\n${knowledgeFileSelectionNotice}`
+
   const knowledgeFileEntries: KnowledgeFileEntry[] = knowledge.map((k, index) => ({
     fileId: k.id,
     fileName: k.name,
     mimetype: k.type,
     size: k.size,
-    partIndex: index,
+    partIndex: intersperse ? index * 2 + 1 : index,
   }))
+
   return {
     systemPromptMessage,
     knowledgePrompt,
     knowledgeFileEntries,
+    intersperseFileMetadata: intersperse || undefined,
+    // Limit concurrency to avoid saturating the libuv thread pool and the Node.js microtask queue
+    // when an assistant has many knowledge files — unbounded Promise.all causes multi-second stalls.
     materializeKnowledgeSegment: async () => {
-      // Limit concurrency to avoid saturating the libuv thread pool and
-      // the Node.js microtask queue when an assistant has many knowledge files.
-      // Unbounded Promise.all over hundreds of files causes multi-second
-      // health-check stalls and S3 socket pool exhaustion.
-      const parts = await mapWithConcurrency(
-        knowledge,
-        (k) => (knowledgePlugin as InstanceType<typeof KnowledgePlugin>).knowledgeToInputPart(k, llmModel),
+      const indexed = knowledge.map((k, i) => ({ k, i }))
+      const loaded = await mapWithConcurrency(
+        indexed,
+        async ({ k, i }) => ({
+          fileId: k.id,
+          descriptor: intersperse
+            ? fileDescriptorText(k.name, k.id, k.type, k.size, i + 1, 'Knowledge')
+            : null,
+          content: await loadKnowledgeFilePart(k, llmModel),
+        }),
         8
       )
-      const analysisFileIds = parts
-        .flatMap((part, index) => (part.type === 'file' ? [knowledge[index]?.id ?? ''] : []))
-        .filter((id) => id.length > 0)
-      return {
-        message: { role: 'user', content: parts },
-        analysisFileIds,
+      const parts: (ai.TextPart | ai.ImagePart | ai.FilePart)[] = []
+      const analysisFileIds: string[] = []
+      for (const { fileId, descriptor, content } of loaded) {
+        if (descriptor) parts.push({ type: 'text', text: descriptor })
+        parts.push(content)
+        if (content.type === 'file') analysisFileIds.push(fileId)
       }
+      return { message: { role: 'user', content: parts }, analysisFileIds }
     },
   }
 }

--- a/apps/backend/lib/tools/knowledge/implementation.ts
+++ b/apps/backend/lib/tools/knowledge/implementation.ts
@@ -18,6 +18,36 @@ import { dtoFileToLlmFilePart } from '@/backend/lib/chat/conversion'
 import { cachingExtractor } from '@/lib/textextraction/cache'
 import type { FileDbRow } from '@/backend/models/file'
 
+export async function loadKnowledgeFilePart(
+  knowledgeFile: dto.AssistantFile,
+  llmModel: LlmModel
+): Promise<ai.TextPart | ai.ImagePart | ai.FilePart> {
+  const fileEntry = await db
+    .selectFrom('File')
+    .leftJoin('FileBlob', 'FileBlob.id', 'File.fileBlobId')
+    .select([
+      'File.id as id',
+      'File.name as name',
+      'File.ownerType as ownerType',
+      'File.ownerId as ownerId',
+      'File.path as path',
+      'File.type as type',
+      'File.createdAt as createdAt',
+      'File.fileBlobId as fileBlobId',
+      'FileBlob.size as size',
+      'FileBlob.encrypted as encrypted',
+    ])
+    .where('File.id', '=', `${knowledgeFile.id}`)
+    .executeTakeFirst() as FileDbRow | undefined
+  if (!fileEntry) {
+    return {
+      type: 'text',
+      text: `The knowledge file with id ${knowledgeFile.id} could not be found.`,
+    } satisfies ai.TextPart
+  }
+  return dtoFileToLlmFilePart(fileEntry, llmModel.capabilities)
+}
+
 export class KnowledgePlugin extends KnowledgePluginInterface implements ToolImplementation {
   static builder: ToolBuilder = (toolParams: ToolParams, params: Record<string, unknown>) =>
     new KnowledgePlugin(toolParams, params as KnowledgePluginParams)
@@ -29,12 +59,7 @@ export class KnowledgePlugin extends KnowledgePluginInterface implements ToolImp
     super()
   }
 
-  functions = async (_model: LlmModel, _context: ToolFunctionContext) => {
-    if (env.knowledge.sendInPrompt) {
-      return {}
-    }
-    return this.functions_
-  }
+  functions = async (_model: LlmModel, _context: ToolFunctionContext) => this.functions_
 
   functions_: ToolFunctions = {
     GetFile: {
@@ -94,33 +119,6 @@ export class KnowledgePlugin extends KnowledgePluginInterface implements ToolImp
         }
       },
     },
-  }
-
-  async knowledgeToInputPart(knowledgeFile: dto.AssistantFile, llmModel: LlmModel) {
-    const fileEntry = await db
-      .selectFrom('File')
-      .leftJoin('FileBlob', 'FileBlob.id', 'File.fileBlobId')
-      .select([
-        'File.id as id',
-        'File.name as name',
-        'File.ownerType as ownerType',
-        'File.ownerId as ownerId',
-        'File.path as path',
-        'File.type as type',
-        'File.createdAt as createdAt',
-        'File.fileBlobId as fileBlobId',
-        'FileBlob.size as size',
-        'FileBlob.encrypted as encrypted',
-      ])
-      .where('File.id', '=', `${knowledgeFile.id}`)
-      .executeTakeFirst() as FileDbRow | undefined
-    if (!fileEntry) {
-      return {
-        type: 'text',
-        text: `The knowledge file with id ${knowledgeFile.id} could not be found.`,
-      } satisfies ai.TextPart
-    }
-    return dtoFileToLlmFilePart(fileEntry, llmModel.capabilities)
   }
 
 }


### PR DESCRIPTION
## Summary

When `sendInPrompt=true` (the default), `KnowledgePlugin` was added to the tools array only to be immediately re-found via `find + instanceof + cast` to call its `knowledgeToInputPart` method. This extracts that logic into a standalone `loadKnowledgeFilePart` function and calls it directly from `preparePreamblePlan`. `withBuiltinTools` now skips adding the plugin entirely when `sendInPrompt=true`, since the plugin's `GetFile` function is never exposed to the LLM in that mode.

## Details

- `loadKnowledgeFilePart(file, model)` exported from `knowledge/implementation.ts` — same DB query + `dtoFileToLlmFilePart` logic that was previously `KnowledgePlugin.knowledgeToInputPart`
- `withBuiltinTools` returns early without adding `KnowledgePlugin` when `env.knowledge.sendInPrompt` is true; comment explains why
- `KnowledgePlugin.functions()` simplified to `async (_model, _context) => this.functions_` — the `sendInPrompt` guard is no longer needed there
- Duplicate `knowledgePrompt` template strings in `preparePreamblePlan` consolidated into a single ternary + shared `knowledgeFileSelectionNotice` constant
- Fixed `vi.doMock('@/lib/env', ...)` in `withBuiltinTools` tests — was polluting the env cache and breaking the `findReasonableSummarizationBackend` tests; replaced with direct mutation of the cached mock object

## Tests

- `npx vitest run` — 747 passed, 12 skipped, 0 failed