### PR TITLE
test: cover openapi tool, imagegen providers, and MeiliIndex

### DIFF
--- a/apps/backend/lib/imagegen/providers/__tests__/gemini.test.ts
+++ b/apps/backend/lib/imagegen/providers/__tests__/gemini.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest'
+import { generateWithGemini, editWithGemini } from '../gemini'
+import type { ImageEditRequest, ImageGenerationRequest } from '../../types'
+
+vi.mock('@/lib/logging', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+const mockGenerateContentStream = vi.fn()
+const mockGenerateContent = vi.fn()
+
+vi.mock('@google/generative-ai', () => ({
+  GoogleGenerativeAI: class {
+    getGenerativeModel() {
+      return {
+        generateContentStream: mockGenerateContentStream,
+        generateContent: mockGenerateContent,
+      }
+    }
+  },
+}))
+
+async function* toAsyncIterable<T>(items: T[]) {
+  for (const item of items) yield item
+}
+
+const baseRequest: ImageGenerationRequest = {
+  apiKey: 'key',
+  model: 'gemini-2.5-flash-image',
+  prompt: 'a dog',
+}
+
+describe('generateWithGemini', () => {
+  it('skips stream chunks with no inline image data and returns the first one that has it', async () => {
+    mockGenerateContentStream.mockResolvedValue({
+      stream: toAsyncIterable([
+        { candidates: [{ content: { parts: [{ text: 'thinking...' }] } }] },
+        {
+          candidates: [
+            { content: { parts: [{ inlineData: { data: 'b64-data', mimeType: 'image/png' } }] } },
+          ],
+        },
+        {
+          candidates: [
+            { content: { parts: [{ inlineData: { data: 'later-data' } }] } },
+          ],
+        },
+      ]),
+    })
+
+    const result = await generateWithGemini(baseRequest)
+
+    expect(result.data).toEqual([{ b64_json: 'b64-data', mimeType: 'image/png' }])
+  })
+
+  it('throws when no chunk ever contains image data', async () => {
+    mockGenerateContentStream.mockResolvedValue({
+      stream: toAsyncIterable([{ candidates: [{ content: { parts: [{ text: 'no image' }] } }] }]),
+    })
+
+    await expect(generateWithGemini(baseRequest)).rejects.toThrow(/No image data received/)
+  })
+})
+
+describe('editWithGemini', () => {
+  const editRequest: ImageEditRequest = {
+    ...baseRequest,
+    images: [{ data: Buffer.from('source'), fileName: 'a.png', mimeType: 'image/png' }],
+  }
+
+  it('extracts the first inline image from the response parts', async () => {
+    mockGenerateContent.mockResolvedValue({
+      response: {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'here' }, { inlineData: { data: 'edited-b64', mimeType: 'image/png' } }],
+            },
+          },
+        ],
+      },
+    })
+
+    const result = await editWithGemini(editRequest)
+
+    expect(result.data).toEqual([{ b64_json: 'edited-b64', mimeType: 'image/png' }])
+  })
+
+  it('throws when the response has no image data', async () => {
+    mockGenerateContent.mockResolvedValue({
+      response: { candidates: [{ content: { parts: [{ text: 'no image here' }] } }] },
+    })
+
+    await expect(editWithGemini(editRequest)).rejects.toThrow(/No image data received/)
+  })
+
+  it('base64-encodes source images into inlineData parts', async () => {
+    mockGenerateContent.mockResolvedValue({
+      response: {
+        candidates: [{ content: { parts: [{ inlineData: { data: 'x' } }] } }],
+      },
+    })
+
+    await editWithGemini(editRequest)
+
+    const call = mockGenerateContent.mock.calls[0][0]
+    const imagePart = call.contents[0].parts[1]
+    expect(imagePart.inlineData.mimeType).toBe('image/png')
+    expect(imagePart.inlineData.data).toBe(Buffer.from('source').toString('base64'))
+  })
+})

