### PR TITLE
mcp: resolve resource_link content items via resources/read

### DIFF
--- a/apps/backend/lib/tools/file-output-normalization.ts
+++ b/apps/backend/lib/tools/file-output-normalization.ts
@@ -56,9 +56,12 @@ export const saveFile = async (
   })
 }
 
+type ReadResourceFn = (uri: string) => Promise<{ blob?: string; text?: string; mimeType?: string } | undefined>
+
 export const normalizeMcpToolResult = async (
   result: any,
-  params: Pick<ToolInvokeParams, 'rootOwner' | 'conversationId' | 'userId' | 'assistantId'>
+  params: Pick<ToolInvokeParams, 'rootOwner' | 'conversationId' | 'userId' | 'assistantId'>,
+  readResource?: ReadResourceFn
 ): Promise<dto.ToolCallResultOutput> => {
   const contentParts: Extract<dto.ToolCallResultOutput, { type: 'content' }>['value'] = []
   for (const item of Array.isArray(result?.content) ? result.content : []) {
@@ -75,6 +78,28 @@ export const normalizeMcpToolResult = async (
       })
       contentParts.push(persisted)
       continue
+    }
+    if (item?.type === 'resource_link' && typeof item.uri === 'string' && readResource) {
+      try {
+        const contents = await readResource(item.uri)
+        if (contents?.blob) {
+          const persisted = await saveFile({
+            ...params,
+            content: Buffer.from(contents.blob, 'base64'),
+            mimeType: contents.mimeType ?? item.mimeType ?? defaultMimeType,
+            nameHint: item.name,
+            source: 'MCP',
+          })
+          contentParts.push(persisted)
+          continue
+        }
+        if (contents?.text !== undefined) {
+          contentParts.push({ type: 'text', text: contents.text })
+          continue
+        }
+      } catch (e) {
+        logger.warn(`Failed to resolve MCP resource_link ${item.uri}`, e)
+      }
     }
     if (item?.type === 'resource' && typeof item.resource?.blob === 'string') {
       const persisted = await saveFile({

--- a/apps/backend/lib/tools/file-output-normalization.ts
+++ b/apps/backend/lib/tools/file-output-normalization.ts
@@ -58,11 +58,17 @@ export const saveFile = async (
 
 type ReadResourceFn = (uri: string) => Promise<{ blob?: string; text?: string; mimeType?: string } | undefined>
 
+interface NormalizeMcpOptions {
+  readResource?: ReadResourceFn
+  resolveResourceLinks?: boolean
+}
+
 export const normalizeMcpToolResult = async (
   result: any,
   params: Pick<ToolInvokeParams, 'rootOwner' | 'conversationId' | 'userId' | 'assistantId'>,
-  readResource?: ReadResourceFn
+  options: NormalizeMcpOptions = {}
 ): Promise<dto.ToolCallResultOutput> => {
+  const { readResource, resolveResourceLinks = true } = options
   const contentParts: Extract<dto.ToolCallResultOutput, { type: 'content' }>['value'] = []
   for (const item of Array.isArray(result?.content) ? result.content : []) {
     if (item?.type === 'text' && typeof item.text === 'string') {
@@ -79,26 +85,28 @@ export const normalizeMcpToolResult = async (
       contentParts.push(persisted)
       continue
     }
-    if (item?.type === 'resource_link' && typeof item.uri === 'string' && readResource) {
-      try {
-        const contents = await readResource(item.uri)
-        if (contents?.blob) {
-          const persisted = await saveFile({
-            ...params,
-            content: Buffer.from(contents.blob, 'base64'),
-            mimeType: contents.mimeType ?? item.mimeType ?? defaultMimeType,
-            nameHint: item.name,
-            source: 'MCP',
-          })
-          contentParts.push(persisted)
-          continue
+    if (item?.type === 'resource_link' && typeof item.uri === 'string') {
+      if (resolveResourceLinks && readResource) {
+        try {
+          const contents = await readResource(item.uri)
+          if (contents?.blob) {
+            const persisted = await saveFile({
+              ...params,
+              content: Buffer.from(contents.blob, 'base64'),
+              mimeType: contents.mimeType ?? item.mimeType ?? defaultMimeType,
+              nameHint: item.name,
+              source: 'MCP',
+            })
+            contentParts.push(persisted)
+            continue
+          }
+          if (contents?.text !== undefined) {
+            contentParts.push({ type: 'text', text: contents.text })
+            continue
+          }
+        } catch (e) {
+          logger.warn(`Failed to resolve MCP resource_link ${item.uri}`, e)
         }
-        if (contents?.text !== undefined) {
-          contentParts.push({ type: 'text', text: contents.text })
-          continue
-        }
-      } catch (e) {
-        logger.warn(`Failed to resolve MCP resource_link ${item.uri}`, e)
       }
     }
     if (item?.type === 'resource' && typeof item.resource?.blob === 'string') {

--- a/apps/backend/lib/tools/mcp/implementation.ts
+++ b/apps/backend/lib/tools/mcp/implementation.ts
@@ -200,10 +200,39 @@ async function convertMcpSpecToToolFunctions(
           const errorMessage = e instanceof Error ? e.message : 'MCP tool invocation failed'
           return { type: 'error-text' as const, value: errorMessage }
         }
+        // Resolve resource_link items by fetching their bytes via resources/read,
+        // converting them into embedded resources that normalizeMcpToolResult can save.
+        if (Array.isArray(result?.content)) {
+          result = {
+            ...result,
+            content: await Promise.all(
+              result.content.map(async (item: any) => {
+                if (item?.type !== 'resource_link' || typeof item.uri !== 'string') return item
+                try {
+                  const read = await clientToUse.readResource({ uri: item.uri })
+                  const contents = read.contents?.[0]
+                  if (contents && 'blob' in contents && contents.blob) {
+                    return {
+                      type: 'resource',
+                      resource: { uri: item.uri, blob: contents.blob, mimeType: contents.mimeType ?? item.mimeType, name: item.name },
+                    }
+                  }
+                  if (contents && 'text' in contents && contents.text !== undefined) {
+                    return { type: 'text', text: contents.text }
+                  }
+                } catch (e) {
+                  logger.warn(`Failed to resolve MCP resource_link ${item.uri}`, e)
+                }
+                return item
+              })
+            ),
+          }
+        }
         return await normalizeMcpToolResult(result, invokeParams)
       },
     }
   }
+
   return result
 }
 

--- a/apps/backend/lib/tools/mcp/implementation.ts
+++ b/apps/backend/lib/tools/mcp/implementation.ts
@@ -200,35 +200,10 @@ async function convertMcpSpecToToolFunctions(
           const errorMessage = e instanceof Error ? e.message : 'MCP tool invocation failed'
           return { type: 'error-text' as const, value: errorMessage }
         }
-        // Resolve resource_link items by fetching their bytes via resources/read,
-        // converting them into embedded resources that normalizeMcpToolResult can save.
-        if (Array.isArray(result?.content)) {
-          result = {
-            ...result,
-            content: await Promise.all(
-              result.content.map(async (item: any) => {
-                if (item?.type !== 'resource_link' || typeof item.uri !== 'string') return item
-                try {
-                  const read = await clientToUse.readResource({ uri: item.uri })
-                  const contents = read.contents?.[0]
-                  if (contents && 'blob' in contents && contents.blob) {
-                    return {
-                      type: 'resource',
-                      resource: { uri: item.uri, blob: contents.blob, mimeType: contents.mimeType ?? item.mimeType, name: item.name },
-                    }
-                  }
-                  if (contents && 'text' in contents && contents.text !== undefined) {
-                    return { type: 'text', text: contents.text }
-                  }
-                } catch (e) {
-                  logger.warn(`Failed to resolve MCP resource_link ${item.uri}`, e)
-                }
-                return item
-              })
-            ),
-          }
-        }
-        return await normalizeMcpToolResult(result, invokeParams)
+        return await normalizeMcpToolResult(result, invokeParams, async (uri) => {
+          const read = await clientToUse.readResource({ uri })
+          return read.contents?.[0] as { blob?: string; text?: string; mimeType?: string } | undefined
+        })
       },
     }
   }

--- a/apps/backend/lib/tools/mcp/implementation.ts
+++ b/apps/backend/lib/tools/mcp/implementation.ts
@@ -25,6 +25,9 @@ import { LlmModel } from '@/lib/chat/models'
 import { LRUCache } from 'lru-cache'
 import * as dto from '@/types/dto'
 import { normalizeMcpToolResult } from '@/backend/lib/tools/file-output-normalization'
+import { getFileWithId } from '@/models/file'
+import { canAccessFile } from '@/backend/lib/files/authorization'
+import { storage } from '@/lib/storage'
 
 interface CacheItem {
   id: string
@@ -129,6 +132,61 @@ const getClient = async (
   return client
 }
 
+// Detects a parameter that carries base64-encoded file bytes.
+function isBlobProperty(name: string, schema: JSONSchema7): boolean {
+  if (schema.type !== 'string') return false
+  const lower = name.toLowerCase()
+  if (lower === 'data' || lower === 'blob' || lower === 'content') {
+    const desc = (schema.description ?? '').toLowerCase()
+    if (desc.includes('base64')) return true
+  }
+  const fmt = (schema as Record<string, unknown>).format
+  if (fmt === 'byte' || fmt === 'base64') return true
+  return false
+}
+
+function isMimeTypeProperty(name: string): boolean {
+  const lower = name.toLowerCase()
+  return lower === 'mimetype' || lower === 'mime_type' || lower === 'mediatype' || lower === 'media_type'
+}
+
+// Returns the blob and mimeType property names if the schema has a blob+mimeType pair.
+function detectBlobSignature(
+  schema: JSONSchema7
+): { blobProp: string; mimeTypeProp: string } | null {
+  const props = schema.properties
+  if (!props) return null
+  let blobProp: string | null = null
+  let mimeTypeProp: string | null = null
+  for (const [name, propSchema] of Object.entries(props)) {
+    if (typeof propSchema === 'boolean') continue
+    if (isBlobProperty(name, propSchema)) blobProp = name
+    if (isMimeTypeProperty(name)) mimeTypeProp = name
+  }
+  return blobProp && mimeTypeProp ? { blobProp, mimeTypeProp } : null
+}
+
+// Rewrites a blob+mimeType schema to accept a file_id instead.
+function rewriteSchemaForFileId(
+  schema: JSONSchema7,
+  blobProp: string,
+  mimeTypeProp: string
+): JSONSchema7 {
+  const { [blobProp]: _b, [mimeTypeProp]: _m, ...rest } = schema.properties ?? {}
+  const required = (schema.required ?? []).filter((r) => r !== blobProp && r !== mimeTypeProp)
+  return {
+    ...schema,
+    properties: {
+      ...rest,
+      file_id: {
+        type: 'string',
+        description: 'Logicle file ID of the document to import.',
+      },
+    },
+    required: [...required, 'file_id'],
+  }
+}
+
 async function convertMcpSpecToToolFunctions(
   toolParams: McpPluginParams,
   toolId: string,
@@ -156,10 +214,19 @@ async function convertMcpSpecToToolFunctions(
   const result: ToolFunctions = {}
   for (const tool_ of tools) {
     const tool = tool_ as any
+    const originalSchema = tool.inputSchema as JSONSchema7
+    const blobSig = detectBlobSignature(originalSchema)
+    const exposedSchema = blobSig
+      ? rewriteSchemaForFileId(originalSchema, blobSig.blobProp, blobSig.mimeTypeProp)
+      : originalSchema
+    const exposedDescription = blobSig
+      ? `${tool.description ?? ''}\n\nProvide a Logicle file_id; the file bytes are fetched automatically.`
+      : (tool.description ?? '')
+
     result[tool.name] = {
-      description: tool.description ?? '',
+      description: exposedDescription,
       // the code below is highly unsafe... but it's a start
-      parameters: tool.inputSchema as JSONSchema7,
+      parameters: exposedSchema,
       auth: async () => null,
       invoke: async (invokeParams: ToolInvokeParams) => {
         const { params, userId } = invokeParams
@@ -189,20 +256,47 @@ async function convertMcpSpecToToolFunctions(
           }
           clientToUse = await getClient(toolParams, resolution.accessToken, userId)
         }
+
+        // Resolve file_id → base64 bytes before forwarding to the real MCP tool.
+        let callArgs: Record<string, unknown> = { ...params }
+        if (blobSig) {
+          const fileId = `${params.file_id ?? ''}`
+          if (!fileId) {
+            return { type: 'error-text' as const, value: 'file_id is required' }
+          }
+          if (userId && !(await canAccessFile({ userId }, fileId))) {
+            return { type: 'error-text' as const, value: `Access denied to file: ${fileId}` }
+          }
+          const fileEntry = await getFileWithId(fileId)
+          if (!fileEntry) {
+            return { type: 'error-text' as const, value: `File not found: ${fileId}` }
+          }
+          const fileBytes = await storage.readBuffer(fileEntry.path, !!fileEntry.encrypted)
+          const { file_id: _ignored, ...restParams } = callArgs
+          callArgs = {
+            ...restParams,
+            [blobSig.blobProp]: Buffer.from(fileBytes).toString('base64'),
+            [blobSig.mimeTypeProp]: fileEntry.type,
+          }
+        }
+
         let result
         try {
           result = await clientToUse.callTool({
             name: tool.name,
-            arguments: params,
+            arguments: callArgs,
           })
         } catch (e) {
           logger.error(`MCP tool '${tool.name}' invocation failed`, e)
           const errorMessage = e instanceof Error ? e.message : 'MCP tool invocation failed'
           return { type: 'error-text' as const, value: errorMessage }
         }
-        return await normalizeMcpToolResult(result, invokeParams, async (uri) => {
-          const read = await clientToUse.readResource({ uri })
-          return read.contents?.[0] as { blob?: string; text?: string; mimeType?: string } | undefined
+        return await normalizeMcpToolResult(result, invokeParams, {
+          resolveResourceLinks: !blobSig,
+          readResource: async (uri) => {
+            const read = await clientToUse.readResource({ uri })
+            return read.contents?.[0] as { blob?: string; text?: string; mimeType?: string } | undefined
+          },
         })
       },
     }


### PR DESCRIPTION
## Summary

Two improvements to MCP tool result handling:

1. **\`resource_link\` resolution** — MCP tools can return \`resource_link\` content items (a URI reference without inline bytes). \`normalizeMcpToolResult\` now accepts an optional \`readResource\` callback; when provided, \`resource_link\` items are resolved via \`resources/read\` and persisted as files or text alongside other content types (\`resource\`, \`image\`, \`text\`).

2. **Upload tool bridging** — MCP tools whose input schema carries a base64 blob+mimeType pair are automatically rewritten to accept a \`file_id\` instead. The LLM passes a Logicle file ID; the invoke layer fetches the bytes, base64-encodes them, and forwards to the real MCP tool. For these upload tools, \`resource_link\` items in the response are intentionally not resolved or persisted as downloads — the file was just uploaded, not produced — so the LLM receives the raw reference (e.g. an \`office://\` URI) as text.

## Tests

- \`npm run check-types\` — passed