### PR TITLE
fix(assistant): prevent Instructions tab from resetting to General after auto-save

### DIFF
--- a/apps/frontend/app/assistants/[id]/page.tsx
+++ b/apps/frontend/app/assistants/[id]/page.tsx
@@ -516,7 +516,7 @@ const AssistantPage = () => {
       </div>
       <div className={`flex-1 min-h-0 grid grid-cols-2 overflow-hidden`}>
         <AssistantForm
-          key={`${assistant.id}-${formResetKey}`}
+          key={`${assistant.assistantId}-${formResetKey}`}
           assistant={assistant}
           onPublish={onPublish}
           onChange={onChange}


### PR DESCRIPTION
## Summary

When editing a published assistant, switching to the Instructions tab and waiting ~5 seconds caused the tab to snap back to General. This happened because the auto-save — triggered 5 seconds after the first edit — caused the backend to clone the draft into a new version with a new ID, which changed the `key` prop on `AssistantForm`, unmounting and remounting the form.

## Details

- The `AssistantForm` key was `${assistant.id}-${formResetKey}`, where `assistant.id` is the **draft version ID**.
- On first save of a published assistant (draft version = published version), `updateAssistantDraft` clones the draft into a new version — so `assistant.id` changes after the auto-save completes.
- Changing the key causes React to fully unmount and remount `AssistantForm`, resetting `activeTab` to `'general'`.
- Fix: use `assistant.assistantId` (the stable assistant entity ID) instead of `assistant.id` (the mutable draft version ID). The `formResetKey` still handles the explicit "discard changes" remount path.

Closes https://github.com/logicleai/logicle-issues/issues/273