### PR TITLE
fix(auth): invalidate password sessions on admin password change

### DIFF
--- a/apps/backend/api/users/[userId]/password/route.ts
+++ b/apps/backend/api/users/[userId]/password/route.ts
@@ -2,6 +2,7 @@ import { hashPassword } from '@/lib/auth/password'
 import { db } from '@/db/database'
 import { forbidden, noBody, notFound, operation, responseSpec, errorSpec } from '@/lib/routes'
 import { getUserById } from '@/models/user'
+import { deleteUserSessionsByAuthMethod } from '@/models/session'
 import { adminChangePasswordRequestSchema } from '@/types/dto'
 
 export const PUT = operation({
@@ -25,6 +26,7 @@ export const PUT = operation({
       .set({ password: await hashPassword(newPassword) })
       .where('id', '=', params.userId)
       .execute()
+    await deleteUserSessionsByAuthMethod(params.userId, 'password')
     return noBody()
   },
 })
@@ -43,6 +45,7 @@ export const DELETE = operation({
       return forbidden("Can't modify a provisioned user")
     }
     await db.updateTable('User').set({ password: null }).where('id', '=', params.userId).execute()
+    await deleteUserSessionsByAuthMethod(params.userId, 'password')
     return noBody()
   },
 })

--- a/apps/backend/models/session.ts
+++ b/apps/backend/models/session.ts
@@ -86,6 +86,17 @@ export const deleteUserSessionById = async (userId: string, sessionId: string) =
     .execute()
 }
 
+export const deleteUserSessionsByAuthMethod = async (
+  userId: string,
+  authMethod: schema.Session['authMethod']
+) => {
+  await db
+    .deleteFrom('Session')
+    .where('userId', '=', userId)
+    .where('authMethod', '=', authMethod)
+    .execute()
+}
+
 export const updateSessionActivity = async (
   sessionId: string,
   data: { lastSeenAt: Date; userAgent?: string | null; ipAddress?: string | null }


### PR DESCRIPTION
## Summary

When an admin sets or removes a user's password via the admin API, all active password-authenticated sessions for that user are now invalidated immediately. This forces the affected user to re-authenticate with the new credentials. IdP/SSO sessions are left untouched since those credentials are managed externally.

## Details

- Added `deleteUserSessionsByAuthMethod(userId, authMethod)` to `apps/backend/models/session.ts`
- Both `PUT` (set password) and `DELETE` (remove password) in `apps/backend/api/users/[userId]/password/route.ts` call this after updating the DB