### PR TITLE
fix model alias ids

### DIFF
--- a/packages/core/src/models/anthropic.ts
+++ b/packages/core/src/models/anthropic.ts
@@ -14,7 +14,7 @@ export const claudeThinkingBudgetTokens = (reasoning_effort?: ReasoningEffort) =
 }
 
 export const claude3HaikuModel: LlmModel = {
-  id: 'claude-3-haiku-20240307',
+  id: 'claude-3-haiku',
   model: 'claude-3-haiku-20240307',
   name: 'Claude 3 Haiku',
   description: 'Fastest and most compact model for near-instant responsiveness',
@@ -30,7 +30,7 @@ export const claude3HaikuModel: LlmModel = {
 }
 
 export const claude3SonnetModel: LlmModel = {
-  id: 'claude-3-sonnet-20240229',
+  id: 'claude-3-sonnet',
   model: 'claude-3-sonnet-20240229',
   name: 'Claude 3 Sonnet',
   description: 'Balance of intelligence and speed',

--- a/packages/core/src/models/openai.ts
+++ b/packages/core/src/models/openai.ts
@@ -480,7 +480,7 @@ export const gptChatLatestModel: LlmModel = {
 
 export const gptLatest: LlmModel = {
   ...gpt54Model,
-  id: 'gpt-latest',
+  id: 'gpt-5-latest',
   name: 'Gpt latest (5.4)',
   tags: ['latest'],
 }


### PR DESCRIPTION
## Summary

Updates shared model metadata so stable alias IDs are used for the Claude 3 Haiku, Claude 3 Sonnet, and GPT latest entries while preserving the concrete provider model names used for requests.

## Tests

- `npm run check-types` failed because the local install resolves Perplexity as `LanguageModelV4` while `provider-factory.ts` currently expects `LanguageModelV3`; this is addressed by the separate Perplexity SDK upgrade PR.
