### PR TITLE
fix(ci): prevent GitHub Pages deployment collisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
     needs: unit-tests
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    concurrency:
+      group: pages
+      cancel-in-progress: true
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Summary

Adds a `concurrency` group to the `deploy-coverage` job in CI so that concurrent pushes to `main` do not collide on the GitHub Pages deployment lock. When multiple deployments are in-flight, the older one is cancelled in favour of the newer commit.

## Tests

- Observed collision error in [CI run 27831717310](https://github.com/logicleai/logicle/actions/runs/27831717310/job/82370052073)
- Fix follows GitHub's recommended pattern for Pages deployments