### PR TITLE
fix(satellite): reject duplicate connections for the same satellite ID

### DIFF
--- a/__tests__/satelliteHub.test.ts
+++ b/__tests__/satelliteHub.test.ts
@@ -250,6 +250,30 @@ describe('register message', () => {
     expect(connections.get('sat-1')!.tools).toEqual([{ name: 'b' }])
   })
 
+  test('rejects duplicate registration for an already-connected satelliteId', async () => {
+    mockFindSatelliteAuthByApiKey.mockResolvedValue(validAuth())
+    mockGetSatellite.mockResolvedValue(validSatellite('sat-1'))
+
+    // First satellite connects successfully
+    const ws1 = new MockWebSocket()
+    await handleSatelliteConnection(ws1 as any, makeReq('Bearer valid-key'))
+    ws1.emit('message', JSON.stringify({ type: 'register', satelliteId: 'sat-1', name: 'sat', tools: [] }))
+    await flushAsyncWork()
+    expect(connections.has('sat-1')).toBe(true)
+    expect(connections.get('sat-1')!.socket).toBe(ws1)
+
+    // Second satellite with same id is rejected
+    const ws2 = new MockWebSocket()
+    await handleSatelliteConnection(ws2 as any, makeReq('Bearer valid-key'))
+    ws2.emit('message', JSON.stringify({ type: 'register', satelliteId: 'sat-1', name: 'sat', tools: [] }))
+    await flushAsyncWork()
+
+    expect(ws2.closeCode).toBe(1008)
+    expect(ws2.closeReason).toBe('Satellite already connected')
+    // First connection is untouched
+    expect(connections.get('sat-1')!.socket).toBe(ws1)
+  })
+
   test('rejects registration for unknown satellite id', async () => {
     mockFindSatelliteAuthByApiKey.mockResolvedValue(validAuth())
     mockGetSatellite.mockResolvedValue(undefined)

--- a/apps/backend/lib/satellite/hub.ts
+++ b/apps/backend/lib/satellite/hub.ts
@@ -192,13 +192,12 @@ async function handleSatelliteMessage(
         finalName = name
       }
 
-      // Replace existing connection with same ID
+      // Reject if another connection is already using this satelliteId
       const existing = connections.get(satelliteId)
       if (existing && existing.socket !== socket) {
-        for (const { reject } of existing.pendingCalls.values()) {
-          reject(new Error('Satellite replaced by a new connection'))
-        }
-        existing.pendingCalls.clear()
+        logger.warn(`[SatelliteHub] Satellite ${satelliteId} already connected, rejecting duplicate`)
+        socket.close(1008, 'Satellite already connected')
+        return
       }
 
       const kind: SatelliteConnection['kind'] = requestedSatelliteId ? 'registered' : 'ephemeral'


### PR DESCRIPTION
## Summary

When a satellite WebSocket connects with a `satelliteId` that is already active in the hub, the new connection is now rejected with close code 1008 (`Satellite already connected`) instead of silently evicting the first connection. The CLI will receive this error during registration, giving clear feedback that the bind is already in use.

## Details

- `apps/backend/lib/satellite/hub.ts`: replaced the "evict existing" branch with an early-return that closes the incoming socket.
- `__tests__/satelliteHub.test.ts`: added a test covering the duplicate-registration scenario.

## Tests

- `npx vitest run __tests__/satelliteHub.test.ts` — 18 tests passed (including the new one).

Closes https://github.com/logicleai/logicle-issues/issues/266