### PR TITLE
[release/v0.31.x] backport o3 deep research web search

### DIFF
--- a/packages/core/src/models/openai.ts
+++ b/packages/core/src/models/openai.ts
@@ -195,6 +195,7 @@ export const o3DeepResearchModel: LlmModel = {
     vision: true, // Deep Research can analyze images/PDFs it finds or that you attach
     function_calling: true, // uses Responses API "tools" (web_search_preview, code_interpreter, mcp)
     knowledge: false,
+    web_search: true,
     supportedMedia: ['text/html', 'application/pdf', 'image/png', 'image/jpeg'],
   },
   supportedReasoningEfforts: ['low', 'medium', 'high'],


### PR DESCRIPTION
## Summary
Backport the `o3-deep-research` capability update from `logicleai/logicle#1001` onto `release/v0.31.x`.

## Details
- Sets `web_search: true` for `o3-deep-research` in `packages/core/src/models/openai.ts`.
- Keeps the release branch aligned with the model capability metadata from `main`.

## Tests
- `npm run check-types`
