### PR TITLE
fix(vertex): correct Gemini 3.1 Pro model ID and latest pointer

### DIFF
--- a/packages/core/src/models/vertex.ts
+++ b/packages/core/src/models/vertex.ts
@@ -110,7 +110,7 @@ export const gemini25ProModel: LlmModel = {
 
 export const gemini30ProModel: LlmModel = {
   id: 'gemini-3.0-pro',
-  model: 'gemini-3-pro-preview',
+  model: 'gemini-3.1-pro-preview',
   name: 'Gemini 3.0 Pro',
   description:
     "Google's most intelligent model family to date, built on a foundation of state-of-the-art reasoning",
@@ -177,9 +177,9 @@ export const gemini35FlashModel: LlmModel = {
 }
 
 export const geminiProLatest: LlmModel = {
-  ...gemini30ProModel,
+  ...gemini31ProModel,
   id: 'gemini-pro-latest',
-  name: 'Gemini pro latest (3.0)',
+  name: 'Gemini pro latest (3.1)',
   tags: ['latest'],
 }
 


### PR DESCRIPTION
## Summary

Fixes two related mistakes in the Vertex/Gemini model definitions: the model string for `gemini-3.0-pro` was set to `gemini-3-pro-preview` (wrong version segment) instead of `gemini-3.1-pro-preview`, and `geminiProLatest` was still spreading `gemini30ProModel` and labelled as 3.0 rather than pointing to `gemini31ProModel`.

## Details

- `gemini30ProModel.model`: `gemini-3-pro-preview` → `gemini-3.1-pro-preview`
- `geminiProLatest`: now spreads `gemini31ProModel` and is labelled `Gemini pro latest (3.1)`