### PR TITLE
fix: rename i18n "default" key to avoid resourcesToBackend collision

### DIFF
--- a/apps/frontend/app/assistants/components/GeneralTabPanel.tsx
+++ b/apps/frontend/app/assistants/components/GeneralTabPanel.tsx
@@ -148,12 +148,12 @@ export const GeneralTabPanel = ({ form, backendModels, visible, className }: Pro
                   onValueChange={(value) => field.onChange(value === NULL_VALUE ? null : value)}
                 >
                   <SelectTrigger>
-                    <SelectValue placeholder={t('default')}>
+                    <SelectValue placeholder={t('default-option')}>
                       {field.value ? t(field.value) : undefined}
                     </SelectValue>
                   </SelectTrigger>
                   <SelectContentScrollable className="max-h-72">
-                    <SelectItem value={NULL_VALUE}>{t('default')}</SelectItem>
+                    <SelectItem value={NULL_VALUE}>{t('default-option')}</SelectItem>
                     {supportedReasoningEfforts.map((effort) => (
                       <SelectItem key={effort} value={effort}>
                         {t(effort)}

--- a/apps/frontend/components/app/UserPreferences.tsx
+++ b/apps/frontend/components/app/UserPreferences.tsx
@@ -61,7 +61,7 @@ export const UserPreferences = () => {
           <FormRow label={t('language')}>
             <Select onValueChange={field.onChange} value={field.value}>
               <SelectTrigger className="w-auto min-w-[4rem]">
-                <SelectValue placeholder={t('default')} />
+                <SelectValue placeholder={t('default-option')} />
               </SelectTrigger>
               <SelectContent align="end" sideOffset={0}>
                 <SelectGroup>

--- a/apps/frontend/locales/en/logicle.json
+++ b/apps/frontend/locales/en/logicle.json
@@ -240,7 +240,7 @@
   "daily-usage": "Daily Usage",
   "dashboard": "Dashboard",
   "default-redirect-url": "Default redirect URL",
-  "default": "Default",
+  "default-option": "Default",
   "default-model": "Default model",
   "delete": "Delete",
   "delete-member-warning": "Deleting a member will delete all activites related to that member. This action cannot be undone.",

--- a/apps/frontend/locales/it/logicle.json
+++ b/apps/frontend/locales/it/logicle.json
@@ -240,7 +240,7 @@
   "daily-usage": "Utilizzo Giornaliero",
   "dashboard": "Dashboard",
   "default-redirect-url": "URL di reindirizzamento predefinito",
-  "default": "Predefinito",
+  "default-option": "Predefinito",
   "default-model": "Modello predefinito",
   "delete": "Elimina",
   "delete-member-warning": "Eliminare un membro comporterà la cancellazione di tutte le attività correlate. Questa azione non può essere annullata.",


### PR DESCRIPTION
## Summary

Fixes a complete i18n breakage introduced by the kebab-case key normalization in #977 (absorbed into #980). Translations across the entire app were rendering as raw keys (e.g. `email`, `sign-in`) instead of translated text, for every language.

Root cause: `i18next-resources-to-backend`'s `read()` unwraps whatever the custom backend resolver returns via `data.default || data`, on the assumption that it might be an ES-module-style `{ default: ... }` object. The key normalization renamed the locale key `default_` to plain `default`, so the merged translation bundle produced in `apps/frontend/app/context/client.ts` now legitimately contains a top-level `default` entry. The library mistook that for the module-wrapper convention and returned only the string `"Default"` as the resource set, discarding the other 700+ keys — breaking every `t(...)` lookup.

## Details

- Renamed the locale key `default` → `default-option` in both `en` and `it` `logicle.json` files.
- Updated the two call sites (`GeneralTabPanel.tsx`, `UserPreferences.tsx`) that referenced `t('default')` to use `t('default-option')`.

## Tests

- `npm run check:i18n` passes.
- Verified live against the dev server with Playwright: the anonymous `/auth/login` page now renders "Email" / "Password" / "Sign in" / "Don't have an account? Sign up" instead of raw keys.
- Verified live logged-in session renders the full Italian UI correctly ("Nuova Chat", "Ricerca chat", etc.).