### PR TITLE
feature: add Claude Sonnet 5 and honour temperature capability flag

### DIFF
--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -619,9 +619,10 @@ export class ChatAssistant {
         this.llmModelCapabilities.function_calling && Object.keys(this.functions).length !== 0
           ? 'auto'
           : undefined,
-      temperature: modelSupportsReasoning(this.llmModel)
-        ? undefined
-        : this.assistantParams.temperature,
+      temperature:
+        modelSupportsReasoning(this.llmModel) || this.llmModelCapabilities.temperature === false
+          ? undefined
+          : this.assistantParams.temperature,
       providerOptions,
       experimental_transform: ai.smoothStream({ delayInMs: 20, chunking: 'word' }),
       abortSignal: this.options.abortSignal,

--- a/packages/core/src/models/anthropic.ts
+++ b/packages/core/src/models/anthropic.ts
@@ -266,9 +266,31 @@ export const claude46SonnetModel: LlmModel = {
   maxOutputTokens: 64000,
 }
 
+export const claude5SonnetModel: LlmModel = {
+  id: 'claude-sonnet-5', // was incorrectly 4-5
+  model: 'claude-sonnet-5',
+  name: 'Claude 5 Sonnet',
+  description:
+    'High-performance hybrid reasoning model with exceptional efficiency, enhanced coding capabilities, and support for extended/adaptive thinking.',
+  provider: 'anthropic',
+  owned_by: 'anthropic',
+  context_length: 1048576,
+  capabilities: {
+    vision: true,
+    function_calling: true,
+    web_search: true,
+    supportedMedia: ['application/pdf'],
+    nativePdfPageLimit: 100,
+    promptCaching: true,
+    temperature: false,
+  },
+  supportedReasoningEfforts: [],
+  maxOutputTokens: 64000,
+}
+
 export const claudeSonnetLatest: LlmModel = {
-  ...claude46SonnetModel,
-  name: 'Claude Sonnet latest (4.6)',
+  ...claude5SonnetModel,
+  name: 'Claude Sonnet latest (5)',
   id: 'claude-sonnet-latest',
   tags: ['latest'],
 }
@@ -288,4 +310,5 @@ export const anthropicModels: LlmModel[] = [
   claude45SonnetModel,
   claude45OpusModel,
   claude46SonnetModel,
+  claude5SonnetModel,
 ]

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -18,9 +18,15 @@ export interface LlmModelCapabilities {
   knowledge?: boolean
   nativePdfPageLimit?: number
   promptCaching?: boolean
+  temperature?: boolean
 }
 
-export const tokenizerStrategies = ['cl100k_base', 'o200k_base', 'approx_4chars', 'anthropic_heuristic'] as const
+export const tokenizerStrategies = [
+  'cl100k_base',
+  'o200k_base',
+  'approx_4chars',
+  'anthropic_heuristic',
+] as const
 export type TokenizerStrategy = (typeof tokenizerStrategies)[number]
 
 export const llmModelNoCapabilities: LlmModelCapabilities = {

--- a/packages/core/src/models/logicle.ts
+++ b/packages/core/src/models/logicle.ts
@@ -13,6 +13,7 @@ import {
   claude46SonnetModel,
   claude4OpusModel,
   claude4SonnetModel,
+  claude5SonnetModel,
   claudeSonnetLatest,
 } from './anthropic'
 import {
@@ -85,6 +86,7 @@ export const logicleModels: LlmModel[] = [
   claude45SonnetModel,
   claude46SonnetModel,
   claude45OpusModel,
+  claude5SonnetModel,
   claudeSonnetLatest,
   gemini15ProModel,
   gemini15FlashModel,


### PR DESCRIPTION
## Summary

Adds `claude-sonnet-5` to the Anthropic model catalogue (promoted to `claude-sonnet-latest`) and introduces a `temperature` field in `LlmModelCapabilities`. When a model declares `temperature: false`, the chat request builder omits the temperature parameter entirely, fixing API errors for models like Claude Sonnet 5 that do not accept it.

## Details

- `LlmModelCapabilities.temperature?: boolean` — new optional field; absence means the model supports temperature as before
- `claude-sonnet-5` sets `temperature: false`; `claudeSonnetLatest` now points to it
- Chat request builder (`apps/backend/lib/chat/index.ts`) checks `capabilities.temperature === false` alongside the existing reasoning-model guard and omits temperature accordingly
- `claude5SonnetModel` added to `logicleModels` list

## Tests

- `npm run check-types` — passed