### PR TITLE
[codex] move message limit banner

### DIFF
--- a/apps/frontend/app/chat/components/Chat.tsx
+++ b/apps/frontend/app/chat/components/Chat.tsx
@@ -13,6 +13,8 @@ import { ConversationSidebar } from './ConversationSidebar'
 import { useTranslation } from 'react-i18next'
 import { useTokenRateLimit } from '@/components/providers/tokenRateLimitContext'
 import { TokenRateLimitBanner } from './TokenRateLimitBanner'
+import { MessageLimitBanner } from './MessageLimitBanner'
+import { useEnvironment } from '@/app/context/environmentProvider'
 
 export interface ChatProps {
   assistant: dto.AssistantIdentification & {
@@ -43,6 +45,7 @@ export const Chat = ({
     setSideBarContent,
   } = useContext(ChatPageContext)
   const tokenRateLimit = useTokenRateLimit()
+  const environment = useEnvironment()
   const { t } = useTranslation()
 
   const [chatInput, setChatInput] = useChatInput(selectedConversation?.id ?? '')
@@ -125,6 +128,12 @@ export const Chat = ({
     streamingMessageId
   )
   const userMessageCount = groupList.filter((g) => g.actor === 'user').length
+  const hardMessageLimitReached =
+    environment.hardMessageLimit !== undefined && userMessageCount >= environment.hardMessageLimit
+  const softMessageLimitReached =
+    !hardMessageLimitReached &&
+    environment.softMessageLimit !== undefined &&
+    userMessageCount >= environment.softMessageLimit
 
   return (
     <div className={`flex overflow-hidden gap-4 ${className ?? ''}`}>
@@ -181,6 +190,16 @@ export const Chat = ({
             })
           }}
         />
+        {(hardMessageLimitReached || softMessageLimitReached) && (
+          <MessageLimitBanner
+            variant={hardMessageLimitReached ? 'block' : 'warning'}
+            count={
+              hardMessageLimitReached
+                ? environment.hardMessageLimit ?? userMessageCount
+                : environment.softMessageLimit ?? userMessageCount
+            }
+          />
+        )}
         {tokenRateLimit?.enabled && tokenRateLimit.exceeded && <TokenRateLimitBanner />}
       </div>
       {sideBarContent && <ConversationSidebar content={sideBarContent} />}

--- a/apps/frontend/app/chat/components/ChatInput.tsx
+++ b/apps/frontend/app/chat/components/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { IconAlertTriangle, IconBan, IconPaperclip, IconPlayerStopFilled, IconSend2 } from '@tabler/icons-react'
+import { IconPaperclip, IconPlayerStopFilled, IconSend2 } from '@tabler/icons-react'
 import {
   ChangeEvent,
   DragEvent,
@@ -96,8 +96,6 @@ export const ChatInput = ({
   }
   const environment = useEnvironment()
   const model = environment.models.find((candidate) => candidate.id === modelId)
-  const softLimitReached =
-    environment.softMessageLimit !== undefined && (userMessageCount ?? 0) >= environment.softMessageLimit
   const hardLimitReached =
     (environment.hardMessageLimit !== undefined && (userMessageCount ?? 0) >= environment.hardMessageLimit) ||
     !!locked
@@ -541,30 +539,6 @@ export const ChatInput = ({
             </>
           )}
         </div>
-        {(softLimitReached || hardLimitReached) && (
-          <div
-            className={`mt-2 flex items-center gap-2.5 rounded-xl border px-4 py-2.5 text-sm font-medium ${
-              hardLimitReached
-                ? 'border-destructive/40 bg-destructive/10 text-destructive'
-                : 'border-amber-400 bg-amber-50 text-amber-800 dark:border-amber-600 dark:bg-amber-950 dark:text-amber-300'
-            }`}
-          >
-            {hardLimitReached ? (
-              <IconBan size={16} className="shrink-0" />
-            ) : (
-              <IconAlertTriangle size={16} className="shrink-0" />
-            )}
-            <span>
-              {hardLimitReached
-                ? t('chat-hard-message-limit-reached', {
-                    count: environment.hardMessageLimit ?? userMessageCount,
-                  })
-                : t('chat-soft-message-limit-warning', {
-                    count: environment.softMessageLimit ?? userMessageCount,
-                  })}
-            </span>
-          </div>
-        )}
         <ChatDisclaimer
           rightSlot={
             <ContextLengthIndicator

--- a/apps/frontend/app/chat/components/MessageLimitBanner.tsx
+++ b/apps/frontend/app/chat/components/MessageLimitBanner.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { IconAlertTriangle, IconBan } from '@tabler/icons-react'
+import { useTranslation } from 'react-i18next'
+
+import { cn } from '@/frontend/lib/utils'
+
+export interface MessageLimitBannerProps {
+  variant: 'warning' | 'block'
+  count?: number
+  className?: string
+}
+
+export function MessageLimitBanner({ variant, count, className }: MessageLimitBannerProps) {
+  const { t } = useTranslation()
+  const isBlock = variant === 'block'
+
+  return (
+    <output
+      className={cn(
+        'block border-t px-4 py-1.5',
+        isBlock
+          ? 'border-destructive/40 bg-destructive/10 text-destructive'
+          : 'border-amber-300/60 bg-amber-50 text-amber-800',
+        className
+      )}
+    >
+      <div className="mx-auto flex max-w-[var(--thread-content-max-width)] items-center gap-2">
+        {isBlock ? (
+          <IconBan size={16} stroke={2} className="shrink-0" aria-hidden="true" />
+        ) : (
+          <IconAlertTriangle size={16} stroke={2} className="shrink-0" aria-hidden="true" />
+        )}
+        <p className="text-sm">
+          {t(isBlock ? 'chat-hard-message-limit-reached' : 'chat-soft-message-limit-warning', { count })}
+        </p>
+      </div>
+    </output>
+  )
+}


### PR DESCRIPTION
## Summary
Move the message limit notice out of the chat input and into the chat surface so the warning/blocking state is visible in the thread layout instead of competing with the composer.

## Details
- Introduce a shared `MessageLimitBanner` component for warning and hard-block states.
- Render the banner from `Chat` based on the environment soft/hard message limits.
- Remove the inline limit notice from `ChatInput` so the composer stays focused on message entry.

## Tests
- `npm run check-types`
