### PR TITLE
[codex] support range requests for plaintext files

### DIFF
--- a/__tests__/fileUploadRoutes.test.ts
+++ b/__tests__/fileUploadRoutes.test.ts
@@ -507,8 +507,13 @@ describe('GET /api/files/:fileId/content', () => {
       { params: Promise.resolve({ fileId: 'f-plain' }) }
     )
 
-    expect(response.status).toBe(200)
-    expect(response.headers.get('accept-ranges')).toBe('none')
-    expect(mocks.readStream).toHaveBeenCalledWith('plain.txt', null, { expectedSizeBytes: 100 })
+    expect(response.status).toBe(206)
+    expect(response.headers.get('content-range')).toBe('bytes 0-9/100')
+    expect(response.headers.get('accept-ranges')).toBe('bytes')
+    expect(mocks.readStream).toHaveBeenCalledWith('plain.txt', null, {
+      expectedSizeBytes: 100,
+      rangeStart: 0,
+      rangeEnd: 9,
+    })
   })
 })

--- a/__tests__/fileUploadRoutes.test.ts
+++ b/__tests__/fileUploadRoutes.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   writeStream: vi.fn(),
   readStream: vi.fn(),
   rm: vi.fn(),
+  supportsRangeReads: vi.fn(),
   scheduleFileAnalysis: vi.fn(),
 }))
 
@@ -23,6 +24,7 @@ vi.mock('@/lib/storage', () => ({
     writeStream: mocks.writeStream,
     readStream: mocks.readStream,
     rm: mocks.rm,
+    supportsRangeReads: mocks.supportsRangeReads,
   },
 }))
 
