### PR TITLE
fix: always show satellite nav icon for admins

### DIFF
--- a/apps/frontend/app/layouts/MainLayout.tsx
+++ b/apps/frontend/app/layouts/MainLayout.tsx
@@ -16,10 +16,14 @@ import { useLayoutConfig } from '@/components/providers/layoutconfigContext'
 import { t } from 'i18next'
 import { useEnvironment } from '../context/environmentProvider'
 import { useSatellites } from '@/hooks/satellites'
+import { useUserProfile } from '@/components/providers/userProfileContext'
+import * as dto from '@/types/dto'
 
 const SatelliteNavIcon: React.FC = () => {
+  const userProfile = useUserProfile()
   const { data, isLoading } = useSatellites()
-  if (!isLoading && data.length === 0) return null
+  const isAdmin = userProfile?.role === dto.UserRole.ADMIN
+  if (!isAdmin && !isLoading && data.length === 0) return null
   return (
     <Link href="/satellites" title="Satellites" className="relative">
       <IconSatellite size={28}></IconSatellite>


### PR DESCRIPTION
## Summary
The satellite nav icon in the quick bar is now always visible to admins, and for non-admin users it remains visible only once they have at least one satellite. Previously the icon was hidden for everyone until a satellite already existed, which made it impossible for admins to reach `/satellites` to create the first non-ephemeral satellite.

## Tests
- `npm run check-types` — passes