### PR TITLE
refactor: make file metadata interspersing unconditional

### DIFF
--- a/__tests__/conversion.test.ts
+++ b/__tests__/conversion.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { LlmModelCapabilities } from '@/lib/chat/models'
 import type * as dto from '@/types/dto'
+import { fileDescriptorText } from '@/backend/lib/chat/message-projection'
 
 const ensureFileAnalysis = vi.fn()
 const readBuffer = vi.fn()
@@ -240,16 +241,7 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
             value: [
               {
                 type: 'text',
-                text: JSON.stringify({
-                  attached_files: [
-                    {
-                      id: pdfFile.id,
-                      name: pdfFile.name,
-                      size: pdfFile.size,
-                      mimetype: pdfFile.type,
-                    },
-                  ],
-                }),
+                text: fileDescriptorText(pdfFile.name, pdfFile.id, pdfFile.type, pdfFile.size, 1, 'Attachment'),
               },
               { type: 'file-data', data: Buffer.from('pdf-bytes').toString('base64'), mediaType: pdfFile.type },
             ],
@@ -330,16 +322,7 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
             value: [
               {
                 type: 'text',
-                text: JSON.stringify({
-                  attached_files: [
-                    {
-                      id: pdfFile.id,
-                      name: pdfFile.name,
-                      size: pdfFile.size,
-                      mimetype: pdfFile.type,
-                    },
-                  ],
-                }),
+                text: fileDescriptorText(pdfFile.name, pdfFile.id, pdfFile.type, pdfFile.size, 1, 'Attachment'),
               },
               {
                 type: 'file-data',
@@ -423,16 +406,7 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
             value: [
               {
                 type: 'text',
-                text: JSON.stringify({
-                  attached_files: [
-                    {
-                      id: pdfFile.id,
-                      name: pdfFile.name,
-                      size: pdfFile.size,
-                      mimetype: pdfFile.type,
-                    },
-                  ],
-                }),
+                text: fileDescriptorText(pdfFile.name, pdfFile.id, pdfFile.type, pdfFile.size, 1, 'Attachment'),
               },
               {
                 type: 'text',
@@ -496,16 +470,7 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
             value: [
               {
                 type: 'text',
-                text: JSON.stringify({
-                  attached_files: [
-                    {
-                      id: pdfFile.id,
-                      name: pdfFile.name,
-                      size: pdfFile.size,
-                      mimetype: pdfFile.type,
-                    },
-                  ],
-                }),
+                text: fileDescriptorText(pdfFile.name, pdfFile.id, pdfFile.type, pdfFile.size, 1, 'Attachment'),
               },
               {
                 type: 'text',
@@ -577,16 +542,7 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
             value: [
               {
                 type: 'text',
-                text: JSON.stringify({
-                  attached_files: [
-                    {
-                      id: imageFile.id,
-                      name: imageFile.name,
-                      size: imageFile.size,
-                      mimetype: imageFile.type,
-                    },
-                  ],
-                }),
+                text: fileDescriptorText(imageFile.name, imageFile.id, imageFile.type, imageFile.size, 1, 'Attachment'),
               },
               {
                 type: 'text',
@@ -665,9 +621,7 @@ describe('dtoMessageToLlmMessage contract', () => {
         { type: 'text', text: 'hello' },
         {
           type: 'text',
-          text: `The user has attached the following files to this chat: \n${JSON.stringify([
-            { id: imageFile.id, name: imageFile.name, mimetype: imageFile.type, size: imageFile.size },
-          ])}`,
+          text: fileDescriptorText(imageFile.name, imageFile.id, imageFile.type, imageFile.size, 1, 'Attachment'),
         },
         {
           type: 'image',

--- a/__tests__/fileMetadataInterspersing.test.ts
+++ b/__tests__/fileMetadataInterspersing.test.ts
@@ -1,11 +1,11 @@
 /**
- * Tests for the INTERSPERSE_FILE_METADATA feature (issue #251).
+ * Tests for interspersed file metadata (issue #251).
  *
  * Covers:
  *  - fileDescriptorText: all naming/fallback rules
- *  - projectMessageForEstimation: classic vs interspersed projection
- *  - dtoMessageToLlmMessage: content ordering in interspersed mode
- *  - preparePreamblePlan: knowledge segment structure in interspersed mode
+ *  - projectMessageForEstimation: interspersed projection
+ *  - dtoMessageToLlmMessage: content ordering
+ *  - preparePreamblePlan: knowledge segment structure
  *  - Token estimation alignment for user attachments and knowledge files
  */
 import { beforeEach, describe, expect, test, vi } from 'vitest'
@@ -147,74 +147,9 @@ describe('fileDescriptorText', () => {
 })
 
 // ---------------------------------------------------------------------------
-// 2. projectMessageForEstimation — classic mode (intersperseFileMetadata=false)
+// 2. projectMessageForEstimation
 // ---------------------------------------------------------------------------
-describe('projectMessageForEstimation — classic mode', () => {
-  beforeEach(() => {
-    vi.resetModules()
-    vi.clearAllMocks()
-  })
-
-  test('single attachment: global descriptor then attachment item', async () => {
-    const { projectMessageForEstimation } = await import('@/backend/lib/chat/message-projection')
-    const msg: dto.UserMessage = {
-      id: 'm1',
-      conversationId: 'c1',
-      parent: null,
-      sentAt: new Date().toISOString(),
-      citations: [],
-      role: 'user',
-      content: 'hello',
-      attachments: [{ id: 'img-1', name: 'screenshot.png', mimetype: 'image/png', size: 9321 }],
-    }
-    const projection = projectMessageForEstimation(msg, false)
-    expect(projection.role).toBe('user')
-    const textItems = projection.items.filter((i) => i.kind === 'text')
-    const attachmentItems = projection.items.filter((i) => i.kind === 'attachment')
-    // One content text + one global descriptor text
-    expect(textItems).toHaveLength(2)
-    expect(textItems[0]).toMatchObject({ source: 'content', text: 'hello' })
-    expect(textItems[1]).toMatchObject({ source: 'attachment_descriptor' })
-    expect(asText(textItems[1]).text).toContain('screenshot.png')
-    // Attachments come last
-    expect(attachmentItems).toHaveLength(1)
-    const lastItem = projection.items[projection.items.length - 1]
-    expect(lastItem?.kind).toBe('attachment')
-  })
-
-  test('two attachments: single global descriptor, attachments appended in order', async () => {
-    const { projectMessageForEstimation } = await import('@/backend/lib/chat/message-projection')
-    const msg: dto.UserMessage = {
-      id: 'm2',
-      conversationId: 'c1',
-      parent: null,
-      sentAt: new Date().toISOString(),
-      citations: [],
-      role: 'user',
-      content: '',
-      attachments: [
-        { id: 'img-1', name: 'a.png', mimetype: 'image/png', size: 100 },
-        { id: 'img-2', name: 'b.jpg', mimetype: 'image/jpeg', size: 200 },
-      ],
-    }
-    const projection = projectMessageForEstimation(msg, false)
-    const descriptorItems = projection.items.filter(
-      (i) => i.kind === 'text' && i.source === 'attachment_descriptor'
-    )
-    const attachmentItems = projection.items.filter((i) => i.kind === 'attachment')
-    // One aggregated descriptor
-    expect(descriptorItems).toHaveLength(1)
-    // Both attachments in order
-    expect(attachmentItems).toHaveLength(2)
-    expect(attachmentItems[0]).toMatchObject({ attachment: { id: 'img-1' } })
-    expect(attachmentItems[1]).toMatchObject({ attachment: { id: 'img-2' } })
-  })
-})
-
-// ---------------------------------------------------------------------------
-// 3. projectMessageForEstimation — interspersed mode (intersperseFileMetadata=true)
-// ---------------------------------------------------------------------------
-describe('projectMessageForEstimation — interspersed mode', () => {
+describe('projectMessageForEstimation', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
@@ -232,7 +167,7 @@ describe('projectMessageForEstimation — interspersed mode', () => {
       content: 'check this',
       attachments: [{ id: 'img-1', name: 'screenshot.png', mimetype: 'image/png', size: 9321 }],
     }
-    const projection = projectMessageForEstimation(msg, true)
+    const projection = projectMessageForEstimation(msg)
     // Items should be: [content text, descriptor text, attachment]
     expect(projection.items).toHaveLength(3)
     expect(projection.items[0]).toMatchObject({ kind: 'text', source: 'content', text: 'check this' })
@@ -256,7 +191,7 @@ describe('projectMessageForEstimation — interspersed mode', () => {
         { id: 'img-2', name: 'b.jpg', mimetype: 'image/jpeg', size: 200 },
       ],
     }
-    const projection = projectMessageForEstimation(msg, true)
+    const projection = projectMessageForEstimation(msg)
     // Items: [desc1, att1, desc2, att2] (no content text since content='')
     expect(projection.items).toHaveLength(4)
     expect(projection.items[0]).toMatchObject({ kind: 'text', source: 'attachment_descriptor' })
@@ -281,7 +216,7 @@ describe('projectMessageForEstimation — interspersed mode', () => {
       content: '',
       attachments: [{ id: 'paste-1', name: '', mimetype: 'image/png', size: 50000 }],
     }
-    const projection = projectMessageForEstimation(msg, true)
+    const projection = projectMessageForEstimation(msg)
     expect(asText(projection.items[0]).text).toContain('pasted image')
     expect(asText(projection.items[0]).text).toContain('id paste-1')
   })
@@ -298,11 +233,11 @@ describe('projectMessageForEstimation — interspersed mode', () => {
       content: '',
       attachments: [{ id: 'paste-2', name: '', mimetype: 'application/pdf', size: 10000 }],
     }
-    const projection = projectMessageForEstimation(msg, true)
+    const projection = projectMessageForEstimation(msg)
     expect(asText(projection.items[0]).text).toContain('Attachment 1: pasted (id paste-2')
   })
 
-  test('no attachments: behaves identically in both modes', async () => {
+  test('no attachments: no descriptor items emitted', async () => {
     const { projectMessageForEstimation } = await import('@/backend/lib/chat/message-projection')
     const msg: dto.UserMessage = {
       id: 'm7',
@@ -314,25 +249,22 @@ describe('projectMessageForEstimation — interspersed mode', () => {
       content: 'no files here',
       attachments: [],
     }
-    const classic = projectMessageForEstimation(msg, false)
-    const interspersed = projectMessageForEstimation(msg, true)
-    expect(classic.items).toEqual(interspersed.items)
+    const projection = projectMessageForEstimation(msg)
+    expect(projection.items).toHaveLength(1)
+    expect(projection.items[0]).toMatchObject({ kind: 'text', source: 'content' })
   })
 })
 
 // ---------------------------------------------------------------------------
-// 4. dtoMessageToLlmMessage — interspersed mode content ordering
+// 3. dtoMessageToLlmMessage — content ordering
 // ---------------------------------------------------------------------------
-describe('dtoMessageToLlmMessage — interspersed mode', () => {
+describe('dtoMessageToLlmMessage', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
   })
 
   test('image: descriptor text precedes image part', async () => {
-    vi.doMock('@/lib/env', () => ({
-      default: { knowledge: { intersperseFileMetadata: true } },
-    }))
     getFileWithId.mockResolvedValue(pngFile)
     readBuffer.mockResolvedValue(Buffer.from('png-bytes'))
 
@@ -365,9 +297,6 @@ describe('dtoMessageToLlmMessage — interspersed mode', () => {
   })
 
   test('two images: two descriptor+image pairs', async () => {
-    vi.doMock('@/lib/env', () => ({
-      default: { knowledge: { intersperseFileMetadata: true } },
-    }))
     getFileWithId
       .mockResolvedValueOnce(pngFile)
       .mockResolvedValueOnce(jpgFile)
@@ -403,48 +332,7 @@ describe('dtoMessageToLlmMessage — interspersed mode', () => {
     expect(parts[3]).toMatchObject({ type: 'image' })
   })
 
-  test('classic mode (intersperseFileMetadata=false): text first then images', async () => {
-    vi.doMock('@/lib/env', () => ({
-      default: { knowledge: { intersperseFileMetadata: false } },
-    }))
-    getFileWithId
-      .mockResolvedValueOnce(pngFile)
-      .mockResolvedValueOnce(jpgFile)
-    readBuffer.mockResolvedValue(Buffer.from('img-bytes'))
-
-    const { dtoMessageToLlmMessage } = await import('@/backend/lib/chat/conversion')
-    const msg = await dtoMessageToLlmMessage(
-      {
-        id: 'u3',
-        conversationId: 'c1',
-        parent: null,
-        sentAt: new Date().toISOString(),
-        citations: [],
-        role: 'user',
-        content: 'hi',
-        attachments: [
-          { id: pngFile.id, name: pngFile.name, mimetype: pngFile.type, size: pngFile.size },
-          { id: jpgFile.id, name: jpgFile.name, mimetype: jpgFile.type, size: jpgFile.size },
-        ],
-      },
-      visionCapabilities,
-      'openai.chat'
-    )
-
-    const parts = msg!.content as Array<{ type: string; text?: string }>
-    // Classic: [content text, global descriptor, img1, img2]
-    expect(parts).toHaveLength(4)
-    expect(parts[0]).toMatchObject({ type: 'text', text: 'hi' })
-    expect(parts[1]).toMatchObject({ type: 'text' })
-    expect(parts[1]!.text).toContain('The user has attached')
-    expect(parts[2]).toMatchObject({ type: 'image' })
-    expect(parts[3]).toMatchObject({ type: 'image' })
-  })
-
-  test('interspersed: text fallback file gets descriptor before text content', async () => {
-    vi.doMock('@/lib/env', () => ({
-      default: { knowledge: { intersperseFileMetadata: true } },
-    }))
+  test('text fallback file gets descriptor before text content', async () => {
     getFileWithId.mockResolvedValue(pdfFile)
     extractFromFile.mockResolvedValue('pdf text content')
 
@@ -473,10 +361,7 @@ describe('dtoMessageToLlmMessage — interspersed mode', () => {
     expect(parts[1]!.text).toContain('pdf text content')
   })
 
-  test('missing file entry is skipped with a warning (interspersed mode)', async () => {
-    vi.doMock('@/lib/env', () => ({
-      default: { knowledge: { intersperseFileMetadata: true } },
-    }))
+  test('missing file entry is skipped with a warning', async () => {
     // First file OK, second not found
     getFileWithId
       .mockResolvedValueOnce(pngFile)
@@ -503,17 +388,15 @@ describe('dtoMessageToLlmMessage — interspersed mode', () => {
     )
 
     const parts = msg!.content as Array<{ type: string }>
-    // Descriptor for first + image for first; descriptor for second emitted but file skipped
-    // Items: [desc1, img1, desc2] — second descriptor is still emitted, file part is omitted
     expect(parts.some((p) => p.type === 'image')).toBe(true)
     expect(warn).toHaveBeenCalled()
   })
 })
 
 // ---------------------------------------------------------------------------
-// 5. preparePreamblePlan — knowledge segment in interspersed mode
+// 4. preparePreamblePlan — knowledge segment
 // ---------------------------------------------------------------------------
-describe('preparePreamblePlan — interspersed knowledge mode', () => {
+describe('preparePreamblePlan — knowledge', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
@@ -532,10 +415,10 @@ describe('preparePreamblePlan — interspersed knowledge mode', () => {
 
   const assistantParams = { systemPrompt: 'You are helpful.' }
 
-  test('interspersed: knowledgePrompt does not contain JSON file listing', async () => {
+  test('knowledgePrompt does not contain JSON file listing', async () => {
     vi.doMock('@/lib/env', () => ({
       default: {
-        knowledge: { sendInPrompt: true, intersperseFileMetadata: true, alwaysConvertToText: true },
+        knowledge: { sendInPrompt: true, alwaysConvertToText: true },
       },
     }))
     const mockLoadKnowledgeFilePart = vi.fn().mockResolvedValue({ type: 'text', text: 'extracted' })
@@ -557,21 +440,18 @@ describe('preparePreamblePlan — interspersed knowledge mode', () => {
       knowledge: knowledgeFiles,
     })
 
-    expect(plan.intersperseFileMetadata).toBe(true)
     expect(plan.knowledgePrompt).toBeDefined()
-    // No JSON dump of the file list
     expect(plan.knowledgePrompt).not.toContain('"handbook.pdf"')
     expect(plan.knowledgePrompt).not.toContain(JSON.stringify(knowledgeFiles))
     expect(plan.knowledgeFileEntries).toHaveLength(2)
-    // size is present in each entry
     expect(plan.knowledgeFileEntries![0]!.size).toBe(123456)
     expect(plan.knowledgeFileEntries![1]!.size).toBe(78900)
   })
 
-  test('interspersed: materializeKnowledgeSegment returns [descriptor, content] pairs', async () => {
+  test('materializeKnowledgeSegment returns [descriptor, content] pairs', async () => {
     vi.doMock('@/lib/env', () => ({
       default: {
-        knowledge: { sendInPrompt: true, intersperseFileMetadata: true, alwaysConvertToText: true },
+        knowledge: { sendInPrompt: true, alwaysConvertToText: true },
       },
     }))
     const mockLoadKnowledgeFilePart = vi.fn()
@@ -608,74 +488,10 @@ describe('preparePreamblePlan — interspersed knowledge mode', () => {
     expect(parts[3]).toMatchObject({ type: 'text', text: 'photo text' })
   })
 
-  test('classic: knowledgePrompt contains JSON file listing', async () => {
+  test('no knowledge files → empty plan', async () => {
     vi.doMock('@/lib/env', () => ({
       default: {
-        knowledge: { sendInPrompt: true, intersperseFileMetadata: false, alwaysConvertToText: true },
-      },
-    }))
-    const mockLoadKnowledgeFilePart = vi.fn().mockResolvedValue({ type: 'text', text: 'x' })
-    vi.doMock('@/backend/lib/tools/knowledge/implementation', () => ({
-      loadKnowledgeFilePart: mockLoadKnowledgeFilePart,
-      KnowledgePlugin: class {
-        toolParams = { promptFragment: '' }
-        supportedMedia = []
-        functions = async () => ({})
-      },
-    }))
-
-    const { preparePreamblePlan } = await import('@/backend/lib/chat/preamble')
-    const plan = await preparePreamblePlan({
-      assistantParams,
-      llmModel: makeLlmModel(noVisionCapabilities) as any,
-      tools: [],
-      parameters: {},
-      knowledge: knowledgeFiles,
-    })
-
-    expect(plan.intersperseFileMetadata).toBeUndefined()
-    expect(plan.knowledgePrompt).toContain('"handbook.pdf"')
-  })
-
-  test('classic: materializeKnowledgeSegment returns flat file parts (no descriptors)', async () => {
-    vi.doMock('@/lib/env', () => ({
-      default: {
-        knowledge: { sendInPrompt: true, intersperseFileMetadata: false, alwaysConvertToText: true },
-      },
-    }))
-    const mockLoadKnowledgeFilePart = vi.fn()
-      .mockResolvedValueOnce({ type: 'text', text: 'handbook text' })
-      .mockResolvedValueOnce({ type: 'text', text: 'photo text' })
-    vi.doMock('@/backend/lib/tools/knowledge/implementation', () => ({
-      loadKnowledgeFilePart: mockLoadKnowledgeFilePart,
-      KnowledgePlugin: class {
-        toolParams = { promptFragment: '' }
-        supportedMedia = []
-        functions = async () => ({})
-      },
-    }))
-
-    const { preparePreamblePlan } = await import('@/backend/lib/chat/preamble')
-    const plan = await preparePreamblePlan({
-      assistantParams,
-      llmModel: makeLlmModel(noVisionCapabilities) as any,
-      tools: [],
-      parameters: {},
-      knowledge: knowledgeFiles,
-    })
-
-    const rendered = await plan.materializeKnowledgeSegment!()
-    const parts = rendered!.message.content as Array<{ type: string; text?: string }>
-    // Classic: just [content1, content2] — no descriptor text parts
-    expect(parts).toHaveLength(2)
-    expect(parts[0]).toMatchObject({ type: 'text', text: 'handbook text' })
-    expect(parts[1]).toMatchObject({ type: 'text', text: 'photo text' })
-  })
-
-  test('no knowledge files → empty plan regardless of mode', async () => {
-    vi.doMock('@/lib/env', () => ({
-      default: {
-        knowledge: { sendInPrompt: true, intersperseFileMetadata: true, alwaysConvertToText: true },
+        knowledge: { sendInPrompt: true, alwaysConvertToText: true },
       },
     }))
     vi.doMock('@/backend/lib/tools/knowledge/implementation', () => ({
@@ -700,10 +516,10 @@ describe('preparePreamblePlan — interspersed knowledge mode', () => {
     expect(plan.materializeKnowledgeSegment).toBeUndefined()
   })
 
-  test('ordinals are 1-based and sequential for knowledge files', async () => {
+  test('ordinals are 1-based and sequential', async () => {
     vi.doMock('@/lib/env', () => ({
       default: {
-        knowledge: { sendInPrompt: true, intersperseFileMetadata: true, alwaysConvertToText: true },
+        knowledge: { sendInPrompt: true, alwaysConvertToText: true },
       },
     }))
     const mockLoadKnowledgeFilePart = vi.fn().mockResolvedValue({ type: 'text', text: '' })
@@ -740,7 +556,7 @@ describe('preparePreamblePlan — interspersed knowledge mode', () => {
 })
 
 // ---------------------------------------------------------------------------
-// 6. Edge cases for projectMessageForEstimation — non-user messages unchanged
+// 5. Edge cases — non-user messages unaffected
 // ---------------------------------------------------------------------------
 describe('projectMessageForEstimation — non-user messages', () => {
   beforeEach(() => {
@@ -748,7 +564,7 @@ describe('projectMessageForEstimation — non-user messages', () => {
     vi.clearAllMocks()
   })
 
-  test('assistant messages are unaffected by intersperseFileMetadata flag', async () => {
+  test('assistant messages produce no attachment items', async () => {
     const { projectMessageForEstimation } = await import('@/backend/lib/chat/message-projection')
     const msg: dto.AssistantMessage = {
       id: 'a1',
@@ -759,12 +575,11 @@ describe('projectMessageForEstimation — non-user messages', () => {
       role: 'assistant',
       parts: [{ type: 'text', text: 'hi' }],
     }
-    const classic = projectMessageForEstimation(msg, false)
-    const interspersed = projectMessageForEstimation(msg, true)
-    expect(classic.items).toEqual(interspersed.items)
+    const projection = projectMessageForEstimation(msg)
+    expect(projection.items.every((i) => i.kind !== 'attachment')).toBe(true)
   })
 
-  test('user-request role is ignored in both modes', async () => {
+  test('user-request role is ignored', async () => {
     const { projectMessageForEstimation } = await import('@/backend/lib/chat/message-projection')
     const msg = {
       id: 'ur1',
@@ -776,7 +591,6 @@ describe('projectMessageForEstimation — non-user messages', () => {
       content: 'hi',
       attachments: [],
     } as unknown as dto.Message
-    expect(projectMessageForEstimation(msg, false).role).toBe('ignored')
-    expect(projectMessageForEstimation(msg, true).role).toBe('ignored')
+    expect(projectMessageForEstimation(msg).role).toBe('ignored')
   })
 })

--- a/__tests__/preamblePlanning.test.ts
+++ b/__tests__/preamblePlanning.test.ts
@@ -50,7 +50,7 @@ describe('preamble planning and rendering', () => {
     })
 
     expect(plan.knowledgeFileEntries).toEqual([
-      { fileId: 'k1', fileName: 'k1.png', mimetype: 'image/png', size: 1, partIndex: 0 },
+      { fileId: 'k1', fileName: 'k1.png', mimetype: 'image/png', size: 1, partIndex: 1 },
     ])
     expect(mockLoadKnowledgeFilePart).not.toHaveBeenCalled()
   })
@@ -70,7 +70,7 @@ describe('preamble planning and rendering', () => {
     expect(segments).toHaveLength(2)
     expect(segments[1]?.message).toEqual({ role: 'user', content: [] })
     expect(segments[1]?.knowledgeFileEntries).toEqual([
-      { fileId: 'k1', fileName: 'k1.png', mimetype: 'image/png', size: 1, partIndex: 0 },
+      { fileId: 'k1', fileName: 'k1.png', mimetype: 'image/png', size: 1, partIndex: 1 },
     ])
     expect(mockLoadKnowledgeFilePart).not.toHaveBeenCalled()
   })
@@ -91,7 +91,10 @@ describe('preamble planning and rendering', () => {
     expect(mockLoadKnowledgeFilePart).toHaveBeenCalledTimes(1)
     expect(segments[1]?.message).toEqual({
       role: 'user',
-      content: [{ type: 'text', text: 'knowledge content' }],
+      content: [
+        { type: 'text', text: 'Knowledge 1: k1.png (id k1, image/png, 1 bytes)' },
+        { type: 'text', text: 'knowledge content' },
+      ],
     })
   })
 

--- a/__tests__/promptTokenCounter.test.ts
+++ b/__tests__/promptTokenCounter.test.ts
@@ -18,6 +18,7 @@ import {
   setTokenizerCounter,
 } from '@/backend/lib/chat/prompt-token-counter'
 import { dtoMessageToLlmMessage } from '@/backend/lib/chat/conversion'
+import { fileDescriptorText } from '@/backend/lib/chat/message-projection'
 import type { LlmModel } from '@/lib/chat/models'
 
 const fakeModel = {
@@ -113,17 +114,8 @@ describe('countModelMessageTokens', () => {
 
     expect(tokens).toBe(
       JSON.stringify({ toolCallId: 'call_456', toolName: 'GenerateImage' }).length +
-        JSON.stringify({
-          attached_files: [
-            {
-              id: imageFile.id,
-              name: imageFile.name,
-              size: imageFile.size,
-              mimetype: imageFile.type,
-            },
-          ],
-        }).length +
         'The tool displayed 1 images.'.length +
+        fileDescriptorText(imageFile.name, imageFile.id, imageFile.type, imageFile.size, 1, 'Attachment').length +
         placeholderText.length
     )
     expect(mockEstimateNativeImageTokens).not.toHaveBeenCalled()

--- a/__tests__/tokenEstimator.test.ts
+++ b/__tests__/tokenEstimator.test.ts
@@ -5,7 +5,7 @@ import { gpt35Model, gpt41Model, gpt41MiniModel } from '@/lib/chat/models/openai
 import { countTextForModel, countTextWithTokenizer } from '@/lib/chat/tokenizer'
 import { normalizeExtractedText } from '@/backend/lib/chat/pdf-token-estimator'
 import { estimateNativeImageTokensFromDimensions } from '@/backend/lib/chat/image-token-estimator'
-import { projectedToolResultAttachedFilesDescriptor } from '@/backend/lib/chat/message-projection'
+import { fileDescriptorText } from '@/backend/lib/chat/message-projection'
 
 // Regression helpers — intentionally NOT delegating to the implementation so that bugs in
 // resolvePdfEstimatorModel() or predictPdfTokenCount() are caught by the tests.
@@ -93,16 +93,17 @@ const makeImageFile = (id: string) => ({
   encrypted: 0 as const,
 })
 
-const countUserAttachmentDescriptorTokens = (model: Parameters<typeof countTextForModel>[0], attachments: dto.Attachment[]) =>
-  countTextForModel(
-    model,
-    `The user has attached the following files to this chat: \n${JSON.stringify(attachments)}`
-  )
-
-const countToolResultAttachedFilesDescriptorTokens = (
+const countFileDescriptorTokens = (
   model: Parameters<typeof countTextForModel>[0],
   files: Array<{ id: string; name: string; mimetype: string; size: number }>
-) => countTextForModel(model, JSON.stringify(projectedToolResultAttachedFilesDescriptor(files)))
+) =>
+  files.reduce(
+    (sum, f, i) => sum + countTextForModel(model, fileDescriptorText(f.name, f.id, f.mimetype, f.size, i + 1, 'Attachment')),
+    0
+  )
+
+const countUserAttachmentDescriptorTokens = countFileDescriptorTokens
+const countToolResultAttachedFilesDescriptorTokens = countFileDescriptorTokens
 
 describe('estimateInputTokens', () => {
   beforeEach(async () => {
@@ -1650,7 +1651,7 @@ describe('estimateInputTokens', () => {
     const preambleModule = await import('@/backend/lib/chat/preamble')
     vi.spyOn(preambleModule, 'preparePreamblePlan').mockResolvedValue({
       systemPromptMessage: { role: 'system', content: 'system' },
-      knowledgeFileEntries: [{ fileId, fileName: file.name, mimetype: file.type, size: file.size, partIndex: 0 }],
+      knowledgeFileEntries: [{ fileId, fileName: file.name, mimetype: file.type, size: file.size, partIndex: 1 }],
     })
     vi.spyOn(preambleModule, 'renderPreamblePlan')
 
@@ -1664,7 +1665,8 @@ describe('estimateInputTokens', () => {
     })
 
     const expectedText = `Here is the text content of the file "${file.name}" with id ${file.id}\nknowledge text fallback content`
-    expect(result).toBe(countTextForModel(gpt35Model, 'system') + countTextForModel(gpt35Model, expectedText))
+    const expectedDescriptor = countTextForModel(gpt35Model, fileDescriptorText(file.name, fileId, file.type, file.size, 1, 'Knowledge'))
+    expect(result).toBe(countTextForModel(gpt35Model, 'system') + expectedDescriptor + countTextForModel(gpt35Model, expectedText))
     expect(preambleModule.renderPreamblePlan).not.toHaveBeenCalled()
     expect(readBuffer).not.toHaveBeenCalled()
   })

--- a/apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
+++ b/apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
@@ -324,12 +324,10 @@ describe('message projection parity', () => {
     const output = toolResultPart?.output
     expect(output && typeof output === 'object' ? (output as any).type : undefined).toBe('content')
     const outputParts = output && typeof output === 'object' && 'value' in output ? (output as any).value : []
-    expect(outputParts[0]).toEqual(
-      expect.objectContaining({
-        type: 'text',
-      })
-    )
-    expect(String(outputParts[0]?.text ?? '')).toContain('"attached_files"')
+    // [text 'summary', descriptor for doc.txt, file part]
+    expect(outputParts[0]).toEqual(expect.objectContaining({ type: 'text', text: 'summary' }))
+    expect(outputParts[1]).toEqual(expect.objectContaining({ type: 'text' }))
+    expect(String(outputParts[1]?.text ?? '')).toContain('doc.txt')
   })
 })
 

--- a/apps/backend/lib/chat/conversion.ts
+++ b/apps/backend/lib/chat/conversion.ts
@@ -13,7 +13,7 @@ import {
   canSendAsNativeImage,
   resolvePdfNativeAttachmentDecision,
 } from './file-attachment-policy'
-import { projectMessageForEstimation, projectedToolResultAttachedFilesDescriptor } from './message-projection'
+import { projectMessageForEstimation, fileDescriptorText } from './message-projection'
 
 // LiteLLM does not support binary attachments inside tool results. Detect this by inspecting
 // the AI SDK provider string rather than storing the limitation in model capabilities.
@@ -174,37 +174,22 @@ export const dtoMessageToLlmMessage = async (
           case 'error-text':
             return output
           case 'content': {
-            const files = output.value.filter((v) => v.type === 'file')
-            const description = projectedToolResultAttachedFilesDescriptor(files)
-            const outputs = await Promise.all(
-              output.value.map(async (v) => {
-                switch (v.type) {
-                  case 'text':
-                    return v
-                  case 'file': {
-                    const fileEntry = await getFileWithId(v.id)
-                    if (!fileEntry) {
-                      throw new Error(`Can't find entry for attachment ${v.id}`)
-                    }
-                    return dtoFileToToolResultOutputPart(fileEntry, capabilities, providerName)
-                  }
+            const parts: Awaited<ReturnType<typeof dtoFileToToolResultOutputPart>>[] = []
+            let fileOrdinal = 0
+            for (const v of output.value) {
+              if (v.type === 'text') {
+                parts.push(v)
+              } else {
+                const fileEntry = await getFileWithId(v.id)
+                if (!fileEntry) {
+                  throw new Error(`Can't find entry for attachment ${v.id}`)
                 }
-              })
-            )
-            return {
-              type: 'content',
-              value: [
-                ...(files.length === 0
-                  ? []
-                  : [
-                      {
-                        type: 'text' as const,
-                        text: JSON.stringify(description),
-                      },
-                    ]),
-                ...outputs,
-              ],
-            } satisfies ToolCallResultOutput
+                fileOrdinal++
+                parts.push({ type: 'text', text: fileDescriptorText(v.name, v.id, v.mimetype, v.size, fileOrdinal, 'Attachment') })
+                parts.push(await dtoFileToToolResultOutputPart(fileEntry, capabilities, providerName))
+              }
+            }
+            return { type: 'content', value: parts } satisfies ToolCallResultOutput
           }
         }
       } else {

--- a/apps/backend/lib/chat/conversion.ts
+++ b/apps/backend/lib/chat/conversion.ts
@@ -8,16 +8,12 @@ import { logger } from '@/lib/logging'
 import { storage } from '@/lib/storage'
 import { LlmModelCapabilities } from '@/lib/chat/models'
 import { cachingExtractor } from '@/lib/textextraction/cache'
-import env from '@/lib/env'
 import {
   canSendAsNativeFile,
   canSendAsNativeImage,
   resolvePdfNativeAttachmentDecision,
 } from './file-attachment-policy'
-import {
-  projectMessageForEstimation,
-  projectedToolResultAttachedFilesDescriptor,
-} from './message-projection'
+import { projectMessageForEstimation, projectedToolResultAttachedFilesDescriptor } from './message-projection'
 
 // LiteLLM does not support binary attachments inside tool results. Detect this by inspecting
 // the AI SDK provider string rather than storing the limitation in model capabilities.
@@ -164,8 +160,7 @@ export const dtoMessageToLlmMessage = async (
   capabilities: LlmModelCapabilities,
   providerName: string
 ): Promise<ai.ModelMessage | undefined> => {
-  const intersperseFileMetadata = env.knowledge.intersperseFileMetadata
-  const projected = projectMessageForEstimation(m, intersperseFileMetadata)
+  const projected = projectMessageForEstimation(m)
   if (projected.role === 'ignored') return undefined
   if (projected.role === 'tool') {
     const results = projected.items.filter((item) => item.kind === 'tool_result')
@@ -282,44 +277,20 @@ export const dtoMessageToLlmMessage = async (
   const message: ai.ModelMessage = { role: 'user', content: '' }
   const attachments = projected.items.filter((item) => item.kind === 'attachment')
   if (attachments.length !== 0) {
-    if (intersperseFileMetadata) {
-      // Interspersed: process projected items in order so each descriptor immediately
-      // precedes the corresponding file part.
-      const parts: Array<ai.TextPart | ai.ImagePart | ai.FilePart> = []
-      for (const item of projected.items) {
-        if (item.kind === 'text') {
-          parts.push({ type: 'text', text: item.text })
-        } else if (item.kind === 'attachment') {
-          const fileEntry = await getFileWithId(item.attachment.id)
-          if (!fileEntry) {
-            logger.warn(`Can't find entry for attachment ${item.attachment.id}`)
-            continue
-          }
-          parts.push(await dtoFileToLlmFilePart(fileEntry, capabilities))
+    const parts: Array<ai.TextPart | ai.ImagePart | ai.FilePart> = []
+    for (const item of projected.items) {
+      if (item.kind === 'text') {
+        parts.push({ type: 'text', text: item.text })
+      } else if (item.kind === 'attachment') {
+        const fileEntry = await getFileWithId(item.attachment.id)
+        if (!fileEntry) {
+          logger.warn(`Can't find entry for attachment ${item.attachment.id}`)
+          continue
         }
+        parts.push(await dtoFileToLlmFilePart(fileEntry, capabilities))
       }
-      message.content = parts
-    } else {
-      // Classic: all text parts first, then all file parts appended at the end.
-      const messageParts: typeof message.content = []
-      for (const item of projected.items) {
-        if (item.kind !== 'text') continue
-        messageParts.push({ type: 'text', text: item.text })
-      }
-      const fileParts = (
-        await Promise.all(
-          attachments.map(async (item) => {
-            const fileEntry = await getFileWithId(item.attachment.id)
-            if (!fileEntry) {
-              logger.warn(`Can't find entry for attachment ${item.attachment.id}`)
-              return undefined
-            }
-            return await dtoFileToLlmFilePart(fileEntry, capabilities)
-          })
-        )
-      ).filter((a) => a !== undefined)
-      message.content = [...messageParts, ...fileParts]
     }
+    message.content = parts
   } else {
     const textItems = projected.items.filter((item) => item.kind === 'text')
     const messageParts: typeof message.content = []

--- a/apps/backend/lib/chat/message-projection.ts
+++ b/apps/backend/lib/chat/message-projection.ts
@@ -18,17 +18,6 @@ export const fileDescriptorText = (
   return `${label} ${ordinal}: ${displayName} (id ${id}, ${mimetype}, ${size} bytes)`
 }
 
-export const projectedToolResultAttachedFilesDescriptor = (
-  files: Array<{ id: string; name: string; size: number; mimetype: string }>
-) => ({
-  attached_files: files.map((f) => ({
-    id: f.id,
-    name: f.name,
-    size: f.size,
-    mimetype: f.mimetype,
-  })),
-})
-
 export const userMessageMetadataText = (message: dto.UserMessage): string | undefined =>
   message.metadata
     ? `Message metadata (system-use): ${JSON.stringify(message.metadata)}`

--- a/apps/backend/lib/chat/message-projection.ts
+++ b/apps/backend/lib/chat/message-projection.ts
@@ -34,11 +34,6 @@ export const userMessageMetadataText = (message: dto.UserMessage): string | unde
     ? `Message metadata (system-use): ${JSON.stringify(message.metadata)}`
     : undefined
 
-export const userAttachmentDescriptorText = (message: dto.UserMessage): string | undefined =>
-  message.attachments.length === 0
-    ? undefined
-    : `The user has attached the following files to this chat: \n${JSON.stringify(message.attachments)}`
-
 export const shouldIncludeAssistantReasoningPart = (part: dto.ReasoningPart): boolean =>
   Boolean(part.reasoning_signature)
 
@@ -84,8 +79,7 @@ export type ProjectedMessageForEstimation =
   | { role: 'ignored'; items: [] }
 
 export const projectMessageForEstimation = (
-  message: dto.Message,
-  intersperseFileMetadata = false
+  message: dto.Message
 ): ProjectedMessageForEstimation => {
   if (message.role === 'user-request' || message.role === 'user-response') {
     return { role: 'ignored', items: [] }
@@ -95,30 +89,14 @@ export const projectMessageForEstimation = (
     const metadataText = userMessageMetadataText(message)
     if (metadataText) items.push({ kind: 'text', text: metadataText, source: 'metadata' })
     if (message.content.length !== 0) items.push({ kind: 'text', text: message.content, source: 'content' })
-    if (intersperseFileMetadata) {
-      // Interspersed: emit (descriptor text, attachment) pairs in order
-      message.attachments.forEach((attachment, index) => {
-        items.push({
-          kind: 'text',
-          text: fileDescriptorText(attachment.name, attachment.id, attachment.mimetype, attachment.size, index + 1, 'Attachment'),
-          source: 'attachment_descriptor',
-        })
-        items.push({ kind: 'attachment', attachment })
+    message.attachments.forEach((attachment, index) => {
+      items.push({
+        kind: 'text',
+        text: fileDescriptorText(attachment.name, attachment.id, attachment.mimetype, attachment.size, index + 1, 'Attachment'),
+        source: 'attachment_descriptor',
       })
-    } else {
-      // Classic: one aggregated descriptor block, then all file parts
-      const attachmentDescriptorText = userAttachmentDescriptorText(message)
-      if (attachmentDescriptorText) {
-        items.push({
-          kind: 'text',
-          text: attachmentDescriptorText,
-          source: 'attachment_descriptor',
-        })
-      }
-      for (const attachment of message.attachments) {
-        items.push({ kind: 'attachment', attachment })
-      }
-    }
+      items.push({ kind: 'attachment', attachment })
+    })
     return { role: 'user', items }
   }
   if (message.role === 'assistant') {

--- a/apps/backend/lib/chat/preamble.ts
+++ b/apps/backend/lib/chat/preamble.ts
@@ -48,7 +48,6 @@ export type PreamblePlan = {
   systemPromptMessage: ai.SystemModelMessage
   knowledgePrompt?: string
   knowledgeFileEntries?: KnowledgeFileEntry[]
-  intersperseFileMetadata?: boolean
   materializeKnowledgeSegment?: () => Promise<{
     message: ai.UserModelMessage
     analysisFileIds: string[]
@@ -153,25 +152,20 @@ export async function preparePreamblePlan({
   }
   const { loadKnowledgeFilePart } = await import('@/backend/lib/tools/knowledge/implementation')
 
-  const intersperse = env.knowledge.intersperseFileMetadata
-
-  const knowledgePrompt = intersperse
-    ? `Assistant knowledge files are embedded in this conversation, each preceded by a brief descriptor.\n${knowledgeFileSelectionNotice}`
-    : `More files are available as assistant knowledge. These files can be retrieved or processed by function calls referring to their id.\nHere is the assistant knowledge:\n${JSON.stringify(knowledge)}\n${knowledgeFileSelectionNotice}`
+  const knowledgePrompt = `Assistant knowledge files are embedded in this conversation, each preceded by a brief descriptor.\n${knowledgeFileSelectionNotice}`
 
   const knowledgeFileEntries: KnowledgeFileEntry[] = knowledge.map((k, index) => ({
     fileId: k.id,
     fileName: k.name,
     mimetype: k.type,
     size: k.size,
-    partIndex: intersperse ? index * 2 + 1 : index,
+    partIndex: index * 2 + 1,
   }))
 
   return {
     systemPromptMessage,
     knowledgePrompt,
     knowledgeFileEntries,
-    intersperseFileMetadata: intersperse || undefined,
     // Limit concurrency to avoid saturating the libuv thread pool and the Node.js microtask queue
     // when an assistant has many knowledge files — unbounded Promise.all causes multi-second stalls.
     materializeKnowledgeSegment: async () => {
@@ -180,9 +174,7 @@ export async function preparePreamblePlan({
         indexed,
         async ({ k, i }) => ({
           fileId: k.id,
-          descriptor: intersperse
-            ? fileDescriptorText(k.name, k.id, k.type, k.size, i + 1, 'Knowledge')
-            : null,
+          descriptor: fileDescriptorText(k.name, k.id, k.type, k.size, i + 1, 'Knowledge'),
           content: await loadKnowledgeFilePart(k, llmModel),
         }),
         8
@@ -190,7 +182,7 @@ export async function preparePreamblePlan({
       const parts: (ai.TextPart | ai.ImagePart | ai.FilePart)[] = []
       const analysisFileIds: string[] = []
       for (const { fileId, descriptor, content } of loaded) {
-        if (descriptor) parts.push({ type: 'text', text: descriptor })
+        parts.push({ type: 'text', text: descriptor })
         parts.push(content)
         if (content.type === 'file') analysisFileIds.push(fileId)
       }

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -382,7 +382,7 @@ const estimateDtoMessageTokens = async (
   onDetail?: (part: dto.TokenDetailPart) => void
 ): Promise<number> => {
   const algorithm = tokenizerForModel(model)
-  const projected = projectMessageForEstimation(message, env.knowledge.intersperseFileMetadata)
+  const projected = projectMessageForEstimation(message)
   if (projected.role === 'ignored') return 0
   let tokens = 0
   for (const item of projected.items) {
@@ -583,11 +583,8 @@ export const estimatePreambleTokensFromPlan = async ({
       const fileEntry = await estimateKnowledgeFileTokens(
         entry.fileId, entry.fileName, entry.mimetype, entry.partIndex, messageParts, model, stats
       )
-      let entryTokens = fileEntry.tokens
-      if (plan.intersperseFileMetadata) {
-        const descText = fileDescriptorText(entry.fileName, entry.fileId, entry.mimetype, entry.size, ordinal0 + 1, 'Knowledge')
-        entryTokens += await countTextTokensCached(model, descText, stats)
-      }
+      const descText = fileDescriptorText(entry.fileName, entry.fileId, entry.mimetype, entry.size, ordinal0 + 1, 'Knowledge')
+      let entryTokens = fileEntry.tokens + await countTextTokensCached(model, descText, stats)
       knowledgeTokens += entryTokens
       collector?.addPreamblePart({
         type: 'knowledge_file',

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -36,7 +36,6 @@ import type * as ai from 'ai'
 import { buildEstimatedPreambleSegments, preparePreamblePlan, PreamblePlan } from '@/backend/lib/chat/preamble'
 import { tokenizerForModel } from '@/lib/chat/tokenizer'
 import { projectMessageForEstimation, fileDescriptorText } from '@/backend/lib/chat/message-projection'
-import { projectedToolResultAttachedFilesDescriptor } from '@/backend/lib/chat/message-projection'
 import env from '@/lib/env'
 
 // --- File token cache -----------------------------------------------------------
@@ -294,19 +293,18 @@ const estimateToolResultOutputTokens = async (
       return countTextTokensCached(model, JSON.stringify(output.value), stats)
     case 'content': {
       let tokens = 0
-      const files = output.value.filter((item) => item.type === 'file')
-      if (files.length > 0) {
-        tokens += await countTextTokensCached(
-          model,
-          JSON.stringify(projectedToolResultAttachedFilesDescriptor(files)),
-          stats
-        )
-      }
+      let fileOrdinal = 0
       for (const item of output.value) {
         if (item.type === 'text') {
           tokens += await countTextTokensCached(model, item.text, stats)
           continue
         }
+        fileOrdinal++
+        tokens += await countTextTokensCached(
+          model,
+          fileDescriptorText(item.name, item.id, item.mimetype, item.size, fileOrdinal, 'Attachment'),
+          stats
+        )
         tokens += await estimateAttachmentTokens(
           model,
           { id: item.id, mimetype: item.mimetype, name: item.name, size: item.size },

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -161,7 +161,6 @@ const env = {
   knowledge: {
     sendInPrompt: process.env.KNOWLEDGE_SEND_IN_PROMPT !== '0',
     alwaysConvertToText: process.env.KNOWLEDGE_ALWAYS_CONVERT !== '0',
-    intersperseFileMetadata: process.env.INTERSPERSE_FILE_METADATA === '1',
   },
   provision: {
     config: process.env.PROVISION_PATH,


### PR DESCRIPTION
## Summary

Removes the `INTERSPERSE_FILE_METADATA` env flag and the dual-path "classic" vs "interspersed" logic throughout the chat pipeline. Interspersed ordering — where each file descriptor immediately precedes its file content — is now the only behaviour for both user attachments and assistant knowledge files.

## Details

- `packages/core/src/env.ts`: `knowledge.intersperseFileMetadata` field removed
- `apps/backend/lib/chat/message-projection.ts`: `intersperseFileMetadata` parameter removed from `projectMessageForEstimation`; `userAttachmentDescriptorText` (classic-only helper) removed; classic branch eliminated
- `apps/backend/lib/chat/conversion.ts`: `env` import dropped; `if/else` on the flag collapsed to the interspersed path only
- `apps/backend/lib/chat/preamble.ts`: `intersperseFileMetadata` field removed from `PreamblePlan`; knowledge prompt and `materializeKnowledgeSegment` always emit descriptors; `partIndex` always `index * 2 + 1`
- `apps/backend/lib/chat/token-estimator.ts`: descriptor tokens always counted for knowledge files
- `__tests__/fileMetadataInterspersing.test.ts`: classic-mode tests removed; env mocks simplified

## Tests

- `npm run check-types` — clean
- `npx vitest run __tests__/fileMetadataInterspersing.test.ts` — 21 tests passed