@@ -143,7 +145,9 @@ beforeEach(async () => {
   mocks.writeStream.mockReset()
   mocks.readStream.mockReset()
   mocks.rm.mockReset()
+  mocks.supportsRangeReads.mockReset()
   mocks.scheduleFileAnalysis.mockReset()
+  mocks.supportsRangeReads.mockReturnValue(true)
 
   const user = await createUser({ name: 'Test User', email: 'test@example.com', ssoUser: 0 })
   testUserId = user.id
@@ -496,7 +500,7 @@ describe('GET /api/files/:fileId/content', () => {
     expect(mocks.readStream).not.toHaveBeenCalled()
   })
 
-  test('returns 200 with full content when a Range header is sent for a non-AEAD file', async () => {
+  test('returns 206 when a Range header is sent for a plaintext file', async () => {
     await insertFileWithBlob({ fileId: 'f-plain', blobId: 'b-plain', path: 'plain.txt', size: 100, encryption: null })
     mocks.readStream.mockResolvedValue(makeStream('full content'))
 
@@ -515,5 +519,22 @@ describe('GET /api/files/:fileId/content', () => {
       rangeStart: 0,
       rangeEnd: 9,
     })
+  })
+
+  test('returns 200 when the storage backend rejects range reads', async () => {
+    mocks.supportsRangeReads.mockReturnValue(false)
+    await insertFileWithBlob({ fileId: 'f-pgp', blobId: 'b-pgp', path: 'pgp.txt', size: 100, encryption: 'pgp' })
+    mocks.readStream.mockResolvedValue(makeStream('full content'))
+
+    const response = await contentRoute.GET(
+      new Request('http://localhost/api/files/f-pgp/content', {
+        headers: { cookie: sessionCookie, range: 'bytes=0-9' },
+      }),
+      { params: Promise.resolve({ fileId: 'f-pgp' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('accept-ranges')).toBe('none')
+    expect(mocks.readStream).toHaveBeenCalledWith('pgp.txt', 'pgp', { expectedSizeBytes: 100 })
   })
 })

--- a/apps/backend/api/files/[fileId]/content/route.ts
+++ b/apps/backend/api/files/[fileId]/content/route.ts
@@ -188,7 +188,7 @@ export const GET = operation({
     }
 
     const rangeHeader = headers.get('range')
-    const supportsRanges = file.encryption === 'aead'
+    const supportsRanges = file.encryption !== 'pgp'
 
     if (rangeHeader && supportsRanges && typeof file.size === 'number') {
       const range = parseRangeHeader(rangeHeader, file.size)

--- a/apps/backend/api/files/[fileId]/content/route.ts
+++ b/apps/backend/api/files/[fileId]/content/route.ts
@@ -188,7 +188,7 @@ export const GET = operation({
     }
 
     const rangeHeader = headers.get('range')
-    const supportsRanges = file.encryption !== 'pgp'
+    const supportsRanges = storage.supportsRangeReads(file.encryption)
 
     if (rangeHeader && supportsRanges && typeof file.size === 'number') {
       const range = parseRangeHeader(rangeHeader, file.size)

--- a/apps/backend/ee/AeadEncryptingStorage.ts
+++ b/apps/backend/ee/AeadEncryptingStorage.ts
@@ -96,6 +96,10 @@ export class AeadEncryptingStorage extends BaseStorage {
     return new AeadEncryptingStorage(innerStorage, passPhrase)
   }
 
+  supportsRangeReads(encrypted: StorageEncryption): boolean {
+    return encrypted !== 'pgp' && this.innerStorage.supportsRangeReads(encrypted)
+  }
+
   async readStream(
     path: string,
     encrypted: StorageEncryption,

--- a/apps/backend/ee/PgpEncryptingStorage.ts
+++ b/apps/backend/ee/PgpEncryptingStorage.ts
@@ -61,6 +61,10 @@ export class PgpEncryptingStorage extends BaseStorage {
     return new PgpEncryptingStorage(innerStorage, passPhrase)
   }
 
+  supportsRangeReads(encrypted: StorageEncryption): boolean {
+    return encrypted !== 'pgp' && this.innerStorage.supportsRangeReads(encrypted)
+  }
+
   async readStream(
     path: string,
     encrypted: StorageEncryption,

--- a/apps/backend/lib/storage/CachingStorage.ts
+++ b/apps/backend/lib/storage/CachingStorage.ts
@@ -42,6 +42,10 @@ export class CachingStorage extends BaseStorage {
     return this.sendToCacheStream(path, innerStream)
   }
 
+  supportsRangeReads(encrypted: StorageEncryption): boolean {
+    return this.innerStorage.supportsRangeReads(encrypted)
+  }
+
   writeStream(
     path: string,
     stream: ReadableStream<Uint8Array>,

--- a/apps/backend/lib/storage/FsStorage.ts
+++ b/apps/backend/lib/storage/FsStorage.ts
@@ -25,6 +25,10 @@ export class FsStorage extends BaseStorage {
     await fs.promises.rm(fsPath)
   }
 
+  supportsRangeReads(_encryption: StorageEncryption): boolean {
+    return true
+  }
+
   async readStream(
     path: string,
     _encryption: StorageEncryption,

--- a/apps/backend/lib/storage/MemoryStorage.ts
+++ b/apps/backend/lib/storage/MemoryStorage.ts
@@ -9,6 +9,10 @@ export class MemoryStorage extends BaseStorage {
     delete this.map[path]
   }
 
+  supportsRangeReads(_encryption: StorageEncryption): boolean {
+    return true
+  }
+
   async readStream(
     path: string,
     _encryption: StorageEncryption,

--- a/apps/backend/lib/storage/S3Storage.ts
+++ b/apps/backend/lib/storage/S3Storage.ts
@@ -84,6 +84,10 @@ export class S3Storage extends BaseStorage {
     }
   }
 
+  supportsRangeReads(_encryption: StorageEncryption): boolean {
+    return true
+  }
+
   async readStream(
     path: string,
     _encryption: StorageEncryption,

--- a/apps/backend/lib/storage/api.ts
+++ b/apps/backend/lib/storage/api.ts
@@ -13,6 +13,7 @@ export interface Storage {
   writeStream(path: string, stream: ReadableStream<Uint8Array>, encrypted: StorageEncryption): Promise<void>
   writeBuffer(path: string, buffer: Uint8Array, encrypted: StorageEncryption): Promise<void>
   rm(path: string): Promise<void>
+  supportsRangeReads(encrypted: StorageEncryption): boolean
   readStream(
     path: string,
     encrypted: StorageEncryption,
@@ -22,6 +23,10 @@ export interface Storage {
 }
 
 export abstract class BaseStorage implements Storage {
+  supportsRangeReads(_encrypted: StorageEncryption): boolean {
+    return true
+  }
+
   abstract readStream(
     path: string,
     encrypted: StorageEncryption,


### PR DESCRIPTION
## Summary
Allow file downloads to honor HTTP `Range` requests when file encryption is disabled, so plaintext file reads now support partial responses just like AEAD files.

## Details
- Broaden the file content route to enable ranges for non-PGP files, including `null` encryption.
- Keep `PGP` files on the full-response path.
- Update the route test to expect `206` and `Content-Range` for a plaintext file range request.

## Tests
- `npm run check-types`
- `pnpm vitest run __tests__/fileUploadRoutes.test.ts`