--- a/apps/backend/lib/imagegen/providers/__tests__/imagen.test.ts
+++ b/apps/backend/lib/imagegen/providers/__tests__/imagen.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+import { generateWithImagen } from '../imagen'
+import type { ImageGenerationRequest } from '../../types'
+
+vi.mock('@/lib/logging', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+const mockGenerateImages = vi.fn()
+
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: class {
+    models = { generateImages: mockGenerateImages }
+  },
+}))
+
+const baseRequest: ImageGenerationRequest = {
+  apiKey: 'key',
+  model: 'imagen-4.0-generate-001',
+  prompt: 'a sunset',
+}
+
+describe('generateWithImagen', () => {
+  it('drops generated images with no image bytes', async () => {
+    mockGenerateImages.mockResolvedValue({
+      generatedImages: [{ image: { imageBytes: 'abc' } }, { image: {} }, {}],
+    })
+
+    const result = await generateWithImagen(baseRequest)
+
+    expect(result.data).toEqual([{ b64_json: 'abc' }])
+  })
+
+  it('throws when none of the generated images contain data', async () => {
+    mockGenerateImages.mockResolvedValue({ generatedImages: [{ image: {} }] })
+
+    await expect(generateWithImagen(baseRequest)).rejects.toThrow(/No image data received/)
+  })
+
+  it('throws when the response has no generatedImages at all', async () => {
+    mockGenerateImages.mockResolvedValue({})
+
+    await expect(generateWithImagen(baseRequest)).rejects.toThrow(/No image data received/)
+  })
+
+  it('only forwards aspectRatio when provided', async () => {
+    mockGenerateImages.mockResolvedValue({ generatedImages: [{ image: { imageBytes: 'x' } }] })
+
+    await generateWithImagen(baseRequest)
+    expect(mockGenerateImages).toHaveBeenCalledWith(
+      expect.objectContaining({ config: { numberOfImages: 1 } })
+    )
+
+    await generateWithImagen({ ...baseRequest, aspectRatio: '16:9', n: 2 })
+    expect(mockGenerateImages).toHaveBeenCalledWith(
+      expect.objectContaining({ config: { numberOfImages: 2, aspectRatio: '16:9' } })
+    )
+  })
+})

--- a/apps/backend/lib/imagegen/providers/__tests__/openai.test.ts
+++ b/apps/backend/lib/imagegen/providers/__tests__/openai.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+import { generateWithOpenAI, editWithOpenAI } from '../openai'
+import type { ImageEditRequest, ImageGenerationRequest } from '../../types'
+
+vi.mock('@/lib/logging', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+const mockGenerate = vi.fn()
+const mockEdit = vi.fn()
+
+vi.mock('openai', () => ({
+  default: class {
+    images = { generate: mockGenerate, edit: mockEdit }
+  },
+}))
+
+const baseRequest: ImageGenerationRequest = {
+  apiKey: 'key',
+  model: 'dall-e-3',
+  prompt: 'a cat',
+}
+
+describe('generateWithOpenAI', () => {
+  it('drops items with no b64_json instead of returning them as empty images', async () => {
+    mockGenerate.mockResolvedValue({
+      data: [{ b64_json: 'abc' }, { url: 'http://example.com/no-b64.png' }],
+    })
+
+    const result = await generateWithOpenAI(baseRequest)
+
+    expect(result.data).toEqual([{ b64_json: 'abc' }])
+  })
+
+  it('requests response_format only for models that support it', async () => {
+    mockGenerate.mockResolvedValue({ data: [] })
+
+    await generateWithOpenAI({ ...baseRequest, model: 'dall-e-3' })
+    expect(mockGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ response_format: 'b64_json' })
+    )
+
+    await generateWithOpenAI({ ...baseRequest, model: 'gpt-image-1' })
+    expect(mockGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ response_format: undefined })
+    )
+  })
+
+  it('falls back to a default size for unsupported/missing size values', async () => {
+    mockGenerate.mockResolvedValue({ data: [] })
+
+    await generateWithOpenAI({ ...baseRequest, size: 'not-a-real-size' })
+    expect(mockGenerate).toHaveBeenCalledWith(expect.objectContaining({ size: '1024x1024' }))
+
+    await generateWithOpenAI({ ...baseRequest, size: '1536x1024' })
+    expect(mockGenerate).toHaveBeenCalledWith(expect.objectContaining({ size: '1536x1024' }))
+  })
+
+  it('defaults n to 1 when not provided', async () => {
+    mockGenerate.mockResolvedValue({ data: [] })
+    await generateWithOpenAI(baseRequest)
+    expect(mockGenerate).toHaveBeenCalledWith(expect.objectContaining({ n: 1 }))
+  })
+})
+
+describe('editWithOpenAI', () => {
+  const editRequest: ImageEditRequest = {
+    ...baseRequest,
+    images: [{ data: Buffer.from('img'), fileName: 'a.png', mimeType: 'image/png' }],
+  }
+
+  it('drops items with no b64_json in the response', async () => {
+    mockEdit.mockResolvedValue({ data: [{ b64_json: 'edited' }, {}] })
+
+    const result = await editWithOpenAI(editRequest)
+
+    expect(result.data).toEqual([{ b64_json: 'edited' }])
+  })
+
+  it('only includes a mask in the request when one is provided', async () => {
+    mockEdit.mockResolvedValue({ data: [] })
+
+    await editWithOpenAI(editRequest)
+    expect(mockEdit).toHaveBeenCalledWith(expect.not.objectContaining({ mask: expect.anything() }))
+
+    await editWithOpenAI({
+      ...editRequest,
+      mask: { data: Buffer.from('mask'), fileName: 'm.png', mimeType: 'image/png' },
+    })
+    expect(mockEdit).toHaveBeenCalledWith(expect.objectContaining({ mask: expect.anything() }))
+  })
+})

