### PR TITLE
fix(editor): re-enable fold gutter in advanced instructions editor

### DIFF
--- a/apps/frontend/app/assistants/components/AdvancedInstructionsEditor.tsx
+++ b/apps/frontend/app/assistants/components/AdvancedInstructionsEditor.tsx
@@ -74,7 +74,7 @@ const AdvancedInstructionsEditor = forwardRef<HTMLDivElement, Props>(function In
       editable={!disabled}
       basicSetup={{
         lineNumbers: false,
-        foldGutter: false,
+        foldGutter: true,
         highlightActiveLineGutter: false,
       }}
       placeholder={placeholder}


### PR DESCRIPTION
## Summary

Re-enables section folding (collapse/open) in the advanced instructions CodeMirror editor, which was inadvertently disabled via `foldGutter: false` in `basicSetup`. Markdown headings can now be collapsed and expanded using the gutter icon or via keyboard shortcuts (Ctrl+Shift+[ / Ctrl+Shift+]).

## Tests

- `npm run check-types` — passed

Closes logicleai/logicle-issues#229