### PR TITLE
feature: HTTP range request support for AEAD-encrypted file downloads

### DIFF
--- a/__tests__/storageCoverage.test.ts
+++ b/__tests__/storageCoverage.test.ts
@@ -169,6 +169,87 @@ describe('apps/backend/ee/PgpEncryptingStorage', () => {
   })
 })
 
+describe('apps/backend/ee/AeadEncryptingStorage', () => {
+  async function makeAead() {
+    const inner = new MemoryStorage()
+    const { AeadEncryptingStorage } = await import('@/ee/AeadEncryptingStorage')
+    const storage = await AeadEncryptingStorage.create(inner, password)
+    return { inner, storage }
+  }
+
+  test('round-trips plaintext without a range', async () => {
+    const { storage } = await makeAead()
+    const plaintext = Buffer.from('hello AEAD world')
+
+    await storage.writeBuffer('f', plaintext, 'aead')
+    const result = await storage.readBuffer('f', 'aead')
+
+    expect(result).toEqual(plaintext)
+  })
+
+  test('returns correct bytes for a sub-range within a single chunk', async () => {
+    const { storage } = await makeAead()
+    const plaintext = Buffer.from('abcdefghijklmnopqrstuvwxyz')
+
+    await storage.writeBuffer('f', plaintext, 'aead')
+    const result = await collectStreamToBuffer(
+      await storage.readStream('f', 'aead', { rangeStart: 5, rangeEnd: 14 })
+    )
+
+    expect(result).toEqual(plaintext.subarray(5, 15))
+  })
+
+  test('returns correct bytes for a range spanning a chunk boundary', async () => {
+    const { storage } = await makeAead()
+    const CHUNK = 1024 * 1024
+    const plaintext = Buffer.alloc(CHUNK + 512, 0xab)
+    // make the two halves distinguishable
+    plaintext.fill(0xcd, CHUNK - 8, CHUNK + 8)
+
+    await storage.writeBuffer('large', plaintext, 'aead')
+
+    const rangeStart = CHUNK - 8
+    const rangeEnd = CHUNK + 7
+    const result = await collectStreamToBuffer(
+      await storage.readStream('large', 'aead', { rangeStart, rangeEnd })
+    )
+
+    expect(result).toEqual(plaintext.subarray(rangeStart, rangeEnd + 1))
+  })
+
+  test('round-trips an empty file', async () => {
+    const { storage } = await makeAead()
+
+    await storage.writeBuffer('empty', Buffer.alloc(0), 'aead')
+    const result = await storage.readBuffer('empty', 'aead')
+
+    expect(result).toEqual(Buffer.alloc(0))
+  })
+
+  test('throws for an out-of-bounds range', async () => {
+    const { storage } = await makeAead()
+    await storage.writeBuffer('f', Buffer.from('hello'), 'aead')
+
+    await expect(
+      storage.readStream('f', 'aead', { rangeStart: 0, rangeEnd: 5 })
+    ).rejects.toThrow(/Invalid AEAD read range/)
+  })
+
+  test('passes range through to inner storage when encryption is null', async () => {
+    const { inner, storage } = await makeAead()
+    const data = Buffer.from('passthrough data')
+    await inner.writeBuffer('raw', data, null)
+    const readStreamSpy = vi.spyOn(inner, 'readStream')
+
+    const result = await collectStreamToBuffer(
+      await storage.readStream('raw', null, { rangeStart: 4, rangeEnd: 11 })
+    )
+
+    expect(result).toEqual(data.subarray(4, 12))
+    expect(readStreamSpy).toHaveBeenCalledWith('raw', null, { rangeStart: 4, rangeEnd: 11 })
+  })
+})
+
 describe('apps/backend/lib/storage/S3Storage', () => {
   test('covers constructor, reads, writes, and error handling', async () => {
     process.env.AWS_DEFAULT_REGION = 'eu-west-1'

--- a/apps/backend/api/files/[fileId]/content/route.ts
+++ b/apps/backend/api/files/[fileId]/content/route.ts
@@ -151,11 +151,30 @@ export const PUT = operation({
   },
 })
 
+function parseRangeHeader(header: string, totalSize: number): { start: number; end: number } | null {
+  const match = /^bytes=(\d*)-(\d*)$/.exec(header)
+  if (!match) return null
+  const [, startStr, endStr] = match
+  if (!startStr && !endStr) return null
+  let start: number
+  let end: number
+  if (!startStr) {
+    const suffix = parseInt(endStr, 10)
+    start = Math.max(0, totalSize - suffix)
+    end = totalSize - 1
+  } else {
+    start = parseInt(startStr, 10)
+    end = endStr ? parseInt(endStr, 10) : totalSize - 1
+  }
+  if (start < 0 || end >= totalSize || start > end) return null
+  return { start, end }
+}
+
 export const GET = operation({
   name: 'Download file content',
   authentication: 'user',
   responses: [responseSpec(200, z.any()), errorSpec(403), errorSpec(404)] as const,
-  implementation: async ({ params, session }) => {
+  implementation: async ({ params, headers, session }) => {
     const file = await db
       .selectFrom('File')
       .leftJoin('FileBlob', 'FileBlob.id', 'File.fileBlobId')
@@ -168,6 +187,35 @@ export const GET = operation({
     if (!(await canAccessFile({ userId: session.userId, userRole: session.userRole }, params.fileId))) {
       return forbidden()
     }
+
+    const rangeHeader = headers.get('range')
+    const supportsRanges = file.encryption === 'aead'
+
+    if (rangeHeader && supportsRanges && typeof file.size === 'number') {
+      const range = parseRangeHeader(rangeHeader, file.size)
+      if (!range) {
+        return new Response(null, {
+          status: 416,
+          headers: { 'content-range': `bytes */${file.size}` },
+        })
+      }
+      const { start, end } = range
+      const stream = await storage.readStream(file.path, file.encryption, {
+        expectedSizeBytes: file.size,
+        rangeStart: start,
+        rangeEnd: end,
+      })
+      return new Response(stream, {
+        status: 206,
+        headers: {
+          'content-type': file.type,
+          'content-range': `bytes ${start}-${end}/${file.size}`,
+          'content-length': `${end - start + 1}`,
+          'accept-ranges': 'bytes',
+        },
+      })
+    }
+
     const fileContent = await storage.readStream(file.path, file.encryption, {
       expectedSizeBytes: file.size ?? undefined,
     })
@@ -175,6 +223,7 @@ export const GET = operation({
       headers: {
         'content-type': file.type,
         ...(typeof file.size === 'number' ? { 'content-length': `${file.size}` } : {}),
+        'accept-ranges': supportsRanges ? 'bytes' : 'none',
       },
     })
   },


### PR DESCRIPTION
## Summary

Adds HTTP `Range` request support (`206 Partial Content`) to `GET /api/files/[fileId]/content` for files stored with AEAD encryption. Clients can now fetch arbitrary byte slices of AEAD-encrypted files without downloading the full blob. Non-AEAD files (PGP-encrypted or unencrypted) ignore the `Range` header and continue to return `200` with the full content.

## Details

- `parseRangeHeader` handles all standard single-range forms: `bytes=<start>-<end>`, `bytes=<start>-` (open-ended), and `bytes=-<suffix>` (last N bytes). Malformed or unsatisfiable ranges return `416 Range Not Satisfiable`.
- AEAD responses include `Accept-Ranges: bytes`; non-AEAD responses include `Accept-Ranges: none`.
- Range requests are delegated to `AeadEncryptingStorage.readStream` which already handles chunk-level decryption for arbitrary byte windows.

## Tests

- Added `describe('apps/backend/ee/AeadEncryptingStorage')` in `storageCoverage.test.ts` with 6 cases: full round-trip, sub-range within a single chunk, range spanning the 1 MB chunk boundary, empty file, out-of-bounds range (throws), and non-AEAD passthrough.
- `npm run check-types` — clean.
- `npx vitest run __tests__/storageCoverage.test.ts` — 20/20 tests passed.