--- a/apps/backend/lib/imagegen/providers/__tests__/replicate.test.ts
+++ b/apps/backend/lib/imagegen/providers/__tests__/replicate.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { generateWithReplicate } from '../replicate'
+import type { ImageGenerationRequest } from '../../types'
+
+vi.mock('@/lib/logging', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+const mockCreate = vi.fn()
+const mockWait = vi.fn()
+
+vi.mock('replicate', () => ({
+  default: class {
+    predictions = { create: mockCreate }
+    wait = mockWait
+  },
+}))
+
+const baseRequest: ImageGenerationRequest = {
+  apiKey: 'key',
+  model: 'owner/model:version',
+  prompt: 'a mountain',
+}
+
+describe('generateWithReplicate', () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    mockCreate.mockResolvedValue({ id: 'pred-1' })
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it('throws when the prediction output is not a single image URL', async () => {
+    mockWait.mockResolvedValue({ output: [42] })
+
+    await expect(generateWithReplicate(baseRequest)).rejects.toThrow(/did not return an image URL/)
+  })
+
+  it('throws when the prediction output is an empty array', async () => {
+    mockWait.mockResolvedValue({ output: [] })
+
+    await expect(generateWithReplicate(baseRequest)).rejects.toThrow(/did not return an image URL/)
+  })
+
+  it('throws when downloading the generated image fails', async () => {
+    mockWait.mockResolvedValue({ output: ['http://example.com/img.png'] })
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 503 }) as any
+
+    await expect(generateWithReplicate(baseRequest)).rejects.toThrow(/Failed downloading.*503/)
+  })
+
+  it('downloads and base64-encodes the first output image, using the response content-type', async () => {
+    mockWait.mockResolvedValue({ output: ['http://example.com/img.png'] })
+    const bytes = new TextEncoder().encode('image-bytes')
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => bytes.buffer,
+      headers: new Headers({ 'content-type': 'image/webp' }),
+    }) as any
+
+    const result = await generateWithReplicate(baseRequest)
+
+    expect(result.data).toEqual([
+      { b64_json: Buffer.from(bytes).toString('base64'), mimeType: 'image/webp' },
+    ])
+  })
+})

