### PR TITLE
fix(stats): include editor-accessible assistants in mine/stats API

### DIFF
--- a/apps/backend/api/me/assistants/mine/stats/route.ts
+++ b/apps/backend/api/me/assistants/mine/stats/route.ts
@@ -1,6 +1,7 @@
 import { db } from '@/db/database'
 import { sql } from 'kysely'
 import { ok, operation, responseSpec } from '@/lib/routes'
+import { WorkspaceRole } from '@/types/workspace'
 import { z } from 'zod'
 
 export const dynamic = 'force-dynamic'
@@ -18,14 +19,34 @@ export const GET = operation({
   authentication: 'user',
   responses: [responseSpec(200, assistantStatsSchema.array())] as const,
   implementation: async ({ session }) => {
-      const ownedAssistants = await db
+      const editableAssistants = await db
         .selectFrom('Assistant')
         .select('id')
-        .where('owner', '=', session.userId)
         .where('deleted', '=', 0)
+        .where((eb) =>
+          eb.or([
+            eb('Assistant.owner', '=', session.userId),
+            eb.exists(
+              eb
+                .selectFrom('AssistantSharing')
+                .select('AssistantSharing.id')
+                .whereRef('AssistantSharing.assistantId', '=', 'Assistant.id')
+                .where('AssistantSharing.workspaceId', 'is not', null)
+                .where(
+                  'AssistantSharing.workspaceId',
+                  'in',
+                  eb
+                    .selectFrom('WorkspaceMember')
+                    .select('WorkspaceMember.workspaceId')
+                    .where('WorkspaceMember.userId', '=', session.userId)
+                    .where('WorkspaceMember.role', 'in', [WorkspaceRole.EDITOR, WorkspaceRole.OWNER, WorkspaceRole.ADMIN])
+                )
+            ),
+          ])
+        )
         .execute()
 
-      const assistantIds = ownedAssistants.map((a) => a.id)
+      const assistantIds = editableAssistants.map((a) => a.id)
       if (assistantIds.length === 0) return ok([])
 
       const msgRows = await db


### PR DESCRIPTION
## Summary

The `/api/me/assistants/mine/stats` endpoint was only returning usage statistics for assistants owned by the requesting user. Since the "My Assistants" page already displays assistants accessible via workspace editor role, editors saw their assistants in the table but with empty stats. The fix extends the query to include assistants shared to a workspace where the user holds an EDITOR, OWNER, or ADMIN role — matching the same access rule used by the frontend filter (`canEditAssistant`).

## Tests

- `npm run check-types` — passes with no errors