### PR TITLE
fix(chat): send text files as plain text regardless of MIME type

### DIFF
--- a/__tests__/analyzeFileBuffer.test.ts
+++ b/__tests__/analyzeFileBuffer.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest'
+import { analyzeFileBuffer } from '@logicle/file-analyzer'
+
+describe('analyzeFileBuffer — unknown MIME type sniffing', () => {
+  test('marks a text file as isText=true', async () => {
+    const buffer = Buffer.from('# Hello\nThis is a markdown file.\n')
+    const result = await analyzeFileBuffer(buffer, 'application/octet-stream')
+    expect(result.kind).toBe('unknown')
+    if (result.kind === 'unknown') {
+      expect(result.isText).toBe(true)
+    }
+  })
+
+  test('marks a binary file as isText=false', async () => {
+    const buffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x00, 0x00, 0x0a])
+    const result = await analyzeFileBuffer(buffer, 'application/octet-stream')
+    expect(result.kind).toBe('unknown')
+    if (result.kind === 'unknown') {
+      expect(result.isText).toBe(false)
+    }
+  })
+
+  test('marks an empty file as isText=true', async () => {
+    const result = await analyzeFileBuffer(Buffer.alloc(0), 'application/octet-stream')
+    expect(result.kind).toBe('unknown')
+    if (result.kind === 'unknown') {
+      expect(result.isText).toBe(true)
+    }
+  })
+
+})

--- a/__tests__/fileAnalysisPayload.test.ts
+++ b/__tests__/fileAnalysisPayload.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/file-analysis/payload'
 import { claude35SonnetModel } from '@/lib/chat/models/anthropic'
 import { gpt41MiniModel } from '@/lib/chat/models/openai'
+import { unknownFileAnalysisPayloadSchema } from '@/types/dto/file-analysis'
 import type * as dto from '@/types/dto'
 
 const pdfPayload: Extract<dto.FileAnalysisPayload, { kind: 'pdf' }> = {
@@ -40,6 +41,12 @@ describe('fileAnalysisPayload helpers', () => {
     expect(isPdfAnalysisPayload(null)).toBe(false)
     expect(isImageAnalysisPayload(imagePayload)).toBe(true)
     expect(isImageAnalysisPayload(pdfPayload)).toBe(false)
+  })
+
+  test('unknown payload without isText defaults to false (backward compat)', () => {
+    const legacy = { kind: 'unknown', mimeType: 'application/octet-stream', sizeBytes: 100, extractedTextPath: null }
+    const parsed = unknownFileAnalysisPayloadSchema.parse(legacy)
+    expect(parsed.isText).toBe(false)
   })
 
   test('reports PDFs over model page limit', () => {

--- a/apps/backend/lib/textextraction/cache.ts
+++ b/apps/backend/lib/textextraction/cache.ts
@@ -1,6 +1,6 @@
 import { LRUCache } from 'lru-cache'
 import type { FileDbRow } from '@/backend/models/file'
-import { findExtractor } from '.'
+import { findExtractor, genericTextExtractor } from '.'
 import { storage } from '../storage'
 import { ensureFileAnalysisForFile, readExtractedTextFromAnalysis } from '@/lib/file-analysis'
 
@@ -29,7 +29,8 @@ export const cachingExtractor = {
       return analyzedText
     }
 
-    const extractor = findExtractor(fileEntry.type)
+    const isUnknownText = analysis?.status === 'ready' && analysis.payload?.kind === 'unknown' && analysis.payload.isText
+    const extractor = findExtractor(fileEntry.type) ?? (isUnknownText ? genericTextExtractor : undefined)
     if (!extractor) {
       return undefined
     }

--- a/apps/backend/lib/textextraction/index.ts
+++ b/apps/backend/lib/textextraction/index.ts
@@ -13,7 +13,7 @@ export interface TextExtractionOption {
 
 export type TextExtractor = (buffer: Buffer, options?: TextExtractionOption) => Promise<string>
 
-const genericTextExtractor: TextExtractor = async (data: Buffer) => {
+export const genericTextExtractor: TextExtractor = async (data: Buffer) => {
   return data.toString('utf8')
 }
 

--- a/packages/core/src/types/dto/file-analysis.ts
+++ b/packages/core/src/types/dto/file-analysis.ts
@@ -20,6 +20,7 @@ export const unknownFileAnalysisPayloadSchema = z.object({
   kind: z.literal('unknown'),
   mimeType: z.string(),
   sizeBytes: z.number().int().nonnegative(),
+  isText: z.boolean().default(false),
   extractedTextPath: z.string().nullable(),
 }).meta({ id: 'UnknownFileAnalysisPayload' })
 

--- a/packages/file-analyzer/src/analyzers.ts
+++ b/packages/file-analyzer/src/analyzers.ts
@@ -9,6 +9,7 @@ export type AnalyzerPayload =
       kind: 'unknown'
       mimeType: string
       sizeBytes: number
+      isText: boolean
       extractedText: null
     }
   | {
@@ -260,5 +261,6 @@ export const analyzeFileBuffer = async (buffer: Buffer, mimeType: string): Promi
   if (spreadsheetMimeTypes.has(mimeType)) return analyzeSpreadsheet(buffer, mimeType)
   if (presentationMimeTypes.has(mimeType)) return analyzePresentation(buffer, mimeType)
   if (wordMimeTypes.has(mimeType)) return analyzeWord(buffer, mimeType)
-  return { kind: 'unknown', mimeType, sizeBytes: buffer.byteLength, extractedText: null }
+  const isText = !buffer.slice(0, 8192).includes(0)
+  return { kind: 'unknown', mimeType, sizeBytes: buffer.byteLength, isText, extractedText: null }
 }

--- a/packages/file-analyzer/src/index.ts
+++ b/packages/file-analyzer/src/index.ts
@@ -1,3 +1,3 @@
-export { analyzePdfGraphics } from './analyzers.ts'
+export { analyzePdfGraphics, analyzeFileBuffer } from './analyzers.ts'
 export type { AnalyzerPayload } from './analyzers.ts'
 export type { FileAnalyzerRuntime } from './runtime'


### PR DESCRIPTION
## Summary

Files uploaded with missing or unrecognized MIME types (e.g. `.md` without a MIME type, `.vue`, or any unknown extension) are now sniffed for binary content at analysis time. If the first 8 KB contains no null bytes the file is flagged as text and its content is sent to the LLM as plain text, matching user expectation that any readable file should be accessible to the model.

## Details

- `analyzeFileBuffer` now performs a null-byte sniff on unrecognized MIME types and sets `isText` on the `unknown` analysis payload — no sidecar file is written; the original file is read directly at extraction time
- `cachingExtractor` falls back to `genericTextExtractor` when analysis indicates `isText`, bypassing the MIME-type extractor registry
- `unknownFileAnalysisPayloadSchema` adds `isText: z.boolean().default(false)` — existing DB records without the field parse safely and are treated as binary (conservative fallback)
- `fileAnalyzerVersion` is intentionally left at `1`; new uploads are analyzed correctly, and retroactive re-analysis of old unknown-kind files can be triggered by a targeted DB operation if needed

## Tests

- `npm run check-types` — passed