### PR TITLE
refactor(chat): fix computeSystemPrompt, deduplicate DB query, tighten types

### DIFF
--- a/__tests__/chatAssistant.test.ts
+++ b/__tests__/chatAssistant.test.ts
@@ -380,33 +380,49 @@ describe('ChatAssistant.build', () => {
 // ChatAssistant.computeSystemPrompt
 // ============================================================
 
+const attachmentSystemPrompt = `
+      Files uploaded by the user are described in the conversation.
+      They are listed in the message to which they are attached. The content, if possible, is in the message. They can also be retrieved or processed by means of function calls referring to their id.
+    `
+
 describe('ChatAssistant.computeSystemPrompt', () => {
-  test('returns system role message', async () => {
+  test('no tools: system prompt + attachment notice, nothing else', async () => {
     const result = await ChatAssistant.computeSystemPrompt(
       { assistantId: 'a1', model: 'gpt-4', systemPrompt: 'Be helpful', temperature: 0, tokenLimit: 1000, reasoning_effort: null },
       [],
       {}
     )
     expect(result.role).toBe('system')
+    expect(result.content).toBe(`Be helpful${attachmentSystemPrompt}`)
   })
 
-  test('includes system prompt in content', async () => {
+  test('empty system prompt: only attachment notice', async () => {
     const result = await ChatAssistant.computeSystemPrompt(
-      { assistantId: 'a1', model: 'gpt-4', systemPrompt: 'Custom prompt', temperature: 0, tokenLimit: 1000, reasoning_effort: null },
+      { assistantId: 'a1', model: 'gpt-4', systemPrompt: '', temperature: 0, tokenLimit: 1000, reasoning_effort: null },
       [],
       {}
     )
-    expect(result.content).toContain('Custom prompt')
+    expect(result.content).toBe(attachmentSystemPrompt)
   })
 
-  test('concatenates tool prompt fragments', async () => {
-    const tools = [makeToolImpl('tool-fragment-here')]
+  test('tool fragments appended after attachment notice, joined without separator', async () => {
+    const tools = [makeToolImpl('fragment-a'), makeToolImpl('fragment-b')]
     const result = await ChatAssistant.computeSystemPrompt(
       { assistantId: 'a1', model: 'gpt-4', systemPrompt: 'Base', temperature: 0, tokenLimit: 1000, reasoning_effort: null },
       tools,
       {}
     )
-    expect(result.content).toContain('tool-fragment-here')
+    expect(result.content).toBe(`Base${attachmentSystemPrompt}fragment-afragment-b`)
+  })
+
+  test('empty tool fragments are excluded', async () => {
+    const tools = [makeToolImpl(''), makeToolImpl('non-empty'), makeToolImpl('')]
+    const result = await ChatAssistant.computeSystemPrompt(
+      { assistantId: 'a1', model: 'gpt-4', systemPrompt: 'S', temperature: 0, tokenLimit: 1000, reasoning_effort: null },
+      tools,
+      {}
+    )
+    expect(result.content).toBe(`S${attachmentSystemPrompt}non-empty`)
   })
 
   test('applies template substitution from parameters', async () => {
@@ -415,7 +431,7 @@ describe('ChatAssistant.computeSystemPrompt', () => {
       [],
       { user: { value: 'Alice', defaultValue: '', description: 'user' } } as any
     )
-    expect(result.content).toContain('Hello Alice')
+    expect(result.content).toBe(`Hello Alice${attachmentSystemPrompt}`)
   })
 })
 

--- a/apps/backend/lib/chat/preamble.ts
+++ b/apps/backend/lib/chat/preamble.ts
@@ -52,7 +52,7 @@ export type PreamblePlan = {
   materializeKnowledgeSegment?: () => Promise<{
     message: ai.UserModelMessage
     analysisFileIds: string[]
-  } | null>
+  }>
 }
 
 export function fillTemplate(
@@ -83,16 +83,13 @@ export async function computeSystemPrompt(
 ): Promise<ai.SystemModelMessage> {
   const userSystemPrompt = assistantParams.systemPrompt ?? ''
   const attachmentSystemPrompt = `
-      Files uploaded by the user are described in the conversation. 
+      Files uploaded by the user are described in the conversation.
       They are listed in the message to which they are attached. The content, if possible, is in the message. They can also be retrieved or processed by means of function calls referring to their id.
     `
-  const promptFragments = [
-    assistantParams.systemPrompt,
-    ...tools.map((t) => t.toolParams.promptFragment),
-  ].filter((f) => f.length !== 0)
+  const toolFragments = tools.map((t) => t.toolParams.promptFragment).filter((f) => f.length !== 0)
 
   const systemPrompt = fillTemplate(
-    `${userSystemPrompt}${attachmentSystemPrompt}${promptFragments}`,
+    [userSystemPrompt, attachmentSystemPrompt, ...toolFragments].join(''),
     parameters
   )
 
@@ -103,17 +100,12 @@ export async function computeSystemPrompt(
 }
 
 export async function withBuiltinTools(tools: ToolImplementation[], llmModel: LlmModel): Promise<ToolImplementation[]> {
-  if (!(llmModel.capabilities.knowledge ?? true)) {
+  // KnowledgePlugin exposes GetFile to the LLM only in tool-call mode (sendInPrompt=false).
+  // In prompt-injection mode the content is embedded directly; the plugin contributes nothing.
+  if (!(llmModel.capabilities.knowledge ?? true) || env.knowledge.sendInPrompt) {
     return tools
   }
   const { KnowledgePlugin } = await import('@/backend/lib/tools/knowledge/implementation')
-  // Only add the plugin when sendInPrompt is off — that is the only mode where
-  // the plugin exposes an active function (GetFile) to the LLM. When sendInPrompt
-  // is on, knowledge content is injected directly into the prompt; the plugin
-  // contributes nothing as a tool.
-  if (env.knowledge.sendInPrompt) {
-    return tools
-  }
   return [
     ...tools,
     new KnowledgePlugin({ id: 'knowledge', provisioned: false, promptFragment: '', name: 'knowledge' }, {}),
@@ -240,7 +232,6 @@ export async function renderPreamblePlan(
     return segments
   }
   const renderedKnowledge = await plan.materializeKnowledgeSegment()
-  if (!renderedKnowledge) return segments
   segments[1] = {
     scope: 'prompt',
     message: renderedKnowledge.message,

--- a/apps/backend/lib/tools/knowledge/implementation.ts
+++ b/apps/backend/lib/tools/knowledge/implementation.ts
@@ -18,11 +18,8 @@ import { dtoFileToLlmFilePart } from '@/backend/lib/chat/conversion'
 import { cachingExtractor } from '@/lib/textextraction/cache'
 import type { FileDbRow } from '@/backend/models/file'
 
-export async function loadKnowledgeFilePart(
-  knowledgeFile: dto.AssistantFile,
-  llmModel: LlmModel
-): Promise<ai.TextPart | ai.ImagePart | ai.FilePart> {
-  const fileEntry = await db
+const fetchFileEntry = (id: string): Promise<FileDbRow | undefined> =>
+  db
     .selectFrom('File')
     .leftJoin('FileBlob', 'FileBlob.id', 'File.fileBlobId')
     .select([
@@ -37,8 +34,14 @@ export async function loadKnowledgeFilePart(
       'FileBlob.size as size',
       'FileBlob.encrypted as encrypted',
     ])
-    .where('File.id', '=', `${knowledgeFile.id}`)
-    .executeTakeFirst() as FileDbRow | undefined
+    .where('File.id', '=', `${id}`)
+    .executeTakeFirst() as Promise<FileDbRow | undefined>
+
+export async function loadKnowledgeFilePart(
+  knowledgeFile: dto.AssistantFile,
+  llmModel: LlmModel
+): Promise<ai.TextPart | ai.ImagePart | ai.FilePart> {
+  const fileEntry = await fetchFileEntry(knowledgeFile.id)
   if (!fileEntry) {
     return {
       type: 'text',
@@ -76,23 +79,7 @@ export class KnowledgePlugin extends KnowledgePluginInterface implements ToolImp
         required: ['id'],
       },
       invoke: async ({ llmModel, params }): Promise<dto.ToolCallResultOutput> => {
-        const fileEntry = await db
-          .selectFrom('File')
-          .leftJoin('FileBlob', 'FileBlob.id', 'File.fileBlobId')
-          .select([
-            'File.id as id',
-            'File.name as name',
-            'File.ownerType as ownerType',
-            'File.ownerId as ownerId',
-            'File.path as path',
-            'File.type as type',
-            'File.createdAt as createdAt',
-            'File.fileBlobId as fileBlobId',
-            'FileBlob.size as size',
-            'FileBlob.encrypted as encrypted',
-          ])
-          .where('File.id', '=', `${params.id}`)
-          .executeTakeFirst() as FileDbRow | undefined
+        const fileEntry = await fetchFileEntry(`${params.id}`)
         if (!fileEntry) {
           return { type: 'error-text', value: 'File not found' }
         }


### PR DESCRIPTION
## Summary

Four independent cleanups in the preamble / knowledge plugin area, all with no observable behavior change except the `computeSystemPrompt` bug fix.

## Details

- **`computeSystemPrompt` bug fix**: `assistantParams.systemPrompt` was included in `promptFragments` (duplicating `userSystemPrompt` which was already prepended), and `\`${promptFragments}\`` coerced the array to a comma-joined string — so tool prompt fragments would be joined with commas instead of concatenated. Fixed by collecting only tool fragments and joining all parts with `''`.

- **`withBuiltinTools` guard order**: the two early-return conditions (capability disabled, `sendInPrompt=true`) are now combined into one, so the dynamic `import('@/.../implementation')` is skipped entirely when the plugin would not be used.

- **DB query deduplication**: `loadKnowledgeFilePart` and `GetFile.invoke` executed the identical 20-line `File JOIN FileBlob` SELECT. Extracted as a module-private `fetchFileEntry(id)` helper used by both.

- **`PreamblePlan.materializeKnowledgeSegment` return type**: removed the dead `| null` — the implementation never returns null, and `renderPreamblePlan` no longer needs to guard against it.

## Tests

- `npm run check-types` — no errors
- `npx vitest run` — 747 passed, 12 skipped, 0 failed