### PR TITLE
test: cover remaining router and retrieve-file tool branches

### DIFF
--- a/apps/backend/lib/tools/retrieve-file/__tests__/implementation.test.ts
+++ b/apps/backend/lib/tools/retrieve-file/__tests__/implementation.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { FileManagerPlugin } from '@/backend/lib/tools/retrieve-file/implementation'
+import type { ToolFunction, ToolInvokeParams, ToolParams } from '@/lib/chat/tools'
+
+const mockFileExecuteTakeFirst = vi.fn()
+const mockBlobExecuteTakeFirst = vi.fn()
+const mockCanAccessFile = vi.fn()
+const mockExtractFromFile = vi.fn()
+const mockReadBuffer = vi.fn()
+
+vi.mock('@/db/database', () => ({
+  db: {
+    selectFrom: (table: string) => {
+      if (table === 'File') {
+        return {
+          selectAll: () => ({
+            where: () => ({ where: () => ({ executeTakeFirst: mockFileExecuteTakeFirst }), executeTakeFirst: mockFileExecuteTakeFirst }),
+          }),
+        }
+      }
+      return {
+        select: () => ({
+          where: () => ({ executeTakeFirst: mockBlobExecuteTakeFirst }),
+        }),
+      }
+    },
+  },
+}))
+
+vi.mock('@/backend/lib/files/authorization', () => ({
+  canAccessFile: (...args: unknown[]) => mockCanAccessFile(...args),
+}))
+vi.mock('@/lib/textextraction/cache', () => ({
+  cachingExtractor: { extractFromFile: (...args: unknown[]) => mockExtractFromFile(...args) },
+}))
+vi.mock('@/lib/storage', () => ({
+  storage: { readBuffer: (...args: unknown[]) => mockReadBuffer(...args) },
+}))
+
+beforeEach(() => {
+  mockFileExecuteTakeFirst.mockReset()
+  mockBlobExecuteTakeFirst.mockReset()
+  mockCanAccessFile.mockReset().mockResolvedValue(true)
+  mockExtractFromFile.mockReset()
+  mockReadBuffer.mockReset()
+})
+
+const toolParams: ToolParams = { id: 't1', name: 'fm', provisioned: false, promptFragment: '' }
+
+function makeInvokeParams(params: Record<string, unknown>, userId = 'user-1'): ToolInvokeParams {
+  return {
+    llmModel: {} as any,
+    messages: [],
+    assistantId: 'assistant-1',
+    userId,
+    params,
+    uiLink: { debugMessage: vi.fn(), addCitations: vi.fn(), attachments: [], citations: [] },
+  }
+}
+
+describe('FileManagerPlugin getFile', () => {
+  it('returns an error when no file matches the given name', async () => {
+    mockFileExecuteTakeFirst.mockResolvedValue(undefined)
+    const plugin = new FileManagerPlugin(toolParams, {})
+    const fns = (await plugin.functions({} as any, { userId: 'user-1' })) as Record<
+      string,
+      ToolFunction
+    >
+
+    const result = await fns.getFile.invoke(makeInvokeParams({ name: 'missing.txt' }))
+
+    expect(result).toEqual({ type: 'error-text', value: 'File not found' })
+  })
+
+  it('returns an error when the caller cannot access the matched file', async () => {
+    mockFileExecuteTakeFirst.mockResolvedValue({ id: 'f1', name: 'a.txt', type: 'text/plain', size: 10 })
+    mockCanAccessFile.mockResolvedValue(false)
+    const plugin = new FileManagerPlugin(toolParams, {})
+    const fns = (await plugin.functions({} as any, { userId: 'user-1' })) as Record<
+      string,
+      ToolFunction
+    >
+
+    const result = await fns.getFile.invoke(makeInvokeParams({ name: 'a.txt' }))
+
+    expect(result).toEqual({ type: 'error-text', value: 'File not found' })
+  })
+
+  it('returns the file as a content attachment when found and accessible', async () => {
+    mockFileExecuteTakeFirst.mockResolvedValue({
+      id: 'f1',
+      name: 'a.txt',
+      type: 'text/plain',
+      size: 10,
+      fileBlobId: null,
+    })
+    const plugin = new FileManagerPlugin(toolParams, {})
+    const fns = (await plugin.functions({} as any, { userId: 'user-1' })) as Record<
+      string,
+      ToolFunction
+    >
+
+    const result = await fns.getFile.invoke(makeInvokeParams({ name: 'a.txt' }))
+
+    expect(result).toEqual({
+      type: 'content',
+      value: [{ type: 'file', id: 'f1', size: 10, name: 'a.txt', mimetype: 'text/plain' }],
+    })
+  })
+})
+
+describe('FileManagerPlugin getFileDbRowBy blob resolution', () => {
+  it('overrides size/encryption from the linked FileBlob row when fileBlobId is set', async () => {
+    mockFileExecuteTakeFirst.mockResolvedValue({
+      id: 'f1',
+      name: 'a.txt',
+      type: 'text/plain',
+      size: 999,
+      encryption: null,
+      fileBlobId: 'blob-1',
+      path: 'files/a.txt',
+    })
+    mockBlobExecuteTakeFirst.mockResolvedValue({ size: 42, encryption: 'pgp' })
+    mockExtractFromFile.mockResolvedValue('extracted')
+
+    const plugin = new FileManagerPlugin(toolParams, {})
+    const fns = (await plugin.functions({} as any, { userId: 'user-1' })) as Record<
+      string,
+      ToolFunction
+    >
+
+    const result = await fns.getFile.invoke(makeInvokeParams({ name: 'a.txt' }))
+
+    expect(result).toEqual({
+      type: 'content',
+      value: [{ type: 'file', id: 'f1', size: 42, name: 'a.txt', mimetype: 'text/plain' }],
+    })
+  })
+
+  it('falls back to the File row size/encryption when there is no linked blob', async () => {
+    mockFileExecuteTakeFirst.mockResolvedValue({
+      id: 'f1',
+      name: 'a.txt',
+      type: 'text/plain',
+      size: 7,
+      encryption: 'none',
+      fileBlobId: null,
+      path: 'files/a.txt',
+    })
+
+    const plugin = new FileManagerPlugin(toolParams, {})
+    const fns = (await plugin.functions({} as any, { userId: 'user-1' })) as Record<
+      string,
+      ToolFunction
+    >
+
+    const result = await fns.getFile.invoke(makeInvokeParams({ name: 'a.txt' }))
+
+    expect(result).toEqual({
+      type: 'content',
+      value: [{ type: 'file', id: 'f1', size: 7, name: 'a.txt', mimetype: 'text/plain' }],
+    })
+    expect(mockBlobExecuteTakeFirst).not.toHaveBeenCalled()
+  })
+})
+
+describe('FileManagerPlugin read_file not-found path', () => {
+  it('returns an error when no file matches the given id', async () => {
+    mockFileExecuteTakeFirst.mockResolvedValue(undefined)
+    const plugin = new FileManagerPlugin(toolParams, {})
+    const fns = (await plugin.functions({} as any, { userId: 'user-1' })) as Record<
+      string,
+      ToolFunction
+    >
+
+    const result = await fns.read_file.invoke(makeInvokeParams({ id: 'missing' }))
+
+    expect(result).toEqual({ type: 'error-text', value: 'File not found' })
+  })
+})

