### PR TITLE
fix(ci): tolerate Pages deployment cancellation in deploy-coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
     needs: unit-tests
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    continue-on-error: true
     concurrency:
       group: pages
       cancel-in-progress: true


### PR DESCRIPTION
## Summary

When two CI runs overlap on `main` (e.g. a push followed by a `workflow_dispatch`), the GitHub Pages API can cancel one of the concurrent deployments from the outside. This caused the `deploy-coverage` job to fail and marked the overall workflow run as failed.

## Details

- The existing `concurrency: cancel-in-progress: true` prevents two `deploy-coverage` jobs from running simultaneously at the Actions level, but does not prevent the GitHub Pages API from externally cancelling a deployment that was submitted before the concurrency group kicked in.
- Adding `continue-on-error: true` ensures a cancelled Pages deployment is treated as a non-fatal outcome, since coverage publishing is non-critical CI infrastructure.