### PR TITLE
Hide satellite nav icon when no satellites exist

### DIFF
--- a/apps/frontend/app/layouts/MainLayout.tsx
+++ b/apps/frontend/app/layouts/MainLayout.tsx
@@ -15,6 +15,17 @@ import { usePathname } from 'next/navigation'
 import { useLayoutConfig } from '@/components/providers/layoutconfigContext'
 import { t } from 'i18next'
 import { useEnvironment } from '../context/environmentProvider'
+import { useSatellites } from '@/hooks/satellites'
+
+const SatelliteNavIcon: React.FC = () => {
+  const { data, isLoading } = useSatellites()
+  if (!isLoading && data.length === 0) return null
+  return (
+    <Link href="/satellites" title="Satellites" className="relative">
+      <IconSatellite size={28}></IconSatellite>
+    </Link>
+  )
+}
 
 export interface Props {
   leftBar?: JSX.Element
@@ -46,11 +57,7 @@ const MobileLayout: React.FC<Props> = ({ leftBar, leftBarCollapsible, children }
           <Link href="/images">
             <Images size={28}></Images>
           </Link>
-          {environment.enableSatellitesUi && (
-            <Link href="/satellites" title="Satellites" className="relative">
-              <IconSatellite size={28}></IconSatellite>
-            </Link>
-          )}
+          {environment.enableSatellitesUi && <SatelliteNavIcon />}
         </div>
         <div>
           <AppMenu />
@@ -106,11 +113,7 @@ const StandardLayout: React.FC<Props> = ({ leftBar, children }) => {
           <Link title={t('images')} href="/images">
             <Images size={28}></Images>
           </Link>
-          {environment.enableSatellitesUi && (
-            <Link href="/satellites" title="Satellites" className="relative">
-              <IconSatellite size={28}></IconSatellite>
-            </Link>
-          )}
+          {environment.enableSatellitesUi && <SatelliteNavIcon />}
         </div>
         <div>
           <AppMenu />


### PR DESCRIPTION
## Summary

The satellite action bar icon is now hidden when the user has no satellite DB entries and no active connections. Previously the icon was always visible whenever `ENABLE_SATELLITES_UI` was set; now it dynamically disappears when the satellite list is empty and reappears as soon as a satellite is registered or connects.

## Details

- Added a `SatelliteNavIcon` component in `MainLayout.tsx` that calls `useSatellites()` and returns `null` when loading is complete and the list is empty.
- The outer `enableSatellitesUi` guard is preserved — the hook and EventSource are only opened when the feature flag is enabled.
- During the initial fetch the icon stays visible to avoid a layout flash; it collapses only once the server confirms zero satellites.

## Tests

- `npm run check-types` — passed