### PR TITLE
feat(tools): prefix tool function names with tool__function format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ The repository is structured as:
 - Use Markdown headings with this structure (in order): `## Summary`, optional additional `##` sections as needed (for example `## Details`, `## Breaking changes`, `## Migration`, `## Risks`), and `## Tests`.
 - In `## Summary`, use a short paragraph that describes the final merged result at a high level, including the user-visible or operational impact when relevant.
 - In follow-up sections, use concise bullet points (`- ...`), one change, risk, or note per bullet.
-- PR text must describe the net result after merge, not commit history, chronology, or intermediate refactors.
+- PR text must describe the net result after merge, not commit history, chronology, or intermediate refactors. Always derive the description from `git diff main...HEAD` — never from the conversation or the sequence of commits on the branch.
 - In `## Tests`, list the exact validation already performed (commands run, scope, and outcome). This section records what was done, not future instructions. Use bullet points, not checkboxes. If tests were not run, simply skip the section.
 - Use inline code formatting for env vars, flags, endpoints, and commands (for example `ENABLE_CSRF_PROTECTION`, `npm run check-types`).
 

--- a/__tests__/googleNativeSearchCompatibility.test.ts
+++ b/__tests__/googleNativeSearchCompatibility.test.ts
@@ -75,7 +75,7 @@ describe('Google native search compatibility', () => {
       { userId: 'u1', assistantId: 'a1' }
     )
 
-    expect(functions.regular_function).toBeDefined()
+    expect(functions['regular-tool__regular_function']).toBeDefined()
     expect(functions.google_search).toBeDefined()
   })
 
@@ -98,7 +98,7 @@ describe('Google native search compatibility', () => {
       { userId: 'u1', assistantId: 'a1' }
     )
 
-    expect(functions.regular_function).toBeDefined()
+    expect(functions['regular-tool__regular_function']).toBeDefined()
     expect(functions.google_search).toBeDefined()
   })
 

--- a/apps/backend/lib/chat/__tests__/computeFunctions-satellite.test.ts
+++ b/apps/backend/lib/chat/__tests__/computeFunctions-satellite.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 import WebSocket from 'ws'
 import type { SatelliteConnection } from '@/lib/satellite/hub'
