### PR TITLE
[codex] fix postgres assistant parent query

### DIFF
--- a/apps/backend/models/assistant.ts
+++ b/apps/backend/models/assistant.ts
@@ -3,7 +3,7 @@ import { db } from 'db/database'
 import * as schema from '@/db/schema'
 import { nanoid } from 'nanoid'
 import { BuildableTool, dbToolToBuildableTool } from './tool'
-import { Expression, SqlBool, sql } from 'kysely'
+import { Expression, SqlBool, SqliteAdapter, sql } from 'kysely'
 import { getOrCreateImageFromDataUri } from './images'
 import { getBackendsWithModels } from './backend'
 import { listUserSecretStatuses } from './userSecrets'
@@ -814,13 +814,17 @@ export const assistantUserData = async (assistantId: string, userId: string) => 
 export const getAssistantParentAssistants = async (
   assistantId: string
 ): Promise<{ id: string; name: string }[]> => {
+  const isSqlite = db.getExecutor().adapter instanceof SqliteAdapter
+  const subAssistantsFilter = isSqlite
+    ? sql<SqlBool>`"AssistantVersion"."subAssistants" LIKE ${`%"${assistantId}"%`}`
+    : sql<SqlBool>`"AssistantVersion"."subAssistants" @> ${JSON.stringify([assistantId])}::jsonb`
   return db
     .selectFrom('Assistant')
     .innerJoin('AssistantVersion', (join) =>
       join.onRef('AssistantVersion.id', '=', 'Assistant.publishedVersionId')
     )
     .select(['Assistant.id', 'AssistantVersion.name'])
-    .where('AssistantVersion.subAssistants', 'like', `%"${assistantId}"%`)
+    .where(subAssistantsFilter)
     .where('Assistant.deleted', '=', 0)
     .execute()
 }


### PR DESCRIPTION
## Summary
Fix the assistant-parent lookup query so it works correctly on Postgres while preserving the SQLite fallback.

## Details
- Use `@>` against the `jsonb` column on Postgres to test whether `subAssistants` contains the current assistant ID.
- Keep the existing `LIKE` match for SQLite, where the column is stored as JSON text.
- Route the query through a typed Kysely boolean expression instead of hard-coding one operator for both engines.

## Root cause
The previous query used `LIKE` against `AssistantVersion.subAssistants` unconditionally. That is a brittle fit for Postgres `jsonb`, where containment should be expressed with JSON operators instead of string matching.

## Tests
- `npm run check-types`
