### PR TITLE
fix(analytics): fill empty time buckets with zeros in breakdown charts

### DIFF
--- a/apps/backend/api/analytics/usage/byassistant/route.ts
+++ b/apps/backend/api/analytics/usage/byassistant/route.ts
@@ -106,7 +106,7 @@ export const GET = operation({
       )
     }
 
-    const result = (await usageQuery.execute()).map((row) => ({
+    const rows = (await usageQuery.execute()).map((row) => ({
       start: row.start,
       end: row.end,
       id: row.id ?? null,
@@ -115,12 +115,27 @@ export const GET = operation({
       tokens: Number(row.tokens ?? 0),
     }))
 
+    const populatedStarts = new Set(rows.map((r) => r.start))
+    const filledRows = [
+      ...rows,
+      ...buckets
+        .filter((b) => !populatedStarts.has(formatDateTime(b.start)))
+        .map((b) => ({
+          start: formatDateTime(b.start),
+          end: formatDateTime(b.end),
+          id: null,
+          name: null,
+          messages: 0,
+          tokens: 0,
+        })),
+    ]
+
     return ok({
       period: range.period,
       granularity: range.granularity,
       from: formatDateTime(range.start),
       to: formatDateTime(range.end),
-      rows: result,
+      rows: filledRows,
     })
   },
 })

--- a/apps/backend/api/analytics/usage/byuser/route.ts
+++ b/apps/backend/api/analytics/usage/byuser/route.ts
@@ -101,7 +101,7 @@ export const GET = operation({
       )
     }
 
-    const result = (await usageQuery.execute()).map((row) => ({
+    const rows = (await usageQuery.execute()).map((row) => ({
       start: row.start,
       end: row.end,
       id: row.id ?? null,
@@ -110,12 +110,27 @@ export const GET = operation({
       tokens: Number(row.tokens ?? 0),
     }))
 
+    const populatedStarts = new Set(rows.map((r) => r.start))
+    const filledRows = [
+      ...rows,
+      ...buckets
+        .filter((b) => !populatedStarts.has(formatDateTime(b.start)))
+        .map((b) => ({
+          start: formatDateTime(b.start),
+          end: formatDateTime(b.end),
+          id: null,
+          name: null,
+          messages: 0,
+          tokens: 0,
+        })),
+    ]
+
     return ok({
       period: range.period,
       granularity: range.granularity,
       from: formatDateTime(range.start),
       to: formatDateTime(range.end),
-      rows: result,
+      rows: filledRows,
     })
   },
 })


### PR DESCRIPTION
## Summary

The stacked usage charts (by assistant, by user) were skipping days with no activity, causing gaps in the X-axis and distorted visual interpretation. The root cause is that per-bucket queries in `byassistant` and `byuser` use `GROUP BY`, so an interval with no messages produces zero rows in the union result. The frontend derived its bucket list from the returned rows, so empty days were never shown.

After executing the query, each route now compares the returned bucket starts against the full set of expected buckets from `buildBuckets`. Any bucket absent from the DB result gets a synthetic `{id: null, name: null, messages: 0, tokens: 0}` row injected, ensuring the time axis is always continuous.

The plain `analytics/usage` endpoint (Overview chart) was already correct — its per-bucket queries are scalar aggregates without `GROUP BY` and always return one row per interval.

## Tests

- `npm run check-types` — passed