### PR TITLE
chore: upgrade biome to 2.5.2 and add lint hardening rules

### DIFF
--- a/apps/backend/api/mcp/oauth/callback/route.ts
+++ b/apps/backend/api/mcp/oauth/callback/route.ts
@@ -126,7 +126,7 @@ export const GET = operation({
       return renderError('Missing OAuth session')
     }
     const tool = await getTool(oauthSession.toolId)
-    if (!tool || tool.type !== 'mcp') {
+    if (tool?.type !== 'mcp') {
       return renderError('Tool not found', 404)
     }
     const parsed = mcpPluginSchema.safeParse(tool.configuration)

--- a/apps/backend/api/mcp/oauth/start/route.ts
+++ b/apps/backend/api/mcp/oauth/start/route.ts
@@ -37,7 +37,7 @@ export const GET = operation({
       return error(400, 'Missing toolId')
     }
     const tool = await getTool(toolId)
-    if (!tool || tool.type !== 'mcp') {
+    if (tool?.type !== 'mcp') {
       return notFound('Tool not found')
     }
     const parsed = mcpPluginSchema.safeParse(tool.configuration)

--- a/apps/backend/api/oauth/oidc/route.ts
+++ b/apps/backend/api/oauth/oidc/route.ts
@@ -19,7 +19,7 @@ export const GET = operation({
   implementation: async ({ headers, cookies, url }) => {
     const session = await getSsoFlowSession(cookies)
     const idpConnection = await findIdpConnection(session.idp)
-    if (!idpConnection || idpConnection.type !== 'OIDC') {
+    if (idpConnection?.type !== 'OIDC') {
       return error(400, 'Unknown OIDC connection')
     }
     if (!session.state) {

--- a/apps/backend/api/oauth/saml/route.ts
+++ b/apps/backend/api/oauth/saml/route.ts
@@ -43,7 +43,7 @@ export const POST = operation({
 
     const idpConnection = await findIdpConnection(connectionId)
 
-    if (!idpConnection || idpConnection.type !== 'SAML') {
+    if (idpConnection?.type !== 'SAML') {
       return error(400, 'Unknown SAML connection')
     }
 

--- a/apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
+++ b/apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
@@ -311,7 +311,7 @@ describe('message projection parity', () => {
 
     const llm = await dtoMessageToLlmMessage(toolMessage, approxModel.capabilities, 'litellm')
     expect(llm?.role).toBe('tool')
-    if (!llm || llm.role !== 'tool') return
+    if (llm?.role !== 'tool') return
     const content = llm.content
     expect(content[0]).toEqual(
       expect.objectContaining({

--- a/apps/backend/lib/chat/chatRunEventsResponse.ts
+++ b/apps/backend/lib/chat/chatRunEventsResponse.ts
@@ -46,7 +46,7 @@ export const createChatRunEventsResponse = ({
 
         flushBufferedEvents()
         const currentRun = getChatRunById(runId)
-        if (!currentRun || currentRun.status !== 'running') {
+        if (currentRun?.status !== 'running') {
           close()
           return
         }
@@ -64,7 +64,7 @@ export const createChatRunEventsResponse = ({
 
         flushBufferedEvents()
         const refreshedRun = getChatRunById(runId)
-        if (!refreshedRun || refreshedRun.status !== 'running') {
+        if (refreshedRun?.status !== 'running') {
           close()
           return
         }

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -925,7 +925,7 @@ export class ChatAssistant {
           clientSink.enqueue({ type: 'part', part: toolCall })
         } else if (chunk.type === 'text-start') {
           const streamingMsg = chatState.chatHistory[chatState.chatHistory.length - 1]
-          if (!streamingMsg || streamingMsg.role !== 'assistant') {
+          if (streamingMsg?.role !== 'assistant') {
             throw new Error('Received text start but no active assistant message')
           }
           if (
@@ -941,7 +941,7 @@ export class ChatAssistant {
         } else if (chunk.type === 'text-delta') {
           const delta = chunk.text
           const streamingMsg = chatState.chatHistory[chatState.chatHistory.length - 1]
-          if (!streamingMsg || streamingMsg.role !== 'assistant') {
+          if (streamingMsg?.role !== 'assistant') {
             throw new Error('Received text but no active assistant message')
           }
           if (streamingMsg.parts.length === 0) {
@@ -955,7 +955,7 @@ export class ChatAssistant {
           clientSink.enqueue({ type: 'text', text: delta })
         } else if (chunk.type === 'reasoning-start') {
           const streamingMsg = chatState.chatHistory[chatState.chatHistory.length - 1]
-          if (!streamingMsg || streamingMsg.role !== 'assistant') {
+          if (streamingMsg?.role !== 'assistant') {
             throw new Error('Received reasoning start but no active assistant message')
           }
           const part: dto.ReasoningPart = { type: 'reasoning', reasoning: '' }
@@ -966,7 +966,7 @@ export class ChatAssistant {
         } else if (chunk.type === 'reasoning-delta') {
           const delta = chunk.text
           const streamingMsg = chatState.chatHistory[chatState.chatHistory.length - 1]
-          if (!streamingMsg || streamingMsg.role !== 'assistant') {
+          if (streamingMsg?.role !== 'assistant') {
             throw new Error('Received reasoning but no active assistant message')
           }
           if (streamingMsg.parts.length === 0) {

--- a/apps/backend/lib/chat/token-estimator.ts
+++ b/apps/backend/lib/chat/token-estimator.ts
@@ -203,7 +203,7 @@ const estimateAnalyzedFileTokens = async (
   if (cached !== undefined) return cached
 
   const file = await getFileWithId(fileId)
-  if (!file || !file.fileBlobId) return { tokens: 0, algorithm: 'none' }
+  if (!file?.fileBlobId) return { tokens: 0, algorithm: 'none' }
   const analysis = await ensureFileAnalysis(file)
   if (!isReadyFileAnalysis(analysis)) return { tokens: 0, algorithm: 'none' }
 
@@ -233,7 +233,7 @@ const estimateTextFallbackAttachmentTokens = async (
   stats?: CacheStats
 ): Promise<number> => {
   const file = await getFileWithId(fileId)
-  if (!file || !file.fileBlobId) return 0
+  if (!file?.fileBlobId) return 0
 
   const extractedText = await cachingExtractor.extractFromFile(file)
   const fallbackText = extractedText
@@ -330,7 +330,7 @@ const estimateAttachmentTokens = async (
         return cached.tokens
       }
       const file = await getFileWithId(attachment.id)
-      if (!file || !file.fileBlobId || file.type !== 'application/pdf') return 0
+      if (!file?.fileBlobId || file.type !== 'application/pdf') return 0
       const analysis = await ensureFileAnalysis(file)
       if (!isReadyFileAnalysis(analysis) || !isPdfAnalysisPayload(analysis.payload)) return 0
       if (isPdfOverNativePageLimit(analysis.payload, model)) {

--- a/apps/backend/lib/docx/export.ts
+++ b/apps/backend/lib/docx/export.ts
@@ -217,7 +217,7 @@ const remarkNonImageFileLinks: Plugin<[string], Root> = (baseUrl: string) => {
 
         tasks.push(
           getFileWithId(fileId).then((file) => {
-            if (!file || !file.type.startsWith('image/')) {
+            if (!file?.type.startsWith('image/')) {
               replacements.push({
                 parent: p,
                 index: idx,

--- a/apps/backend/lib/file-analysis/index.ts
+++ b/apps/backend/lib/file-analysis/index.ts
@@ -71,7 +71,7 @@ class FileAnalysisRuntime {
 
     try {
       const file = await getFileWithId(fileId)
-      if (!file || !file.fileBlobId) {
+      if (!file?.fileBlobId) {
         throw new Error(`File not ready (fileBlobId=${file?.fileBlobId ?? 'missing'})`)
       }
 

--- a/apps/backend/lib/tools/subassistant/implementation.ts
+++ b/apps/backend/lib/tools/subassistant/implementation.ts
@@ -155,7 +155,7 @@ export class SubAssistantTool implements ToolImplementation {
             await assistant.invokeLlmAndProcessResponse(chatState, nullSink)
 
             const lastMsg = chatState.getLastMessage()
-            if (!lastMsg || lastMsg.role !== 'assistant') {
+            if (lastMsg?.role !== 'assistant') {
               return { type: 'error-text', value: 'Sub-assistant did not produce a response' }
             }
             const assistantMsg = lastMsg as dto.AssistantMessage

--- a/apps/frontend/app/admin/tools/components/OpenApiToolFields.tsx
+++ b/apps/frontend/app/admin/tools/components/OpenApiToolFields.tsx
@@ -54,7 +54,7 @@ const OpenApiToolFields = ({ form, apiKeys, setApiKeys }: Props) => {
         const nextKeys = await extractApiKeysFromOpenApiSchema(docObject)
         setApiKeys(nextKeys)
       } catch {
-        console.log(`Failed extracting API keys...`)
+        console.error(`Failed extracting API keys...`)
         setApiKeys([])
       }
       const result = validateSchema(docObject)
@@ -74,7 +74,7 @@ const OpenApiToolFields = ({ form, apiKeys, setApiKeys }: Props) => {
         }
       }
     } catch (e) {
-      console.log(e)
+      console.error(e)
     }
     return diagnostics
   }

--- a/apps/frontend/app/chat/[chatId]/page.tsx
+++ b/apps/frontend/app/chat/[chatId]/page.tsx
@@ -21,9 +21,6 @@ const ChatPage = () => {
     // when routing between them, we must ensure that it matches the
     // page URL
     if (selectedConversation?.id !== chatId) {
-      console.debug(
-        `Loading messages for chat ${chatId} because selectedConversation is ${selectedConversation?.id}`
-      )
       void loadConversation(chatId).catch(() => {
         toast.error('Failed loading the chat')
       })

--- a/apps/frontend/app/chat/components/ChatFolder.tsx
+++ b/apps/frontend/app/chat/components/ChatFolder.tsx
@@ -17,7 +17,6 @@ export const ChatFolder: React.FC<Params> = ({ folder }) => {
     evt.preventDefault()
     const dndData = JSON.parse(evt.dataTransfer.getData('application/json')) as DndData
     if (dndData.type === 'chat') {
-      console.log(`Dropped chat ${dndData.id}`)
       await post(`/api/me/folders/${folder.id}`, {
         conversationId: dndData.id,
       })

--- a/apps/frontend/app/chat/components/MermaidDiagram.tsx
+++ b/apps/frontend/app/chat/components/MermaidDiagram.tsx
@@ -37,11 +37,11 @@ const MermaidDiagram = (props: MermaidDiagramProps) => {
           svgRef.current = svg
         }
       } catch (e: any) {
-        console.log(`Error: ${e}`)
+        console.error(`Error: ${e}`)
       }
     }
     renderDiagram().catch((e) => {
-      console.log(`Mysterious error: ${e}`)
+      console.error(`Mysterious error: ${e}`)
     })
     return () => {
       cancelled = true

--- a/apps/frontend/app/chat/components/markdown/CodeBlock.tsx
+++ b/apps/frontend/app/chat/components/markdown/CodeBlock.tsx
@@ -33,7 +33,7 @@ export const CodeBlock: FC<Props> = memo(({ language, value, forExport }) => {
   }, [language])
 
   const copyToClipboard = async () => {
-    if (!navigator.clipboard || !navigator.clipboard.writeText) {
+    if (!navigator.clipboard?.writeText) {
       return
     }
 

--- a/apps/frontend/components/providers/activeWorkspaceContext.tsx
+++ b/apps/frontend/components/providers/activeWorkspaceContext.tsx
@@ -24,7 +24,7 @@ const getWorkspaceFromLocalStorage = (): Workspace | undefined => {
     const w = localStorage.getItem('activeWorkspace')
     return w ? JSON.parse(w) : undefined
   } catch {
-    console.log('Failed loading active workspace')
+    console.error('Failed loading active workspace')
   }
 }
 

--- a/apps/frontend/components/providers/localstoragechatstate.tsx
+++ b/apps/frontend/components/providers/localstoragechatstate.tsx
@@ -22,7 +22,7 @@ const parseChatsState = (key: string): ChatsState => {
       return JSON.parse(data)
     }
   } catch {
-    console.log('Failed parsing cache storage')
+    console.error('Failed parsing cache storage')
   }
   return {}
 }
@@ -54,7 +54,7 @@ const parseContextLengthsState = (key: string): ContextLengthsState => {
       return JSON.parse(data)
     }
   } catch {
-    console.log('Failed parsing context length cache storage')
+    console.error('Failed parsing context length cache storage')
   }
   return {}
 }

--- a/apps/frontend/components/providers/uistate.tsx
+++ b/apps/frontend/components/providers/uistate.tsx
@@ -10,7 +10,7 @@ const parseUIState = (key: string): UIProps => {
       return JSON.parse(data)
     }
   } catch {
-    console.log('Failed parsing cache storage')
+    console.error('Failed parsing cache storage')
   }
   return {}
 }

--- a/apps/frontend/hooks/useCreateReducer.ts
+++ b/apps/frontend/hooks/useCreateReducer.ts
@@ -24,5 +24,5 @@ export const useCreateReducer = <T>({ initialState }: { initialState: T }) => {
 
   const [state, dispatch] = useReducer(reducer, initialState)
 
-  return useMemo(() => ({ state, dispatch }), [state, dispatch])
+  return useMemo(() => ({ state, dispatch }), [state])
 }

--- a/biome.json
+++ b/biome.json
@@ -1,17 +1,7 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
 
   "files": {
-    "experimentalScannerIgnores": [
-      ".next",
-      "node_modules",
-      "dist",
-      "dist-server",
-      "dist-scripts",
-      "coverage",
-      "vendor",
-      "pdf2md"
-    ],
     "includes": [
       "**/*.{js,ts,tsx}",
       "!**/node_modules",
@@ -20,7 +10,8 @@
       "!**/dist-server",
       "!**/dist-scripts",
       "!**/coverage",
-      "!vendor",
+      "!**/vendor",
+      "!**/pdf2md",
       "!apps/backend/lib/vendor/pdf2md"
     ]
   },
@@ -56,6 +47,7 @@
             "ignoreRestSiblings": true
           }
         },
+        "noUnusedImports": "warn",
         "useExhaustiveDependencies": "off"
       },
       "nursery": {
@@ -67,7 +59,13 @@
       "suspicious": {
         "noExplicitAny": "off",
         "useIterableCallbackReturn": "off",
-        "noArrayIndexKey": "off"
+        "noArrayIndexKey": "off",
+        "noConsole": {
+          "level": "warn",
+          "options": {
+            "allow": ["error", "warn"]
+          }
+        }
       },
       "style": {
         "useImportType": "off",
@@ -78,5 +76,42 @@
 
   "javascript": {
     "globals": ["React", "JSX"]
-  }
+  },
+
+  "overrides": [
+    {
+      "includes": ["apps/frontend/hooks/**/*.{js,ts,tsx}"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "useExhaustiveDependencies": "warn"
+          }
+        }
+      }
+    },
+    {
+      "includes": [
+        "apps/backend/scripts/**/*.{js,ts,tsx}",
+        "apps/backend/testapps/**/*.{js,ts,tsx}",
+        "apps/backend/lib/tracing/**/*.{js,ts,tsx}",
+        "apps/backend/lib/bootstrap.ts",
+        "apps/backend/lib/logging.ts",
+        "apps/backend/lib/file-analysis/runtime.ts",
+        "apps/backend/ee/pgp-s2k-worker/**/*.{js,ts,tsx}",
+        "apps/backend/ee/PgpEncryptingStorage.ts",
+        "apps/backend/server.ts",
+        "apps/backend/generate_openapi.ts",
+        "apps/frontend/dev.ts",
+        "apps/proxy.ts",
+        "bench/**/*.{js,ts,tsx}"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.2.0",
+    "@biomejs/biome": "^2.5.2",
     "@tailwindcss/forms": "0.5.6",
     "@trivago/prettier-plugin-sort-imports": "4.2.0",
     "@types/bcryptjs": "2.4.3",

--- a/packages/core/src/chat/streamApply.ts
+++ b/packages/core/src/chat/streamApply.ts
@@ -47,7 +47,7 @@ export function applyStreamPartToMessage(
       throw new Error('Received text delta for non-assistant message')
     }
     const lastPart = message.parts[message.parts.length - 1]
-    if (!lastPart || lastPart.type !== 'text') {
+    if (lastPart?.type !== 'text') {
       throw new Error('Received text delta but last part is not text')
     }
     return {
@@ -64,7 +64,7 @@ export function applyStreamPartToMessage(
       throw new Error('Received reasoning delta for non-assistant message')
     }
     const lastPart = message.parts[message.parts.length - 1]
-    if (!lastPart || lastPart.type !== 'reasoning') {
+    if (lastPart?.type !== 'reasoning') {
       throw new Error('Received reasoning delta but last part is not reasoning')
     }
     return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,8 +434,8 @@ importers:
         version: 4.3.5
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.2.0
-        version: 2.2.0
+        specifier: ^2.5.2
+        version: 2.5.2
       '@tailwindcss/forms':
         specifier: 0.5.6
         version: 0.5.6(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@5.9.2)))
@@ -873,55 +873,55 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@2.2.0':
-    resolution: {integrity: sha512-3On3RSYLsX+n9KnoSgfoYlckYBoU6VRM22cw1gB4Y0OuUVSYd/O/2saOJMrA4HFfA1Ff0eacOvMN1yAAvHtzIw==}
+  '@biomejs/biome@2.5.2':
+    resolution: {integrity: sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.2.0':
-    resolution: {integrity: sha512-zKbwUUh+9uFmWfS8IFxmVD6XwqFcENjZvEyfOxHs1epjdH3wyyMQG80FGDsmauPwS2r5kXdEM0v/+dTIA9FXAg==}
+  '@biomejs/cli-darwin-arm64@2.5.2':
+    resolution: {integrity: sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.2.0':
-    resolution: {integrity: sha512-+OmT4dsX2eTfhD5crUOPw3RPhaR+SKVspvGVmSdZ9y9O/AgL8pla6T4hOn1q+VAFBHuHhsdxDRJgFCSC7RaMOw==}
+  '@biomejs/cli-darwin-x64@2.5.2':
+    resolution: {integrity: sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.2.0':
-    resolution: {integrity: sha512-egKpOa+4FL9YO+SMUMLUvf543cprjevNc3CAgDNFLcjknuNMcZ0GLJYa3EGTCR2xIkIUJDVneBV3O9OcIlCEZQ==}
+  '@biomejs/cli-linux-arm64-musl@2.5.2':
+    resolution: {integrity: sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@2.2.0':
-    resolution: {integrity: sha512-6eoRdF2yW5FnW9Lpeivh7Mayhq0KDdaDMYOJnH9aT02KuSIX5V1HmWJCQQPwIQbhDh68Zrcpl8inRlTEan0SXw==}
+  '@biomejs/cli-linux-arm64@2.5.2':
+    resolution: {integrity: sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.2.0':
-    resolution: {integrity: sha512-I5J85yWwUWpgJyC1CcytNSGusu2p9HjDnOPAFG4Y515hwRD0jpR9sT9/T1cKHtuCvEQ/sBvx+6zhz9l9wEJGAg==}
+  '@biomejs/cli-linux-x64-musl@2.5.2':
+    resolution: {integrity: sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@2.2.0':
-    resolution: {integrity: sha512-5UmQx/OZAfJfi25zAnAGHUMuOd+LOsliIt119x2soA2gLggQYrVPA+2kMUxR6Mw5M1deUF/AWWP2qpxgH7Nyfw==}
+  '@biomejs/cli-linux-x64@2.5.2':
+    resolution: {integrity: sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@2.2.0':
-    resolution: {integrity: sha512-n9a1/f2CwIDmNMNkFs+JI0ZjFnMO0jdOyGNtihgUNFnlmd84yIYY2KMTBmMV58ZlVHjgmY5Y6E1hVTnSRieggA==}
+  '@biomejs/cli-win32-arm64@2.5.2':
+    resolution: {integrity: sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.2.0':
-    resolution: {integrity: sha512-Nawu5nHjP/zPKTIryh2AavzTc/KEg4um/MxWdXW0A6P/RZOyIpa7+QSjeXwAwX/utJGaCoXRPWtF3m5U/bB3Ww==}
+  '@biomejs/cli-win32-x64@2.5.2':
+    resolution: {integrity: sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -8015,39 +8015,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@2.2.0':
+  '@biomejs/biome@2.5.2':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.2.0
-      '@biomejs/cli-darwin-x64': 2.2.0
-      '@biomejs/cli-linux-arm64': 2.2.0
-      '@biomejs/cli-linux-arm64-musl': 2.2.0
-      '@biomejs/cli-linux-x64': 2.2.0
-      '@biomejs/cli-linux-x64-musl': 2.2.0
-      '@biomejs/cli-win32-arm64': 2.2.0
-      '@biomejs/cli-win32-x64': 2.2.0
+      '@biomejs/cli-darwin-arm64': 2.5.2
+      '@biomejs/cli-darwin-x64': 2.5.2
+      '@biomejs/cli-linux-arm64': 2.5.2
+      '@biomejs/cli-linux-arm64-musl': 2.5.2
+      '@biomejs/cli-linux-x64': 2.5.2
+      '@biomejs/cli-linux-x64-musl': 2.5.2
+      '@biomejs/cli-win32-arm64': 2.5.2
+      '@biomejs/cli-win32-x64': 2.5.2
 
-  '@biomejs/cli-darwin-arm64@2.2.0':
+  '@biomejs/cli-darwin-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.2.0':
+  '@biomejs/cli-darwin-x64@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.2.0':
+  '@biomejs/cli-linux-arm64-musl@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.2.0':
+  '@biomejs/cli-linux-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.2.0':
+  '@biomejs/cli-linux-x64-musl@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.2.0':
+  '@biomejs/cli-linux-x64@2.5.2':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.2.0':
+  '@biomejs/cli-win32-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.2.0':
+  '@biomejs/cli-win32-x64@2.5.2':
     optional: true
 
   '@braintree/sanitize-url@7.1.1': {}


### PR DESCRIPTION
## Summary
Upgrades `@biomejs/biome` from 2.2.0 to 2.5.2 and tightens the lint configuration with three new checks: `noUnusedImports`, `noConsole` (allowing `error`/`warn`, since the frontend has no dedicated logger), and a scoped `useExhaustiveDependencies` for `apps/frontend/hooks/**`. `noConsole` is turned off for CLI/bootstrap/worker code (`server.ts`, `proxy.ts`, `scripts/**`, `testapps/**`, `bench/**`, `tracing/**`, worker runtimes, `PgpEncryptingStorage.ts`) where console output is intentional.

## Details
- Migrated `biome.json` off the deprecated `experimentalScannerIgnores` property into `files.includes`.
- Applied the mechanical `useOptionalChain` autofix across 13 files (`!x || x.foo !== y` → `x?.foo !== y`).
- Fixed mislabeled `console.log`/`console.debug` calls in catch blocks (converted to `console.error`, or removed where purely a debug trace).
- Dropped an over-specified `dispatch` dependency from a `useMemo` in `useCreateReducer.ts` (React guarantees `dispatch` identity is stable).

## Tests
- `npx biome check` — 0 warnings/errors
- `npm run check-types` — passes