### PR TITLE
[codex] add o3 deep research web search

### DIFF
--- a/packages/core/src/models/openai.ts
+++ b/packages/core/src/models/openai.ts
@@ -195,6 +195,7 @@ export const o3DeepResearchModel: LlmModel = {
     vision: true, // Deep Research can analyze images/PDFs it finds or that you attach
     function_calling: true, // uses Responses API "tools" (web_search_preview, code_interpreter, mcp)
     knowledge: false,
+    web_search: true,
     supportedMedia: ['text/html', 'application/pdf', 'image/png', 'image/jpeg'],
   },
   supportedReasoningEfforts: ['low', 'medium', 'high'],


### PR DESCRIPTION
## Summary
Enable `web_search` on the `o3-deep-research` model capability metadata so the registry reflects the model's supported toolset.

## Details
- Marks `o3-deep-research` as supporting `web_search` in `packages/core/src/models/openai.ts`.
- Keeps the shared model manifest aligned with the model's documented deep research behavior.

## Tests
- `npm run check-types`
