### PR TITLE
fix(textextraction): swallow extractor errors instead of propagating them

### DIFF
--- a/apps/backend/lib/textextraction/__tests__/cache.test.ts
+++ b/apps/backend/lib/textextraction/__tests__/cache.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test, vi } from 'vitest'
+import { cachingExtractor } from '@/lib/textextraction/cache'
+
+const extractor = vi.fn(async () => {
+  throw new Error('Unencoded <\nLine: 85\nColumn: 83\nChar: 0')
+})
+
+vi.mock('@/lib/textextraction', () => ({
+  findExtractor: vi.fn(() => extractor),
+  genericTextExtractor: vi.fn(),
+}))
+
+vi.mock('@/lib/file-analysis', () => ({
+  ensureFileAnalysisForFile: vi.fn(async () => undefined),
+  readExtractedTextFromAnalysis: vi.fn(async () => null),
+}))
+
+vi.mock('@/lib/storage', () => ({
+  storage: {
+    readBuffer: vi.fn(async () => Buffer.from('mock pptx bytes')),
+  },
+}))
+
+describe('cachingExtractor', () => {
+  test('returns undefined when the file extractor fails', async () => {
+    const fileEntry = {
+      id: 'file-1',
+      path: '/tmp/file-1.pptx',
+      name: 'corrupted.pptx',
+      type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      encrypted: false,
+      fileBlobId: 'blob-1',
+    }
+
+    await expect(cachingExtractor.extractFromFile(fileEntry as any)).resolves.toBeUndefined()
+    expect(extractor).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/backend/lib/textextraction/cache.ts
+++ b/apps/backend/lib/textextraction/cache.ts
@@ -3,6 +3,7 @@ import type { FileDbRow } from '@/backend/models/file'
 import { findExtractor, genericTextExtractor } from '.'
 import { storage } from '../storage'
 import { ensureFileAnalysisForFile, readExtractedTextFromAnalysis } from '@/lib/file-analysis'
+import { logger } from '@/lib/logging'
 
 const cacheSizeInMb = 100
 
@@ -34,9 +35,19 @@ export const cachingExtractor = {
     if (!extractor) {
       return undefined
     }
-    const fileContent = await storage.readBuffer(fileEntry.path, !!fileEntry.encrypted)
-    const text = await extractor(fileContent)
-    cache.set(fileEntry.path, text)
-    return text
+    try {
+      const fileContent = await storage.readBuffer(fileEntry.path, !!fileEntry.encrypted)
+      const text = await extractor(fileContent)
+      cache.set(fileEntry.path, text)
+      return text
+    } catch (error) {
+      logger.warn('File text extraction failed; continuing without extracted text', {
+        fileId: fileEntry.id,
+        fileName: fileEntry.name,
+        fileType: fileEntry.type,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return undefined
+    }
   },
 }


### PR DESCRIPTION
## Summary

A malformed file (e.g. a PPTX with invalid XML characters) could throw inside `cachingExtractor.extractFromFile`, crashing the chat request that triggered text extraction. The extractor call is now wrapped in a try/catch; on failure a warning is logged and `undefined` is returned so the conversation continues without the extracted text.

## Details

- `apps/backend/lib/textextraction/cache.ts`: wrapped `storage.readBuffer` + `extractor(fileContent)` in try/catch; logs `fileId`, `fileName`, `fileType`, and the error message then returns `undefined`.

## Tests

- New unit test `apps/backend/lib/textextraction/__tests__/cache.test.ts` confirms `extractFromFile` resolves to `undefined` when the extractor throws.
- `npm run check-types` — clean
- `npx vitest run apps/backend/lib/textextraction/__tests__/cache.test.ts` — 1 test passed