--- a/apps/backend/lib/imagegen/providers/__tests__/together.test.ts
+++ b/apps/backend/lib/imagegen/providers/__tests__/together.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+import { generateWithTogether, editWithTogether } from '../together'
+import type { ImageEditRequest, ImageGenerationRequest } from '../../types'
+
+vi.mock('@/lib/logging', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+const mockGenerate = vi.fn()
+
+vi.mock('together-ai', () => ({
+  Together: class {
+    images = { generate: mockGenerate }
+  },
+}))
+
+const baseRequest: ImageGenerationRequest = {
+  apiKey: 'key',
+  model: 'FLUX.1-schnell',
+  prompt: 'a river',
+}
+
+describe('generateWithTogether', () => {
+  it('prefixes the model with the black-forest-labs namespace', async () => {
+    mockGenerate.mockResolvedValue({ data: [] })
+
+    await generateWithTogether(baseRequest)
+
+    expect(mockGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'black-forest-labs/FLUX.1-schnell' })
+    )
+  })
+
+  it('parses a WxH size string, falling back to 1024x1024 when malformed or missing', async () => {
+    mockGenerate.mockResolvedValue({ data: [] })
+
+    await generateWithTogether({ ...baseRequest, size: '768x512' })
+    expect(mockGenerate).toHaveBeenCalledWith(expect.objectContaining({ width: 768, height: 512 }))
+
+    await generateWithTogether({ ...baseRequest, size: 'not-a-size' })
+    expect(mockGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ width: 1024, height: 1024 })
+    )
+
+    await generateWithTogether(baseRequest)
+    expect(mockGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ width: 1024, height: 1024 })
+    )
+  })
+
+  it('drops items with no b64_json and tags the rest as png', async () => {
+    mockGenerate.mockResolvedValue({ data: [{ b64_json: 'abc' }, {}] })
+
+    const result = await generateWithTogether(baseRequest)
+
+    expect(result.data).toEqual([{ b64_json: 'abc', mimeType: 'image/png' }])
+  })
+})
+
+describe('editWithTogether', () => {
+  const editRequest: ImageEditRequest = {
+    ...baseRequest,
+    images: [{ data: Buffer.from('source'), fileName: 'a.png', mimeType: 'image/jpeg' }],
+  }
+
+  it('builds a data URL from the first source image', async () => {
+    mockGenerate.mockResolvedValue({ data: [] })
+
+    await editWithTogether(editRequest)
+
+    expect(mockGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        image_url: `data:image/jpeg;base64,${Buffer.from('source').toString('base64')}`,
+      })
+    )
+  })
+
+  it('drops items with no b64_json in the response', async () => {
+    mockGenerate.mockResolvedValue({ data: [{ b64_json: 'edited' }, {}] })
+
+    const result = await editWithTogether(editRequest)
+
+    expect(result.data).toEqual([{ b64_json: 'edited', mimeType: 'image/png' }])
+  })
+})