--- a/apps/backend/lib/tools/router/__tests__/implementation.test.ts
+++ b/apps/backend/lib/tools/router/__tests__/implementation.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { LlmModel } from '@/lib/chat/models'
+import type { ToolImplementation, ToolParams } from '@/lib/chat/tools'
+
+const mockBuildTool = vi.fn()
+
+vi.mock('@/backend/lib/tools/enumerate', () => ({
+  buildTool: (...args: unknown[]) => mockBuildTool(...args),
+}))
+
+import { Router } from '@/backend/lib/tools/router/implementation'
+
+const model = { model: 'gemini-2.5-pro' } as unknown as LlmModel
+
+const routerToolParams: ToolParams = {
+  id: 'r1',
+  name: 'router',
+  promptFragment: '',
+  provisioned: false,
+}
+
+const makeTool = (overrides: Partial<ToolImplementation>): ToolImplementation =>
+  ({
+    supportedMedia: [],
+    toolParams: { id: 't1', name: 'tool', promptFragment: '', provisioned: false } as ToolParams,
+    functions: async () => ({}),
+    ...overrides,
+  }) as ToolImplementation
+
+describe('Router matching exclusions', () => {
+  it('skips a choice whose implementation reports the model as unsupported', async () => {
+    const unsupported = makeTool({
+      isModelSupported: () => false,
+      functions: async () => ({ from_unsupported: { description: '', invoke: async () => ({ type: 'text', value: 'x' }) } }),
+    })
+    const fallback = makeTool({
+      functions: async () => ({ from_fallback: { description: '', invoke: async () => ({ type: 'text', value: 'x' }) } }),
+    })
+    const router = new Router(routerToolParams, [
+      { implementation: unsupported },
+      { implementation: fallback },
+    ])
+
+    const functions = await router.functions(model, { userId: 'u1' })
+
+    expect(Object.keys(functions)).toEqual(['from_fallback'])
+  })
+
+  it('skips a choice whose restrictions exclude the current model', async () => {
+    const restricted = makeTool({
+      functions: async () => ({ from_restricted: { description: '', invoke: async () => ({ type: 'text', value: 'x' }) } }),
+    })
+    const fallback = makeTool({
+      functions: async () => ({ from_fallback: { description: '', invoke: async () => ({ type: 'text', value: 'x' }) } }),
+    })
+    const router = new Router(routerToolParams, [
+      { implementation: restricted, restrictions: { models: ['some-other-model'] } },
+      { implementation: fallback },
+    ])
+
+    const functions = await router.functions(model, { userId: 'u1' })
+
+    expect(Object.keys(functions)).toEqual(['from_fallback'])
+  })
+
+  it('matches a restricted choice when the current model is in its allow-list', async () => {
+    const restricted = makeTool({
+      functions: async () => ({ from_restricted: { description: '', invoke: async () => ({ type: 'text', value: 'x' }) } }),
+    })
+    const router = new Router(routerToolParams, [
+      { implementation: restricted, restrictions: { models: ['gemini-2.5-pro'] } },
+    ])
+
+    const functions = await router.functions(model, { userId: 'u1' })
+
+    expect(Object.keys(functions)).toEqual(['from_restricted'])
+  })
+
+  it('returns no functions and empty provider options when nothing matches', async () => {
+    const unsupported = makeTool({ isModelSupported: () => false })
+    const router = new Router(routerToolParams, [{ implementation: unsupported }])
+
+    expect(await router.functions(model, { userId: 'u1' })).toEqual({})
+    expect(router.providerOptions(model)).toEqual({})
+  })
+})
+
+describe('Router.builder', () => {
+  it('builds one implementation per choice and drops choices whose tool fails to build', async () => {
+    mockBuildTool
+      .mockResolvedValueOnce(
+        makeTool({
+          functions: async () => ({
+            built: { description: '', invoke: async () => ({ type: 'text', value: 'x' }) },
+          }),
+        })
+      )
+      .mockResolvedValueOnce(undefined)
+
+    const router = await Router.builder(
+      routerToolParams,
+      {
+        choices: [
+          { type: 'dummy', configuration: { a: 1 } },
+          { type: 'unbuildable', configuration: {} },
+        ],
+      },
+      'gemini-2.5-pro'
+    )
+
+    expect(mockBuildTool).toHaveBeenCalledTimes(2)
+    expect(mockBuildTool).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ type: 'dummy', configuration: { a: 1 } }),
+      'gemini-2.5-pro'
+    )
+    // Only the successfully built choice should end up in the router's choices.
+    const functions = await (router as Router).functions(model, { userId: 'u1' })
+    expect(Object.keys(functions)).toEqual(['built'])
+  })
+})


### PR DESCRIPTION
## Summary
Closes the remaining coverage gaps in two tool implementations that already had partial coverage. `router/implementation.ts` and `retrieve-file/implementation.ts` both move to 100% statement coverage. Overall project statement coverage moves from 68.31% to 68.7%.

## Details
- `tools/router/implementation.ts`: the existing top-level test (`routerFirstMatch.test.ts`) only covered the first-match happy path. Added coverage for the exclusion branches (`isModelSupported` returning false, `restrictions.models` not including the current model), the case where no choice matches (empty functions/providerOptions), and the `Router.builder` static method assembling choices while dropping any whose underlying tool fails to build.
- `tools/retrieve-file/implementation.ts`: the existing test (`retrieveFileTool.test.ts`) only covered `read_file`. Added coverage for `getFile` (not-found, access-denied, success), the `FileBlob` join in `getFileDbRowBy` (size/encryption overridden from the linked blob vs. falling back to the `File` row's own values), and the not-found path for `read_file`.

## Tests
- `npx vitest run` — 912 passed, 12 skipped (pre-existing skips), no regressions
- `npm run check-types` — clean
- `npx biome check` on the new test files — clean