### PR TITLE
[0.31 backport] add o3 deep research web search

### DIFF
--- a/packages/core/src/models/openai.ts
+++ b/packages/core/src/models/openai.ts
@@ -195,6 +195,7 @@ export const o3DeepResearchModel: LlmModel = {
     vision: true, // Deep Research can analyze images/PDFs it finds or that you attach
     function_calling: true, // uses Responses API "tools" (web_search_preview, code_interpreter, mcp)
     knowledge: false,
+    web_search: true,
     supportedMedia: ['text/html', 'application/pdf', 'image/png', 'image/jpeg'],
   },
   supportedReasoningEfforts: ['low', 'medium', 'high'],


### PR DESCRIPTION
## Summary
Backport the `o3-deep-research` capability update from `logicleai/logicle#1001` onto the `0.31` release line.

## Details
- Sets `web_search: true` for `o3-deep-research` in `packages/core/src/models/openai.ts`.
- Keeps the release branch aligned with the same model capability metadata used on `main`.

## Tests
- `npm run check-types`
