### PR TITLE
fix(storage): restore download backpressure and offload/dedupe PGP S2K derivation

### DIFF
--- a/__tests__/pgpEncryptingStorageCache.test.ts
+++ b/__tests__/pgpEncryptingStorageCache.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { BaseStorage } from '@/lib/storage/api'
+import { PgpEncryptingStorage, setPgpS2kWorker } from '@/ee/PgpEncryptingStorage'
+
+const { readMessageMock, decryptMock } = vi.hoisted(() => ({
+  readMessageMock: vi.fn(),
+  decryptMock: vi.fn(),
+}))
+
+vi.mock('openpgp', () => ({
+  readMessage: readMessageMock,
+  decrypt: decryptMock,
+  decryptSessionKeys: vi.fn(),
+  encrypt: vi.fn(),
+  createMessage: vi.fn(),
+}))
+
+class StaticStorage extends BaseStorage {
+  constructor(private readonly payload: Uint8Array) {
+    super()
+  }
+
+  async readStream(): Promise<ReadableStream<Uint8Array>> {
+    const payload = this.payload
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(payload.subarray(0, 32))
+        controller.enqueue(payload.subarray(32))
+        controller.close()
+      },
+    })
+  }
+
+  async writeStream(): Promise<void> {}
+
+  async rm(): Promise<void> {}
+}
+
+function makeSessionKey() {
+  return { algorithm: 'aes256', data: new Uint8Array([1, 2, 3, 4]) }
+}
+
+function makeClearStream(): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.close()
+    },
+  })
+}
+
+describe('PgpEncryptingStorage session key promise cache failure handling', () => {
+  beforeEach(() => {
+    readMessageMock.mockReset()
+    decryptMock.mockReset()
+    readMessageMock.mockResolvedValue({})
+    decryptMock.mockResolvedValue({ data: makeClearStream() })
+  })
+
+  test('evicts failed cached promise so next request can retry', async () => {
+    const deriveSessionKey = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('s2k failed'))
+      .mockResolvedValueOnce(makeSessionKey())
+    setPgpS2kWorker({ deriveSessionKey } as any)
+
+    const storage = await PgpEncryptingStorage.create(
+      new StaticStorage(new Uint8Array(128).fill(7)),
+      'passphrase'
+    )
+
+    await expect(storage.readStream('file-a', true)).rejects.toThrow('s2k failed')
+    await expect(storage.readStream('file-a', true)).resolves.toBeInstanceOf(ReadableStream)
+
+    expect(deriveSessionKey).toHaveBeenCalledTimes(2)
+    expect(readMessageMock).toHaveBeenCalledTimes(1)
+    expect(decryptMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('shares one failing in-flight promise across concurrent reads, then retries cleanly', async () => {
+    let rejectFirst: (error: Error) => void = () => {}
+    const firstFailure = new Promise<ReturnType<typeof makeSessionKey>>((_, reject) => {
+      rejectFirst = reject
+    })
+
+    const deriveSessionKey = vi.fn().mockReturnValueOnce(firstFailure).mockResolvedValue(makeSessionKey())
+    setPgpS2kWorker({ deriveSessionKey } as any)
+
+    const storage = await PgpEncryptingStorage.create(
+      new StaticStorage(new Uint8Array(128).fill(9)),
+      'passphrase'
+    )
+
+    const firstRead = storage.readStream('file-b', true)
+    const secondRead = storage.readStream('file-b', true)
+    rejectFirst(new Error('shared failure'))
+
+    const [firstResult, secondResult] = await Promise.allSettled([firstRead, secondRead])
+    expect(firstResult.status).toBe('rejected')
+    expect(secondResult.status).toBe('rejected')
+    expect(deriveSessionKey).toHaveBeenCalledTimes(1)
+
+    await expect(storage.readStream('file-b', true)).resolves.toBeInstanceOf(ReadableStream)
+    expect(deriveSessionKey).toHaveBeenCalledTimes(2)
+    expect(readMessageMock).toHaveBeenCalledTimes(1)
+    expect(decryptMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/__tests__/pgpS2k.test.ts
+++ b/__tests__/pgpS2k.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from 'vitest'
+import * as openpgp from 'openpgp'
+import { streamingIteratedS2kProduceKey } from '@/ee/pgp-s2k-worker/streaming-s2k'
+
+/**
+ * Build an OpenPGP.js GenericS2K (iterated type) from explicit parameters by
+ * synthesising a minimal version-4 SKESK payload and letting openpgp parse it.
+ *
+ * v4 SKESK layout: [version=4] [symAlgo] [s2kType=3] [hashAlgo] [salt×8] [countByte]
+ */
+function makeOpenpgpS2k(hashAlgoByte: number, salt: Uint8Array, encodedCount: number): any {
+  const pkt = new openpgp.SymEncryptedSessionKeyPacket() as any
+  pkt.read(
+    new Uint8Array([
+      4, // version 4
+      9, // aes256 — does not affect key derivation
+      3, // iterated S2K
+      hashAlgoByte,
+      ...salt,
+      encodedCount,
+    ]),
+  )
+  return pkt.s2k
+}
+
+async function openpgpProduceKey(
+  hashAlgoByte: number,
+  salt: Uint8Array,
+  encodedCount: number,
+  passphrase: string,
+  keySizeBytes: number,
+): Promise<Uint8Array> {
+  const s2k = makeOpenpgpS2k(hashAlgoByte, salt, encodedCount)
+  // Normalise to plain Uint8Array so vitest toEqual works regardless of
+  // whether the runtime returns a Buffer subclass or a Uint8Array.
+  return new Uint8Array(await (s2k.produceKey(passphrase, keySizeBytes) as Promise<Uint8Array>))
+}
+
+function toU8(b: Uint8Array): Uint8Array {
+  return new Uint8Array(b)
+}
+
+// Fixed 8-byte salt — reproducible across runs
+const SALT = new Uint8Array([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef])
+
+// OpenPGP hash enum bytes
+const SHA256 = 8
+const SHA512 = 10
+
+describe('streamingIteratedS2kProduceKey matches OpenPGP.js GenericS2K', () => {
+  // ── Count bytes ─────────────────────────────────────────────────────────────
+  // Encoded count C expands to (16 + (C & 15)) << ((C >> 4) + 6) bytes.
+  // The production default is 224 (~16 MB). 255 is the maximum (~65 MB).
+  const COUNT_BYTES = [96, 160, 208, 224, 255]
+
+  // ── Key sizes ───────────────────────────────────────────────────────────────
+  // 64 B forces a second digest round (sha256 output is 32 B), exercising the
+  // zero-prefix rule.
+  const KEY_SIZES = [16, 24, 32, 64]
+
+  // ── Passphrases ─────────────────────────────────────────────────────────────
+  const PASSPHRASES: [string, string][] = [
+    ['empty', ''],
+    ['short-ascii', 'hello'],
+    ['long-ascii', 'this is a much longer passphrase for testing S2K key derivation'],
+    ['non-ascii', 'pässwörð🔑'],
+  ]
+
+  // Section 1: all count bytes × key sizes, sha256, short passphrase
+  describe('count byte and key size coverage (sha256, passphrase="hello")', () => {
+    for (const encodedCount of COUNT_BYTES) {
+      for (const keySizeBytes of KEY_SIZES) {
+        test(`count=${encodedCount} key=${keySizeBytes}B`, async () => {
+          const expected = await openpgpProduceKey(SHA256, SALT, encodedCount, 'hello', keySizeBytes)
+          const actual = streamingIteratedS2kProduceKey(SHA256, SALT, encodedCount, 'hello', keySizeBytes)
+          expect(toU8(actual)).toEqual(expected)
+          expect(actual).toHaveLength(keySizeBytes)
+        })
+      }
+    }
+  })
+
+  // Section 2: passphrase variety at production defaults (sha256, count=224, key=32B)
+  describe('passphrase variety (sha256, count=224, key=32B)', () => {
+    for (const [label, passphrase] of PASSPHRASES) {
+      test(`passphrase=${label}`, async () => {
+        const expected = await openpgpProduceKey(SHA256, SALT, 224, passphrase, 32)
+        const actual = streamingIteratedS2kProduceKey(SHA256, SALT, 224, passphrase, 32)
+        expect(toU8(actual)).toEqual(expected)
+      })
+    }
+  })
+
+  // Section 3: hash algorithm coverage (count=224, key=32B, short passphrase)
+  describe('hash algorithm coverage (count=224, key=32B, passphrase="hello")', () => {
+    const HASH_ALGOS: [string, number][] = [
+      ['sha256', SHA256],
+      ['sha512', SHA512],
+    ]
+    for (const [name, byte] of HASH_ALGOS) {
+      test(`hash=${name}`, async () => {
+        const expected = await openpgpProduceKey(byte, SALT, 224, 'hello', 32)
+        const actual = streamingIteratedS2kProduceKey(byte, SALT, 224, 'hello', 32)
+        expect(toU8(actual)).toEqual(expected)
+      })
+    }
+  })
+
+  // Section 4: edge cases
+  describe('edge cases', () => {
+    test('key length exactly equals one digest output (sha256, key=32B)', async () => {
+      // No second digest round needed — exercises single-round path only
+      const expected = await openpgpProduceKey(SHA256, SALT, 224, 'hello', 32)
+      const actual = streamingIteratedS2kProduceKey(SHA256, SALT, 224, 'hello', 32)
+      expect(actual).toHaveLength(32)
+      expect(toU8(actual)).toEqual(expected)
+    })
+
+    test('key length requires two digest rounds (sha256, key=64B)', async () => {
+      // sha256 output is 32B; a 64B key requires round 0 + round 1 (1-zero prefix)
+      const expected = await openpgpProduceKey(SHA256, SALT, 224, 'hello', 64)
+      const actual = streamingIteratedS2kProduceKey(SHA256, SALT, 224, 'hello', 64)
+      expect(actual).toHaveLength(64)
+      expect(toU8(actual)).toEqual(expected)
+    })
+
+    test('key length requires two digest rounds (sha256, key=33B, odd truncation)', async () => {
+      // Forces a second round whose output is partially discarded
+      const expected = await openpgpProduceKey(SHA256, SALT, 224, 'hello', 33)
+      const actual = streamingIteratedS2kProduceKey(SHA256, SALT, 224, 'hello', 33)
+      expect(actual).toHaveLength(33)
+      expect(toU8(actual)).toEqual(expected)
+    })
+
+    test('count=96 — decoded count (65536B) close to chunk boundary', async () => {
+      // count=96 decodes to exactly 65536 bytes; the chunk is ~65530 bytes,
+      // so the last chunk is a small partial slice
+      const expected = await openpgpProduceKey(SHA256, SALT, 96, 'hello', 32)
+      const actual = streamingIteratedS2kProduceKey(SHA256, SALT, 96, 'hello', 32)
+      expect(toU8(actual)).toEqual(expected)
+    })
+
+    test('decoded count less than block length — Math.max path', async () => {
+      // Use a very low encoded count so getCount() < block.length; the streaming
+      // implementation must use block.length as the effective count
+      // encodedCount=0 → (16+0)<<6 = 1024 bytes; with a 12-char passphrase
+      // block = 8(salt) + 12(passphrase) = 20 bytes < 1024, so this uses count normally.
+      // We just verify the Math.max branch still produces the correct result.
+      const expected = await openpgpProduceKey(SHA256, SALT, 0, 'short', 32)
+      const actual = streamingIteratedS2kProduceKey(SHA256, SALT, 0, 'short', 32)
+      expect(toU8(actual)).toEqual(expected)
+    })
+
+    test('different salts produce different keys', () => {
+      const salt2 = new Uint8Array([0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88])
+      const key1 = streamingIteratedS2kProduceKey(SHA256, SALT, 224, 'hello', 32)
+      const key2 = streamingIteratedS2kProduceKey(SHA256, salt2, 224, 'hello', 32)
+      expect(key1).not.toEqual(key2)
+    })
+
+    test('different passphrases produce different keys', () => {
+      const key1 = streamingIteratedS2kProduceKey(SHA256, SALT, 224, 'password1', 32)
+      const key2 = streamingIteratedS2kProduceKey(SHA256, SALT, 224, 'password2', 32)
+      expect(key1).not.toEqual(key2)
+    })
+
+    test('different count bytes produce different keys', () => {
+      const key1 = streamingIteratedS2kProduceKey(SHA256, SALT, 96, 'hello', 32)
+      const key2 = streamingIteratedS2kProduceKey(SHA256, SALT, 224, 'hello', 32)
+      expect(key1).not.toEqual(key2)
+    })
+
+    test('unsupported hash algorithm byte throws', () => {
+      expect(() => streamingIteratedS2kProduceKey(99, SALT, 224, 'hello', 32)).toThrow(
+        'Unsupported OpenPGP hash algorithm byte: 99',
+      )
+    })
+  })
+})

--- a/__tests__/storageCoverage.test.ts
+++ b/__tests__/storageCoverage.test.ts
@@ -92,7 +92,7 @@ describe('backpressure', () => {
     expect(destroySpy).toHaveBeenCalled()
   })
 
-  test('CachingStorage eagerly drains the inner stream to avoid blocking uploads on downstream S3 speed', async () => {
+  test('CachingStorage does not consume inner stream until consumer reads', async () => {
     const chunks = Array.from({ length: 10 }, (_, i) => new Uint8Array([i]))
     const { stream: inner, pullCount } = makeCountedStream(chunks)
 
@@ -103,10 +103,9 @@ describe('backpressure', () => {
     const out = await cachingStorage.readStream('x', false)
     const reader = out.getReader()
 
-    // Yield without reading — the inner stream must have been pre-drained eagerly
-    // so that uploads are not blocked by slow downstream (e.g. S3 connection pool).
+    // Yield without reading — inner stream must not have been pre-drained
     await new Promise<void>((r) => setImmediate(r))
-    expect(pullCount()).toBe(chunks.length + 1) // +1 for the done sentinel
+    expect(pullCount()).toBeLessThan(chunks.length)
 
     const first = await reader.read()
     expect(first.value).toEqual(new Uint8Array([0]))
@@ -251,7 +250,7 @@ describe('apps/backend/lib/storage/S3Storage', () => {
     expect(storage.bucketName).toBe('bucket-name')
     expect(storage.region).toBe('eu-west-1')
     expect(storage.hostName).toBe('bucket-name.s3.eu-west-1.amazonaws.com')
-    expect(clientConfigs[0]).toEqual({
+    expect(clientConfigs[0]).toMatchObject({
       region: 'eu-west-1',
       credentials: {
         accessKeyId: 'key',

--- a/__tests__/storageCoverage.test.ts
+++ b/__tests__/storageCoverage.test.ts
@@ -61,7 +61,75 @@ function makeCountedStream(chunks: Uint8Array[]): { stream: ReadableStream<Uint8
   return { stream, pullCount: () => count }
 }
 
+// Simulates a slow web client: reads one chunk every `delayMs` milliseconds.
+// Returns the maximum number of chunks the source produced ahead of the consumer
+// at any single point during consumption (i.e. peak in-flight chunks).
+async function slowClientPeakInFlight(stream: ReadableStream<Uint8Array>, delayMs: number, readCount: number) {
+  let chunksConsumed = 0
+  let maxInFlight = 0
+  const reader = stream.getReader()
+  try {
+    for (let i = 0; i < readCount; i++) {
+      await new Promise<void>((r) => setTimeout(r, delayMs))
+      const { done } = await reader.read()
+      if (done) break
+      chunksConsumed++
+      // Access internals aren't exposed — we track in-flight via the source's pull count
+    }
+  } finally {
+    await reader.cancel()
+  }
+  return { chunksConsumed, maxInFlight }
+}
+
 describe('backpressure', () => {
+  test('slow client: source is not drained ahead of consumer', async () => {
+    const TOTAL_CHUNKS = 50
+    const CHUNK_SIZE = 64 * 1024 // 64 KB — realistic HTTP chunk
+
+    let chunksProduced = 0
+    let chunksConsumed = 0
+    let peakInFlight = 0
+
+    // Fast source: produces chunks synchronously whenever pull() is called.
+    // Simulates a file that can be read quickly from disk.
+    const source = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (chunksProduced < TOTAL_CHUNKS) {
+          controller.enqueue(new Uint8Array(CHUNK_SIZE).fill(chunksProduced % 256))
+          chunksProduced++
+        } else {
+          controller.close()
+        }
+      },
+    })
+
+    const inner = new MemoryStorage()
+    vi.spyOn(inner, 'readStream').mockResolvedValue(source)
+    const cachingStorage = new CachingStorage(inner, 100) // large cache — no bypass
+
+    const out = await cachingStorage.readStream('huge.bin', false)
+    const reader = out.getReader()
+
+    // Slow consumer: 10 ms between reads, simulating a rate-limited HTTP client.
+    for (let i = 0; i < 10; i++) {
+      await new Promise<void>((r) => setTimeout(r, 10))
+      const { done } = await reader.read()
+      if (done) break
+      chunksConsumed++
+      peakInFlight = Math.max(peakInFlight, chunksProduced - chunksConsumed)
+    }
+    await reader.cancel()
+
+    // With pull-based backpressure the source stays at most 2 chunks ahead:
+    // one in the inner stream's queue (its reader is held by CachingStorage) and
+    // one in the outer stream's queue (held by the consumer reader).
+    // Without backpressure all 50 chunks would be produced immediately.
+    expect(peakInFlight).toBeLessThanOrEqual(2)
+    expect(chunksProduced).toBeLessThan(TOTAL_CHUNKS)
+  })
+
+
   test('Readable.toWeb streams data in order and supports mid-stream cancellation', async () => {
     const total = 20
     let readCount = 0

--- a/__tests__/storageCoverage.test.ts
+++ b/__tests__/storageCoverage.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { AesEncryptingStorage } from '@/ee/AesEncryptingStorage'
+import { CachingStorage } from '@/lib/storage/CachingStorage'
 import { MemoryStorage } from '@/lib/storage/MemoryStorage'
 import { bufferToReadableStream, collectStreamToBuffer } from '@/lib/storage/utils'
 
@@ -39,6 +40,98 @@ describe('apps/backend/lib/storage/utils', () => {
     await webStream.cancel()
 
     expect(destroySpy).toHaveBeenCalled()
+  })
+})
+
+// A controlled ReadableStream whose source is only pulled on consumer demand.
+// pullCount tracks how many times the source has been asked for data.
+function makeCountedStream(chunks: Uint8Array[]): { stream: ReadableStream<Uint8Array>; pullCount: () => number } {
+  let count = 0
+  let index = 0
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      count++
+      if (index < chunks.length) {
+        controller.enqueue(chunks[index++])
+      } else {
+        controller.close()
+      }
+    },
+  })
+  return { stream, pullCount: () => count }
+}
+
+describe('backpressure', () => {
+  test('Readable.toWeb streams data in order and supports mid-stream cancellation', async () => {
+    const total = 20
+    let readCount = 0
+    const nodeStream = new Readable({
+      read() {
+        if (readCount < total) {
+          this.push(Buffer.from([readCount++]))
+        } else {
+          this.push(null)
+        }
+      },
+    })
+    const destroySpy = vi.spyOn(nodeStream, 'destroy')
+
+    const webStream = Readable.toWeb(nodeStream) as ReadableStream<Uint8Array>
+    const reader = webStream.getReader()
+
+    // Read only the first 5 chunks
+    const received: number[] = []
+    for (let i = 0; i < 5; i++) {
+      const { value } = await reader.read()
+      received.push(value![0])
+    }
+    expect(received).toEqual([0, 1, 2, 3, 4])
+
+    // Cancel mid-stream — underlying node stream must be destroyed
+    await reader.cancel()
+    expect(destroySpy).toHaveBeenCalled()
+  })
+
+  test('CachingStorage does not consume inner stream until consumer reads', async () => {
+    const chunks = Array.from({ length: 10 }, (_, i) => new Uint8Array([i]))
+    const { stream: inner, pullCount } = makeCountedStream(chunks)
+
+    const inner_storage = new MemoryStorage()
+    vi.spyOn(inner_storage, 'readStream').mockResolvedValue(inner)
+
+    const cachingStorage = new CachingStorage(inner_storage, 10)
+    const out = await cachingStorage.readStream('x', false)
+    const reader = out.getReader()
+
+    // Yield without reading — inner stream must not have been pre-drained
+    await new Promise<void>((r) => setImmediate(r))
+    expect(pullCount()).toBeLessThan(chunks.length)
+
+    const first = await reader.read()
+    expect(first.value).toEqual(new Uint8Array([0]))
+
+    await reader.cancel()
+  })
+
+  test('AesEncryptingStorage does not consume inner stream until consumer reads', async () => {
+    const chunks = Array.from({ length: 10 }, (_, i) => new Uint8Array(16).fill(i))
+    const { stream: inner, pullCount } = makeCountedStream(chunks)
+
+    const inner_storage = new MemoryStorage()
+    vi.spyOn(inner_storage, 'readStream').mockResolvedValue(inner)
+
+    const aesStorage = await AesEncryptingStorage.create(inner_storage, 'key')
+    const out = await aesStorage.readStream('path', true)
+    const reader = out.getReader()
+
+    // Yield without reading
+    await new Promise<void>((r) => setImmediate(r))
+    expect(pullCount()).toBeLessThan(chunks.length)
+
+    const first = await reader.read()
+    expect(first.done).toBe(false)
+
+    await reader.cancel()
   })
 })
 

--- a/__tests__/storageCoverage.test.ts
+++ b/__tests__/storageCoverage.test.ts
@@ -61,75 +61,7 @@ function makeCountedStream(chunks: Uint8Array[]): { stream: ReadableStream<Uint8
   return { stream, pullCount: () => count }
 }
 
-// Simulates a slow web client: reads one chunk every `delayMs` milliseconds.
-// Returns the maximum number of chunks the source produced ahead of the consumer
-// at any single point during consumption (i.e. peak in-flight chunks).
-async function slowClientPeakInFlight(stream: ReadableStream<Uint8Array>, delayMs: number, readCount: number) {
-  let chunksConsumed = 0
-  let maxInFlight = 0
-  const reader = stream.getReader()
-  try {
-    for (let i = 0; i < readCount; i++) {
-      await new Promise<void>((r) => setTimeout(r, delayMs))
-      const { done } = await reader.read()
-      if (done) break
-      chunksConsumed++
-      // Access internals aren't exposed — we track in-flight via the source's pull count
-    }
-  } finally {
-    await reader.cancel()
-  }
-  return { chunksConsumed, maxInFlight }
-}
-
 describe('backpressure', () => {
-  test('slow client: source is not drained ahead of consumer', async () => {
-    const TOTAL_CHUNKS = 50
-    const CHUNK_SIZE = 64 * 1024 // 64 KB — realistic HTTP chunk
-
-    let chunksProduced = 0
-    let chunksConsumed = 0
-    let peakInFlight = 0
-
-    // Fast source: produces chunks synchronously whenever pull() is called.
-    // Simulates a file that can be read quickly from disk.
-    const source = new ReadableStream<Uint8Array>({
-      pull(controller) {
-        if (chunksProduced < TOTAL_CHUNKS) {
-          controller.enqueue(new Uint8Array(CHUNK_SIZE).fill(chunksProduced % 256))
-          chunksProduced++
-        } else {
-          controller.close()
-        }
-      },
-    })
-
-    const inner = new MemoryStorage()
-    vi.spyOn(inner, 'readStream').mockResolvedValue(source)
-    const cachingStorage = new CachingStorage(inner, 100) // large cache — no bypass
-
-    const out = await cachingStorage.readStream('huge.bin', false)
-    const reader = out.getReader()
-
-    // Slow consumer: 10 ms between reads, simulating a rate-limited HTTP client.
-    for (let i = 0; i < 10; i++) {
-      await new Promise<void>((r) => setTimeout(r, 10))
-      const { done } = await reader.read()
-      if (done) break
-      chunksConsumed++
-      peakInFlight = Math.max(peakInFlight, chunksProduced - chunksConsumed)
-    }
-    await reader.cancel()
-
-    // With pull-based backpressure the source stays at most 2 chunks ahead:
-    // one in the inner stream's queue (its reader is held by CachingStorage) and
-    // one in the outer stream's queue (held by the consumer reader).
-    // Without backpressure all 50 chunks would be produced immediately.
-    expect(peakInFlight).toBeLessThanOrEqual(2)
-    expect(chunksProduced).toBeLessThan(TOTAL_CHUNKS)
-  })
-
-
   test('Readable.toWeb streams data in order and supports mid-stream cancellation', async () => {
     const total = 20
     let readCount = 0
@@ -160,7 +92,7 @@ describe('backpressure', () => {
     expect(destroySpy).toHaveBeenCalled()
   })
 
-  test('CachingStorage does not consume inner stream until consumer reads', async () => {
+  test('CachingStorage eagerly drains the inner stream to avoid blocking uploads on downstream S3 speed', async () => {
     const chunks = Array.from({ length: 10 }, (_, i) => new Uint8Array([i]))
     const { stream: inner, pullCount } = makeCountedStream(chunks)
 
@@ -171,9 +103,10 @@ describe('backpressure', () => {
     const out = await cachingStorage.readStream('x', false)
     const reader = out.getReader()
 
-    // Yield without reading — inner stream must not have been pre-drained
+    // Yield without reading — the inner stream must have been pre-drained eagerly
+    // so that uploads are not blocked by slow downstream (e.g. S3 connection pool).
     await new Promise<void>((r) => setImmediate(r))
-    expect(pullCount()).toBeLessThan(chunks.length)
+    expect(pullCount()).toBe(chunks.length + 1) // +1 for the done sentinel
 
     const first = await reader.read()
     expect(first.value).toEqual(new Uint8Array([0]))

--- a/__tests__/storageCoverage.test.ts
+++ b/__tests__/storageCoverage.test.ts
@@ -5,11 +5,7 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { AesEncryptingStorage } from '@/ee/AesEncryptingStorage'
 import { MemoryStorage } from '@/lib/storage/MemoryStorage'
-import {
-  bufferToReadableStream,
-  collectStreamToBuffer,
-  nodeStreamToReadableStream,
-} from '@/lib/storage/utils'
+import { bufferToReadableStream, collectStreamToBuffer } from '@/lib/storage/utils'
 
 const password = 'my_key'
 
@@ -38,7 +34,7 @@ describe('apps/backend/lib/storage/utils', () => {
   test('destroy node streams when web stream is cancelled', async () => {
     const nodeStream = new Readable({ read() {} })
     const destroySpy = vi.spyOn(nodeStream, 'destroy')
-    const webStream = nodeStreamToReadableStream(nodeStream)
+    const webStream = Readable.toWeb(nodeStream) as ReadableStream<Uint8Array>
 
     await webStream.cancel()
 

--- a/apps/backend/api/files/[fileId]/content/route.ts
+++ b/apps/backend/api/files/[fileId]/content/route.ts
@@ -9,35 +9,6 @@ import { createHash } from 'node:crypto'
 import { z } from 'zod'
 import env from '@/lib/env'
 
-const MAX_ACTIVE_FILE_DOWNLOADS_GLOBAL = 24
-const MAX_ACTIVE_FILE_DOWNLOADS_PER_USER_FILE = 2
-let activeFileDownloads = 0
-const activeFileDownloadsByUserFile = new Map<string, number>()
-
-const acquireDownloadSlot = (sessionUserId: string, fileId: string): boolean => {
-  const key = `${sessionUserId}:${fileId}`
-  const perKey = activeFileDownloadsByUserFile.get(key) ?? 0
-  if (activeFileDownloads >= MAX_ACTIVE_FILE_DOWNLOADS_GLOBAL) {
-    return false
-  }
-  if (perKey >= MAX_ACTIVE_FILE_DOWNLOADS_PER_USER_FILE) {
-    return false
-  }
-  activeFileDownloads += 1
-  activeFileDownloadsByUserFile.set(key, perKey + 1)
-  return true
-}
-
-const releaseDownloadSlot = (sessionUserId: string, fileId: string): void => {
-  const key = `${sessionUserId}:${fileId}`
-  const perKey = activeFileDownloadsByUserFile.get(key) ?? 0
-  if (perKey <= 1) {
-    activeFileDownloadsByUserFile.delete(key)
-  } else {
-    activeFileDownloadsByUserFile.set(key, perKey - 1)
-  }
-  activeFileDownloads = Math.max(0, activeFileDownloads - 1)
-}
 
 // A synchronized tee, i.e. faster reader has to wait
 function _synchronizedTee(
@@ -182,7 +153,7 @@ export const PUT = operation({
 export const GET = operation({
   name: 'Download file content',
   authentication: 'user',
-  responses: [responseSpec(200, z.any()), errorSpec(403), errorSpec(404), errorSpec(429)] as const,
+  responses: [responseSpec(200, z.any()), errorSpec(403), errorSpec(404)] as const,
   implementation: async ({ params, session }) => {
     const file = await db
       .selectFrom('File')
@@ -196,49 +167,14 @@ export const GET = operation({
     if (!(await canAccessFile({ userId: session.userId, userRole: session.userRole }, params.fileId))) {
       return forbidden()
     }
-    if (!acquireDownloadSlot(session.userId, params.fileId)) {
-      return error(429, 'Too many concurrent downloads for this file')
-    }
-    let released = false
-    const release = () => {
-      if (released) return
-      released = true
-      releaseDownloadSlot(session.userId, params.fileId)
-    }
-    try {
-      const fileContent = await storage.readStream(file.path, !!file.encrypted, {
-        expectedSizeBytes: file.size ?? undefined,
-      })
-      const reader = fileContent.getReader()
-      const guardedStream = new ReadableStream<Uint8Array>({
-        async pull(controller) {
-          try {
-            const { done, value } = await reader.read()
-            if (done) {
-              release()
-              controller.close()
-            } else {
-              controller.enqueue(value)
-            }
-          } catch (err) {
-            release()
-            controller.error(err)
-          }
-        },
-        async cancel(reason) {
-          release()
-          await reader.cancel(reason)
-        },
-      })
-      return new Response(guardedStream, {
-        headers: {
-          'content-type': file.type,
-          ...(typeof file.size === 'number' ? { 'content-length': `${file.size}` } : {}),
-        },
-      })
-    } catch (err) {
-      release()
-      throw err
-    }
+    const fileContent = await storage.readStream(file.path, !!file.encrypted, {
+      expectedSizeBytes: file.size ?? undefined,
+    })
+    return new Response(fileContent, {
+      headers: {
+        'content-type': file.type,
+        ...(typeof file.size === 'number' ? { 'content-length': `${file.size}` } : {}),
+      },
+    })
   },
 })

--- a/apps/backend/api/files/[fileId]/content/route.ts
+++ b/apps/backend/api/files/[fileId]/content/route.ts
@@ -9,6 +9,36 @@ import { createHash } from 'node:crypto'
 import { z } from 'zod'
 import env from '@/lib/env'
 
+const MAX_ACTIVE_FILE_DOWNLOADS_GLOBAL = 24
+const MAX_ACTIVE_FILE_DOWNLOADS_PER_USER_FILE = 2
+let activeFileDownloads = 0
+const activeFileDownloadsByUserFile = new Map<string, number>()
+
+const acquireDownloadSlot = (sessionUserId: string, fileId: string): boolean => {
+  const key = `${sessionUserId}:${fileId}`
+  const perKey = activeFileDownloadsByUserFile.get(key) ?? 0
+  if (activeFileDownloads >= MAX_ACTIVE_FILE_DOWNLOADS_GLOBAL) {
+    return false
+  }
+  if (perKey >= MAX_ACTIVE_FILE_DOWNLOADS_PER_USER_FILE) {
+    return false
+  }
+  activeFileDownloads += 1
+  activeFileDownloadsByUserFile.set(key, perKey + 1)
+  return true
+}
+
+const releaseDownloadSlot = (sessionUserId: string, fileId: string): void => {
+  const key = `${sessionUserId}:${fileId}`
+  const perKey = activeFileDownloadsByUserFile.get(key) ?? 0
+  if (perKey <= 1) {
+    activeFileDownloadsByUserFile.delete(key)
+  } else {
+    activeFileDownloadsByUserFile.set(key, perKey - 1)
+  }
+  activeFileDownloads = Math.max(0, activeFileDownloads - 1)
+}
+
 // A synchronized tee, i.e. faster reader has to wait
 function _synchronizedTee(
   input: ReadableStream
@@ -152,7 +182,7 @@ export const PUT = operation({
 export const GET = operation({
   name: 'Download file content',
   authentication: 'user',
-  responses: [responseSpec(200, z.any()), errorSpec(403), errorSpec(404)] as const,
+  responses: [responseSpec(200, z.any()), errorSpec(403), errorSpec(404), errorSpec(429)] as const,
   implementation: async ({ params, session }) => {
     const file = await db
       .selectFrom('File')
@@ -166,14 +196,49 @@ export const GET = operation({
     if (!(await canAccessFile({ userId: session.userId, userRole: session.userRole }, params.fileId))) {
       return forbidden()
     }
-    const fileContent = await storage.readStream(file.path, !!file.encrypted, {
-      expectedSizeBytes: file.size ?? undefined,
-    })
-    return new Response(fileContent, {
-      headers: {
-        'content-type': file.type,
-        ...(typeof file.size === 'number' ? { 'content-length': `${file.size}` } : {}),
-      },
-    })
+    if (!acquireDownloadSlot(session.userId, params.fileId)) {
+      return error(429, 'Too many concurrent downloads for this file')
+    }
+    let released = false
+    const release = () => {
+      if (released) return
+      released = true
+      releaseDownloadSlot(session.userId, params.fileId)
+    }
+    try {
+      const fileContent = await storage.readStream(file.path, !!file.encrypted, {
+        expectedSizeBytes: file.size ?? undefined,
+      })
+      const reader = fileContent.getReader()
+      const guardedStream = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          try {
+            const { done, value } = await reader.read()
+            if (done) {
+              release()
+              controller.close()
+            } else {
+              controller.enqueue(value)
+            }
+          } catch (err) {
+            release()
+            controller.error(err)
+          }
+        },
+        async cancel(reason) {
+          release()
+          await reader.cancel(reason)
+        },
+      })
+      return new Response(guardedStream, {
+        headers: {
+          'content-type': file.type,
+          ...(typeof file.size === 'number' ? { 'content-length': `${file.size}` } : {}),
+        },
+      })
+    } catch (err) {
+      release()
+      throw err
+    }
   },
 })

--- a/apps/backend/api/files/[fileId]/content/route.ts
+++ b/apps/backend/api/files/[fileId]/content/route.ts
@@ -166,7 +166,9 @@ export const GET = operation({
     if (!(await canAccessFile({ userId: session.userId, userRole: session.userRole }, params.fileId))) {
       return forbidden()
     }
-    const fileContent = await storage.readStream(file.path, !!file.encrypted)
+    const fileContent = await storage.readStream(file.path, !!file.encrypted, {
+      expectedSizeBytes: file.size ?? undefined,
+    })
     return new Response(fileContent, {
       headers: {
         'content-type': file.type,

--- a/apps/backend/ee/AesEncryptingStorage.ts
+++ b/apps/backend/ee/AesEncryptingStorage.ts
@@ -123,31 +123,29 @@ export class AesEncryptingStorage extends BaseStorage {
       return new Uint8Array(encrypted)
     }
 
-    return new ReadableStream({
-      start(controller) {
-        const reader = stream.getReader()
-        async function push() {
-          try {
-            const { done, value } = await reader.read()
-            if (done) {
-              const clearText = concatenate(chunks)
-              const encryptedData = await encrypt(clearText)
-              controller.enqueue(encryptedData)
-              controller.close()
-              return
-            }
-            chunks.push(value) // Collect data for Buffer
-            const clearText = getAvailableDataAligned16()
+    const reader = stream.getReader()
+    return new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        try {
+          const { done, value } = await reader.read()
+          if (done) {
+            const clearText = concatenate(chunks)
             const encryptedData = await encrypt(clearText)
             controller.enqueue(encryptedData)
-          } catch (e) {
-            logger.error('Readable stream failed')
-            controller.error(e)
+            controller.close()
             return
           }
-          await push() // Read the next chunk
+          chunks.push(value)
+          const clearText = getAvailableDataAligned16()
+          const encryptedData = await encrypt(clearText)
+          controller.enqueue(encryptedData)
+        } catch (e) {
+          logger.error('Readable stream failed')
+          controller.error(e)
         }
-        void push()
+      },
+      cancel() {
+        return reader.cancel()
       },
     })
   }

--- a/apps/backend/ee/PgpEncryptingStorage.ts
+++ b/apps/backend/ee/PgpEncryptingStorage.ts
@@ -1,44 +1,17 @@
 import { Storage, BaseStorage, StorageReadOptions } from '@/lib/storage/api'
 import * as openpgp from 'openpgp'
+import type { PgpS2kWorkerRuntime } from './pgp-s2k-worker/runtime'
 
-// PGP S2K (String-to-Key) key derivation is synchronous JavaScript and blocks
-// the event loop for ~15ms per call. Serializing decrypt initiations ensures
-// the event loop is only blocked for one S2K at a time instead of N × 15ms.
-class Semaphore {
-  private queue: Array<() => void> = []
-  private running = 0
-  constructor(private readonly limit: number) {}
+// Injected at bootstrap so the EE module doesn't need to construct the worker itself.
+let s2kWorker: PgpS2kWorkerRuntime | null = null
 
-  acquire(): Promise<() => void> {
-    return new Promise((resolve) => {
-      const attempt = () => {
-        if (this.running < this.limit) {
-          this.running++
-          resolve(() => {
-            this.running--
-            const next = this.queue.shift()
-            // setImmediate yields to the macrotask queue so the event loop can
-            // process pending I/O between consecutive S2K derivations.
-            if (next) setImmediate(next)
-          })
-        } else {
-          this.queue.push(attempt)
-        }
-      }
-      attempt()
-    })
-  }
+export function setPgpS2kWorker(worker: PgpS2kWorkerRuntime) {
+  s2kWorker = worker
 }
 
 export class PgpEncryptingStorage extends BaseStorage {
   innerStorage: Storage
   passPhrase: string
-  private readonly decryptSemaphore = new Semaphore(1)
-  // Coalesces concurrent S2K derivations for the same file.
-  // All requests that arrive while S2K is in-flight share one Promise and get
-  // the key as soon as it resolves. The entry is deleted immediately after
-  // resolution so the key is never retained beyond the requests that needed it.
-  private readonly pendingSessionKeys = new Map<string, Promise<openpgp.DecryptedSessionKey>>()
 
   constructor(innerStorage: Storage, passPhrase: string) {
     super()
@@ -58,29 +31,45 @@ export class PgpEncryptingStorage extends BaseStorage {
     const innerStream = await this.innerStorage.readStream(path, encrypted, options)
     if (!encrypted) return innerStream
 
-    // readMessage reads only the PGP packet headers (a few hundred bytes of I/O).
-    // Keeping it outside the semaphore lets concurrent S3/disk reads happen in parallel.
-    const message = await openpgp.readMessage({ binaryMessage: innerStream })
+    // Read the first chunk from the storage stream. The SKESK (session-key
+    // encrypted session key) packet lives in the first ~50 bytes of a PGP
+    // message, well within any single storage chunk.
+    const initialReader = innerStream.getReader()
+    const { value: firstChunk, done } = await initialReader.read()
+    initialReader.releaseLock()
 
-    let pending = this.pendingSessionKeys.get(path)
-    if (!pending) {
-      pending = (async () => {
-        const release = await this.decryptSemaphore.acquire()
-        try {
-          const [sk] = await openpgp.decryptSessionKeys({ message, passwords: [this.passPhrase] })
-          return sk
-        } finally {
-          release()
-          // Remove immediately: requests already awaiting this Promise still
-          // receive the value, but the next request starts a fresh derivation.
-          this.pendingSessionKeys.delete(path)
+    if (!firstChunk || done) throw new Error(`PGP stream for ${path} is empty`)
+
+    // Derive the session key in the worker thread — S2K is synchronous JavaScript
+    // that blocks for ~15ms; running it off the main thread keeps the event loop free
+    // regardless of how many concurrent requests arrive.
+    const worker = s2kWorker
+    if (!worker) throw new Error('PGP S2K worker is not initialised')
+    const sessionKey = await worker.deriveSessionKey(
+      firstChunk.slice(0, Math.min(512, firstChunk.length)),
+      this.passPhrase
+    )
+
+    // Reconstruct the full stream by prepending the already-read first chunk.
+    const restReader = innerStream.getReader()
+    let firstSent = false
+    const fullStream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        if (!firstSent) {
+          firstSent = true
+          controller.enqueue(firstChunk)
+          return
         }
-      })()
-      this.pendingSessionKeys.set(path, pending)
-    }
+        const { done, value } = await restReader.read()
+        if (done) controller.close()
+        else controller.enqueue(value)
+      },
+      cancel() {
+        return restReader.cancel()
+      },
+    })
 
-    const sessionKey = await pending
-
+    const message = await openpgp.readMessage({ binaryMessage: fullStream })
     const { data: clearStream } = await openpgp.decrypt({
       message,
       sessionKeys: [sessionKey as openpgp.SessionKey],

--- a/apps/backend/ee/PgpEncryptingStorage.ts
+++ b/apps/backend/ee/PgpEncryptingStorage.ts
@@ -1,9 +1,40 @@
 import { Storage, BaseStorage, StorageReadOptions } from '@/lib/storage/api'
 import * as openpgp from 'openpgp'
 
+// PGP S2K (String-to-Key) key derivation is synchronous JavaScript and blocks
+// the event loop for ~15ms per call. Serializing decrypt initiations ensures
+// the event loop is only blocked for one S2K at a time instead of N × 15ms.
+class Semaphore {
+  private queue: Array<() => void> = []
+  private running = 0
+  constructor(private readonly limit: number) {}
+
+  acquire(): Promise<() => void> {
+    return new Promise((resolve) => {
+      const attempt = () => {
+        if (this.running < this.limit) {
+          this.running++
+          resolve(() => {
+            this.running--
+            const next = this.queue.shift()
+            // setImmediate yields to the macrotask queue so the event loop can
+            // process pending I/O between consecutive S2K derivations.
+            if (next) setImmediate(next)
+          })
+        } else {
+          this.queue.push(attempt)
+        }
+      }
+      attempt()
+    })
+  }
+}
+
 export class PgpEncryptingStorage extends BaseStorage {
   innerStorage: Storage
   passPhrase: string
+  private readonly decryptSemaphore = new Semaphore(1)
+
   constructor(innerStorage: Storage, passPhrase: string) {
     super()
     this.innerStorage = innerStorage
@@ -21,12 +52,17 @@ export class PgpEncryptingStorage extends BaseStorage {
   ): Promise<ReadableStream<Uint8Array>> {
     const innerStream = await this.innerStorage.readStream(path, encrypted, options)
     if (!encrypted) return innerStream
-    const { data: clearStream } = await openpgp.decrypt({
-      message: await openpgp.readMessage({ binaryMessage: innerStream }),
-      passwords: [this.passPhrase], // Use the passphrase for encryption
-      format: 'binary', // Use 'binary' format for streaming
-    })
-    return clearStream
+    const release = await this.decryptSemaphore.acquire()
+    try {
+      const { data: clearStream } = await openpgp.decrypt({
+        message: await openpgp.readMessage({ binaryMessage: innerStream }),
+        passwords: [this.passPhrase],
+        format: 'binary',
+      })
+      return clearStream
+    } finally {
+      release()
+    }
   }
 
   async writeStream(

--- a/apps/backend/ee/PgpEncryptingStorage.ts
+++ b/apps/backend/ee/PgpEncryptingStorage.ts
@@ -1,12 +1,39 @@
 import { Storage, BaseStorage, StorageReadOptions } from '@/lib/storage/api'
 import * as openpgp from 'openpgp'
 import type { PgpS2kWorkerRuntime } from './pgp-s2k-worker/runtime'
+import { streamingIteratedS2kProduceKey } from './pgp-s2k-worker/streaming-s2k'
 
 // Injected at bootstrap so the EE module doesn't need to construct the worker itself.
 let s2kWorker: PgpS2kWorkerRuntime | null = null
 
 export function setPgpS2kWorker(worker: PgpS2kWorkerRuntime) {
   s2kWorker = worker
+}
+
+// Direct (same-thread) fallback used when the worker is not running (e.g. tests).
+async function deriveSessionKeyDirect(
+  headerBytes: Uint8Array,
+  passphrase: string
+): Promise<openpgp.DecryptedSessionKey> {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(headerBytes)
+      // Intentionally do NOT close — same reasoning as the worker script.
+    },
+  })
+  const message = await openpgp.readMessage({ binaryMessage: stream })
+
+  for (const pkt of message.packets.filterByTag(openpgp.enums.packet.symEncryptedSessionKey)) {
+    const s2k = (pkt as any).s2k
+    if (s2k?.type === 'iterated') {
+      const { algorithm, salt, c } = s2k
+      s2k.produceKey = (pass: string, keySizeBytes: number): Promise<Uint8Array> =>
+        Promise.resolve(streamingIteratedS2kProduceKey(algorithm, salt, c, pass, keySizeBytes))
+    }
+  }
+
+  const [sk] = await openpgp.decryptSessionKeys({ message, passwords: [passphrase] })
+  return sk
 }
 
 export class PgpEncryptingStorage extends BaseStorage {
@@ -40,15 +67,13 @@ export class PgpEncryptingStorage extends BaseStorage {
 
     if (!firstChunk || done) throw new Error(`PGP stream for ${path} is empty`)
 
-    // Derive the session key in the worker thread — S2K is synchronous JavaScript
-    // that blocks for ~15ms; running it off the main thread keeps the event loop free
-    // regardless of how many concurrent requests arrive.
-    const worker = s2kWorker
-    if (!worker) throw new Error('PGP S2K worker is not initialised')
-    const sessionKey = await worker.deriveSessionKey(
-      firstChunk.slice(0, Math.min(512, firstChunk.length)),
-      this.passPhrase
-    )
+    // Derive the session key. The worker offloads the ~4ms S2K computation off
+    // the main thread; fall back to a direct call when the worker is not running
+    // (e.g. in tests or standalone scripts).
+    const headerBytes = firstChunk.slice(0, Math.min(512, firstChunk.length))
+    const sessionKey = s2kWorker
+      ? await s2kWorker.deriveSessionKey(headerBytes, this.passPhrase)
+      : await deriveSessionKeyDirect(headerBytes, this.passPhrase)
 
     // Reconstruct the full stream by prepending the already-read first chunk.
     const restReader = innerStream.getReader()

--- a/apps/backend/ee/PgpEncryptingStorage.ts
+++ b/apps/backend/ee/PgpEncryptingStorage.ts
@@ -1,7 +1,7 @@
 import { Storage, BaseStorage, StorageReadOptions } from '@/lib/storage/api'
 import * as openpgp from 'openpgp'
 import type { PgpS2kWorkerRuntime } from './pgp-s2k-worker/runtime'
-import { streamingIteratedS2kProduceKey } from './pgp-s2k-worker/streaming-s2k'
+import { patchSkeskPackets } from './pgp-s2k-worker/streaming-s2k'
 
 // Injected at bootstrap so the EE module doesn't need to construct the worker itself.
 let s2kWorker: PgpS2kWorkerRuntime | null = null
@@ -23,14 +23,7 @@ async function deriveSessionKeyDirect(
   })
   const message = await openpgp.readMessage({ binaryMessage: stream })
 
-  for (const pkt of message.packets.filterByTag(openpgp.enums.packet.symEncryptedSessionKey)) {
-    const s2k = (pkt as any).s2k
-    if (s2k?.type === 'iterated') {
-      const { algorithm, salt, c } = s2k
-      s2k.produceKey = (pass: string, keySizeBytes: number): Promise<Uint8Array> =>
-        Promise.resolve(streamingIteratedS2kProduceKey(algorithm, salt, c, pass, keySizeBytes))
-    }
-  }
+  patchSkeskPackets(message)
 
   const [sk] = await openpgp.decryptSessionKeys({ message, passwords: [passphrase] })
   return sk

--- a/apps/backend/ee/PgpEncryptingStorage.ts
+++ b/apps/backend/ee/PgpEncryptingStorage.ts
@@ -1,5 +1,6 @@
 import { Storage, BaseStorage, StorageReadOptions } from '@/lib/storage/api'
 import * as openpgp from 'openpgp'
+import { LRUCache } from 'lru-cache'
 import type { PgpS2kWorkerRuntime } from './pgp-s2k-worker/runtime'
 import { patchSkeskPackets } from './pgp-s2k-worker/streaming-s2k'
 
@@ -29,9 +30,21 @@ async function deriveSessionKeyDirect(
   return sk
 }
 
+// Minimum bytes needed to contain the PGP SKESK header (v4 iterated S2K ≈ 18B)
+// plus the start of the following SEIPD packet header. 64B is a comfortable margin.
+const MIN_HEADER_BYTES = 64
+const MAX_HEADER_BYTES = 512
+
 export class PgpEncryptingStorage extends BaseStorage {
   innerStorage: Storage
   passPhrase: string
+
+  // Session keys are deterministic for a given (path, passphrase) pair and
+  // expensive to derive (~4ms per S2K at count=224). Cache them for 1 hour.
+  private sessionKeyCache = new LRUCache<string, openpgp.DecryptedSessionKey>({
+    max: 1000,
+    ttl: 60 * 60 * 1000,
+  })
 
   constructor(innerStorage: Storage, passPhrase: string) {
     super()
@@ -51,36 +64,56 @@ export class PgpEncryptingStorage extends BaseStorage {
     const innerStream = await this.innerStorage.readStream(path, encrypted, options)
     if (!encrypted) return innerStream
 
-    // Read the first chunk from the storage stream. The SKESK (session-key
-    // encrypted session key) packet lives in the first ~50 bytes of a PGP
-    // message, well within any single storage chunk.
+    // Accumulate chunks until we have enough bytes to parse the SKESK header.
+    // Storage backends may return arbitrarily small initial chunks (e.g. an
+    // in-memory stream that yields one byte at a time), so we cannot assume
+    // the first chunk alone contains the full header.
+    const bufferedChunks: Uint8Array[] = []
+    let bufferedSize = 0
+
     const initialReader = innerStream.getReader()
-    const { value: firstChunk, done } = await initialReader.read()
+    while (bufferedSize < MIN_HEADER_BYTES) {
+      const { value, done } = await initialReader.read()
+      if (done) break
+      bufferedChunks.push(value)
+      bufferedSize += value.length
+    }
     initialReader.releaseLock()
 
-    if (!firstChunk || done) throw new Error(`PGP stream for ${path} is empty`)
+    if (bufferedSize === 0) throw new Error(`PGP stream for ${path} is empty`)
 
-    // Derive the session key. The worker offloads the ~4ms S2K computation off
-    // the main thread; fall back to a direct call when the worker is not running
-    // (e.g. in tests or standalone scripts).
-    const headerBytes = firstChunk.slice(0, Math.min(512, firstChunk.length))
-    const sessionKey = s2kWorker
-      ? await s2kWorker.deriveSessionKey(headerBytes, this.passPhrase)
-      : await deriveSessionKeyDirect(headerBytes, this.passPhrase)
+    // Build a header slice (up to MAX_HEADER_BYTES) from the buffered chunks.
+    const headerBuf = new Uint8Array(Math.min(bufferedSize, MAX_HEADER_BYTES))
+    let off = 0
+    for (const chunk of bufferedChunks) {
+      if (off >= headerBuf.length) break
+      const n = Math.min(chunk.length, headerBuf.length - off)
+      headerBuf.set(chunk.subarray(0, n), off)
+      off += n
+    }
 
-    // Reconstruct the full stream by prepending the already-read first chunk.
+    // Session key derivation — cached by path (each blob has a fixed SKESK).
+    let sessionKey = this.sessionKeyCache.get(path)
+    if (!sessionKey) {
+      sessionKey = s2kWorker
+        ? await s2kWorker.deriveSessionKey(headerBuf, this.passPhrase)
+        : await deriveSessionKeyDirect(headerBuf, this.passPhrase)
+      this.sessionKeyCache.set(path, sessionKey)
+    }
+
+    // Reconstruct the full stream: replay buffered chunks, then continue reading.
     const restReader = innerStream.getReader()
-    let firstSent = false
+    let chunkIdx = 0
     const fullStream = new ReadableStream<Uint8Array>({
-      async pull(controller) {
-        if (!firstSent) {
-          firstSent = true
-          controller.enqueue(firstChunk)
+      pull(controller) {
+        if (chunkIdx < bufferedChunks.length) {
+          controller.enqueue(bufferedChunks[chunkIdx++])
           return
         }
-        const { done, value } = await restReader.read()
-        if (done) controller.close()
-        else controller.enqueue(value)
+        return restReader.read().then(({ done, value }) => {
+          if (done) controller.close()
+          else controller.enqueue(value)
+        })
       },
       cancel() {
         return restReader.cancel()

--- a/apps/backend/ee/PgpEncryptingStorage.ts
+++ b/apps/backend/ee/PgpEncryptingStorage.ts
@@ -40,8 +40,9 @@ export class PgpEncryptingStorage extends BaseStorage {
   passPhrase: string
 
   // Session keys are deterministic for a given (path, passphrase) pair and
-  // expensive to derive (~4ms per S2K at count=224). Cache them for 1 hour.
-  private sessionKeyCache = new LRUCache<string, openpgp.DecryptedSessionKey>({
+  // expensive to derive (~4ms per S2K at count=224). Cache the derivation
+  // promise so concurrent requests for the same file share one S2K task.
+  private sessionKeyCache = new LRUCache<string, Promise<openpgp.DecryptedSessionKey>>({
     max: 1000,
     ttl: 60 * 60 * 1000,
   })
@@ -93,13 +94,19 @@ export class PgpEncryptingStorage extends BaseStorage {
     }
 
     // Session key derivation — cached by path (each blob has a fixed SKESK).
-    let sessionKey = this.sessionKeyCache.get(path)
-    if (!sessionKey) {
-      sessionKey = s2kWorker
-        ? await s2kWorker.deriveSessionKey(headerBuf, this.passPhrase)
-        : await deriveSessionKeyDirect(headerBuf, this.passPhrase)
-      this.sessionKeyCache.set(path, sessionKey)
+    // Cache in-flight promises to deduplicate concurrent work.
+    let sessionKeyPromise = this.sessionKeyCache.get(path)
+    if (!sessionKeyPromise) {
+      sessionKeyPromise = (s2kWorker
+        ? s2kWorker.deriveSessionKey(headerBuf, this.passPhrase)
+        : deriveSessionKeyDirect(headerBuf, this.passPhrase)
+      ).catch((error) => {
+        this.sessionKeyCache.delete(path)
+        throw error
+      })
+      this.sessionKeyCache.set(path, sessionKeyPromise)
     }
+    const sessionKey = await sessionKeyPromise
 
     // Reconstruct the full stream: replay buffered chunks, then continue reading.
     const restReader = innerStream.getReader()

--- a/apps/backend/ee/PgpEncryptingStorage.ts
+++ b/apps/backend/ee/PgpEncryptingStorage.ts
@@ -34,11 +34,11 @@ export class PgpEncryptingStorage extends BaseStorage {
   innerStorage: Storage
   passPhrase: string
   private readonly decryptSemaphore = new Semaphore(1)
-  // Session keys are deterministic per file (same S2K params + same password = same key).
-  // Caching them amortises the ~15ms S2K cost across all reads of the same file:
-  // 100 concurrent requests go from 100×15ms = 1500ms to 1×15ms + 99×<1ms = ~15ms.
-  // Invalidated on write/delete so stale keys are never used after file replacement.
-  private readonly sessionKeyCache = new Map<string, openpgp.DecryptedSessionKey>()
+  // Coalesces concurrent S2K derivations for the same file.
+  // All requests that arrive while S2K is in-flight share one Promise and get
+  // the key as soon as it resolves. The entry is deleted immediately after
+  // resolution so the key is never retained beyond the requests that needed it.
+  private readonly pendingSessionKeys = new Map<string, Promise<openpgp.DecryptedSessionKey>>()
 
   constructor(innerStorage: Storage, passPhrase: string) {
     super()
@@ -62,21 +62,24 @@ export class PgpEncryptingStorage extends BaseStorage {
     // Keeping it outside the semaphore lets concurrent S3/disk reads happen in parallel.
     const message = await openpgp.readMessage({ binaryMessage: innerStream })
 
-    let sessionKey = this.sessionKeyCache.get(path)
-    if (!sessionKey) {
-      const release = await this.decryptSemaphore.acquire()
-      try {
-        // Re-check after acquiring: another request may have populated the cache.
-        sessionKey = this.sessionKeyCache.get(path)
-        if (!sessionKey) {
+    let pending = this.pendingSessionKeys.get(path)
+    if (!pending) {
+      pending = (async () => {
+        const release = await this.decryptSemaphore.acquire()
+        try {
           const [sk] = await openpgp.decryptSessionKeys({ message, passwords: [this.passPhrase] })
-          this.sessionKeyCache.set(path, sk)
-          sessionKey = sk
+          return sk
+        } finally {
+          release()
+          // Remove immediately: requests already awaiting this Promise still
+          // receive the value, but the next request starts a fresh derivation.
+          this.pendingSessionKeys.delete(path)
         }
-      } finally {
-        release()
-      }
+      })()
+      this.pendingSessionKeys.set(path, pending)
     }
+
+    const sessionKey = await pending
 
     const { data: clearStream } = await openpgp.decrypt({
       message,
@@ -92,7 +95,6 @@ export class PgpEncryptingStorage extends BaseStorage {
     encrypted: boolean
   ): Promise<void> {
     if (encrypted) {
-      this.sessionKeyCache.delete(path)
       stream = await openpgp.encrypt({
         message: await openpgp.createMessage({ binary: stream }),
         passwords: [this.passPhrase],
@@ -103,7 +105,6 @@ export class PgpEncryptingStorage extends BaseStorage {
   }
 
   rm(path: string): Promise<void> {
-    this.sessionKeyCache.delete(path)
     return this.innerStorage.rm(path)
   }
 }

--- a/apps/backend/ee/PgpEncryptingStorage.ts
+++ b/apps/backend/ee/PgpEncryptingStorage.ts
@@ -34,6 +34,11 @@ export class PgpEncryptingStorage extends BaseStorage {
   innerStorage: Storage
   passPhrase: string
   private readonly decryptSemaphore = new Semaphore(1)
+  // Session keys are deterministic per file (same S2K params + same password = same key).
+  // Caching them amortises the ~15ms S2K cost across all reads of the same file:
+  // 100 concurrent requests go from 100×15ms = 1500ms to 1×15ms + 99×<1ms = ~15ms.
+  // Invalidated on write/delete so stale keys are never used after file replacement.
+  private readonly sessionKeyCache = new Map<string, openpgp.DecryptedSessionKey>()
 
   constructor(innerStorage: Storage, passPhrase: string) {
     super()
@@ -52,17 +57,33 @@ export class PgpEncryptingStorage extends BaseStorage {
   ): Promise<ReadableStream<Uint8Array>> {
     const innerStream = await this.innerStorage.readStream(path, encrypted, options)
     if (!encrypted) return innerStream
-    const release = await this.decryptSemaphore.acquire()
-    try {
-      const { data: clearStream } = await openpgp.decrypt({
-        message: await openpgp.readMessage({ binaryMessage: innerStream }),
-        passwords: [this.passPhrase],
-        format: 'binary',
-      })
-      return clearStream
-    } finally {
-      release()
+
+    // readMessage reads only the PGP packet headers (a few hundred bytes of I/O).
+    // Keeping it outside the semaphore lets concurrent S3/disk reads happen in parallel.
+    const message = await openpgp.readMessage({ binaryMessage: innerStream })
+
+    let sessionKey = this.sessionKeyCache.get(path)
+    if (!sessionKey) {
+      const release = await this.decryptSemaphore.acquire()
+      try {
+        // Re-check after acquiring: another request may have populated the cache.
+        sessionKey = this.sessionKeyCache.get(path)
+        if (!sessionKey) {
+          const [sk] = await openpgp.decryptSessionKeys({ message, passwords: [this.passPhrase] })
+          this.sessionKeyCache.set(path, sk)
+          sessionKey = sk
+        }
+      } finally {
+        release()
+      }
     }
+
+    const { data: clearStream } = await openpgp.decrypt({
+      message,
+      sessionKeys: [sessionKey as openpgp.SessionKey],
+      format: 'binary',
+    })
+    return clearStream
   }
 
   async writeStream(
@@ -71,16 +92,18 @@ export class PgpEncryptingStorage extends BaseStorage {
     encrypted: boolean
   ): Promise<void> {
     if (encrypted) {
+      this.sessionKeyCache.delete(path)
       stream = await openpgp.encrypt({
         message: await openpgp.createMessage({ binary: stream }),
-        passwords: [this.passPhrase], // Use the passphrase for encryption
-        format: 'binary', // Use 'binary' format for streaming
+        passwords: [this.passPhrase],
+        format: 'binary',
       })
     }
     return this.innerStorage.writeStream(path, stream, encrypted)
   }
 
   rm(path: string): Promise<void> {
+    this.sessionKeyCache.delete(path)
     return this.innerStorage.rm(path)
   }
 }

--- a/apps/backend/ee/pgp-s2k-worker/runtime.ts
+++ b/apps/backend/ee/pgp-s2k-worker/runtime.ts
@@ -1,0 +1,81 @@
+import { Worker } from 'worker_threads'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import fs from 'fs'
+import type * as openpgp from 'openpgp'
+
+type PendingRequest = {
+  resolve: (key: openpgp.DecryptedSessionKey) => void
+  reject: (error: Error) => void
+}
+
+export class PgpS2kWorkerRuntime {
+  private worker: Worker
+  private pending = new Map<number, PendingRequest>()
+  private nextId = 1
+
+  constructor() {
+    const isDev = process.env.NODE_ENV !== 'production'
+    const scriptPath = this.resolveScriptPath(isDev)
+    const execArgv = isDev ? ['--import', 'tsx'] : []
+
+    this.worker = new Worker(scriptPath, { execArgv, name: 'pgp-s2k' })
+
+    this.worker.on(
+      'message',
+      (msg: { id: number; ok: boolean; algorithm?: string; data?: number[]; error?: string }) => {
+        const pending = this.pending.get(msg.id)
+        if (!pending) return
+        this.pending.delete(msg.id)
+        if (msg.ok) {
+          pending.resolve({
+            algorithm: msg.algorithm as openpgp.DecryptedSessionKey['algorithm'],
+            data: new Uint8Array(msg.data!),
+          })
+        } else {
+          pending.reject(new Error(msg.error ?? 'PGP S2K worker failed'))
+        }
+      }
+    )
+
+    this.worker.on('error', (err) => {
+      for (const { reject } of this.pending.values()) reject(err)
+      this.pending.clear()
+    })
+
+    this.worker.on('exit', (code) => {
+      if (code !== 0) {
+        for (const { reject } of this.pending.values()) {
+          reject(new Error(`PGP S2K worker exited with code ${code}`))
+        }
+        this.pending.clear()
+      }
+    })
+  }
+
+  private resolveScriptPath(isDev: boolean): string {
+    const currentDir = path.dirname(fileURLToPath(import.meta.url))
+
+    if (!isDev) {
+      return path.join(currentDir, 'pgp-s2k-script.js')
+    }
+
+    const candidates = [
+      path.join(currentDir, 'script.ts'),
+      path.resolve(process.cwd(), 'apps/backend/ee/pgp-s2k-worker/script.ts'),
+    ]
+    for (const candidate of candidates) {
+      if (fs.existsSync(candidate)) return candidate
+    }
+
+    throw new Error(`Unable to locate PGP S2K worker script. Tried: ${candidates.join(', ')}`)
+  }
+
+  deriveSessionKey(headerBytes: Uint8Array, passphrase: string): Promise<openpgp.DecryptedSessionKey> {
+    return new Promise((resolve, reject) => {
+      const id = this.nextId++
+      this.pending.set(id, { resolve, reject })
+      this.worker.postMessage({ id, headerBytes: Array.from(headerBytes), passphrase })
+    })
+  }
+}

--- a/apps/backend/ee/pgp-s2k-worker/script.ts
+++ b/apps/backend/ee/pgp-s2k-worker/script.ts
@@ -1,5 +1,6 @@
 import { parentPort } from 'worker_threads'
 import * as openpgp from 'openpgp'
+import { streamingIteratedS2kProduceKey } from './streaming-s2k'
 
 if (!parentPort) throw new Error('pgp-s2k worker script must run inside a Worker thread')
 
@@ -22,6 +23,20 @@ parentPort.on('message', async (msg: Request) => {
       },
     })
     const message = await openpgp.readMessage({ binaryMessage: stream })
+
+    // Replace the GenericS2K produceKey on every iterated SKESK packet with
+    // the streaming implementation, which hashes the repeated salt||passphrase
+    // block in 64 KB chunks instead of materialising up to ~65 MB at once.
+    // All other openpgp machinery (CFB session-key unwrap, AEAD, etc.) is unchanged.
+    for (const pkt of message.packets.filterByTag(openpgp.enums.packet.symEncryptedSessionKey)) {
+      const s2k = (pkt as any).s2k
+      if (s2k?.type === 'iterated') {
+        const { algorithm, salt, c } = s2k
+        s2k.produceKey = (passphrase: string, keySizeBytes: number): Promise<Uint8Array> =>
+          Promise.resolve(streamingIteratedS2kProduceKey(algorithm, salt, c, passphrase, keySizeBytes))
+      }
+    }
+
     const [sk] = await openpgp.decryptSessionKeys({ message, passwords: [msg.passphrase] })
     parentPort!.postMessage({
       id: msg.id,

--- a/apps/backend/ee/pgp-s2k-worker/script.ts
+++ b/apps/backend/ee/pgp-s2k-worker/script.ts
@@ -1,0 +1,39 @@
+import { parentPort } from 'worker_threads'
+import * as openpgp from 'openpgp'
+
+if (!parentPort) throw new Error('pgp-s2k worker script must run inside a Worker thread')
+
+type Request = { id: number; headerBytes: number[]; passphrase: string }
+
+parentPort.on('message', async (msg: Request) => {
+  try {
+    // Feed a non-closing ReadableStream rather than a plain Uint8Array.
+    // A truncated Uint8Array would make readMessage throw "Unexpected end of packet"
+    // when it sees the SEIPD body length (107 MB) but only has a few hundred bytes.
+    // A stream that enqueues the header bytes and then never closes lets readMessage
+    // return as soon as it has parsed the SKESK packet (~50 bytes) and the SEIPD
+    // packet header (~5 bytes) without waiting for the bulk ciphertext.
+    const bytes = new Uint8Array(msg.headerBytes)
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes)
+        // Intentionally do NOT close — the stream stays open to simulate an
+        // ongoing PGP message whose SEIPD body has not arrived yet.
+      },
+    })
+    const message = await openpgp.readMessage({ binaryMessage: stream })
+    const [sk] = await openpgp.decryptSessionKeys({ message, passwords: [msg.passphrase] })
+    parentPort!.postMessage({
+      id: msg.id,
+      ok: true,
+      algorithm: sk.algorithm,
+      data: Array.from(sk.data),
+    })
+  } catch (e) {
+    parentPort!.postMessage({
+      id: msg.id,
+      ok: false,
+      error: e instanceof Error ? e.message : String(e),
+    })
+  }
+})

--- a/apps/backend/ee/pgp-s2k-worker/script.ts
+++ b/apps/backend/ee/pgp-s2k-worker/script.ts
@@ -1,6 +1,6 @@
 import { parentPort } from 'worker_threads'
 import * as openpgp from 'openpgp'
-import { streamingIteratedS2kProduceKey } from './streaming-s2k'
+import { patchSkeskPackets } from './streaming-s2k'
 
 if (!parentPort) throw new Error('pgp-s2k worker script must run inside a Worker thread')
 
@@ -24,18 +24,7 @@ parentPort.on('message', async (msg: Request) => {
     })
     const message = await openpgp.readMessage({ binaryMessage: stream })
 
-    // Replace the GenericS2K produceKey on every iterated SKESK packet with
-    // the streaming implementation, which hashes the repeated salt||passphrase
-    // block in 64 KB chunks instead of materialising up to ~65 MB at once.
-    // All other openpgp machinery (CFB session-key unwrap, AEAD, etc.) is unchanged.
-    for (const pkt of message.packets.filterByTag(openpgp.enums.packet.symEncryptedSessionKey)) {
-      const s2k = (pkt as any).s2k
-      if (s2k?.type === 'iterated') {
-        const { algorithm, salt, c } = s2k
-        s2k.produceKey = (passphrase: string, keySizeBytes: number): Promise<Uint8Array> =>
-          Promise.resolve(streamingIteratedS2kProduceKey(algorithm, salt, c, passphrase, keySizeBytes))
-      }
-    }
+    patchSkeskPackets(message)
 
     const [sk] = await openpgp.decryptSessionKeys({ message, passwords: [msg.passphrase] })
     parentPort!.postMessage({

--- a/apps/backend/ee/pgp-s2k-worker/streaming-s2k.ts
+++ b/apps/backend/ee/pgp-s2k-worker/streaming-s2k.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto'
+import * as openpgp from 'openpgp'
 
 /**
  * Maps OpenPGP hash enum bytes (RFC 4880 §9.4) to Node.js crypto names.
@@ -98,4 +99,21 @@ export function streamingIteratedS2kProduceKey(
   }
 
   return Buffer.concat(digests).subarray(0, keySizeBytes)
+}
+
+/**
+ * Patch every iterated SKESK packet in `message` so that its `s2k.produceKey`
+ * calls `streamingIteratedS2kProduceKey` instead of the default OpenPGP.js
+ * implementation.  All other openpgp machinery (CFB session-key unwrap, AEAD,
+ * output formatting) is left unchanged.
+ */
+export function patchSkeskPackets(message: openpgp.Message<Uint8Array>): void {
+  for (const pkt of message.packets.filterByTag(openpgp.enums.packet.symEncryptedSessionKey)) {
+    const s2k = (pkt as any).s2k
+    if (s2k?.type === 'iterated') {
+      const { algorithm, salt, c } = s2k
+      s2k.produceKey = (passphrase: string, keySizeBytes: number): Promise<Uint8Array> =>
+        Promise.resolve(streamingIteratedS2kProduceKey(algorithm, salt, c, passphrase, keySizeBytes))
+    }
+  }
 }

--- a/apps/backend/ee/pgp-s2k-worker/streaming-s2k.ts
+++ b/apps/backend/ee/pgp-s2k-worker/streaming-s2k.ts
@@ -1,0 +1,101 @@
+import { createHash } from 'node:crypto'
+
+/**
+ * Maps OpenPGP hash enum bytes (RFC 4880 §9.4) to Node.js crypto names.
+ */
+const HASH_NAMES: Readonly<Record<number, string>> = {
+  1: 'md5',
+  2: 'sha1',
+  3: 'ripemd160',
+  8: 'sha256',
+  9: 'sha384',
+  10: 'sha512',
+  11: 'sha224',
+  12: 'sha3-256',
+  14: 'sha3-512',
+}
+
+/**
+ * Maximum bytes fed to the hash per update() call.
+ *
+ * We build a reusable chunk of `floor(CHUNK_BYTES / block.length)` copies of
+ * `block`, so the repeating boundary never falls mid-chunk and the total bytes
+ * fed matches the reference implementation exactly.
+ */
+const CHUNK_BYTES = 65_536
+
+/**
+ * Produce an OpenPGP Generic Iterated S2K derived key without materialising
+ * the full `count`-byte buffer in memory.
+ *
+ * Equivalent to OpenPGP.js `GenericS2K.produceKey` for the `iterated` type,
+ * but hashes the repeated `salt || passphrase` block in 64 KB streaming
+ * chunks instead of allocating a single buffer of up to ~65 MB.
+ *
+ * Algorithm (RFC 4880 §3.7.1.3):
+ *   count  = max((16 + (C & 15)) << ((C >> 4) + 6),  block.length)
+ *   block  = salt || passphraseBytes
+ *   round k: SHA(0x00×k || block repeated up to count bytes) → digestK
+ *   key    = concat(digest0, digest1, …)[0 : keySizeBytes]
+ *
+ * @param hashAlgoByte  OpenPGP hash enum byte stored in GenericS2K.algorithm
+ * @param salt          8-byte salt stored in GenericS2K.salt
+ * @param encodedCount  1-byte encoded count stored in GenericS2K.c
+ * @param passphrase    Passphrase string (UTF-8 encoded internally)
+ * @param keySizeBytes  Desired key length in bytes
+ */
+export function streamingIteratedS2kProduceKey(
+  hashAlgoByte: number,
+  salt: Uint8Array,
+  encodedCount: number,
+  passphrase: string,
+  keySizeBytes: number,
+): Uint8Array {
+  const hashName = HASH_NAMES[hashAlgoByte]
+  if (!hashName) throw new Error(`Unsupported OpenPGP hash algorithm byte: ${hashAlgoByte}`)
+
+  const passphraseBytes = Buffer.from(passphrase, 'utf8')
+  const block = Buffer.concat([Buffer.from(salt), passphraseBytes])
+
+  if (block.length === 0) throw new Error('S2K block is empty — salt must be present')
+
+  const decodedCount = (16 + (encodedCount & 15)) << ((encodedCount >> 4) + 6)
+  const count = Math.max(decodedCount, block.length)
+
+  // Build a reusable chunk: an exact multiple of block.length, up to CHUNK_BYTES.
+  // Because the chunk length is a multiple of block.length, `chunk[0..remaining-1]`
+  // always contains the correct repeating-pattern suffix when `count` is not a
+  // multiple of chunk.length.
+  const repeats = Math.max(1, Math.floor(CHUNK_BYTES / block.length))
+  const chunk = Buffer.allocUnsafe(repeats * block.length)
+  for (let i = 0; i < repeats; i++) chunk.set(block, i * block.length)
+  const chunkLen = chunk.length
+
+  const digests: Buffer[] = []
+  let totalBytes = 0
+  let prefixLen = 0 // number of leading zero bytes for digest round k
+
+  while (totalBytes < keySizeBytes) {
+    const h = createHash(hashName)
+    if (prefixLen > 0) h.update(Buffer.alloc(prefixLen))
+
+    let fed = 0
+    while (fed < count) {
+      const remaining = count - fed
+      if (remaining >= chunkLen) {
+        h.update(chunk)
+        fed += chunkLen
+      } else {
+        h.update(chunk.subarray(0, remaining))
+        fed = count
+      }
+    }
+
+    const digest = h.digest()
+    digests.push(digest)
+    totalBytes += digest.length
+    prefixLen++
+  }
+
+  return Buffer.concat(digests).subarray(0, keySizeBytes)
+}

--- a/apps/backend/lib/bootstrap.ts
+++ b/apps/backend/lib/bootstrap.ts
@@ -8,6 +8,8 @@ import env from '@/lib/env'
 import { startSearchWorker } from '@/lib/search/runtime'
 import { TokenizerWorkerRuntime } from '@/backend/lib/chat/tokenizer-worker/runtime'
 import { setTokenizerWorker } from '@/backend/lib/chat/prompt-token-counter'
+import { PgpS2kWorkerRuntime } from '@/ee/pgp-s2k-worker/runtime'
+import { setPgpS2kWorker } from '@/ee/PgpEncryptingStorage'
 import { startFileOrphanCleanupRuntime } from '@/backend/lib/files/orphan-cleanup'
 
 let backendBootstrapped = false
@@ -34,6 +36,7 @@ export async function bootstrapBackendRuntime() {
 
   setFileAnalyzerRuntime(new WorkerRuntime(getLogger()))
   setTokenizerWorker(new TokenizerWorkerRuntime())
+  setPgpS2kWorker(new PgpS2kWorkerRuntime())
 
   if (env.search.meiliHost) {
     startSearchWorker()

--- a/apps/backend/lib/storage/CachingStorage.ts
+++ b/apps/backend/lib/storage/CachingStorage.ts
@@ -55,42 +55,28 @@ export class CachingStorage extends BaseStorage {
     const chunks: Buffer[] = []
     let totalBytes = 0
     let shouldCache = true
-    // Use start (eager) rather than pull so that for writes the upload body is
-    // read independently of downstream S3 speed — backpressure from a full S3
-    // connection pool must not stall the HTTP client that is uploading.
-    // For reads, large files already bypass the cache via expectedSizeBytes, so
-    // only small (cacheable) files reach this path and eager buffering is fine.
     const reader = stream.getReader()
     return new ReadableStream<Uint8Array>({
-      start(controller) {
-        ;(async () => {
-          try {
-            while (true) {
-              const { done, value } = await reader.read()
-              if (done) {
-                controller.close()
-                if (shouldCache) {
-                  cache.set(path, Buffer.concat(chunks))
-                  logger.debug(`cache size is ${cache.calculatedSize}`)
-                }
-                return
-              }
-              if (shouldCache) {
-                totalBytes += value.byteLength
-                if (totalBytes > maxCacheableItemSizeBytes) {
-                  shouldCache = false
-                  chunks.length = 0
-                } else {
-                  chunks.push(Buffer.from(value))
-                }
-              }
-              controller.enqueue(value)
-            }
-          } catch (e) {
-            logger.error('Readable stream failed')
-            controller.error(e)
+      async pull(controller) {
+        const { done, value } = await reader.read()
+        if (done) {
+          controller.close()
+          if (shouldCache) {
+            cache.set(path, Buffer.concat(chunks))
+            logger.debug(`cache size is ${cache.calculatedSize}`)
           }
-        })()
+          return
+        }
+        if (shouldCache) {
+          totalBytes += value.byteLength
+          if (totalBytes > maxCacheableItemSizeBytes) {
+            shouldCache = false
+            chunks.length = 0
+          } else {
+            chunks.push(Buffer.from(value))
+          }
+        }
+        controller.enqueue(value)
       },
       cancel() {
         return reader.cancel()

--- a/apps/backend/lib/storage/CachingStorage.ts
+++ b/apps/backend/lib/storage/CachingStorage.ts
@@ -58,25 +58,30 @@ export class CachingStorage extends BaseStorage {
     const reader = stream.getReader()
     return new ReadableStream<Uint8Array>({
       async pull(controller) {
-        const { done, value } = await reader.read()
-        if (done) {
-          controller.close()
+        try {
+          const { done, value } = await reader.read()
+          if (done) {
+            controller.close()
+            if (shouldCache) {
+              cache.set(path, Buffer.concat(chunks))
+              logger.debug(`cache size is ${cache.calculatedSize}`)
+            }
+            return
+          }
           if (shouldCache) {
-            cache.set(path, Buffer.concat(chunks))
-            logger.debug(`cache size is ${cache.calculatedSize}`)
+            totalBytes += value.byteLength
+            if (totalBytes > maxCacheableItemSizeBytes) {
+              shouldCache = false
+              chunks.length = 0
+            } else {
+              chunks.push(Buffer.from(value))
+            }
           }
-          return
+          controller.enqueue(value)
+        } catch (e) {
+          logger.error('Readable stream failed')
+          controller.error(e)
         }
-        if (shouldCache) {
-          totalBytes += value.byteLength
-          if (totalBytes > maxCacheableItemSizeBytes) {
-            shouldCache = false
-            chunks.length = 0
-          } else {
-            chunks.push(Buffer.from(value))
-          }
-        }
-        controller.enqueue(value)
       },
       cancel() {
         return reader.cancel()

--- a/apps/backend/lib/storage/CachingStorage.ts
+++ b/apps/backend/lib/storage/CachingStorage.ts
@@ -55,38 +55,31 @@ export class CachingStorage extends BaseStorage {
     const chunks: Buffer[] = []
     let totalBytes = 0
     let shouldCache = true
-    return new ReadableStream({
-      start(controller) {
-        const reader = stream.getReader()
-
-        async function push() {
-          try {
-            const { done, value } = await reader.read()
-            if (done) {
-              controller.close()
-              if (shouldCache) {
-                cache.set(path, Buffer.concat(chunks))
-                logger.debug(`cache size is ${cache.calculatedSize}`)
-              }
-              return
-            }
-            if (shouldCache) {
-              totalBytes += value.byteLength
-              if (totalBytes > maxCacheableItemSizeBytes) {
-                shouldCache = false
-                chunks.length = 0
-              } else {
-                chunks.push(Buffer.from(value))
-              }
-            }
-            controller.enqueue(value) // Pass data downstream
-            await push() // Read the next chunk
-          } catch (e) {
-            logger.error('Readable stream failed')
-            controller.error(e)
+    const reader = stream.getReader()
+    return new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        const { done, value } = await reader.read()
+        if (done) {
+          controller.close()
+          if (shouldCache) {
+            cache.set(path, Buffer.concat(chunks))
+            logger.debug(`cache size is ${cache.calculatedSize}`)
+          }
+          return
+        }
+        if (shouldCache) {
+          totalBytes += value.byteLength
+          if (totalBytes > maxCacheableItemSizeBytes) {
+            shouldCache = false
+            chunks.length = 0
+          } else {
+            chunks.push(Buffer.from(value))
           }
         }
-        void push()
+        controller.enqueue(value)
+      },
+      cancel() {
+        return reader.cancel()
       },
     })
   }

--- a/apps/backend/lib/storage/CachingStorage.ts
+++ b/apps/backend/lib/storage/CachingStorage.ts
@@ -55,28 +55,42 @@ export class CachingStorage extends BaseStorage {
     const chunks: Buffer[] = []
     let totalBytes = 0
     let shouldCache = true
+    // Use start (eager) rather than pull so that for writes the upload body is
+    // read independently of downstream S3 speed — backpressure from a full S3
+    // connection pool must not stall the HTTP client that is uploading.
+    // For reads, large files already bypass the cache via expectedSizeBytes, so
+    // only small (cacheable) files reach this path and eager buffering is fine.
     const reader = stream.getReader()
     return new ReadableStream<Uint8Array>({
-      async pull(controller) {
-        const { done, value } = await reader.read()
-        if (done) {
-          controller.close()
-          if (shouldCache) {
-            cache.set(path, Buffer.concat(chunks))
-            logger.debug(`cache size is ${cache.calculatedSize}`)
+      start(controller) {
+        ;(async () => {
+          try {
+            while (true) {
+              const { done, value } = await reader.read()
+              if (done) {
+                controller.close()
+                if (shouldCache) {
+                  cache.set(path, Buffer.concat(chunks))
+                  logger.debug(`cache size is ${cache.calculatedSize}`)
+                }
+                return
+              }
+              if (shouldCache) {
+                totalBytes += value.byteLength
+                if (totalBytes > maxCacheableItemSizeBytes) {
+                  shouldCache = false
+                  chunks.length = 0
+                } else {
+                  chunks.push(Buffer.from(value))
+                }
+              }
+              controller.enqueue(value)
+            }
+          } catch (e) {
+            logger.error('Readable stream failed')
+            controller.error(e)
           }
-          return
-        }
-        if (shouldCache) {
-          totalBytes += value.byteLength
-          if (totalBytes > maxCacheableItemSizeBytes) {
-            shouldCache = false
-            chunks.length = 0
-          } else {
-            chunks.push(Buffer.from(value))
-          }
-        }
-        controller.enqueue(value)
+        })()
       },
       cancel() {
         return reader.cancel()

--- a/apps/backend/lib/storage/FsStorage.ts
+++ b/apps/backend/lib/storage/FsStorage.ts
@@ -1,7 +1,7 @@
 import { logger } from '@/lib/logging'
 import { BaseStorage } from './api'
 import fs, { createReadStream } from 'node:fs'
-import { nodeStreamToReadableStream } from './utils'
+import { Readable } from 'node:stream'
 
 export class FsStorage extends BaseStorage {
   rootPath: string
@@ -36,7 +36,7 @@ export class FsStorage extends BaseStorage {
   ): Promise<ReadableStream<Uint8Array>> {
     const fsPath = `${this.rootPath}/${path}`
     const nodeStream = createReadStream(fsPath)
-    return nodeStreamToReadableStream(nodeStream)
+    return Readable.toWeb(nodeStream) as ReadableStream<Uint8Array>
   }
 
   async writeStream(path: string, stream: ReadableStream<Uint8Array>) {

--- a/apps/backend/lib/storage/S3Storage.ts
+++ b/apps/backend/lib/storage/S3Storage.ts
@@ -2,7 +2,6 @@ import { BaseStorage } from './api'
 import { logger } from '@/lib/logging'
 import { Upload } from '@aws-sdk/lib-storage'
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
-
 export class S3Storage extends BaseStorage {
   bucketName: string
   region: string
@@ -11,12 +10,18 @@ export class S3Storage extends BaseStorage {
   constructor(bucketName: string) {
     super()
     this.region = process.env.AWS_DEFAULT_REGION!
+    // A single shared client is used for both reads and writes.
+    // maxSockets is raised well above the default (50) because pull-based
+    // streaming keeps connections open for the full duration of each download;
+    // many concurrent slow clients would otherwise exhaust the pool and delay
+    // uploads waiting for a free connection.
     this.s3Client = new S3Client({
       region: process.env.AWS_DEFAULT_REGION,
       credentials: {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
       },
+      requestHandler: { maxSockets: 500 } as never,
     })
     this.bucketName = bucketName
     this.hostName = `${this.bucketName}.s3.${this.region}.amazonaws.com`
@@ -24,9 +29,8 @@ export class S3Storage extends BaseStorage {
 
   async writeStream(path: string, stream: ReadableStream<Uint8Array>): Promise<void> {
     try {
-      const client = new S3Client({ region: this.region })
       const upload = new Upload({
-        client,
+        client: this.s3Client,
         params: {
           Bucket: this.bucketName,
           Key: path,

--- a/apps/backend/lib/storage/S3Storage.ts
+++ b/apps/backend/lib/storage/S3Storage.ts
@@ -1,7 +1,11 @@
+import http from 'node:http'
+import https from 'node:https'
 import { BaseStorage } from './api'
 import { logger } from '@/lib/logging'
 import { Upload } from '@aws-sdk/lib-storage'
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
+
 export class S3Storage extends BaseStorage {
   bucketName: string
   region: string
@@ -21,7 +25,10 @@ export class S3Storage extends BaseStorage {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
       },
-      requestHandler: { maxSockets: 500 } as never,
+      requestHandler: new NodeHttpHandler({
+        httpAgent: new http.Agent({ maxSockets: 500 }),
+        httpsAgent: new https.Agent({ maxSockets: 500 }),
+      }),
     })
     this.bucketName = bucketName
     this.hostName = `${this.bucketName}.s3.${this.region}.amazonaws.com`

--- a/apps/backend/lib/storage/utils.ts
+++ b/apps/backend/lib/storage/utils.ts
@@ -1,5 +1,3 @@
-import { Readable } from 'node:stream'
-
 export async function collectStreamToBuffer(
   readableStream: ReadableStream<Uint8Array>
 ): Promise<Buffer> {
@@ -24,19 +22,6 @@ export function bufferToReadableStream(buffer: Uint8Array): ReadableStream<Uint8
     start(controller) {
       controller.enqueue(buffer) // Push the whole buffer as Uint8Array
       controller.close() // Close the stream
-    },
-  })
-}
-
-export function nodeStreamToReadableStream(nodeStream: Readable) {
-  return new ReadableStream({
-    start(controller) {
-      nodeStream.on('data', (chunk: Buffer) => controller.enqueue(chunk))
-      nodeStream.on('end', () => controller.close())
-      nodeStream.on('error', (err) => controller.error(err))
-    },
-    cancel() {
-      nodeStream.destroy()
     },
   })
 }

--- a/bench/pgp-s2k.bench.ts
+++ b/bench/pgp-s2k.bench.ts
@@ -9,9 +9,9 @@
  */
 
 import * as openpgp from 'openpgp'
-import { createHash } from 'node:crypto'
 import assert from 'node:assert/strict'
 import { performance } from 'node:perf_hooks'
+import { streamingIteratedS2kProduceKey } from '../apps/backend/ee/pgp-s2k-worker/streaming-s2k'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -75,75 +75,8 @@ async function openpgpS2kProduceKey(bc: S2kBenchmarkCase): Promise<Uint8Array> {
 
 // ─── Streaming Implementation ─────────────────────────────────────────────────
 
-/**
- * Maximum bytes fed to the hash per update() call.
- *
- * We build a reusable chunk of exactly `floor(MAX_CHUNK / block.length)`
- * copies of `block`.  This reduces the number of update() calls without
- * materialising the full `count`-byte buffer.
- */
-const STREAMING_CHUNK_BYTES = 65_536
-
-/**
- * Produce the same derived key as OpenPGP.js GenericS2K (iterated type)
- * without allocating a buffer of `count` bytes.
- *
- * Algorithm (RFC 4880 §3.7.1.3):
- *   count  = max((16 + (C & 15)) << ((C >> 4) + 6),  block.length)
- *   block  = salt || passphraseBytes
- *   round k: SHA(0x00×k || block repeated up to count bytes) → digestK
- *   key    = concat(digest0, digest1, …)[0 : keySizeBytes]
- */
 function streamingS2kProduceKey(bc: S2kBenchmarkCase): Uint8Array {
-  const passphraseBytes = Buffer.from(bc.passphrase, 'utf8')
-  const block = Buffer.concat([Buffer.from(bc.salt), passphraseBytes])
-
-  if (block.length === 0) {
-    throw new Error('S2K block is empty (salt must be 8 bytes)')
-  }
-
-  const decodedCount = (16 + (bc.encodedCount & 15)) << ((bc.encodedCount >> 4) + 6)
-  const count = Math.max(decodedCount, block.length)
-
-  // Build a chunk: exact multiple of block.length, capped at STREAMING_CHUNK_BYTES.
-  // Because the chunk is an exact multiple of block.length, the repeating
-  // pattern is preserved at chunk boundaries — so `chunk[0..remaining-1]`
-  // always gives the correct suffix when the last chunk is partial.
-  const chunkRepeats = Math.max(1, Math.floor(STREAMING_CHUNK_BYTES / block.length))
-  const chunkBuf = Buffer.allocUnsafe(chunkRepeats * block.length)
-  for (let i = 0; i < chunkRepeats; i++) chunkBuf.set(block, i * block.length)
-  const chunkLen = chunkBuf.length
-
-  const digests: Buffer[] = []
-  let totalBytes = 0
-  let prefixLen = 0 // zero-byte prefix for round k
-
-  while (totalBytes < bc.keySizeBytes) {
-    const h = createHash(bc.hashAlgorithmName)
-
-    // Prefix zeros distinguish digest rounds (OpenPGP multi-round convention).
-    if (prefixLen > 0) h.update(Buffer.alloc(prefixLen))
-
-    // Feed block repeated to satisfy count bytes — no large allocation.
-    let fed = 0
-    while (fed < count) {
-      const remaining = count - fed
-      if (remaining >= chunkLen) {
-        h.update(chunkBuf)
-        fed += chunkLen
-      } else {
-        h.update(chunkBuf.subarray(0, remaining))
-        fed = count
-      }
-    }
-
-    const digest = h.digest()
-    digests.push(digest)
-    totalBytes += digest.length
-    prefixLen++
-  }
-
-  return Buffer.concat(digests).subarray(0, bc.keySizeBytes)
+  return streamingIteratedS2kProduceKey(bc.hashAlgorithmByte, bc.salt, bc.encodedCount, bc.passphrase, bc.keySizeBytes)
 }
 
 // ─── Measurement ──────────────────────────────────────────────────────────────

--- a/bench/pgp-s2k.bench.ts
+++ b/bench/pgp-s2k.bench.ts
@@ -1,0 +1,368 @@
+/**
+ * OpenPGP S2K Key Derivation Benchmark
+ *
+ * Compares OpenPGP.js GenericS2K (reference) with a streaming implementation
+ * that hashes the repeated salt||passphrase block without materialising the
+ * full count-bytes buffer in memory.
+ *
+ * Run: pnpm bench:pgp-s2k
+ */
+
+import * as openpgp from 'openpgp'
+import { createHash } from 'node:crypto'
+import assert from 'node:assert/strict'
+import { performance } from 'node:perf_hooks'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type S2kBenchmarkCase = {
+  name: string
+  hashAlgorithmByte: number // OpenPGP hash enum byte (8=sha256, 10=sha512)
+  hashAlgorithmName: string // Node.js crypto name
+  salt: Uint8Array // always 8 bytes for iterated S2K
+  encodedCount: number // the 1-byte encoded count (C in RFC 4880)
+  passphrase: string
+  keySizeBytes: number
+}
+
+type Stats = {
+  mean: number
+  median: number
+  p95: number
+  p99: number
+  min: number
+  max: number
+  opsSec: number
+  rssBefore: number
+  rssAfter: number
+  heapBefore: number
+  heapAfter: number
+}
+
+// ─── Reference: OpenPGP.js GenericS2K ────────────────────────────────────────
+
+/**
+ * Build a GenericS2K instance by parsing a synthetic version-4 SKESK payload.
+ *
+ * Layout of a v4 SKESK (RFC 4880 §5.3):
+ *   [version=4] [symAlgo] [s2kType=3] [hashAlgo] [salt×8] [countByte]
+ *
+ * `SymEncryptedSessionKeyPacket.read()` initialises `this.s2k` from these
+ * bytes; we then call `s2k.produceKey()` directly.
+ */
+function makeOpenpgpS2k(
+  hashAlgoByte: number,
+  salt: Uint8Array,
+  encodedCount: number,
+): /* GenericS2K */ any {
+  const pkt = new openpgp.SymEncryptedSessionKeyPacket() as any
+  const bytes = new Uint8Array([
+    4, // version 4
+    9, // aes256 — arbitrary, does not affect key derivation
+    3, // iterated S2K (enums.s2k.iterated)
+    hashAlgoByte,
+    ...salt,
+    encodedCount,
+  ])
+  pkt.read(bytes)
+  return pkt.s2k
+}
+
+async function openpgpS2kProduceKey(bc: S2kBenchmarkCase): Promise<Uint8Array> {
+  const s2k = makeOpenpgpS2k(bc.hashAlgorithmByte, bc.salt, bc.encodedCount)
+  return (s2k.produceKey(bc.passphrase, bc.keySizeBytes) as Promise<Uint8Array>)
+}
+
+// ─── Streaming Implementation ─────────────────────────────────────────────────
+
+/**
+ * Maximum bytes fed to the hash per update() call.
+ *
+ * We build a reusable chunk of exactly `floor(MAX_CHUNK / block.length)`
+ * copies of `block`.  This reduces the number of update() calls without
+ * materialising the full `count`-byte buffer.
+ */
+const STREAMING_CHUNK_BYTES = 65_536
+
+/**
+ * Produce the same derived key as OpenPGP.js GenericS2K (iterated type)
+ * without allocating a buffer of `count` bytes.
+ *
+ * Algorithm (RFC 4880 §3.7.1.3):
+ *   count  = max((16 + (C & 15)) << ((C >> 4) + 6),  block.length)
+ *   block  = salt || passphraseBytes
+ *   round k: SHA(0x00×k || block repeated up to count bytes) → digestK
+ *   key    = concat(digest0, digest1, …)[0 : keySizeBytes]
+ */
+function streamingS2kProduceKey(bc: S2kBenchmarkCase): Uint8Array {
+  const passphraseBytes = Buffer.from(bc.passphrase, 'utf8')
+  const block = Buffer.concat([Buffer.from(bc.salt), passphraseBytes])
+
+  if (block.length === 0) {
+    throw new Error('S2K block is empty (salt must be 8 bytes)')
+  }
+
+  const decodedCount = (16 + (bc.encodedCount & 15)) << ((bc.encodedCount >> 4) + 6)
+  const count = Math.max(decodedCount, block.length)
+
+  // Build a chunk: exact multiple of block.length, capped at STREAMING_CHUNK_BYTES.
+  // Because the chunk is an exact multiple of block.length, the repeating
+  // pattern is preserved at chunk boundaries — so `chunk[0..remaining-1]`
+  // always gives the correct suffix when the last chunk is partial.
+  const chunkRepeats = Math.max(1, Math.floor(STREAMING_CHUNK_BYTES / block.length))
+  const chunkBuf = Buffer.allocUnsafe(chunkRepeats * block.length)
+  for (let i = 0; i < chunkRepeats; i++) chunkBuf.set(block, i * block.length)
+  const chunkLen = chunkBuf.length
+
+  const digests: Buffer[] = []
+  let totalBytes = 0
+  let prefixLen = 0 // zero-byte prefix for round k
+
+  while (totalBytes < bc.keySizeBytes) {
+    const h = createHash(bc.hashAlgorithmName)
+
+    // Prefix zeros distinguish digest rounds (OpenPGP multi-round convention).
+    if (prefixLen > 0) h.update(Buffer.alloc(prefixLen))
+
+    // Feed block repeated to satisfy count bytes — no large allocation.
+    let fed = 0
+    while (fed < count) {
+      const remaining = count - fed
+      if (remaining >= chunkLen) {
+        h.update(chunkBuf)
+        fed += chunkLen
+      } else {
+        h.update(chunkBuf.subarray(0, remaining))
+        fed = count
+      }
+    }
+
+    const digest = h.digest()
+    digests.push(digest)
+    totalBytes += digest.length
+    prefixLen++
+  }
+
+  return Buffer.concat(digests).subarray(0, bc.keySizeBytes)
+}
+
+// ─── Measurement ──────────────────────────────────────────────────────────────
+
+async function measure(
+  fn: () => unknown,
+  warmupIter: number,
+  measuredIter: number,
+): Promise<Stats> {
+  for (let i = 0; i < warmupIter; i++) await fn()
+
+  const times: number[] = []
+  const mem0 = process.memoryUsage()
+
+  for (let i = 0; i < measuredIter; i++) {
+    const t0 = performance.now()
+    await fn()
+    times.push(performance.now() - t0)
+  }
+
+  const mem1 = process.memoryUsage()
+  times.sort((a, b) => a - b)
+
+  const sum = times.reduce((a, b) => a + b, 0)
+  const mean = sum / times.length
+
+  const idx = (pct: number) => Math.min(times.length - 1, Math.floor(times.length * pct))
+
+  return {
+    mean,
+    median: times[idx(0.5)],
+    p95: times[idx(0.95)],
+    p99: times[idx(0.99)],
+    min: times[0],
+    max: times[times.length - 1],
+    opsSec: 1000 / mean,
+    rssBefore: mem0.rss,
+    rssAfter: mem1.rss,
+    heapBefore: mem0.heapUsed,
+    heapAfter: mem1.heapUsed,
+  }
+}
+
+// ─── Reporting ────────────────────────────────────────────────────────────────
+
+function fmtMs(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`
+  if (ms >= 1) return `${ms.toFixed(2)}ms`
+  return `${(ms * 1000).toFixed(0)}µs`
+}
+
+function fmtBytes(b: number): string {
+  if (Math.abs(b) >= 1024 * 1024) return `${(b / 1024 / 1024).toFixed(1)}MB`
+  if (Math.abs(b) >= 1024) return `${(b / 1024).toFixed(0)}KB`
+  return `${b}B`
+}
+
+function printStats(label: string, s: Stats): void {
+  const heapDelta = s.heapAfter - s.heapBefore
+  const rssDelta = s.rssAfter - s.rssBefore
+  console.log(
+    `  ${label.padEnd(22)}` +
+      `  mean=${fmtMs(s.mean).padStart(9)}` +
+      `  p50=${fmtMs(s.median).padStart(9)}` +
+      `  p95=${fmtMs(s.p95).padStart(9)}` +
+      `  p99=${fmtMs(s.p99).padStart(9)}` +
+      `  min=${fmtMs(s.min).padStart(9)}` +
+      `  max=${fmtMs(s.max).padStart(9)}` +
+      `  ops/s=${s.opsSec.toFixed(2).padStart(8)}` +
+      `  heap=${fmtBytes(heapDelta).padStart(8)}` +
+      `  rss=${fmtBytes(rssDelta).padStart(8)}`,
+  )
+}
+
+// ─── Case generation ──────────────────────────────────────────────────────────
+
+// Fixed 8-byte salt — reproducible across runs
+const FIXED_SALT = new Uint8Array([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef])
+
+const COUNT_BYTES = [96, 160, 208, 224, 255] as const
+
+const KEY_SIZES = [16, 24, 32, 64] as const
+
+const PASSPHRASES = [
+  { label: 'empty', value: '' },
+  { label: 'short-ascii', value: 'hello' },
+  {
+    label: 'long-ascii',
+    value: 'this is a much longer passphrase for benchmarking S2K key derivation performance',
+  },
+  { label: 'non-ascii', value: 'pässwörð🔑' },
+] as const
+
+// Production default according to openpgp config: sha256 (byte=8)
+const HASH_ALGOS = [
+  { byte: 8, name: 'sha256' },
+  { byte: 10, name: 'sha512' },
+] as const
+
+function buildCases(): S2kBenchmarkCase[] {
+  const cases: S2kBenchmarkCase[] = []
+  const seen = new Set<string>()
+
+  function add(c: S2kBenchmarkCase) {
+    if (!seen.has(c.name)) {
+      seen.add(c.name)
+      cases.push(c)
+    }
+  }
+
+  // Section 1: all count bytes × all key sizes, sha256, short passphrase
+  // Answers: "how does cost scale with count byte and key size?"
+  for (const c of COUNT_BYTES) {
+    for (const k of KEY_SIZES) {
+      add({
+        name: `sha256/count=${c}/key=${k}B/short-ascii`,
+        hashAlgorithmByte: 8,
+        hashAlgorithmName: 'sha256',
+        salt: FIXED_SALT,
+        encodedCount: c,
+        passphrase: 'hello',
+        keySizeBytes: k,
+      })
+    }
+  }
+
+  // Section 2: passphrase variety at production defaults (sha256, count=224, key=32B)
+  // Answers: "does passphrase size/encoding matter?"
+  for (const pp of PASSPHRASES) {
+    add({
+      name: `sha256/count=224/key=32B/${pp.label}`,
+      hashAlgorithmByte: 8,
+      hashAlgorithmName: 'sha256',
+      salt: FIXED_SALT,
+      encodedCount: 224,
+      passphrase: pp.value,
+      keySizeBytes: 32,
+    })
+  }
+
+  // Section 3: sha512 at production count and key size
+  // Answers: "does hash algorithm choice matter?"
+  for (const h of HASH_ALGOS) {
+    add({
+      name: `${h.name}/count=224/key=32B/short-ascii`,
+      hashAlgorithmByte: h.byte,
+      hashAlgorithmName: h.name,
+      salt: FIXED_SALT,
+      encodedCount: 224,
+      passphrase: 'hello',
+      keySizeBytes: 32,
+    })
+  }
+
+  return cases
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const LINE = '═'.repeat(110)
+  console.log(LINE)
+  console.log('OpenPGP S2K Key Derivation Benchmark')
+  console.log('Implementations: openpgp@6.1.1 GenericS2K (reference)  vs  streaming (no full-buffer alloc)')
+  console.log(LINE)
+  console.log()
+
+  const cases = buildCases()
+  let allPassed = true
+
+  for (const bc of cases) {
+    process.stdout.write(`▶ ${bc.name} … correctness … `)
+
+    // Correctness check — must pass before timing runs
+    let refKey: Uint8Array
+    let streamKey: Uint8Array
+    try {
+      refKey = await openpgpS2kProduceKey(bc)
+      streamKey = streamingS2kProduceKey(bc)
+      assert.deepStrictEqual(
+        new Uint8Array(streamKey),
+        new Uint8Array(refKey),
+        `Key mismatch for case: ${bc.name}`,
+      )
+      process.stdout.write(`✓  key=${bc.keySizeBytes}B ref[0..3]=${Array.from(refKey.subarray(0, 4)).map(b => b.toString(16).padStart(2, '0')).join('')}\n`)
+    } catch (e) {
+      process.stdout.write(`✗ FAIL\n`)
+      console.error('  ', e)
+      allPassed = false
+      continue
+    }
+
+    // Adaptive iteration counts: fewer iterations for expensive (high count-byte) cases
+    const warmup = bc.encodedCount >= 224 ? 3 : bc.encodedCount >= 160 ? 5 : 10
+    const iters = bc.encodedCount >= 224 ? 15 : bc.encodedCount >= 160 ? 25 : 50
+
+    const refStats = await measure(() => openpgpS2kProduceKey(bc), warmup, iters)
+    const streamStats = await measure(() => streamingS2kProduceKey(bc), warmup, iters)
+
+    printStats('openpgp (ref):', refStats)
+    printStats('streaming:', streamStats)
+
+    const speedup = refStats.mean / streamStats.mean
+    const heapAdvantage = (refStats.heapAfter - refStats.heapBefore) - (streamStats.heapAfter - streamStats.heapBefore)
+    const faster = speedup > 1 ? `${speedup.toFixed(2)}x faster` : `${(1 / speedup).toFixed(2)}x slower`
+    console.log(`  ↳ streaming is ${faster}  heap advantage=${fmtBytes(heapAdvantage)}`)
+    console.log()
+  }
+
+  console.log(LINE)
+  if (allPassed) {
+    console.log('All correctness checks passed.')
+  } else {
+    console.log('⚠️  Some correctness checks FAILED — see above.')
+    process.exit(1)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "test:watch": "vitest",
     "test:cov": "vitest run --coverage",
     "build-ci": "next build apps/frontend",
-    "generate:openapi": "DATABASE_URL=memory: FILE_STORAGE_LOCATION=. APP_URL=http://localhost:3000 NODE_OPTIONS='--import=tsx' tsx apps/backend/generate_openapi.ts --out apps/frontend/public/openapi.yaml"
+    "generate:openapi": "DATABASE_URL=memory: FILE_STORAGE_LOCATION=. APP_URL=http://localhost:3000 NODE_OPTIONS='--import=tsx' tsx apps/backend/generate_openapi.ts --out apps/frontend/public/openapi.yaml",
+    "bench:pgp-s2k": "tsx bench/pgp-s2k.bench.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.75",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@readme/openapi-parser": "^2.6.0",
+    "@smithy/node-http-handler": "^4.7.5",
     "@tabler/icons-react": "^3.31.0",
     "@tailwindcss/typography": "0.5.19",
     "@tanstack/react-table": "^8.21.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@readme/openapi-parser':
         specifier: ^2.6.0
         version: 2.7.0(openapi-types@12.1.3)
+      '@smithy/node-http-handler':
+        specifier: ^4.7.5
+        version: 4.7.5
       '@tabler/icons-react':
         specifier: ^3.31.0
         version: 3.31.0(react@19.1.0)
@@ -2854,6 +2857,10 @@ packages:
     resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.5':
+    resolution: {integrity: sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.14':
     resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
     engines: {node: '>=18.0.0'}
@@ -2934,8 +2941,8 @@ packages:
     resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-http-handler@4.6.1':
-    resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
+  '@smithy/node-http-handler@4.7.5':
+    resolution: {integrity: sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/property-provider@4.2.14':
@@ -2972,6 +2979,10 @@ packages:
 
   '@smithy/types@4.14.1':
     resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.14':
@@ -3385,6 +3396,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
@@ -6297,6 +6309,7 @@ packages:
   recharts@2.15.1:
     resolution: {integrity: sha512-v8PUTUlyiDe56qUj82w/EDVuzEFXwEHp9/xOowGAZwfLjB9uAy3GllQVIYMWF6nU+qibx85WF75zD7AjqoT54Q==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -7029,6 +7042,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -7540,7 +7554,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.20
       '@smithy/middleware-stack': 4.2.14
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.6.1
+      '@smithy/node-http-handler': 4.7.5
       '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
@@ -7595,7 +7609,7 @@ snapshots:
       '@aws-sdk/core': 3.974.8
       '@aws-sdk/types': 3.973.8
       '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.6.1
+      '@smithy/node-http-handler': 4.7.5
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.13
@@ -7819,7 +7833,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.20
       '@smithy/middleware-stack': 4.2.14
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.6.1
+      '@smithy/node-http-handler': 4.7.5
       '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
@@ -10011,6 +10025,12 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/core@3.24.5':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.14':
     dependencies:
       '@smithy/node-config-provider': 4.3.14
@@ -10145,11 +10165,10 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.6.1':
+  '@smithy/node-http-handler@4.7.5':
     dependencies:
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/querystring-builder': 4.2.14
-      '@smithy/types': 4.14.1
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/property-provider@4.2.14':
@@ -10204,6 +10223,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
     dependencies:
       tslib: 2.8.1
 
@@ -10282,7 +10305,7 @@ snapshots:
   '@smithy/util-stream@4.5.25':
     dependencies:
       '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.6.1
+      '@smithy/node-http-handler': 4.7.5
       '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -24,6 +24,7 @@ export default defineConfig({
     'worker-script': 'packages/file-analyzer/src/worker/script.ts',
     'search-script': 'apps/backend/lib/search/script.ts',
     'tokenizer-script': 'apps/backend/lib/chat/tokenizer-worker/script.ts',
+    'pgp-s2k-script': 'apps/backend/ee/pgp-s2k-worker/script.ts',
   },
   outDir: 'dist-server',
   target: 'node24',


### PR DESCRIPTION
## Summary

This PR improves concurrent file-download behavior by restoring pull-based backpressure across storage streams, skipping cache buffering for oversized reads, and moving PGP S2K session-key derivation off the main thread with per-file deduplication of in-flight derivations.

## Details

- Replaced push/event-driven stream bridging with pull-based streaming (`Readable.toWeb()` and `pull`-driven wrappers) in storage paths so upstream reads follow client consumption.
- Updated file content route to pass `expectedSizeBytes` into `storage.readStream(...)`, allowing `CachingStorage` to bypass caching for large files instead of buffering full payloads.
- Added worker-runtime offload for PGP S2K derivation (`apps/backend/ee/pgp-s2k-worker/*`) and bootstrap wiring via `setPgpS2kWorker(...)`.
- Added direct in-process fallback derivation path for environments without worker runtime.
- Added session-key promise cache in `PgpEncryptingStorage` so concurrent reads for the same path share one derivation; failed promises are evicted to allow retry.
- Increased S3 client connection capacity via explicit `NodeHttpHandler` agent settings to reduce socket-pool contention during many concurrent long-lived downloads.
- Added/updated coverage for backpressure behavior and S2K correctness/failure paths, including dedicated PGP promise-cache failure tests.

## Risks

- Session-key cache is process-local; cross-instance deduplication is not provided.
- Worker offload introduces additional runtime pathing/startup dependency, with direct fallback retained for resilience.

## Tests

- `npm run check-types`
- `npm run test -- __tests__/pgpEncryptingStorageCache.test.ts`
- `npm run test -- __tests__/pgpEncryptingStorageCache.test.ts __tests__/storages.ts`