### PR TITLE
feat(assistants): add Usage tab for reverse sub-assistant lookup (#243)

### DIFF
--- a/apps/backend/api/assistants/[assistantId]/usage/route.ts
+++ b/apps/backend/api/assistants/[assistantId]/usage/route.ts
@@ -1,0 +1,43 @@
+import { forbidden, notFound, ok, operation, responseSpec, errorSpec } from '@/lib/routes'
+import { canEditAssistant } from '@/lib/rbac'
+import {
+  assistantSharingData,
+  getAssistant,
+  getAssistantParentAssistants,
+} from '@/models/assistant'
+import { getUserWorkspaceMemberships } from '@/models/user'
+import { assistantParentSchema } from '@/types/dto/assistant'
+import { z } from 'zod'
+
+export const dynamic = 'force-dynamic'
+
+export const GET = operation({
+  name: 'Get assistant usage',
+  description: 'Return the list of assistants that use this assistant as a sub-assistant.',
+  authentication: 'user',
+  responses: [
+    responseSpec(200, z.array(assistantParentSchema)),
+    errorSpec(403),
+    errorSpec(404),
+  ] as const,
+  implementation: async ({ params, session }) => {
+    const assistantId = params.assistantId
+    const assistant = await getAssistant(assistantId)
+    if (!assistant) {
+      return notFound(`There is no assistant with id ${assistantId}`)
+    }
+    const sharingData = await assistantSharingData(assistant.id)
+    const workspaceMemberships = await getUserWorkspaceMemberships(session.userId)
+    if (
+      !canEditAssistant(
+        { owner: assistant.owner ?? '', sharing: sharingData },
+        session.userId,
+        workspaceMemberships
+      )
+    ) {
+      return forbidden(`You're not authorized to see assistant ${assistantId}`)
+    }
+    const parents = await getAssistantParentAssistants(assistantId)
+    return ok(parents)
+  },
+})

--- a/apps/backend/lib/router/routes.generated.ts
+++ b/apps/backend/lib/router/routes.generated.ts
@@ -15,6 +15,7 @@ export const backendRouteModules = [
   { pathname: '/api/assistants/[assistantId]/reset-draft', load: () => import('@/backend/api/assistants/[assistantId]/reset-draft/route') },
   { pathname: '/api/assistants/[assistantId]', load: () => import('@/backend/api/assistants/[assistantId]/route') },
   { pathname: '/api/assistants/[assistantId]/sharing', load: () => import('@/backend/api/assistants/[assistantId]/sharing/route') },
+  { pathname: '/api/assistants/[assistantId]/usage', load: () => import('@/backend/api/assistants/[assistantId]/usage/route') },
   { pathname: '/api/assistants/[assistantId]/visibility', load: () => import('@/backend/api/assistants/[assistantId]/visibility/route') },
   { pathname: '/api/assistants/drafts/[assistantVersionId]', load: () => import('@/backend/api/assistants/drafts/[assistantVersionId]/route') },
   { pathname: '/api/assistants/evaluate', load: () => import('@/backend/api/assistants/evaluate/route') },

--- a/apps/backend/models/assistant.ts
+++ b/apps/backend/models/assistant.ts
@@ -790,3 +790,17 @@ export const assistantUserData = async (assistantId: string, userId: string) => 
     .where((eb) => eb.and([eb('assistantId', '=', assistantId), eb('userId', '=', userId)]))
     .executeTakeFirst()
 }
+
+export const getAssistantParentAssistants = async (
+  assistantId: string
+): Promise<{ id: string; name: string }[]> => {
+  return db
+    .selectFrom('Assistant')
+    .innerJoin('AssistantVersion', (join) =>
+      join.onRef('AssistantVersion.id', '=', 'Assistant.publishedVersionId')
+    )
+    .select(['Assistant.id', 'AssistantVersion.name'])
+    .where('AssistantVersion.subAssistants', 'like', `%"${assistantId}"%`)
+    .where('Assistant.deleted', '=', 0)
+    .execute()
+}

--- a/apps/frontend/app/assistants/components/AssistantForm.tsx
+++ b/apps/frontend/app/assistants/components/AssistantForm.tsx
@@ -13,6 +13,7 @@ import { KnowledgeTabPanel } from './KnowledgeTabPanel'
 import { GeneralTabPanel } from './GeneralTabPanel'
 import { SystemPromptTabPanel } from './SystemPromptTabPanel'
 import { AdvancedTabPanel } from './AdvancedTabPanel'
+import { UsageTabPanel } from './UsageTabPanel'
 import { llmModelNoCapabilities } from '@/lib/chat/models'
 import { useCachedContextLength } from '@/components/providers/localstoragechatstate'
 import { estimateAssistantDraftTokens } from '@/services/tokens'
@@ -30,7 +31,7 @@ interface Props {
   firePublish?: MutableRefObject<(() => void) | undefined>
 }
 
-type TabState = 'general' | 'instructions' | 'tools' | 'knowledge' | 'advanced'
+type TabState = 'general' | 'instructions' | 'tools' | 'knowledge' | 'advanced' | 'usage'
 
 const tabErrorsEqual = (
   left: Readonly<{
@@ -329,6 +330,7 @@ export const AssistantForm = ({
               <TabsTrigger value="advanced">
                 {t('advanced')} {tabErrors.advanced && <IconAlertCircle color="red" />}
               </TabsTrigger>
+              <TabsTrigger value="usage">{t('usage')}</TabsTrigger>
             </TabsList>
           </Tabs>
           <ContextLengthIndicator
@@ -370,6 +372,11 @@ export const AssistantForm = ({
           className="flex-1 min-w-0"
           form={form}
           visible={activeTab === 'advanced'}
+        />
+        <UsageTabPanel
+          className="flex-1 min-w-0"
+          visible={activeTab === 'usage'}
+          assistantId={assistant.assistantId}
         />
       </form>
     </FormProvider>

--- a/apps/frontend/app/assistants/components/UsageTabPanel.tsx
+++ b/apps/frontend/app/assistants/components/UsageTabPanel.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from 'react-i18next'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { useSWRJson } from '@/hooks/swr'
+import * as dto from '@/types/dto'
+import { Link } from '@/components/ui/link'
+
+interface Props {
+  className: string
+  visible: boolean
+  assistantId?: string
+}
+
+export const UsageTabPanel = ({ visible, className, assistantId }: Props) => {
+  const { t } = useTranslation()
+  const { data: parents } = useSWRJson<dto.AssistantParent[]>(
+    assistantId ? `/api/assistants/${assistantId}/usage` : null
+  )
+
+  return (
+    <ScrollArea className={className} style={{ display: visible ? undefined : 'none' }}>
+      <div className="flex flex-col gap-3 pr-2">
+        {parents && parents.length === 0 && (
+          <p className="text-muted-foreground text-sm">{t('assistant_usage_empty')}</p>
+        )}
+        {parents && parents.length > 0 && (
+          <>
+            <p className="text-muted-foreground text-sm">{t('assistant_usage_used_by')}</p>
+            <ul className="flex flex-col gap-2">
+              {parents.map((parent) => (
+                <li key={parent.id}>
+                  <Link href={`/assistants/${parent.id}`}>{parent.name}</Link>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </div>
+    </ScrollArea>
+  )
+}

--- a/apps/frontend/locales/en/logicle.json
+++ b/apps/frontend/locales/en/logicle.json
@@ -628,6 +628,8 @@
   "failed_unsharing": "Failed to unshare conversation",
   "url": "URL",
   "usage": "Usage",
+  "assistant_usage_empty": "This assistant is not used as a sub-assistant by any other assistant.",
+  "assistant_usage_used_by": "This assistant is used as a sub-assistant by:",
   "user": "User",
   "user-deleted": "User successfully deleted",
   "user-disabled-successfully": "User disabled successfully",

--- a/apps/frontend/locales/it/logicle.json
+++ b/apps/frontend/locales/it/logicle.json
@@ -628,6 +628,8 @@
   "failed_unsharing": "Errore nella rimozione della condivisione",
   "url": "URL",
   "usage": "Utilizzo",
+  "assistant_usage_empty": "Questo assistente non è utilizzato come sottoassistente da nessun altro assistente.",
+  "assistant_usage_used_by": "Questo assistente è utilizzato come sottoassistente da:",
   "user": "Utente",
   "user-deleted": "Utente eliminato con successo",
   "user-disabled-successfully": "Utente disabilitato con successo",

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -504,6 +504,31 @@ paths:
               type: array
               items:
                 $ref: "#/components/schemas/AssistantSharing"
+  /api/assistants/{assistantId}/usage:
+    get:
+      summary: Get assistant usage
+      description: Return the list of assistants that use this assistant as a sub-assistant.
+      responses:
+        "200":
+          description: Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AssistantParent"
+        "403":
+          $ref: "#/components/responses/Error"
+        "404":
+          $ref: "#/components/responses/Error"
+      parameters:
+        - name: assistantId
+          in: path
+          required: true
+          schema:
+            type: string
+      security:
+        - bearerAuth: []
   /api/assistants/{assistantId}/visibility:
     patch:
       summary: Update assistant visibility
@@ -3459,6 +3484,18 @@ components:
             type: string
       additionalProperties: false
       id: UpdateableAssistantDraft
+    AssistantParent:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+      required:
+        - id
+        - name
+      additionalProperties: false
+      id: AssistantParent
     UpdateableAssistantVisibility:
       type: object
       properties:
@@ -4499,6 +4536,9 @@ components:
           type: integer
           minimum: 0
           maximum: 9007199254740991
+        isText:
+          default: false
+          type: boolean
         extractedTextPath:
           anyOf:
             - type: string
@@ -4507,6 +4547,7 @@ components:
         - kind
         - mimeType
         - sizeBytes
+        - isText
         - extractedTextPath
       additionalProperties: false
       id: UnknownFileAnalysisPayload

--- a/packages/core/src/types/dto/assistant.ts
+++ b/packages/core/src/types/dto/assistant.ts
@@ -145,6 +145,15 @@ export type UpdateableAssistantDraft = z.infer<typeof updateableAssistantDraftSc
 
 export type UpdateableAssistantVisibility = z.infer<typeof updateableAssistantVisibilitySchema>
 
+export const assistantParentSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+  })
+  .meta({ id: 'AssistantParent' })
+
+export type AssistantParent = z.infer<typeof assistantParentSchema>
+
 export const assistantWithOwnerSchema = z
   .object({
     id: z.string(),


### PR DESCRIPTION
## Summary

Adds a **Usage** tab to the assistant editor that shows which other assistants reference this assistant as a sub-assistant. Each entry is a direct link to the parent assistant's editor page, making it easy to trace dependencies and understand the impact of changes.

## Details

- `GET /api/assistants/:id/usage` — new endpoint returning `AssistantParent[]` (`id`, `name`); requires edit access on the target assistant
- `getAssistantParentAssistants` model function queries all non-deleted assistants whose **published version** lists the given ID in `subAssistants`
- `UsageTabPanel` component fetches the endpoint and renders a clarifying sentence ("This assistant is used as a sub-assistant by:") followed by clickable links, or an empty-state message when unused
- `AssistantParent` DTO added to `packages/core`; route manifest and OpenAPI spec regenerated

## Tests

- `npm run check-types` — passed