### PR TITLE
fix(chat): surface satellite-offline error to user

### DIFF
--- a/__tests__/chatAssistant.test.ts
+++ b/__tests__/chatAssistant.test.ts
@@ -113,7 +113,7 @@ const makeChatAssistant = (overrides: Partial<InstanceType<typeof ChatAssistant>
     parameters: {},
     knowledge: [],
     options: { user: 'u1' },
-    functions: Promise.resolve({}),
+    functions: {},
     debug: false,
     providerConfig: { providerType: 'openai' },
     languageModel: { provider: 'openai.responses' },
@@ -130,10 +130,6 @@ const makeRealAssistant = () => {
   vi
     .spyOn(ChatAssistant, 'createLanguageModel')
     .mockReturnValue({ provider: 'openai.responses' } as unknown as LanguageModelV3)
-  vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({
-    functions: {},
-    functionToolIdMap: new Map(),
-  })
   return new ChatAssistant(
     { providerType: 'openai', apiKey: 'k', provisioned: false } as unknown as ProviderConfig,
     { assistantId: 'a1', model: 'gpt-4', systemPrompt: '', temperature: 0, tokenLimit: 1000, reasoning_effort: null },
@@ -141,7 +137,8 @@ const makeRealAssistant = () => {
     [],
     { user: 'u1' },
     {},
-    []
+    [],
+    { functions: {}, functionToolIdMap: new Map(), setupError: undefined }
   )
 }
 
@@ -563,7 +560,7 @@ describe('ChatAssistant.createLanguageModel', () => {
 
 describe('ChatAssistant.createAiTools', () => {
   test('returns undefined when there are no functions', async () => {
-    const assistant = makeChatAssistant({ functions: Promise.resolve({}) })
+    const assistant = makeChatAssistant({ functions: {} })
     const tools = await assistant.createAiTools()
     expect(tools).toBeUndefined()
   })
@@ -574,7 +571,7 @@ describe('ChatAssistant.createAiTools', () => {
       parameters: { type: 'object', properties: {}, required: [] } as any,
       invoke: vi.fn(),
     }
-    const assistant = makeChatAssistant({ functions: Promise.resolve({ myTool: fn }) })
+    const assistant = makeChatAssistant({ functions: { myTool: fn } })
     const tools = await assistant.createAiTools()
     expect(tools).toBeDefined()
     expect(tools!.myTool).toMatchObject({ description: 'Does stuff' })
@@ -587,14 +584,14 @@ describe('ChatAssistant.createAiTools', () => {
       id: 'anthropic.web_search_preview',
       args: {},
     }
-    const assistant = makeChatAssistant({ functions: Promise.resolve({ webSearch: fn }) })
+    const assistant = makeChatAssistant({ functions: { webSearch: fn } })
     const tools = await assistant.createAiTools()
     expect(tools!.webSearch).toMatchObject({ type: 'provider', id: 'anthropic.web_search_preview' })
   })
 
   test('maps ToolFunction with undefined parameters to z.any() schema', async () => {
     const fn: ToolFunction = { description: 'No schema', invoke: vi.fn() }
-    const assistant = makeChatAssistant({ functions: Promise.resolve({ noSchema: fn }) })
+    const assistant = makeChatAssistant({ functions: { noSchema: fn } })
     const tools = await assistant.createAiTools()
     expect(tools!.noSchema.inputSchema).toBeDefined()
   })
@@ -612,7 +609,7 @@ describe('ChatAssistant.invokeFunctionByName', () => {
     ({ toolCallId: 'tc1', toolName: name, args: {} }) as unknown as dto.ToolCall
 
   test('returns error when function not found', async () => {
-    const assistant = makeChatAssistant({ functions: Promise.resolve({}) })
+    const assistant = makeChatAssistant({ functions: {} })
     const chatState = { chatHistory: [makeUserMsg()] } as any
     const result = await assistant.invokeFunctionByName(makeToolCall('unknown'), makeUserResponse(true), chatState, {} as any)
     expect(result.type).toBe('error-text')
@@ -620,7 +617,7 @@ describe('ChatAssistant.invokeFunctionByName', () => {
 
   test('returns error when user denied', async () => {
     const fn: ToolFunction = { description: 'Test', invoke: vi.fn() }
-    const assistant = makeChatAssistant({ functions: Promise.resolve({ myTool: fn }) })
+    const assistant = makeChatAssistant({ functions: { myTool: fn } })
     const chatState = { chatHistory: [makeUserMsg()] } as any
     const result = await assistant.invokeFunctionByName(makeToolCall(), makeUserResponse(false), chatState, {} as any)
     expect(result.type).toBe('error-text')
@@ -629,7 +626,7 @@ describe('ChatAssistant.invokeFunctionByName', () => {
 
   test('returns error for provider-type tool', async () => {
     const fn: ToolNative = { type: 'provider', id: 'anthropic.web_search', args: {} }
-    const assistant = makeChatAssistant({ functions: Promise.resolve({ myTool: fn }) })
+    const assistant = makeChatAssistant({ functions: { myTool: fn } })
     const chatState = { chatHistory: [makeUserMsg()] } as any
     const result = await assistant.invokeFunctionByName(makeToolCall(), makeUserResponse(true), chatState, {} as any)
     expect(result.type).toBe('error-text')
@@ -639,7 +636,7 @@ describe('ChatAssistant.invokeFunctionByName', () => {
   test('invokes function when found and allowed', async () => {
     const invokeResult: dto.ToolCallResultOutput = { type: 'content', value: [{ type: 'text', text: 'ok' }] }
     const fn: ToolFunction = { description: 'Test', invoke: vi.fn().mockResolvedValue(invokeResult) }
-    const assistant = makeChatAssistant({ functions: Promise.resolve({ myTool: fn }) })
+    const assistant = makeChatAssistant({ functions: { myTool: fn } })
     const chatState = { chatHistory: [makeUserMsg()], conversationId: 'c1' } as any
     const result = await assistant.invokeFunctionByName(makeToolCall(), makeUserResponse(true), chatState, { attachments: [] } as any)
     expect(result).toEqual(invokeResult)

--- a/__tests__/llm-integration.test.ts
+++ b/__tests__/llm-integration.test.ts
@@ -176,7 +176,7 @@ function makeAssistant(
     tokenLimit: 4096,
     reasoning_effort: null,
   }
-  return new ChatAssistant(config, assistantParams, model, tools, { user: 'test-user' }, {}, [])
+  return new ChatAssistant(config, assistantParams, model, tools, { user: 'test-user' }, {}, [], { functions: {}, functionToolIdMap: new Map(), setupError: undefined })
 }
 
 async function runChat(assistant: ChatAssistant, content: string): Promise<TestSink> {

--- a/__tests__/parallelToolCalls.test.ts
+++ b/__tests__/parallelToolCalls.test.ts
@@ -128,10 +128,6 @@ function makeAssistant(tools: Record<string, ToolFunction>) {
   vi
     .spyOn(ChatAssistant, 'createLanguageModel')
     .mockReturnValue({ provider: 'openai.chat' } as unknown as LanguageModelV3)
-  vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({
-    functions: tools,
-    functionToolIdMap: new Map(),
-  })
 
   const assistantParams: AssistantParams = {
     model: 'gpt-4',
@@ -165,7 +161,8 @@ function makeAssistant(tools: Record<string, ToolFunction>) {
     [],
     { user: 'user-1' },
     {},
-    []
+    [],
+    { functions: tools, functionToolIdMap: new Map(), setupError: undefined }
   )
 }
 
@@ -403,7 +400,6 @@ describe('providerOptions: ENABLE_PARALLEL_TOOL_CALLS controls what is advertise
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'openai.responses',
     } as unknown as LanguageModelV3)
-    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map() })
 
     const assistant = makeAssistant({})
     const testableAssistant = asTestableAssistant(assistant)
@@ -418,7 +414,6 @@ describe('providerOptions: ENABLE_PARALLEL_TOOL_CALLS controls what is advertise
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'openai.responses',
     } as unknown as LanguageModelV3)
-    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map() })
 
     const assistant = makeAssistant({})
     const testableAssistant = asTestableAssistant(assistant)
@@ -433,7 +428,6 @@ describe('providerOptions: ENABLE_PARALLEL_TOOL_CALLS controls what is advertise
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'anthropic.messages',
     } as unknown as LanguageModelV3)
-    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map() })
 
     const assistant = makeAssistant({})
     const testableAssistant = asTestableAssistant(assistant)
@@ -449,7 +443,6 @@ describe('providerOptions: ENABLE_PARALLEL_TOOL_CALLS controls what is advertise
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'anthropic.messages',
     } as unknown as LanguageModelV3)
-    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({ functions: {}, functionToolIdMap: new Map() })
 
     const assistant = makeAssistant({})
     const testableAssistant = asTestableAssistant(assistant)
@@ -470,10 +463,6 @@ describe('providerOptions: Gemini thinking config is forwarded', () => {
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'google.generative-ai',
     } as unknown as LanguageModelV3)
-    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({
-      functions: {},
-      functionToolIdMap: new Map(),
-    })
 
     const assistant = makeAssistant({})
     const testableAssistant = asTestableAssistant(assistant)
@@ -493,10 +482,6 @@ describe('providerOptions: Gemini thinking config is forwarded', () => {
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'google.generative-ai',
     } as unknown as LanguageModelV3)
-    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({
-      functions: {},
-      functionToolIdMap: new Map(),
-    })
 
     const assistant = makeAssistant({})
     const testableAssistant = asTestableAssistant(assistant)
@@ -520,10 +505,6 @@ describe('providerOptions: Gemini thinking config is forwarded', () => {
     vi.spyOn(ChatAssistant, 'createLanguageModel').mockReturnValue({
       provider: 'vertex',
     } as unknown as LanguageModelV3)
-    vi.spyOn(ChatAssistant, 'computeFunctions').mockResolvedValue({
-      functions: {},
-      functionToolIdMap: new Map(),
-    })
 
     const assistant = makeAssistant({})
     const testableAssistant = asTestableAssistant(assistant)

--- a/apps/backend/lib/chat/exceptions.ts
+++ b/apps/backend/lib/chat/exceptions.ts
@@ -14,3 +14,10 @@ export class ToolSetupError extends Error {
     this.toolName = toolName
   }
 }
+
+export class UserVisibleError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'UserVisibleError'
+  }
+}

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -31,7 +31,7 @@ import {
 
 export { fillTemplate } from './preamble'
 export type { PromptSegment } from './preamble'
-export { ToolSetupError } from './exceptions'
+export { ToolSetupError, UserVisibleError } from './exceptions'
 export type { Usage } from './usage'
 
 import {
@@ -52,7 +52,7 @@ import {
   computeSafeSummary,
   findReasonableSummarizationBackend,
 } from './summarizer'
-import { ToolSetupError } from './exceptions'
+import { ToolSetupError, UserVisibleError } from './exceptions'
 import type { Usage } from './usage'
 import { SatelliteTool } from '../tools/satellite/implementation'
 import type { PromptSegment } from './preamble'
@@ -114,12 +114,6 @@ export class ChatAbortedError extends Error {
   }
 }
 
-export class UserVisibleError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options)
-    this.name = 'UserVisibleError'
-  }
-}
 
 class ClientSinkImpl implements ClientSink {
   clientGone: boolean = false
@@ -153,8 +147,9 @@ export class ChatAssistant {
   updateChatTitle: (title: string) => Promise<void>
   debug: boolean
   llmModelCapabilities: LlmModelCapabilities
-  functions: Promise<ToolFunctions>
-  functionToolIdMap: Promise<Map<string, string>>
+  functions: ToolFunctions
+  functionToolIdMap: Map<string, string>
+  setupError: string | undefined
 
   constructor(
     private providerConfig: ProviderConfig,
@@ -163,19 +158,12 @@ export class ChatAssistant {
     private tools: ToolImplementation[],
     private options: Options,
     private parameters: Record<string, ParameterValueAndDescription>,
-    private knowledge: dto.AssistantFile[]
+    private knowledge: dto.AssistantFile[],
+    computed: { functions: ToolFunctions; functionToolIdMap: Map<string, string>; setupError: string | undefined }
   ) {
-    const computed = ChatAssistant.computeFunctions(tools, llmModel, {
-      userId: options.user,
-      assistantId: assistantParams.assistantId,
-      rootOwner: options.rootOwner
-        ? options.rootOwner
-        : options.conversationId
-        ? { type: 'CHAT', id: options.conversationId }
-        : undefined,
-    })
-    this.functions = computed.then((r) => r.functions)
-    this.functionToolIdMap = computed.then((r) => r.functionToolIdMap)
+    this.functions = computed.functions
+    this.functionToolIdMap = computed.functionToolIdMap
+    this.setupError = computed.setupError
     this.llmModel = llmModel
     this.llmModelCapabilities = this.llmModel.capabilities
     this.saveMessage = options.saveMessage || (async () => {})
@@ -250,6 +238,7 @@ export class ChatAssistant {
   ): Promise<{
     functions: ToolFunctions
     functionToolIdMap: Map<string, string>
+    setupError: string | undefined
   }> {
     const satelliteHub = await import('@/lib/satellite/hub')
     const satelliteTools = Array.from(satelliteHub.connections.values())
@@ -259,16 +248,16 @@ export class ChatAssistant {
     const toolFunctionGroups = await Promise.all(
       [...tools, ...satelliteTools].map(async (tool) => {
         try {
-          return {
-            tool,
-            functions: await tool.functions(llmModel, context),
-          }
+          return { tool, functions: await tool.functions(llmModel, context), error: undefined }
         } catch (e) {
           logger.error(`Failed setting up tool "${tool.toolParams.name}"`, e)
-          return { tool, functions: {} }
+          const message = e instanceof UserVisibleError ? e.message : `Tool "${tool.toolParams.name}" could not be initialized`
+          return { tool, functions: {} as ToolFunctions, error: message }
         }
       })
     )
+
+    const setupError = toolFunctionGroups.find((g) => g.error)?.error
 
     const functionToolIdMap = new Map<string, string>()
     const usedFunctionNames = new Set<string>()
@@ -282,7 +271,7 @@ export class ChatAssistant {
       return Object.entries(fns)
     })
 
-    return { functions: Object.fromEntries(toolFunctionEntries), functionToolIdMap }
+    return { functions: Object.fromEntries(toolFunctionEntries), functionToolIdMap, setupError }
   }
 
   static async build(
@@ -305,6 +294,15 @@ export class ChatAssistant {
       )
     }
     tools = await ChatAssistant.withBuiltinTools(tools, llmModel)
+    const computed = await ChatAssistant.computeFunctions(tools, llmModel, {
+      userId: options.user,
+      assistantId: assistantParams.assistantId,
+      rootOwner: options.rootOwner
+        ? options.rootOwner
+        : options.conversationId
+        ? { type: 'CHAT', id: options.conversationId }
+        : undefined,
+    })
     return new ChatAssistant(
       providerConfig,
       assistantParams,
@@ -312,7 +310,8 @@ export class ChatAssistant {
       tools,
       options,
       parameters,
-      files
+      files,
+      computed
     )
   }
 
@@ -336,7 +335,7 @@ export class ChatAssistant {
   }
 
   async createAiTools(): Promise<Record<string, ai.Tool> | undefined> {
-    const functions = await this.functions
+    const functions = this.functions
     if (Object.keys(functions).length === 0) return undefined
     return Object.fromEntries(
       (Object.entries(functions) as Array<[string, ToolFunction | ToolNative]>).map(
@@ -568,7 +567,7 @@ export class ChatAssistant {
       messages: llmMessages,
       tools: this.llmModelCapabilities.function_calling ? { ...tools } : undefined,
       toolChoice:
-        this.llmModelCapabilities.function_calling && Object.keys(await this.functions).length !== 0
+        this.llmModelCapabilities.function_calling && Object.keys(this.functions).length !== 0
           ? 'auto'
           : undefined,
       temperature: modelSupportsReasoning(this.llmModel)
@@ -765,7 +764,7 @@ export class ChatAssistant {
     chatState: ChatState,
     toolUILink: ToolUILink
   ): Promise<dto.ToolCallResultOutput> {
-    const functionDef = (await this.functions)[toolCall.toolName]
+    const functionDef = (this.functions)[toolCall.toolName]
     if (!functionDef) {
       return { type: 'error-text', value: `No such function: ${functionDef}` }
     } else if (!toolCallAuthResponse.allow) {
@@ -808,6 +807,18 @@ export class ChatAssistant {
   }
 
   async invokeLlmAndProcessResponse(chatState: ChatState, clientSink: ClientSink) {
+    const setupError = this.setupError
+    if (setupError) {
+      const assistantMessage = chatState.appendMessage(chatState.createEmptyAssistantMsg())
+      clientSink.enqueue({ type: 'message', msg: assistantMessage })
+      const errorPart: dto.ErrorPart = { type: 'error', error: setupError }
+      chatState.applyStreamPart({ type: 'part', part: errorPart })
+      clientSink.enqueue({ type: 'part', part: errorPart })
+      const updatedMsg = chatState.getLastMessageAssert<dto.AssistantMessage>('assistant')
+      await this.saveMessage(updatedMsg)
+      return
+    }
+
     const generateSummary =
       !this.options.disableAutoSummary &&
       env.chat.autoSummary.enable &&
@@ -833,7 +844,7 @@ export class ChatAssistant {
         ) {
           // do nothing
         } else if (chunk.type === 'tool-call') {
-          const toolId = (await this.functionToolIdMap).get(chunk.toolName)
+          const toolId = (this.functionToolIdMap).get(chunk.toolName)
           const googleMeta = chunk.providerMetadata?.google ?? chunk.providerMetadata?.vertex
           const thoughtSignature =
             typeof googleMeta?.thoughtSignature === 'string'
@@ -978,6 +989,7 @@ export class ChatAssistant {
       const historySnapshot = chatState.chatHistory
       const assistantResponse = chatState.appendMessage(chatState.createEmptyAssistantMsg())
       clientSink.enqueue({ type: 'message', msg: assistantResponse })
+
       let usage: Usage | undefined
       try {
         const responseStream = await this.invokeLlm(historySnapshot)
@@ -1000,11 +1012,10 @@ export class ChatAssistant {
           clientSink.enqueue({ type: 'part', part: errorPart })
         } else {
           this.logInternalError(chatState, 'LLM invocation failure', e)
-          const message = e instanceof UserVisibleError ? e.message : 'Internal error'
-          clientSink.enqueue({ type: 'part', part: { type: 'error', error: message } })
+          clientSink.enqueue({ type: 'part', part: { type: 'error', error: 'Internal error' } })
           chatState.applyStreamPart({
             type: 'part',
-            part: { type: 'error', error: message },
+            part: { type: 'error', error: 'Internal error' },
           })
         }
       } finally {
@@ -1013,7 +1024,7 @@ export class ChatAssistant {
         await this.saveMessage(updatedAssistantResponse, usage)
       }
 
-      const functions = await this.functions
+      const functions = this.functions
       const updatedAssistantResponse =
         chatState.getLastMessageAssert<dto.AssistantMessage>('assistant')
       const nonNativeToolCalls = updatedAssistantResponse.parts

--- a/apps/backend/lib/tools/satellite/implementation.ts
+++ b/apps/backend/lib/tools/satellite/implementation.ts
@@ -9,6 +9,7 @@ import {
   ToolParams,
 } from '@/lib/chat/tools'
 import { SatelliteInterface } from '@/lib/tools/schemas'
+import { UserVisibleError } from '@/backend/lib/chat/exceptions'
 import { LlmModel } from '@/lib/chat/models'
 import { saveFile } from '@/backend/lib/tools/file-output-normalization'
 import { normalizeMcpToolResult } from '@/backend/lib/tools/file-output-normalization'
@@ -118,7 +119,7 @@ export class SatelliteTool extends SatelliteInterface implements ToolImplementat
     const { connections } = await import('@/lib/satellite/hub')
     const conn = connections.get(this.satelliteId)
     if (!conn) {
-      return {}
+      throw new UserVisibleError(`Satellite "${this.toolParams.name}" is currently offline`)
     }
 
     return Object.fromEntries(


### PR DESCRIPTION
## Summary

When a satellite tool is offline at chat time, the user now receives a clear error message in the assistant response instead of the assistant silently operating with no tools. The same per-tool error path also covers MCP tools and any other tool whose `functions()` throws.

## Details

- `SatelliteTool.functions()` now throws `UserVisibleError` when the satellite is not connected, instead of returning an empty object.
- `UserVisibleError` is moved from `chat/index.ts` to `chat/exceptions.ts` to avoid a circular dependency with `satellite/implementation.ts`.
- `computeFunctions` is moved from the `ChatAssistant` constructor into the async `build()` static method. The constructor now accepts a pre-resolved `computed` argument (`functions`, `functionToolIdMap`, `setupError`). This eliminates the previous pattern of storing `Promise` values on instance fields, which caused an unhandled Promise rejection crash when a tool failed to initialize (Node.js 15+ terminates the process on unhandled rejections).
- `invokeLlmAndProcessResponse` has an early-exit at the top: if `setupError` is set, it writes an error part to the chat and returns without calling the LLM.
- Per-tool `try/catch` in `computeFunctions` captures the first tool error; `UserVisibleError` messages are surfaced verbatim, other errors produce a generic message.

## Tests

- `npm run check-types` — passes clean