--- a/apps/backend/lib/search/__tests__/MeiliIndex.test.ts
+++ b/apps/backend/lib/search/__tests__/MeiliIndex.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+import { MeiliSearchIndex } from '../MeiliIndex'
+import type { ConversationSearchDoc } from '../Index'
+
+const toHex = (s: string) => Buffer.from(s).toString('hex')
+
+describe('MeiliSearchIndex', () => {
+  it('hex-encodes conversation ids before writing to Meilisearch (ids may contain chars Meili rejects as a primaryKey)', async () => {
+    const addDocuments = vi.fn().mockResolvedValue({})
+    const fakeIndex = { addDocuments } as any
+    const index = new MeiliSearchIndex(fakeIndex)
+
+    const doc: ConversationSearchDoc = {
+      id: 'conv-1',
+      title: 't',
+      ownerId: 'o',
+      assistantId: 'a',
+      createdAt: '2024-01-01',
+      lastMsgSentAt: null,
+      messages: [],
+    }
+    await index.addDocuments([doc])
+
+    expect(addDocuments).toHaveBeenCalledWith([{ ...doc, id: toHex('conv-1') }], {
+      primaryKey: 'id',
+    })
+  })
+
+  it('hex-encodes ids before deleting them', async () => {
+    const deleteDocuments = vi.fn().mockResolvedValue({})
+    const index = new MeiliSearchIndex({ deleteDocuments } as any)
+
+    await index.deleteDocuments(['conv-1', 'conv-2'])
+
+    expect(deleteDocuments).toHaveBeenCalledWith([toHex('conv-1'), toHex('conv-2')])
+  })
+
+  it('fetchEntriesAfterId filters by the hex-encoded cursor and decodes ids back from hex', async () => {
+    const search = vi.fn().mockResolvedValue({
+      hits: [{ id: toHex('conv-2'), lastMsgSentAt: '2024-01-02' }],
+    })
+    const index = new MeiliSearchIndex({ search } as any)
+
+    const result = await index.fetchEntriesAfterId('conv-1', 50)
+
+    expect(search).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({
+        filter: `id > "${toHex('conv-1')}"`,
+        sort: ['id:asc'],
+        limit: 50,
+      })
+    )
+    expect(result).toEqual([{ id: 'conv-2', lastMsgSentAt: '2024-01-02' }])
+  })
+
+  it('searchConversations combines ownerId/assistantId into an AND filter only when provided', async () => {
+    const search = vi.fn().mockResolvedValue({ hits: [] })
+    const index = new MeiliSearchIndex({ search } as any)
+
+    await index.searchConversations('hello')
+    expect(search).toHaveBeenCalledWith('hello', expect.objectContaining({ filter: undefined }))
+
+    await index.searchConversations('hello', { ownerId: 'o1', assistantId: 'a1' })
+    expect(search).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({ filter: 'ownerId = "o1" AND assistantId = "a1"' })
+    )
+
+    await index.searchConversations('hello', { ownerId: 'o1' })
+    expect(search).toHaveBeenCalledWith(
+      'hello',
+      expect.objectContaining({ filter: 'ownerId = "o1"' })
+    )
+  })
+
+  it('searchConversations decodes ids and falls back to a rank-based score when Meili omits _rankingScore', async () => {
+    const search = vi.fn().mockResolvedValue({
+      hits: [
+        { id: toHex('conv-1'), title: 'a', createdAt: 'c1', lastMsgSentAt: null, _formatted: { title: 'x' } },
+        { id: toHex('conv-2'), title: 'b', createdAt: 'c2', lastMsgSentAt: null },
+      ],
+      estimatedTotalHits: 10,
+    })
+    const index = new MeiliSearchIndex({ search } as any)
+
+    const results = await index.searchConversations('hello')
+
+    expect(results[0]).toMatchObject({ id: 'conv-1', score: 10, snippet: { title: 'x' } })
+    expect(results[1]).toMatchObject({ id: 'conv-2', score: 9, snippet: '' })
+  })
+
+  it('searchConversations uses the actual _rankingScore when Meili provides one', async () => {
+    const search = vi.fn().mockResolvedValue({
+      hits: [{ id: toHex('conv-1'), title: 'a', createdAt: 'c1', lastMsgSentAt: null, _rankingScore: 0.42 }],
+      estimatedTotalHits: 10,
+    })
+    const index = new MeiliSearchIndex({ search } as any)
+
+    const [result] = await index.searchConversations('hello')
+
+    expect(result.score).toBe(0.42)
+  })
+})

--- a/apps/backend/lib/tools/__tests__/configSchema.test.ts
+++ b/apps/backend/lib/tools/__tests__/configSchema.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import { toolConfigSchema } from '@/backend/lib/tools/configSchema'
+
+const mockBuildOpenApiConfigSchema = vi.fn()
+
+vi.mock('@/backend/lib/tools/openapi/utils', () => ({
+  buildOpenApiConfigSchema: (...args: unknown[]) => mockBuildOpenApiConfigSchema(...args),
+}))
+
+describe('toolConfigSchema', () => {
+  it('extracts the spec from a JSON-encoded string config for the openapi tool', async () => {
+    mockBuildOpenApiConfigSchema.mockResolvedValue('schema-for-spec')
+    const config = JSON.stringify({ spec: 'openapi: 3.0.0' })
+
+    const result = await toolConfigSchema('openapi', config)
+
+    expect(mockBuildOpenApiConfigSchema).toHaveBeenCalledWith('openapi: 3.0.0')
+    expect(result).toBe('schema-for-spec')
+  })
+
+  it('extracts the spec from an object config for the openapi tool', async () => {
+    mockBuildOpenApiConfigSchema.mockResolvedValue('schema-for-spec')
+
+    await toolConfigSchema('openapi', { spec: 'openapi: 3.0.0' })
+
+    expect(mockBuildOpenApiConfigSchema).toHaveBeenCalledWith('openapi: 3.0.0')
+  })
+
+  it('falls back to fallbackConfig when the primary config has no usable spec', async () => {
+    mockBuildOpenApiConfigSchema.mockResolvedValue('schema-for-fallback')
+
+    await toolConfigSchema('openapi', undefined, { spec: 'fallback-spec' })
+
+    expect(mockBuildOpenApiConfigSchema).toHaveBeenCalledWith('fallback-spec')
+  })
+
+  it('passes undefined when neither config nor fallbackConfig has a usable spec', async () => {
+    mockBuildOpenApiConfigSchema.mockResolvedValue('schema-empty')
+
+    await toolConfigSchema('openapi', 'not-json', { unrelated: true })
+
+    expect(mockBuildOpenApiConfigSchema).toHaveBeenCalledWith(undefined)
+  })
+
+  it('looks up the schema in the tool schema registry for non-openapi tools', async () => {
+    const result = await toolConfigSchema('dummy')
+    expect(result).toBeDefined()
+  })
+
+  it('returns null for an unknown tool type', async () => {
+    const result = await toolConfigSchema('does-not-exist')
+    expect(result).toBeNull()
+  })
+})