+import type { ToolFunctions, ToolImplementation } from '@/lib/chat/tools'
 
 vi.mock('@/lib/logging', () => ({
   logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
@@ -27,6 +28,22 @@ vi.mock('@/lib/satellite/hub', () => ({
 
 const dummyModel = { id: 'gpt-4', provider: 'openai' } as any
 const context = { userId: 'user-1', assistantId: 'asst-1' }
+const originalPrefixToolNames = process.env.PREFIX_FUNCTION_NAMES
+
+const functionDefinition = {
+  description: '',
+  invoke: async () => ({ type: 'text', value: '' }),
+} as any
+
+const makeToolImplementation = (
+  id: string,
+  name: string,
+  functions: ToolFunctions
+): ToolImplementation => ({
+  supportedMedia: [],
+  toolParams: { id, name, provisioned: true, promptFragment: '' },
+  functions: async () => functions,
+})
 
 async function callComputeFunctions(connections: SatelliteConnection[]) {
   mockConnections.clear()
@@ -40,6 +57,15 @@ describe('ChatAssistant.computeFunctions — satellite injection', () => {
   beforeEach(() => {
     vi.resetModules()
     mockConnections.clear()
+    delete process.env.PREFIX_FUNCTION_NAMES
+  })
+
+  afterAll(() => {
+    if (originalPrefixToolNames === undefined) {
+      delete process.env.PREFIX_FUNCTION_NAMES
+    } else {
+      process.env.PREFIX_FUNCTION_NAMES = originalPrefixToolNames
+    }
   })
 
   it('injects tools from an ephemeral satellite belonging to the user', async () => {
@@ -49,7 +75,7 @@ describe('ChatAssistant.computeFunctions — satellite injection', () => {
     const { ChatAssistant } = await import('@/backend/lib/chat/index')
     const { functions } = await ChatAssistant.computeFunctions([], dummyModel, context)
 
-    expect(Object.keys(functions)).toContain('fs_read')
+    expect(Object.keys(functions)).toContain('test-satellite__fs_read')
   })
 
   it('does not inject tools from a registered satellite', async () => {
@@ -70,5 +96,46 @@ describe('ChatAssistant.computeFunctions — satellite injection', () => {
     const { functions } = await ChatAssistant.computeFunctions([], dummyModel, context)
 
     expect(Object.keys(functions)).not.toContain('fs_read')
+  })
+
+  it('uses bare function names when PREFIX_FUNCTION_NAMES is disabled', async () => {
+    process.env.PREFIX_FUNCTION_NAMES = '0'
+    const conn = makeConn({
+      name: 'Studio Sat! 42',
+      tools: [{ name: 'read file', description: 'read a file' }],
+    })
+
+    const { functions, functionToolIdMap } = await callComputeFunctions([conn])
+
+    expect(Object.keys(functions)).toEqual(['read file'])
+    expect(functionToolIdMap.get('read file')).toBe('sat-1')
+  })
+
+  it('prefixes and sanitizes tool names by default', async () => {
+    const conn = makeConn({
+      name: 'Studio Sat! 42',
+      tools: [{ name: 'read file', description: 'read a file' }],
+    })
+
+    const { functions, functionToolIdMap } = await callComputeFunctions([conn])
+
+    expect(Object.keys(functions)).toEqual(['Studio_Sat_42__read_file'])
+    expect(functionToolIdMap.get('Studio_Sat_42__read_file')).toBe('sat-1')
+  })
+
+  it('prefixes all tool names to disambiguate duplicates by default', async () => {
+    const toolA = makeToolImplementation('tool-a', 'A Tool', { readFile: functionDefinition })
+    const toolB = makeToolImplementation('tool-b', 'B Tool', { readFile: functionDefinition })
+
+    const { ChatAssistant } = await import('@/backend/lib/chat/index')
+    const { functions, functionToolIdMap } = await ChatAssistant.computeFunctions(
+      [toolA, toolB],
+      dummyModel,
+      context
+    )
+
+    expect(Object.keys(functions).sort()).toEqual(['A_Tool__readFile', 'B_Tool__readFile'])
+    expect(functionToolIdMap.get('A_Tool__readFile')).toBe('tool-a')
+    expect(functionToolIdMap.get('B_Tool__readFile')).toBe('tool-b')
   })
 })

--- a/apps/backend/lib/chat/__tests__/toolFunctionNames.test.ts
+++ b/apps/backend/lib/chat/__tests__/toolFunctionNames.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import {
+  prefixedToolFunctionName,
+  prefixToolFunctionNames,
+} from '@/backend/lib/chat/toolFunctionNames'
+
+const functionDefinition = {
+  description: '',
+  invoke: async () => ({ type: 'text', value: '' }),
+} as any
+
+describe('tool function names', () => {
+  it('uses sanitized tool and function name segments joined by __', () => {
+    expect(prefixedToolFunctionName('MCP Files (EU)', 'read file')).toBe('MCP_Files_EU__read_file')
+  })
+
+  it('keeps generated names provider-safe and within the OpenAI function name limit', () => {
+    const name = prefixedToolFunctionName('a'.repeat(80), 'read file')
+
+    expect(name.length).toBeLessThanOrEqual(64)
+    expect(name).toMatch(/^[A-Za-z0-9_-]+$/)
+    // long tool segment is truncated with a hash; function segment follows after __
+    expect(name).toMatch(/_[0-9a-f]{8}__read_file$/)
+  })
+
+  it('adds a hash suffix when sanitization creates collisions', () => {
+    const functions = prefixToolFunctionNames(
+      {
+        'read file': functionDefinition,
+        'read@file': functionDefinition,
+      },
+      'Tool!',
+      new Set()
+    )
+
+    const names = Object.keys(functions)
+    expect(names).toHaveLength(2)
+    expect(new Set(names).size).toBe(2)
+    expect(names[0]).toBe('Tool__read_file')
+    expect(names[1]).toMatch(/^Tool__read_file_[0-9a-f]{8}$/)
+  })
+
+  it('leaves provider-native tool names unchanged', () => {
+    const functions = prefixToolFunctionNames(
+      {
+        web_search: {
+          type: 'provider',
+          id: 'openai.web_search',
+          args: {},
+        },
+      },
+      'OpenAI Search',
+      new Set()
+    )
+
+    expect(Object.keys(functions)).toEqual(['web_search'])
+  })
+})

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -56,6 +56,7 @@ import { ToolSetupError } from './exceptions'
 import type { Usage } from './usage'
 import { SatelliteTool } from '../tools/satellite/implementation'
 import type { PromptSegment } from './preamble'
+import { prefixToolFunctionNames } from './toolFunctionNames'
 
 // Extract a message from:
 // 1) chunk.error.message
@@ -255,23 +256,31 @@ export class ChatAssistant {
       .filter((conn) => conn.kind === 'ephemeral' && conn.userId === context.userId)
       .map(SatelliteTool.fromConnection)
 
-    const functionToolIdMap = new Map<string, string>()
-    const toolFunctionEntries = (
-      await Promise.all(
-        [...tools, ...satelliteTools].map(async (tool) => {
-          try {
-            const fns = await tool.functions(llmModel, context)
-            for (const fnName of Object.keys(fns)) {
-              functionToolIdMap.set(fnName, tool.toolParams.id)
-            }
-            return fns
-          } catch (e) {
-            logger.error(`Failed setting up tool "${tool.toolParams.name}"`, e)
-            return {}
+    const toolFunctionGroups = await Promise.all(
+      [...tools, ...satelliteTools].map(async (tool) => {
+        try {
+          return {
+            tool,
+            functions: await tool.functions(llmModel, context),
           }
-        })
-      )
-    ).flatMap((toolFunctions) => Object.entries(toolFunctions))
+        } catch (e) {
+          logger.error(`Failed setting up tool "${tool.toolParams.name}"`, e)
+          return { tool, functions: {} }
+        }
+      })
+    )
+
+    const functionToolIdMap = new Map<string, string>()
+    const usedFunctionNames = new Set<string>()
+    const toolFunctionEntries = toolFunctionGroups.flatMap(({ tool, functions }) => {
+      const fns = env.tools.prefixFunctionNames
+        ? prefixToolFunctionNames(functions, tool.toolParams.name, usedFunctionNames)
+        : functions
+      for (const fnName of Object.keys(fns)) {
+        functionToolIdMap.set(fnName, tool.toolParams.id)
+      }
+      return Object.entries(fns)
+    })
 
     return { functions: Object.fromEntries(toolFunctionEntries), functionToolIdMap }
   }

--- a/apps/backend/lib/chat/toolFunctionNames.ts
+++ b/apps/backend/lib/chat/toolFunctionNames.ts
@@ -1,0 +1,64 @@
+import { createHash } from 'node:crypto'
+import type { ToolFunctions } from '@/lib/chat/tools'
+
+const MAX_TOOL_FUNCTION_NAME_LENGTH = 64
+const SEPARATOR = '__'
+// Each segment is capped so that tool__function always fits within MAX_TOOL_FUNCTION_NAME_LENGTH.
+const MAX_SEGMENT_LENGTH = Math.floor((MAX_TOOL_FUNCTION_NAME_LENGTH - SEPARATOR.length) / 2) // 31
+const HASH_LENGTH = 8
+
+const hash = (value: string) =>
+  createHash('sha256').update(value).digest('hex').slice(0, HASH_LENGTH)
+
+export const sanitizeToolFunctionNameSegment = (value: string, fallback: string): string => {
+  const ascii = value.normalize('NFKD').replace(/[\u0300-\u036f]/g, '')
+  const sanitized = ascii
+    .replace(/[^A-Za-z0-9_-]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+  return sanitized || fallback
+}
+
+const truncateSegment = (segment: string, identity: string): string => {
+  if (segment.length <= MAX_SEGMENT_LENGTH) return segment
+  const suffix = `_${hash(identity)}`
+  return `${segment.slice(0, MAX_SEGMENT_LENGTH - suffix.length)}${suffix}`
+}
+
+const addHashSuffix = (name: string, identity: string): string => {
+  const suffix = `_${hash(identity)}`
+  return `${name.slice(0, MAX_TOOL_FUNCTION_NAME_LENGTH - suffix.length)}${suffix}`
+}
+
+export const prefixedToolFunctionName = (toolName: string, functionName: string): string => {
+  const toolSegment = truncateSegment(sanitizeToolFunctionNameSegment(toolName, 'tool'), toolName)
+  const fnSegment = truncateSegment(
+    sanitizeToolFunctionNameSegment(functionName, 'function'),
+    functionName
+  )
+  return `${toolSegment}${SEPARATOR}${fnSegment}`
+}
+
+export const prefixToolFunctionNames = (
+  functions: ToolFunctions,
+  toolName: string,
+  usedNames: Set<string>
+): ToolFunctions => {
+  return Object.fromEntries(
+    Object.entries(functions).map(([functionName, definition]) => {
+      if (definition.type === 'provider') {
+        usedNames.add(functionName)
+        return [functionName, definition]
+      }
+
+      let exposedName = prefixedToolFunctionName(toolName, functionName)
+      let attempt = 0
+      while (usedNames.has(exposedName)) {
+        attempt += 1
+        exposedName = addHashSuffix(exposedName, `${toolName}:${functionName}:${attempt}`)
+      }
+      usedNames.add(exposedName)
+      return [exposedName, definition]
+    })
+  )
+}

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -120,6 +120,7 @@ const env = {
       clientCacheTtlSeconds: parseOptionalInt(process.env.MCP_CLIENT_CACHE_TTL_SECONDS) ?? 300,
       clientCacheMaxItems: parseOptionalInt(process.env.MCP_CLIENT_CACHE_MAX_ITEMS) ?? 100,
     },
+    prefixFunctionNames: process.env.PREFIX_FUNCTION_NAMES !== '0',
   },
   providers: {
     openai: {},


### PR DESCRIPTION
## Summary

Introduces `prefixFunctionNames` in `env.tools` (env var `PREFIX_FUNCTION_NAMES`, default **on**) that rewrites each tool's exported function names to `tool__function` format before they are sent to the LLM, following the OpenAI plugin naming convention (`worldtimeapi_org__jit_plugin.list_timezones2`). This eliminates silent name collisions when multiple tools expose the same function name.

## Details

- Flag moved out of the old `provision` block (where it didn't belong) into `env.tools`
- Each segment (tool name and function name) is sanitized to `[A-Za-z0-9_-]` and independently capped at 31 chars so that `tool__function` always fits within the 64-char LLM limit and both sides remain visible
- Overflow is truncated with an 8-char SHA-256 hash suffix on the affected segment
- Same-name collisions across tools (two tools exporting `readFile`) are resolved by appending a hash suffix to the duplicate entry
- `PREFIX_FUNCTION_NAMES=0` disables prefixing and restores bare function names

## Tests

- `npm run check-types` — clean
- `npx vitest run apps/backend/lib/chat/__tests__/toolFunctionNames.test.ts apps/backend/lib/chat/__tests__/computeFunctions-satellite.test.ts` — 10 tests, all passed