### PR TITLE
fix(parameters): hide save button when no parameters exist

### DIFF
--- a/apps/frontend/app/me/components/ParametersPage.tsx
+++ b/apps/frontend/app/me/components/ParametersPage.tsx
@@ -53,6 +53,10 @@ export const ParametersPanel = ({ user }: { user: dto.UserProfile }) => {
     await mutate(adminUserPath)
   }
 
+  if (environment.parameters.length === 0) {
+    return <p className="text-muted-foreground">{t('no-parameters-available')}</p>
+  }
+
   return (
     <Form {...form} onSubmit={form.handleSubmit(onSubmit)} className={`space-y-6`}>
       <FormField

--- a/apps/frontend/locales/en/logicle.json
+++ b/apps/frontend/locales/en/logicle.json
@@ -497,6 +497,7 @@
   "saml-config-updated": "SAML Config updated successfully.",
   "saml-connection-established": "Single Sign-On connection is enabled for your workspace.",
   "save": "Save",
+  "no-parameters-available": "No parameters available",
   "save-changes": "Save Changes",
   "save_and_submit": "Save & Submit",
   "scim-url": "SCIM URL.",

--- a/apps/frontend/locales/it/logicle.json
+++ b/apps/frontend/locales/it/logicle.json
@@ -497,6 +497,7 @@
   "saml-config-updated": "Configurazione SAML modificata con successo.",
   "saml-connection-established": "La connessione Single Sign-On è abilitata per il tuo workspace.",
   "save": "Salva",
+  "no-parameters-available": "Non ci sono parametri disponibili",
   "save-changes": "Salva Modifiche",
   "save_and_submit": "Salva e Invia",
   "scim-url": "URL SCIM",


### PR DESCRIPTION
## Summary

When the assistant has no parameters configured, the Parameters tab now hides the "Save Changes" button and displays "No parameters available" (/ "Non ci sono parametri disponibili") instead of an empty form.

## Tests

- Verified the empty-state branch renders the muted-foreground paragraph and no form/button when `environment.parameters.length === 0`.