### PR TITLE
fix(profile): sort pinned assistants by last used

### DIFF
--- a/apps/backend/api/me/profile/route.ts
+++ b/apps/backend/api/me/profile/route.ts
@@ -45,7 +45,14 @@ export const GET = operation({
         null as dto.UserAssistant | null
       )
 
-    const pinnedAssistants = userAssistants.filter((a) => a.pinned)
+    const pinnedAssistants = userAssistants
+      .filter((a) => a.pinned)
+      .sort((a, b) => {
+        if (!a.lastUsed && !b.lastUsed) return 0
+        if (!a.lastUsed) return 1
+        if (!b.lastUsed) return -1
+        return b.lastUsed < a.lastUsed ? -1 : b.lastUsed > a.lastUsed ? 1 : 0
+      })
 
     if (lastUsedAssistant == null) {
       const lastChat = await getMostRecentConversation(session.userId)


### PR DESCRIPTION
## Summary

Pinned assistants in the sidebar were displayed in arbitrary database order. They are now sorted most-recently-used first, with never-used assistants at the end.

Fixes logicleai/logicle-issues#102.

## Tests

- Manually verified sort logic covers all cases: both used, one never used, both never used.