### PR TITLE
feat(security): prevent search engine indexing

### DIFF
--- a/apps/backend/lib/router.ts
+++ b/apps/backend/lib/router.ts
@@ -159,6 +159,7 @@ export async function handleApiRequest(req: IncomingMessage, res: ServerResponse
 async function sendWebResponse(res: ServerResponse, response: Response) {
   res.statusCode = response.status
   res.statusMessage = response.statusText
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive')
 
   const setCookieHeaders =
     typeof response.headers.getSetCookie === 'function' ? response.headers.getSetCookie() : []

--- a/apps/frontend/app/robots.ts
+++ b/apps/frontend/app/robots.ts
@@ -1,0 +1,10 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      disallow: '/',
+    },
+  }
+}

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -21,6 +21,14 @@ const nextConfig: NextConfig = {
     ],
   },
   output: process.env.BUILD_STANDALONE === 'true' ? 'standalone' : undefined,
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [{ key: 'X-Robots-Tag', value: 'noindex, nofollow, noarchive' }],
+      },
+    ]
+  },
   async redirects() {
     return redirects
   },


### PR DESCRIPTION
## Summary

Prevents search engines from indexing the application by adding `X-Robots-Tag: noindex, nofollow, noarchive` to all HTTP responses and serving a `robots.txt` that disallows all crawlers.

## Details

- `apps/frontend/next.config.ts`: adds a `headers()` rule matching `(.*)` to attach `X-Robots-Tag: noindex, nofollow, noarchive` to every response served by Next.js (pages, static assets)
- `apps/backend/lib/router.ts`: sets the same header in `sendWebResponse` so custom backend API responses are also covered
- `apps/frontend/app/robots.ts`: Next.js Metadata Route that serves `robots.txt` with `User-agent: * / Disallow: /`

## Tests

- `npm run check-types` — passed