### PR TITLE
[codex] fix Anthropic endpoint

### DIFF
--- a/__tests__/providerFactory.test.ts
+++ b/__tests__/providerFactory.test.ts
@@ -88,7 +88,7 @@ describe('createLanguageModelBasic', () => {
 
     expect(mockCreateAnthropic).toHaveBeenCalledWith(
       expect.objectContaining({
-        baseURL: 'https://proxy.example.com/anthropic',
+        baseURL: 'https://proxy.example.com/anthropic/v1',
         headers: { 'x-litellm-customer-id': 'customer-1' },
       })
     )

--- a/apps/backend/lib/chat/provider-factory.ts
+++ b/apps/backend/lib/chat/provider-factory.ts
@@ -113,7 +113,7 @@ export function createLanguageModelBasic(
         return anthropic
           .createAnthropic({
             apiKey: params.provisioned ? expandEnv(params.apiKey) : params.apiKey,
-            baseURL: `${params.endPoint}/anthropic`,
+            baseURL: `${params.endPoint}/anthropic/v1`,
             headers: options.user ? { 'x-litellm-customer-id': options.user } : undefined,
             fetch,
           })


### PR DESCRIPTION
## Summary
Fix Anthropic logiclecloud requests to use the correct `/anthropic/v1` base URL so Claude requests reach the provider endpoint that the SDK expects.

## Details
- Correct the Anthropic base URL used by `logiclecloud` in `createLanguageModelBasic`.
- This fixes failures caused by requests being sent to `/anthropic` instead of `/anthropic/v1`.

## Tests
- Not run; this is a one-line endpoint fix.