--- a/apps/backend/lib/tools/openapi/__tests__/body.test.ts
+++ b/apps/backend/lib/tools/openapi/__tests__/body.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { OpenAPIV3 } from 'openapi-types'
+import { findBodyHandler } from '@/backend/lib/tools/openapi/body'
+
+const mockCanAccessFile = vi.fn()
+const mockGetFileWithId = vi.fn()
+const mockReadBuffer = vi.fn()
+
+vi.mock('@/backend/lib/files/authorization', () => ({
+  canAccessFile: (...args: unknown[]) => mockCanAccessFile(...args),
+}))
+
+vi.mock('@/models/file', () => ({
+  getFileWithId: (...args: unknown[]) => mockGetFileWithId(...args),
+}))
+
+vi.mock('@/lib/storage', () => ({
+  storage: {
+    readBuffer: (...args: unknown[]) => mockReadBuffer(...args),
+  },
+}))
+
+beforeEach(() => {
+  mockCanAccessFile.mockReset()
+  mockGetFileWithId.mockReset()
+  mockReadBuffer.mockReset()
+})
+
+const jsonSpec: OpenAPIV3.RequestBodyObject = {
+  content: {
+    'application/json': {
+      schema: { type: 'object', properties: { name: { type: 'string' } } },
+    },
+  },
+}
+
+const urlEncodedSpec: OpenAPIV3.RequestBodyObject = {
+  content: {
+    'application/x-www-form-urlencoded': {
+      schema: {
+        type: 'object',
+        required: ['requiredField'],
+        properties: {
+          requiredField: { type: 'string' },
+          optionalField: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const formDataSpec: OpenAPIV3.RequestBodyObject = {
+  content: {
+    'multipart/form-data': {
+      schema: {
+        type: 'object',
+        required: ['file'],
+        properties: {
+          file: { type: 'string', format: 'binary' },
+          caption: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+describe('findBodyHandler', () => {
+  it('returns undefined when the spec has no recognized media type', () => {
+    const handler = findBodyHandler({ content: { 'text/plain': { schema: {} } } } as any)
+    expect(handler).toBeUndefined()
+  })
+
+  it('picks multipart/form-data over application/json when both are declared', () => {
+    const spec: OpenAPIV3.RequestBodyObject = {
+      content: { ...jsonSpec.content, ...formDataSpec.content },
+    }
+    mockCanAccessFile.mockResolvedValue(true)
+    mockGetFileWithId.mockResolvedValue({ path: '/f', encryption: null, name: 'a.txt' })
+    mockReadBuffer.mockResolvedValue(Buffer.from('x'))
+
+    const handler = findBodyHandler(spec)
+    expect(handler).toBeDefined()
+  })
+})
+
+describe('createJsonBody via findBodyHandler', () => {
+  it('serializes the body param as JSON with a json content-type header', async () => {
+    const handler = findBodyHandler(jsonSpec)!
+    const result = await handler.createBody({ body: { name: 'alice' } }, 'user-1')
+
+    expect(result.body).toBe(JSON.stringify({ name: 'alice' }))
+    expect(result.headers).toEqual({ 'content-type': 'application/json' })
+  })
+
+  it('merges the body schema into the tool function schema as a required property', () => {
+    const handler = findBodyHandler(jsonSpec)!
+    const toolParams = { properties: {}, required: [] } as any
+    handler.mergeParamsIntoToolFunctionSchema(toolParams)
+
+    expect(toolParams.required).toEqual(['body'])
+    expect(toolParams.properties.body).toEqual(jsonSpec.content['application/json'].schema)
+  })
+})
+
+describe('createWwwFormUrlEncodedBody via findBodyHandler', () => {
+  it('omits optional properties that are null but keeps required ones (stringified)', async () => {
+    const handler = findBodyHandler(urlEncodedSpec)!
+    const result = await handler.createBody(
+      { body: { requiredField: null, optionalField: null } },
+      'user-1'
+    )
+
+    const params = new URLSearchParams(result.body as string)
+    expect(params.get('optionalField')).toBeNull()
+    expect(params.has('optionalField')).toBe(false)
+    // Required fields are not skipped even when null: they end up stringified.
+    expect(params.get('requiredField')).toBe('null')
+    expect(result.headers).toEqual({ 'content-type': 'application/x-www-form-urlencoded' })
+  })
+
+  it('encodes provided values normally', async () => {
+    const handler = findBodyHandler(urlEncodedSpec)!
+    const result = await handler.createBody(
+      { body: { requiredField: 'a b', optionalField: 'c' } },
+      'user-1'
+    )
+
+    const params = new URLSearchParams(result.body as string)
+    expect(params.get('requiredField')).toBe('a b')
+    expect(params.get('optionalField')).toBe('c')
+  })
+})
+
+describe('createFormBody via findBodyHandler', () => {
+  it('throws when a required binary field has no file id', async () => {
+    const handler = findBodyHandler(formDataSpec)!
+    await expect(handler.createBody({ body: { file: undefined } }, 'user-1')).rejects.toThrow(
+      /missing/
+    )
+  })
+
+  it('throws when the user is not authorized to access the referenced file', async () => {
+    mockCanAccessFile.mockResolvedValue(false)
+    const handler = findBodyHandler(formDataSpec)!
+
+    await expect(
+      handler.createBody({ body: { file: 'file-1' } }, 'user-1')
+    ).rejects.toThrow(/unauthorized/i)
+    expect(mockCanAccessFile).toHaveBeenCalledWith({ userId: 'user-1' }, 'file-1')
+  })
+
+  it('throws when the referenced file does not exist', async () => {
+    mockCanAccessFile.mockResolvedValue(true)
+    mockGetFileWithId.mockResolvedValue(undefined)
+    const handler = findBodyHandler(formDataSpec)!
+
+    await expect(handler.createBody({ body: { file: 'file-1' } }, 'user-1')).rejects.toThrow(
+      /non existing/
+    )
+  })
+
+  it('builds multipart form data with the file content and extra fields', async () => {
+    mockCanAccessFile.mockResolvedValue(true)
+    mockGetFileWithId.mockResolvedValue({ path: '/f', encryption: null, name: 'a.txt' })
+    mockReadBuffer.mockResolvedValue(Buffer.from('file-bytes'))
+    const handler = findBodyHandler(formDataSpec)!
+
+    const result = await handler.createBody(
+      { body: { file: 'file-1', caption: 'hello' } },
+      'user-1'
+    )
+
+    expect(result.headers['content-type']).toMatch(/^multipart\/form-data; boundary=/)
+    const text = Buffer.from(result.body as Uint8Array).toString('utf-8')
+    expect(text).toContain('file-bytes')
+    expect(text).toContain('hello')
+    expect(text).toContain('a.txt')
+  })
+})

--- a/apps/backend/lib/tools/openapi/__tests__/utils.test.ts
+++ b/apps/backend/lib/tools/openapi/__tests__/utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { buildOpenApiConfigSchema } from '@/backend/lib/tools/openapi/utils'
+
+const baseDoc = {
+  openapi: '3.0.0',
+  info: { title: 'Test API', version: '1.0.0' },
+  paths: {
+    '/ping': {
+      get: {
+        responses: { '200': { description: 'ok' } },
+      },
+    },
+  },
+}
+
+const specWithApiKey = JSON.stringify({
+  ...baseDoc,
+  components: {
+    securitySchemes: {
+      apiKeyAuth: { type: 'apiKey', in: 'header', name: 'X-Api-Key' },
+      basicAuth: { type: 'http', scheme: 'basic' },
+      oauth: { type: 'oauth2', flows: {} },
+    },
+  },
+})
+
+const specWithoutSecurity = JSON.stringify(baseDoc)
+
+describe('buildOpenApiConfigSchema', () => {
+  it('returns a passthrough base schema when no spec is provided', async () => {
+    const schema = await buildOpenApiConfigSchema(undefined)
+    const parsed = schema.parse({ spec: 'anything', extra: 'kept' })
+    expect(parsed).toEqual({ spec: 'anything', extra: 'kept' })
+  })
+
+  it('falls back to the base schema when the spec is not valid YAML/JSON', async () => {
+    const schema = await buildOpenApiConfigSchema('{ not: valid: yaml: [')
+    const parsed = schema.parse({ spec: 'x' })
+    expect(parsed).toEqual({ spec: 'x' })
+  })
+
+  it('falls back to the base schema when the document has no apiKey/http security schemes', async () => {
+    const schema = await buildOpenApiConfigSchema(specWithoutSecurity)
+    // Base schema only ever declares "spec"; no per-scheme secret fields were added.
+    expect(Object.keys((schema as any).shape)).toEqual(['spec'])
+  })
+
+  it('extends the schema with declared secret fields for apiKey and http security schemes only', async () => {
+    const schema = await buildOpenApiConfigSchema(specWithApiKey)
+
+    const parsed = schema.parse({ spec: specWithApiKey, apiKeyAuth: 'secret-value' })
+    expect(parsed.apiKeyAuth).toBe('secret-value')
+
+    // oauth2 is not an apiKey/http scheme, so it must not become a declared secret field.
+    expect((schema as any).shape.oauth).toBeUndefined()
+    expect((schema as any).shape.apiKeyAuth).toBeDefined()
+    expect((schema as any).shape.basicAuth).toBeDefined()
+  })
+
+  it('treats secret fields as optional', async () => {
+    const schema = await buildOpenApiConfigSchema(specWithApiKey)
+    expect(() => schema.parse({ spec: specWithApiKey })).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
Adds unit tests for three previously untested (0% coverage) backend modules identified from the GitHub Pages coverage report: the OpenAPI tool's request-body/config-schema builders, the direct image-generation provider adapters, and the Meilisearch-backed conversation index. Overall statement coverage moves from 61.71% to 65.15%.

## Details
- `apps/backend/lib/tools/openapi/body.ts` and `utils.ts`, plus `apps/backend/lib/tools/configSchema.ts`: cover `application/json`, `x-www-form-urlencoded` (including the null vs required-field edge case), and `multipart/form-data` body construction (including file authorization/existence errors), and the OpenAPI security-scheme-to-secret-field schema extension logic. Coverage: 0% → 87-93%.
- `apps/backend/lib/imagegen/providers/{gemini,imagen,openai,replicate,together}.ts`: cover response normalization (dropping items without image data), size/model parameter mapping, and provider-specific error paths (missing image data, failed downloads, unauthorized/malformed inputs). Coverage: 7.8% → ~97%.
- `apps/backend/lib/search/MeiliIndex.ts`: covers the id hex-encoding round trip used for Meilisearch primary keys, search filter construction (`ownerId`/`assistantId`), and score/snippet fallback logic. Coverage: 0% → 66.66%.

Left out of scope: `search/{runtime,script}.ts` (worker/process bootstrap, low test value relative to mocking cost) and `search/indexer.ts`'s DB-orchestration functions (`syncIncremental`/`healNextRange`/`runWorker`) — the pure reconciliation logic (`diffRanges`) they call was already covered by an existing test file.

## Tests
- `npx vitest run` — 874 passed, 12 skipped (pre-existing skips), no regressions
- `npm run check-types` — clean
- `npx biome check` on the new test files — clean