### PR TITLE
feature: compact warn-only token rate limit banner

### DIFF
--- a/apps/frontend/app/chat/components/Chat.tsx
+++ b/apps/frontend/app/chat/components/Chat.tsx
@@ -5,14 +5,14 @@ import ChatPageContext from '@/app/chat/components/context'
 import { ChatInputOrApiKey } from './ChatInputOrApiKey'
 import { groupMessages } from '@/lib/chat/conversationUtils'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { IconArrowDown, IconAlertTriangle } from '@tabler/icons-react'
+import { IconArrowDown } from '@tabler/icons-react'
 import * as dto from '@/types/dto'
 import { useChatInput } from '@/components/providers/localstoragechatstate'
 import { MessageGroup } from './MessageGroup'
 import { ConversationSidebar } from './ConversationSidebar'
 import { useTranslation } from 'react-i18next'
 import { useTokenRateLimit } from '@/components/providers/tokenRateLimitContext'
+import { TokenRateLimitBanner } from './TokenRateLimitBanner'
 
 export interface ChatProps {
   assistant: dto.AssistantIdentification & {
@@ -43,8 +43,8 @@ export const Chat = ({
     setSideBarContent,
   } = useContext(ChatPageContext)
   const tokenRateLimit = useTokenRateLimit()
-
   const { t } = useTranslation()
+
   const [chatInput, setChatInput] = useChatInput(selectedConversation?.id ?? '')
   const [autoScrollEnabled, setAutoScrollEnabled] = useState<boolean>(true)
   const [showScrollDownButton, setShowScrollDownButton] = useState<boolean>(false)
@@ -97,14 +97,17 @@ export const Chat = ({
     if (!el || !container) return
     scrolledToFragmentRef.current = true
     setAutoScrollEnabled(false)
-    const elTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop
-    container.scrollTo({ top: elTop - (container.clientHeight - el.offsetHeight) / 2, behavior: 'smooth' })
+    const elTop =
+      el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop
+    container.scrollTo({
+      top: elTop - (container.clientHeight - el.offsetHeight) / 2,
+      behavior: 'smooth',
+    })
   }, [selectedConversation])
 
   useEffect(() => {
     throttledScrollDown()
   }, [selectedConversation, throttledScrollDown, chatStatus])
-
 
   if (!selectedConversation) {
     return null
@@ -155,17 +158,6 @@ export const Chat = ({
             </div>
           )}
         </ScrollArea>
-        {tokenRateLimit?.enabled && tokenRateLimit.exceeded && (
-          <Alert variant="destructive" className="rounded-none border-x-0">
-            <IconAlertTriangle className="h-4 w-4" />
-            <AlertDescription>
-              {t('rate-limit-exceeded-warning', {
-                defaultValue:
-                  'You have reached your token usage limit for this period. Your messages may be restricted.',
-              })}
-            </AlertDescription>
-          </Alert>
-        )}
         <ChatInputOrApiKey
           assistant={assistant}
           chatInput={chatInput}
@@ -189,6 +181,7 @@ export const Chat = ({
             })
           }}
         />
+        {tokenRateLimit?.enabled && tokenRateLimit.exceeded && <TokenRateLimitBanner />}
       </div>
       {sideBarContent && <ConversationSidebar content={sideBarContent} />}
     </div>

--- a/apps/frontend/app/chat/components/TokenRateLimitBanner.tsx
+++ b/apps/frontend/app/chat/components/TokenRateLimitBanner.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { IconAlertTriangle } from '@tabler/icons-react'
+import { useTranslation } from 'react-i18next'
+
+import { cn } from '@/frontend/lib/utils'
+
+export interface TokenRateLimitBannerProps {
+  className?: string
+}
+
+export function TokenRateLimitBanner({ className }: TokenRateLimitBannerProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div
+      className={cn('border-t border-amber-300/60 bg-amber-50 px-4 py-1.5 text-amber-800', className)}
+      role="status"
+    >
+      <div className="mx-auto flex max-w-[var(--thread-content-max-width)] items-center gap-2">
+        <IconAlertTriangle size={16} stroke={2} className="shrink-0" aria-hidden="true" />
+        <p className="text-sm">{t('rate-limit-exceeded-warning')}</p>
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/app/chat/page.tsx
+++ b/apps/frontend/app/chat/page.tsx
@@ -15,8 +15,7 @@ import { useEnvironment } from '../context/environmentProvider'
 import { useTranslation } from 'react-i18next'
 import { useChatInput } from '@/components/providers/localstoragechatstate'
 import { useTokenRateLimit } from '@/components/providers/tokenRateLimitContext'
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { IconAlertTriangle } from '@tabler/icons-react'
+import { TokenRateLimitBanner } from './components/TokenRateLimitBanner'
 
 const deriveChatTitle = (msg: string) => {
   return msg.length > 30 ? `${msg.substring(0, 30)}...` : msg
@@ -116,17 +115,6 @@ const StartChat = () => {
           textareaRef?.current?.focus()
         }}
       ></StartChatFromHere>
-      {tokenRateLimit?.enabled && tokenRateLimit.exceeded && (
-        <Alert variant="destructive" className="rounded-none border-x-0">
-          <IconAlertTriangle className="h-4 w-4" />
-          <AlertDescription>
-            {t('rate-limit-exceeded-warning', {
-              defaultValue:
-                'You have reached your token usage limit for this period. Your messages may be restricted.',
-            })}
-          </AlertDescription>
-        </Alert>
-      )}
       <ChatInputOrApiKey
         // Force remount when assistant changes so input/upload local state resets to the selected assistant.
         key={assistantId}
@@ -140,6 +128,7 @@ const StartChat = () => {
         tokenLimit={assistant.tokenLimit}
         autoFocus
       />
+      {tokenRateLimit?.enabled && tokenRateLimit.exceeded && <TokenRateLimitBanner />}
     </div>
   )
 }

--- a/apps/frontend/locales/en/logicle.json
+++ b/apps/frontend/locales/en/logicle.json
@@ -150,7 +150,7 @@
   "creating": "Creating",
   "loading": "Loading",
   "not-found": "Not found",
-  "rate-limit-exceeded-warning": "You have reached your token usage limit for this period. Your messages may be restricted.",
+  "rate-limit-exceeded-warning": "You have reached your token usage limit for this period. You can keep chatting for now.",
   "choose-new-provider-type": "Choose the provider type",
   "choose-new-provider-type-description": "Choose the type of LLM provider for the new backend",
   "choose-workspace": "Choose your workspace",

--- a/apps/frontend/locales/it/logicle.json
+++ b/apps/frontend/locales/it/logicle.json
@@ -150,7 +150,7 @@
   "creating": "Creazione in corso",
   "loading": "Caricamento",
   "not-found": "Non trovato",
-  "rate-limit-exceeded-warning": "Hai raggiunto il limite di utilizzo dei token per questo periodo. I tuoi messaggi potrebbero essere limitati.",
+  "rate-limit-exceeded-warning": "Hai raggiunto il limite di utilizzo dei token per questo periodo. Per ora puoi continuare a chattare.",
   "choose-new-provider-type": "Scegli il tipo di provider",
   "choose-new-provider-type-description": "Scegli il tipo di provider LLM per il nuovo backend",
   "choose-workspace": "Scegli il tuo workspace",


### PR DESCRIPTION
## Summary

Replaces the full-width destructive token rate limit alert in the chat UI with a compact, single-line amber banner rendered at the very bottom of both chat pages (active conversation and new-chat). The copy now clarifies the limit is a heads-up rather than a block, and is properly localized in English and Italian.

## Details

- New `TokenRateLimitBanner` component: one-line amber strip (`role="status"`) with a small warning icon, shown when the token rate limit is enabled and exceeded.
- Rendered below `ChatInputOrApiKey` in both `Chat.tsx` and `chat/page.tsx`, replacing the inline destructive `Alert` above the input.
- Banner text moved from inline `defaultValue` fallbacks to the `rate_limit_exceeded_warning` key in `locales/en/logicle.json` and `locales/it/logicle.json`; wording states the user can keep chatting for now.
- No backend or config changes: `RATE_LIMIT_WINDOW_TOKENS` keeps acting as a warn-only threshold; enforcement (lock threshold) is deferred to a future version.

## Tests

- `npm run check-types` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)