### PR TITLE
[codex] default file encryption to aead

### DIFF
--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -170,7 +170,7 @@ const env = {
   fileStorage: {
     location: process.env.FILE_STORAGE_LOCATION,
     cacheSizeInMb: parseFloat(process.env.FILE_STORAGE_CACHE_SIZE_MB ?? '0'),
-    encryptionProvider: process.env.FILE_STORAGE_ENCRYPTION_PROVIDER || 'pgp',
+    encryptionProvider: process.env.FILE_STORAGE_ENCRYPTION_PROVIDER || 'aead',
     encryptionKey: process.env.FILE_STORAGE_ENCRYPTION_KEY ?? 'CHANGEIT',
     encryptFiles: process.env.FILE_STORAGE_ENCRYPTION_ENABLE === '1',
   },


### PR DESCRIPTION
## Summary
Update the shared file-storage default encryption provider from `pgp` to `aead` so new environments use the newer provider unless explicitly overridden.

## Details
- Changes the fallback in `packages/core/src/env.ts` for `FILE_STORAGE_ENCRYPTION_PROVIDER`.
- Leaves the explicit environment override behavior unchanged.

## Tests
- Not run; this is a small configuration default change.
