### PR TITLE
Postgres timestamp migration and API smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,26 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        db:
+          - sqlite
+          - postgres
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: admin
+          POSTGRES_PASSWORD: admin
+          POSTGRES_DB: logicle
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U admin -d logicle"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -178,11 +198,17 @@ jobs:
           set -euo pipefail
           trap 'status=$?; if [ "$status" -ne 0 ]; then echo "Smoke test failed; dumping container logs"; docker logs logicle-smoke || true; fi' EXIT
 
+          if [ "${{ matrix.db }}" = "postgres" ]; then
+            DATABASE_URL="postgresql://admin:admin@127.0.0.1:5432/logicle"
+          else
+            DATABASE_URL="file:///data/sqlite/logicle.sqlite"
+          fi
+
           docker run -d \
             --name logicle-smoke \
             -p 3000:3000 \
             -e APP_URL=http://localhost:3000 \
-            -e DATABASE_URL=file:///data/sqlite/logicle.sqlite \
+            -e DATABASE_URL="${DATABASE_URL}" \
             -e FILE_STORAGE_ENCRYPTION_ENABLE=1 \
             -e FILE_STORAGE_LOCATION=/data/files \
             "${SMOKE_IMAGE}"
@@ -206,10 +232,12 @@ jobs:
           node dist-scripts/smoke.js "http://127.0.0.1:3000"
 
       - name: Run integration baseline checks (main/dispatch)
-        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        if: (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && matrix.db == 'sqlite'
         run: |
           set -euo pipefail
           trap 'status=$?; if [ "$status" -ne 0 ]; then echo "Baseline test failed; dumping container logs"; docker logs logicle-smoke || true; fi' EXIT
+
+          DATABASE_URL=file:///data/sqlite/logicle.sqlite
 
           docker rm -f logicle-smoke || true
 
@@ -217,7 +245,7 @@ jobs:
             --name logicle-smoke \
             -p 3000:3000 \
             -e APP_URL=http://localhost:3000 \
-            -e DATABASE_URL=file:///data/sqlite/logicle.sqlite \
+            -e DATABASE_URL="${DATABASE_URL}" \
             -e FILE_STORAGE_ENCRYPTION_ENABLE=1 \
             -e FILE_STORAGE_LOCATION=/data/files \
             "${SMOKE_IMAGE}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,12 +122,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        db:
-          - sqlite
-          - postgres
     services:
       postgres:
         image: postgres:16
@@ -196,44 +190,52 @@ jobs:
       - name: Run smoke and baseline integration checks
         run: |
           set -euo pipefail
-          trap 'status=$?; if [ "$status" -ne 0 ]; then echo "Smoke test failed; dumping container logs"; docker logs logicle-smoke || true; fi' EXIT
 
-          if [ "${{ matrix.db }}" = "postgres" ]; then
-            DATABASE_URL="postgresql://admin:admin@host.docker.internal:5432/logicle"
-          else
-            DATABASE_URL="file:///data/sqlite/logicle.sqlite"
-          fi
+          run_smoke() {
+            local name="$1"
+            local database_url="$2"
 
-          docker run -d \
-            --name logicle-smoke \
-            --add-host=host.docker.internal:host-gateway \
-            -p 3000:3000 \
-            -e APP_URL=http://localhost:3000 \
-            -e DATABASE_URL="${DATABASE_URL}" \
-            -e FILE_STORAGE_ENCRYPTION_ENABLE=1 \
-            -e FILE_STORAGE_LOCATION=/data/files \
-            "${SMOKE_IMAGE}"
+            echo "Running smoke against ${name}"
+            docker rm -f logicle-smoke || true
 
-          echo "Waiting for app startup..."
-          ready=0
-          for i in $(seq 1 20); do
-            if curl -fsS http://localhost:3000/api/health >/dev/null; then
-              ready=1
-              break
+            docker run -d \
+              --name logicle-smoke \
+              --add-host=host.docker.internal:host-gateway \
+              -p 3000:3000 \
+              -e APP_URL=http://localhost:3000 \
+              -e DATABASE_URL="${database_url}" \
+              -e FILE_STORAGE_ENCRYPTION_ENABLE=1 \
+              -e FILE_STORAGE_LOCATION=/data/files \
+              "${SMOKE_IMAGE}"
+
+            echo "Waiting for app startup (${name})..."
+            ready=0
+            for i in $(seq 1 20); do
+              if curl -fsS http://localhost:3000/api/health >/dev/null; then
+                ready=1
+                break
+              fi
+              sleep 1
+            done
+
+            if [ "${ready}" -ne 1 ]; then
+              echo "Smoke test failed: app did not become ready within 20 seconds (${name})"
+              docker logs logicle-smoke || true
+              exit 1
             fi
-            sleep 1
-          done
 
-          if [ "${ready}" -ne 1 ]; then
-            echo "Smoke test failed: app did not become ready within 20 seconds"
-            docker logs logicle-smoke || true
-            exit 1
-          fi
+            if ! node dist-scripts/smoke.js "http://127.0.0.1:3000"; then
+              echo "Smoke test failed (${name}); dumping container logs"
+              docker logs logicle-smoke || true
+              exit 1
+            fi
+          }
 
-          node dist-scripts/smoke.js "http://127.0.0.1:3000"
+          run_smoke "sqlite" "file:///data/sqlite/logicle.sqlite"
+          run_smoke "postgres" "postgresql://admin:admin@host.docker.internal:5432/logicle"
 
       - name: Run integration baseline checks (main/dispatch)
-        if: (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && matrix.db == 'sqlite'
+        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail
           trap 'status=$?; if [ "$status" -ne 0 ]; then echo "Baseline test failed; dumping container logs"; docker logs logicle-smoke || true; fi' EXIT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,13 +199,14 @@ jobs:
           trap 'status=$?; if [ "$status" -ne 0 ]; then echo "Smoke test failed; dumping container logs"; docker logs logicle-smoke || true; fi' EXIT
 
           if [ "${{ matrix.db }}" = "postgres" ]; then
-            DATABASE_URL="postgresql://admin:admin@127.0.0.1:5432/logicle"
+            DATABASE_URL="postgresql://admin:admin@host.docker.internal:5432/logicle"
           else
             DATABASE_URL="file:///data/sqlite/logicle.sqlite"
           fi
 
           docker run -d \
             --name logicle-smoke \
+            --add-host=host.docker.internal:host-gateway \
             -p 3000:3000 \
             -e APP_URL=http://localhost:3000 \
             -e DATABASE_URL="${DATABASE_URL}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
               -p 3000:3000 \
               -e APP_URL=http://localhost:3000 \
               -e DATABASE_URL="${database_url}" \
+              -e ALLOW_MOCK_PROVIDER=1 \
               -e FILE_STORAGE_ENCRYPTION_ENABLE=1 \
               -e FILE_STORAGE_LOCATION=/data/files \
               "${SMOKE_IMAGE}"

--- a/apps/backend/db/migrations.generated.ts
+++ b/apps/backend/db/migrations.generated.ts
@@ -48,6 +48,7 @@ import * as m202606031ToolEnabled from './migrations/20260603.1-tool-enabled'
 import * as m20260622FileBlobEncryptionAlgorithm from './migrations/20260622-file_blob_encryption_algorithm'
 import * as m20260623UserTokenWindow from './migrations/20260623-user-token-window'
 import * as m20260705ContextCompression from './migrations/20260705-context-compression'
+import * as m20260708PostgresTimestampColumns from './migrations/20260708-postgres_timestamp_columns'
 
 import type { MigrationWithDialect } from './migrations'
 
@@ -100,4 +101,5 @@ export const migrationModules: Record<string, MigrationWithDialect> = {
   '20260622-file_blob_encryption_algorithm': m20260622FileBlobEncryptionAlgorithm,
   '20260623-user-token-window': m20260623UserTokenWindow,
   '20260705-context-compression': m20260705ContextCompression,
+  '20260708-postgres_timestamp_columns': m20260708PostgresTimestampColumns,
 }

--- a/apps/backend/db/migrations/20260708-postgres_timestamp_columns.ts
+++ b/apps/backend/db/migrations/20260708-postgres_timestamp_columns.ts
@@ -45,6 +45,11 @@ export async function up(db: Kysely<any>, dialect: 'sqlite' | 'postgresql'): Pro
 
     await sql`
       ALTER TABLE ${sql.table(table)}
+      ALTER COLUMN ${sql.ref(column)} DROP DEFAULT
+    `.execute(db)
+
+    await sql`
+      ALTER TABLE ${sql.table(table)}
       ALTER COLUMN ${sql.ref(column)} TYPE timestamp
       USING ${expression}
     `.execute(db)

--- a/apps/backend/db/migrations/20260708-postgres_timestamp_columns.ts
+++ b/apps/backend/db/migrations/20260708-postgres_timestamp_columns.ts
@@ -1,0 +1,52 @@
+import { Kysely, sql } from 'kysely'
+
+type TimestampColumn = {
+  table: string
+  column: string
+  nullable?: boolean
+}
+
+const timestampColumns: TimestampColumn[] = [
+  { table: 'User', column: 'createdAt' },
+  { table: 'User', column: 'updatedAt' },
+  { table: 'Workspace', column: 'createdAt' },
+  { table: 'Workspace', column: 'updatedAt' },
+  { table: 'WorkspaceMember', column: 'createdAt' },
+  { table: 'WorkspaceMember', column: 'updatedAt' },
+  { table: 'Conversation', column: 'createdAt' },
+  { table: 'Conversation', column: 'lastMsgSentAt', nullable: true },
+  { table: 'Message', column: 'sentAt' },
+  { table: 'AssistantVersion', column: 'createdAt' },
+  { table: 'AssistantVersion', column: 'updatedAt' },
+  { table: 'AssistantUserData', column: 'lastUsed', nullable: true },
+  { table: 'File', column: 'createdAt' },
+  { table: 'FileBlob', column: 'createdAt' },
+  { table: 'Tool', column: 'createdAt' },
+  { table: 'Tool', column: 'updatedAt' },
+  { table: 'ApiKey', column: 'createdAt' },
+  { table: 'ApiKey', column: 'expiresAt', nullable: true },
+  { table: 'Session', column: 'createdAt' },
+  { table: 'Session', column: 'lastSeenAt', nullable: true },
+  { table: 'UserSecret', column: 'createdAt' },
+  { table: 'UserSecret', column: 'updatedAt' },
+  { table: 'ToolSecret', column: 'createdAt' },
+  { table: 'ToolSecret', column: 'updatedAt' },
+  { table: 'JacksonStore', column: 'createdAt', nullable: true },
+  { table: 'JacksonStore', column: 'expiresAt', nullable: true },
+]
+
+export async function up(db: Kysely<any>, dialect: 'sqlite' | 'postgresql'): Promise<void> {
+  if (dialect !== 'postgresql') return
+
+  for (const { table, column, nullable } of timestampColumns) {
+    const expression = nullable
+      ? sql`NULLIF(${sql.ref(column)}, '')::timestamp`
+      : sql`${sql.ref(column)}::timestamp`
+
+    await sql`
+      ALTER TABLE ${sql.table(table)}
+      ALTER COLUMN ${sql.ref(column)} TYPE timestamp
+      USING ${expression}
+    `.execute(db)
+  }
+}

--- a/apps/backend/lib/MessageAuditor.ts
+++ b/apps/backend/lib/MessageAuditor.ts
@@ -97,7 +97,7 @@ export class MessageAuditor {
       model: this.conversation.assistant.model,
       tokens: 0,
       tokenDetails: null,
-      sentAt: message.sentAt ?? new Date().toISOString(),
+      sentAt: message.sentAt,
       errors: null,
     }
   }

--- a/apps/backend/lib/MessageAuditor.ts
+++ b/apps/backend/lib/MessageAuditor.ts
@@ -97,7 +97,7 @@ export class MessageAuditor {
       model: this.conversation.assistant.model,
       tokens: 0,
       tokenDetails: null,
-      sentAt: message.sentAt,
+      sentAt: message.sentAt ?? new Date().toISOString(),
       errors: null,
     }
   }

--- a/apps/backend/models/message.ts
+++ b/apps/backend/models/message.ts
@@ -4,6 +4,8 @@ import * as schema from '@/db/schema'
 import * as dto from '@/types/dto'
 
 export const dtoMessageToDbMessage = (message: dto.Message): schema.Message => {
+  const sentAt = message.sentAt ?? new Date().toISOString()
+  message.sentAt = sentAt
   const content = JSON.stringify({
     ...message,
     id: undefined,
@@ -12,7 +14,6 @@ export const dtoMessageToDbMessage = (message: dto.Message): schema.Message => {
     role: undefined,
     sentAt: undefined,
   })
-  const sentAt = new Date().toISOString()
   return {
     content,
     id: message.id,
@@ -25,6 +26,8 @@ export const dtoMessageToDbMessage = (message: dto.Message): schema.Message => {
 }
 
 export const saveMessage = async (message: dto.Message) => {
+  const sentAt = message.sentAt ?? new Date().toISOString()
+  message.sentAt = sentAt
   const content = JSON.stringify({
     ...message,
     id: undefined,
@@ -33,7 +36,6 @@ export const saveMessage = async (message: dto.Message) => {
     role: undefined,
     sentAt: undefined,
   })
-  const sentAt = new Date().toISOString()
   const mapped = {
     content,
     id: message.id,

--- a/apps/backend/models/utils.ts
+++ b/apps/backend/models/utils.ts
@@ -346,12 +346,12 @@ const convertV3ToV4 = (msg: MessageV3): dto.Message => {
 export const dtoMessageFromDbMessage = (m: schema.Message): dto.Message => {
   if (m.version === 4) {
     const msg = {
+      ...JSON.parse(m.content),
       id: m.id,
       conversationId: m.conversationId,
       parent: m.parent,
       role: m.role,
       sentAt: m.sentAt,
-      ...JSON.parse(m.content),
     } satisfies dto.Message
     return msg
   }

--- a/apps/backend/scripts/smoke.ts
+++ b/apps/backend/scripts/smoke.ts
@@ -163,6 +163,13 @@ function parseJson(text: string, label: string) {
   }
 }
 
+function parseSseData(text: string, label: string) {
+  return text
+    .split('\n')
+    .filter((line) => line.startsWith('data: '))
+    .map((line) => parseJson(line.slice('data: '.length), label))
+}
+
 async function waitForFileAnalysis(
   fileId: string,
   sessionRequest: ReturnType<typeof createSession>['request'],
@@ -617,9 +624,8 @@ async function main() {
     expectedStatus: 201,
     headers: jsonHeaders,
     json: {
-      providerType: 'openai',
+      providerType: 'mock',
       name: `Smoke Backend ${runId}`,
-      apiKey: 'user_provided',
     },
   })
   const backendId = (parseJson(backendCreated.text, '/api/backends POST') as { id: string }).id
@@ -630,7 +636,7 @@ async function main() {
     json: {
       backendId,
       description: 'Smoke assistant',
-      model: 'gpt-4o-mini',
+      model: 'mock-echo',
       name: 'Smoke Assistant',
       systemPrompt: 'You are a smoke test assistant.',
       temperature: 0.2,
@@ -708,6 +714,22 @@ async function main() {
   }
   if (!chat.text.includes('"type":"message"')) {
     throw new Error('Chat response did not contain message chunk')
+  }
+  const chatEvents = parseSseData(chat.text, '/api/chat SSE') as Array<{
+    type?: string
+    text?: string
+    part?: { type?: string; error?: string }
+  }>
+  const streamedText = chatEvents
+    .filter((event) => event.type === 'text')
+    .map((event) => event.text ?? '')
+    .join('')
+  if (streamedText !== 'Echo: hello smoke') {
+    throw new Error(`Chat response did not contain mock provider echo: ${chat.text}`)
+  }
+  const errorEvent = chatEvents.find((event) => event.part?.type === 'error')
+  if (errorEvent?.part?.error) {
+    throw new Error(`Chat response contained error part: ${errorEvent.part.error}`)
   }
 
   console.log('Smoke: conversation share and feedback')

--- a/apps/backend/scripts/smoke.ts
+++ b/apps/backend/scripts/smoke.ts
@@ -165,6 +165,7 @@ function parseJson(text: string, label: string) {
 
 async function waitForFileAnalysis(
   fileId: string,
+  sessionRequest: ReturnType<typeof createSession>['request'],
   opts: { timeoutMs?: number; pollMs?: number } = {}
 ) {
   const timeoutMs = opts.timeoutMs ?? 30000
@@ -172,7 +173,7 @@ async function waitForFileAnalysis(
   const deadline = Date.now() + timeoutMs
 
   while (Date.now() < deadline) {
-    const response = await request('GET', `/api/files/${fileId}/analysis`, {
+    const response = await sessionRequest('GET', `/api/files/${fileId}/analysis`, {
       expectedStatus: 200,
       headers: sameOriginHeaders,
     })
@@ -266,15 +267,18 @@ async function checkSatelliteRejectsUnauthenticated() {
  * Create a satellite + API key, connect with the token, send a register message,
  * and verify the hub replies with a `registered` message.
  */
-async function checkRegisteredSatelliteConnect(runId: string) {
-  const satelliteCreated = await request('POST', '/api/me/satellites', {
+async function checkRegisteredSatelliteConnect(
+  runId: string,
+  sessionRequest: ReturnType<typeof createSession>['request']
+) {
+  const satelliteCreated = await sessionRequest('POST', '/api/me/satellites', {
     expectedStatus: 201,
     headers: jsonHeaders,
     json: { name: `Smoke Satellite ${runId}` },
   })
   const satelliteId = (parseJson(satelliteCreated.text, '/api/me/satellites POST') as { id: string }).id
 
-  const apiKeyCreated = await request('POST', '/api/me/apikeys', {
+  const apiKeyCreated = await sessionRequest('POST', '/api/me/apikeys', {
     expectedStatus: 201,
     headers: jsonHeaders,
     json: {
@@ -329,7 +333,7 @@ async function checkRegisteredSatelliteConnect(runId: string) {
         ws.terminate()
         reject(
           new Error(
-            `Registered satellite: satelliteId mismatch — expected "${satelliteId}", got "${msg.satelliteId}"`
+            `Registered satellite: satelliteId mismatch - expected "${satelliteId}", got "${msg.satelliteId}"`
           )
         )
         return
@@ -351,7 +355,7 @@ async function checkRegisteredSatelliteConnect(runId: string) {
     })
   })
 
-  await request('DELETE', `/api/me/satellites/${satelliteId}`, {
+  await sessionRequest('DELETE', `/api/me/satellites/${satelliteId}`, {
     expectedStatus: 204,
     headers: sameOriginHeaders,
   })
@@ -427,7 +431,8 @@ async function main() {
   if (!profileJson.id) {
     throw new Error('Missing user id in profile response')
   }
-  const owner = { ownerType: 'USER', ownerId: profileJson.id }
+  const userId = profileJson.id
+  const owner = { ownerType: 'USER', ownerId: userId }
 
   console.log('Smoke: user profile patch covers image')
   await requestUser('PATCH', '/api/me/profile', {
@@ -456,7 +461,7 @@ async function main() {
   })
 
   console.log('Smoke: workspace and membership endpoints')
-  const workspaceCreated = await requestUser('POST', '/api/workspaces', {
+  const workspaceCreated = await requestAdmin('POST', '/api/workspaces', {
     expectedStatus: 201,
     headers: jsonHeaders,
     json: { name: `Smoke Workspace ${runId}` },
@@ -465,21 +470,26 @@ async function main() {
     id: string
     name: string
   }
-  await requestUser('GET', `/api/workspaces/${workspaceJson.id}`, {
+  await requestAdmin('GET', `/api/workspaces/${workspaceJson.id}`, {
     expectedStatus: 200,
     headers: sameOriginHeaders,
   })
-  await requestUser('PATCH', `/api/workspaces/${workspaceJson.id}`, {
-    expectedStatus: 204,
+  await requestAdmin('PUT', `/api/workspaces/${workspaceJson.id}`, {
+    expectedStatus: 200,
     headers: jsonHeaders,
     json: { name: `Smoke Workspace Updated ${runId}` },
   })
-  const workspaceMembers = await requestUser('GET', `/api/workspaces/${workspaceJson.id}/members`, {
+  await requestAdmin('POST', `/api/workspaces/${workspaceJson.id}/members`, {
+    expectedStatus: 204,
+    headers: jsonHeaders,
+    json: [{ userId, role: 'MEMBER' }],
+  })
+  const workspaceMembers = await requestAdmin('GET', `/api/workspaces/${workspaceJson.id}/members`, {
     expectedStatus: 200,
     headers: sameOriginHeaders,
   })
-  if (!workspaceMembers.text.includes(profileJson.id)) {
-    throw new Error(`Workspace members did not include the creator: ${workspaceMembers.text}`)
+  if (!workspaceMembers.text.includes(userId)) {
+    throw new Error(`Workspace members did not include the regular user: ${workspaceMembers.text}`)
   }
 
   console.log('Smoke: admin tool CRUD and workspace sharing')
@@ -582,7 +592,7 @@ async function main() {
     headers: { 'content-type': 'application/pdf', ...sameOriginHeaders },
     body: new Uint8Array(pdfBuffer),
   })
-  const pdfAnalysis = await waitForFileAnalysis(pdfFileId)
+  const pdfAnalysis = await waitForFileAnalysis(pdfFileId, requestUser)
   if (pdfAnalysis.status !== 'ready' || pdfAnalysis.payload?.kind !== 'pdf') {
     throw new Error(`Unexpected PDF analysis payload: ${JSON.stringify(pdfAnalysis)}`)
   }
@@ -598,12 +608,12 @@ async function main() {
     id: string
     name: string
     type: string
-    size: number
+    size?: number
     createdAt?: string
   }
 
   console.log('Smoke: setup backend + assistant + conversation')
-  const backendCreated = await requestUser('POST', '/api/backends', {
+  const backendCreated = await requestAdmin('POST', '/api/backends', {
     expectedStatus: 201,
     headers: jsonHeaders,
     json: {
@@ -634,7 +644,7 @@ async function main() {
           id: pdfDetailsJson.id,
           name: pdfDetailsJson.name,
           type: pdfDetailsJson.type,
-          size: pdfDetailsJson.size,
+          size: pdfDetailsJson.size ?? pdfBuffer.length,
           createdAt: pdfDetailsJson.createdAt,
         },
       ],
@@ -805,6 +815,13 @@ async function main() {
     expectedStatus: 204,
     headers: sameOriginHeaders,
   })
+  await requestAdmin('PATCH', `/api/tools/${toolJson.id}`, {
+    expectedStatus: 204,
+    headers: jsonHeaders,
+    json: {
+      sharing: { type: 'public' },
+    },
+  })
   await requestAdmin('DELETE', `/api/tools/${toolJson.id}`, {
     expectedStatus: 204,
     headers: sameOriginHeaders,
@@ -822,7 +839,7 @@ async function main() {
   await checkSatelliteRejectsUnauthenticated()
 
   console.log('Smoke: registered satellite connects, registers, and receives registered ack')
-  await checkRegisteredSatelliteConnect(runId)
+  await checkRegisteredSatelliteConnect(runId, requestUser)
 
   const elapsedSec = Math.floor((Date.now() - startedAt) / 1000)
   console.log(`Smoke + baseline integration checks passed in ${elapsedSec}s.`)

--- a/apps/backend/scripts/smoke.ts
+++ b/apps/backend/scripts/smoke.ts
@@ -41,6 +41,73 @@ function cookieHeader() {
   return [...cookieJar.entries()].map(([k, v]) => `${k}=${v}`).join('; ')
 }
 
+function createSession() {
+  const sessionCookies = new Map<string, string>()
+
+  function setCookiesFromResponse(headers: Headers) {
+    const values =
+      typeof (headers as Headers & { getSetCookie?: () => string[] }).getSetCookie === 'function'
+        ? (headers as Headers & { getSetCookie: () => string[] }).getSetCookie()
+        : headers.get('set-cookie')
+          ? [headers.get('set-cookie') as string]
+          : []
+
+    for (const raw of values) {
+      if (!raw) continue
+      const first = raw.split(';', 1)[0]
+      const idx = first.indexOf('=')
+      if (idx <= 0) continue
+      const name = first.slice(0, idx).trim()
+      const value = first.slice(idx + 1).trim()
+      sessionCookies.set(name, value)
+    }
+  }
+
+  function cookieHeader() {
+    return [...sessionCookies.entries()].map(([k, v]) => `${k}=${v}`).join('; ')
+  }
+
+  async function request(method: string, path: string, opts: RequestOptions = {}) {
+    const {
+      expectedStatus = 200,
+      json,
+      body,
+      headers = {},
+      includeCookies = true,
+      allowStatus = null,
+    } = opts
+    const allHeaders: Record<string, string> = { ...headers }
+    if (includeCookies && sessionCookies.size > 0) {
+      allHeaders.cookie = cookieHeader()
+    }
+    let payload = body
+    if (json !== undefined) {
+      payload = JSON.stringify(json)
+    }
+
+    const res = await fetch(`${baseUrl}${path}`, {
+      method,
+      headers: allHeaders,
+      body: payload,
+    })
+    setCookiesFromResponse(res.headers)
+    const text = await res.text()
+
+    if (allowStatus?.includes(res.status)) {
+      return { res, text }
+    }
+
+    if (res.status !== expectedStatus) {
+      throw new Error(
+        `Request failed: ${method} ${path} -> ${res.status}, expected ${expectedStatus}\n${text}`
+      )
+    }
+    return { res, text }
+  }
+
+  return { request }
+}
+
 type RequestOptions = {
   expectedStatus?: number
   json?: unknown
@@ -291,6 +358,11 @@ async function checkRegisteredSatelliteConnect(runId: string) {
 }
 
 async function main() {
+  const adminSession = createSession()
+  const userSession = createSession()
+  const requestAdmin = adminSession.request
+  const requestUser = userSession.request
+
   console.log('Smoke: health endpoint')
   const health = await request('GET', '/api/health', { expectedStatus: 200 })
   if (!health.text.includes('"status":"ok"')) {
@@ -313,19 +385,31 @@ async function main() {
   const password = 'SmokePassw0rd!'
 
   console.log('Smoke: signup + login')
-  await request('POST', '/api/auth/join', {
+  await requestUser('POST', '/api/auth/join', {
     expectedStatus: 201,
     headers: jsonHeaders,
     json: { name: 'Smoke User', email, password },
   })
-  await request('POST', '/api/auth/login', {
+  await requestUser('POST', '/api/auth/login', {
     expectedStatus: 204,
     headers: jsonHeaders,
     json: { email, password },
   })
+  const adminEmail = `smoke-admin-${runId}@example.com`
+  const adminPassword = 'SmokePassw0rd!'
+  await requestAdmin('POST', '/api/auth/join', {
+    expectedStatus: 201,
+    headers: jsonHeaders,
+    json: { name: 'Smoke Admin', email: adminEmail, password: adminPassword },
+  })
+  await requestAdmin('POST', '/api/auth/login', {
+    expectedStatus: 204,
+    headers: jsonHeaders,
+    json: { email: adminEmail, password: adminPassword },
+  })
 
   console.log('Smoke: authenticated profile read')
-  const profile = await request('GET', '/api/me/profile', {
+  const profile = await requestUser('GET', '/api/me/profile', {
     expectedStatus: 200,
     headers: sameOriginHeaders,
   })
@@ -335,29 +419,99 @@ async function main() {
   }
   const owner = { ownerType: 'USER', ownerId: profileJson.id }
 
+  console.log('Smoke: user profile patch covers image + properties')
+  await requestUser('PATCH', '/api/me/profile', {
+    expectedStatus: 204,
+    headers: jsonHeaders,
+    json: {
+      image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=',
+      properties: {
+        [`smoke-${runId}`]: `value-${runId}`,
+      },
+    },
+  })
+
   console.log('Smoke: CRUD baseline with folders')
-  const folderCreated = await request('POST', '/api/me/folders', {
+  const folderCreated = await requestUser('POST', '/api/me/folders', {
     expectedStatus: 201,
     headers: jsonHeaders,
     json: { name: `Smoke Folder ${runId}` },
   })
   const folderJson = parseJson(folderCreated.text, '/api/me/folders POST') as { id: string }
-  await request('GET', `/api/me/folders/${folderJson.id}`, {
+  await requestUser('GET', `/api/me/folders/${folderJson.id}`, {
     expectedStatus: 200,
     headers: sameOriginHeaders,
   })
-  await request('PATCH', `/api/me/folders/${folderJson.id}`, {
+  await requestUser('PATCH', `/api/me/folders/${folderJson.id}`, {
     expectedStatus: 204,
     headers: jsonHeaders,
     json: { name: `Smoke Folder Updated ${runId}` },
   })
-  await request('DELETE', `/api/me/folders/${folderJson.id}`, {
-    expectedStatus: 204,
+
+  console.log('Smoke: workspace and membership endpoints')
+  const workspaceCreated = await requestUser('POST', '/api/workspaces', {
+    expectedStatus: 201,
+    headers: jsonHeaders,
+    json: { name: `Smoke Workspace ${runId}` },
+  })
+  const workspaceJson = parseJson(workspaceCreated.text, '/api/workspaces POST') as {
+    id: string
+    name: string
+  }
+  await requestUser('GET', `/api/workspaces/${workspaceJson.id}`, {
+    expectedStatus: 200,
     headers: sameOriginHeaders,
   })
+  await requestUser('PATCH', `/api/workspaces/${workspaceJson.id}`, {
+    expectedStatus: 204,
+    headers: jsonHeaders,
+    json: { name: `Smoke Workspace Updated ${runId}` },
+  })
+  const workspaceMembers = await requestUser('GET', `/api/workspaces/${workspaceJson.id}/members`, {
+    expectedStatus: 200,
+    headers: sameOriginHeaders,
+  })
+  if (!workspaceMembers.text.includes(profileJson.id)) {
+    throw new Error(`Workspace members did not include the creator: ${workspaceMembers.text}`)
+  }
+
+  console.log('Smoke: admin tool CRUD and workspace sharing')
+  const toolCreated = await requestAdmin('POST', '/api/tools', {
+    expectedStatus: 201,
+    headers: jsonHeaders,
+    json: {
+      type: 'dummy',
+      name: `Smoke Tool ${runId}`,
+      description: 'Smoke tool',
+      configuration: {},
+      tags: ['smoke'],
+      icon: null,
+      sharing: { type: 'workspace', workspaces: [workspaceJson.id] },
+      promptFragment: 'smoke',
+    },
+  })
+  const toolJson = parseJson(toolCreated.text, '/api/tools POST') as { id: string }
+  await requestAdmin('GET', `/api/tools/${toolJson.id}`, {
+    expectedStatus: 200,
+    headers: sameOriginHeaders,
+  })
+  await requestAdmin('PATCH', `/api/tools/${toolJson.id}`, {
+    expectedStatus: 204,
+    headers: jsonHeaders,
+    json: {
+      description: `Smoke tool updated ${runId}`,
+    },
+  })
+  const visibleTools = await requestUser('GET', '/api/me/tools', {
+    expectedStatus: 200,
+    headers: sameOriginHeaders,
+  })
+  if (!visibleTools.text.includes(toolJson.id)) {
+    throw new Error(`User tools did not include the shared tool: ${visibleTools.text}`)
+  }
 
   console.log('Smoke: file upload baseline')
-  const fileCreated = await request('POST', '/api/files', {
+  const fileCreated = await requestUser('POST', '/api/files', {
     expectedStatus: 201,
     headers: jsonHeaders,
     json: {
@@ -368,12 +522,12 @@ async function main() {
     },
   })
   const fileId = (parseJson(fileCreated.text, '/api/files POST') as { id: string }).id
-  await request('PUT', `/api/files/${fileId}/content`, {
+  await requestUser('PUT', `/api/files/${fileId}/content`, {
     expectedStatus: 204,
     headers: { 'content-type': 'text/plain', ...sameOriginHeaders },
     body: 'hello world',
   })
-  const fileContent = await request('GET', `/api/files/${fileId}/content`, {
+  const fileContent = await requestUser('GET', `/api/files/${fileId}/content`, {
     expectedStatus: 200,
     headers: sameOriginHeaders,
   })
@@ -382,7 +536,7 @@ async function main() {
   }
 
   console.log('Smoke: AEAD file download supports HTTP range requests')
-  const rangedContent = await request('GET', `/api/files/${fileId}/content`, {
+  const rangedContent = await requestUser('GET', `/api/files/${fileId}/content`, {
     expectedStatus: 206,
     headers: {
       ...sameOriginHeaders,
@@ -405,7 +559,7 @@ async function main() {
 
   console.log('Smoke: pdf upload analysis preview')
   const pdfBuffer = await readFile(new URL('./data/basic-text.pdf', import.meta.url))
-  const pdfCreated = await request('POST', '/api/files', {
+  const pdfCreated = await requestUser('POST', '/api/files', {
     expectedStatus: 201,
     headers: jsonHeaders,
     json: {
@@ -416,7 +570,7 @@ async function main() {
     },
   })
   const pdfFileId = (parseJson(pdfCreated.text, '/api/files POST pdf') as { id: string }).id
-  await request('PUT', `/api/files/${pdfFileId}/content`, {
+  await requestUser('PUT', `/api/files/${pdfFileId}/content`, {
     expectedStatus: 204,
     headers: { 'content-type': 'application/pdf', ...sameOriginHeaders },
     body: new Uint8Array(pdfBuffer),
@@ -429,8 +583,20 @@ async function main() {
     throw new Error(`Invalid PDF page count: ${JSON.stringify(pdfAnalysis)}`)
   }
 
+  const pdfDetails = await requestUser('GET', `/api/files/${pdfFileId}`, {
+    expectedStatus: 200,
+    headers: sameOriginHeaders,
+  })
+  const pdfDetailsJson = parseJson(pdfDetails.text, `/api/files/${pdfFileId}`) as {
+    id: string
+    name: string
+    type: string
+    size: number
+    createdAt?: string
+  }
+
   console.log('Smoke: setup backend + assistant + conversation')
-  const backendCreated = await request('POST', '/api/backends', {
+  const backendCreated = await requestUser('POST', '/api/backends', {
     expectedStatus: 201,
     headers: jsonHeaders,
     json: {
@@ -441,7 +607,7 @@ async function main() {
   })
   const backendId = (parseJson(backendCreated.text, '/api/backends POST') as { id: string }).id
 
-  const assistantCreated = await request('POST', '/api/assistants', {
+  const assistantCreated = await requestUser('POST', '/api/assistants', {
     expectedStatus: 201,
     headers: jsonHeaders,
     json: {
@@ -456,15 +622,33 @@ async function main() {
       tags: [],
       prompts: [],
       tools: [],
-      files: [],
+      files: [
+        {
+          id: pdfDetailsJson.id,
+          name: pdfDetailsJson.name,
+          type: pdfDetailsJson.type,
+          size: pdfDetailsJson.size,
+          createdAt: pdfDetailsJson.createdAt,
+        },
+      ],
       iconUri: null,
     },
   })
   const assistantId = (
     parseJson(assistantCreated.text, '/api/assistants POST') as { assistantId: string }
   ).assistantId
+  await requestUser('POST', `/api/assistants/${assistantId}/sharing`, {
+    expectedStatus: 200,
+    headers: jsonHeaders,
+    json: [{ type: 'workspace', workspaceId: workspaceJson.id, workspaceName: workspaceJson.name }],
+  })
+  await requestUser('POST', `/api/assistants/${assistantId}/publish`, {
+    expectedStatus: 200,
+    headers: jsonHeaders,
+    json: { versionName: `Smoke Publish ${runId}` },
+  })
 
-  const conversationCreated = await request('POST', '/api/conversations', {
+  const conversationCreated = await requestUser('POST', '/api/conversations', {
     expectedStatus: 201,
     headers: jsonHeaders,
     json: {
@@ -475,16 +659,26 @@ async function main() {
   const conversationId = (
     parseJson(conversationCreated.text, '/api/conversations POST') as { id: string }
   ).id
+  const chatMessageId = `msg-${runId}`
+  await requestUser('POST', `/api/me/folders/${folderJson.id}`, {
+    expectedStatus: 204,
+    headers: jsonHeaders,
+    json: { conversationId },
+  })
+  await requestUser('GET', `/api/me/folders/${folderJson.id}/conversations`, {
+    expectedStatus: 200,
+    headers: sameOriginHeaders,
+  })
 
   console.log('Smoke: chat SSE endpoint returns stream')
-  const chat = await request('POST', '/api/chat', {
+  const chat = await requestUser('POST', '/api/chat', {
     expectedStatus: 200,
     headers: {
       ...jsonHeaders,
       accept: 'text/event-stream',
     },
     json: {
-      id: `msg-${runId}`,
+      id: chatMessageId,
       conversationId,
       parent: null,
       role: 'user',
@@ -498,6 +692,121 @@ async function main() {
   if (!chat.text.includes('"type":"message"')) {
     throw new Error('Chat response did not contain message chunk')
   }
+
+  console.log('Smoke: conversation share and feedback')
+  const shareCreated = await requestUser('POST', `/api/conversations/${conversationId}/share`, {
+    expectedStatus: 200,
+    headers: sameOriginHeaders,
+  })
+  const shareJson = parseJson(shareCreated.text, `/api/conversations/${conversationId}/share`) as {
+    id: string
+    lastMessageId: string
+  }
+  if (!shareJson.lastMessageId) {
+    throw new Error('Conversation share missing lastMessageId')
+  }
+  await requestUser('PATCH', `/api/conversations/${conversationId}/share`, {
+    expectedStatus: 204,
+    headers: sameOriginHeaders,
+  })
+  await requestUser('PUT', `/api/conversations/${conversationId}/messages/${chatMessageId}/feedback`, {
+    expectedStatus: 204,
+    headers: jsonHeaders,
+    json: { feedback: 'like', comment: 'smoke' },
+  })
+  await requestUser('GET', `/api/conversations/${conversationId}/messages/${chatMessageId}/feedback`, {
+    expectedStatus: 200,
+    headers: sameOriginHeaders,
+  })
+
+  console.log('Smoke: prompt, API key, secret, and satellite CRUD')
+  const promptCreated = await requestUser('POST', '/api/me/prompts', {
+    expectedStatus: 201,
+    headers: jsonHeaders,
+    json: {
+      name: `Smoke Prompt ${runId}`,
+      description: 'Smoke prompt',
+      content: 'hello',
+    },
+  })
+  const promptJson = parseJson(promptCreated.text, '/api/me/prompts POST') as { id: string }
+  await requestUser('PUT', `/api/me/prompts/${promptJson.id}`, {
+    expectedStatus: 204,
+    headers: jsonHeaders,
+    json: {
+      name: `Smoke Prompt Updated ${runId}`,
+      description: 'Smoke prompt updated',
+      content: 'hello again',
+    },
+  })
+  await requestUser('DELETE', `/api/me/prompts/${promptJson.id}`, {
+    expectedStatus: 204,
+    headers: sameOriginHeaders,
+  })
+
+  const apiKeyCreated = await requestUser('POST', '/api/me/apikeys', {
+    expectedStatus: 201,
+    headers: jsonHeaders,
+    json: {
+      description: `Smoke API key ${runId}`,
+      scope: ['chat:read'],
+      expiresAt: null,
+    },
+  })
+  const apiKeyJson = parseJson(apiKeyCreated.text, '/api/me/apikeys POST') as { id: string }
+  await requestUser('DELETE', `/api/me/apikeys/${apiKeyJson.id}`, {
+    expectedStatus: 204,
+    headers: sameOriginHeaders,
+  })
+
+  const secretCreated = await requestUser('POST', '/api/me/secrets', {
+    expectedStatus: 201,
+    headers: jsonHeaders,
+    json: {
+      context: `smoke-${runId}`,
+      type: 'backend-credentials',
+      label: `Smoke Secret ${runId}`,
+      value: 'secret',
+    },
+  })
+  const secretJson = parseJson(secretCreated.text, '/api/me/secrets POST') as { id: string }
+  await requestUser('GET', '/api/me/secrets', {
+    expectedStatus: 200,
+    headers: sameOriginHeaders,
+  })
+  await requestUser('DELETE', `/api/me/secrets/${secretJson.id}`, {
+    expectedStatus: 204,
+    headers: sameOriginHeaders,
+  })
+
+  const satelliteCreated = await requestUser('POST', '/api/me/satellites', {
+    expectedStatus: 201,
+    headers: jsonHeaders,
+    json: { name: `Smoke Satellite ${runId}` },
+  })
+  const satelliteJson = parseJson(satelliteCreated.text, '/api/me/satellites POST') as { id: string }
+  await requestUser('GET', `/api/me/satellites/${satelliteJson.id}`, {
+    expectedStatus: 200,
+    headers: sameOriginHeaders,
+  })
+  await requestUser('PATCH', `/api/me/satellites/${satelliteJson.id}`, {
+    expectedStatus: 200,
+    headers: jsonHeaders,
+    json: { name: `Smoke Satellite Updated ${runId}` },
+  })
+  await requestUser('DELETE', `/api/me/satellites/${satelliteJson.id}`, {
+    expectedStatus: 204,
+    headers: sameOriginHeaders,
+  })
+  await requestAdmin('DELETE', `/api/tools/${toolJson.id}`, {
+    expectedStatus: 204,
+    headers: sameOriginHeaders,
+  })
+
+  await requestUser('DELETE', `/api/me/folders/${folderJson.id}`, {
+    expectedStatus: 204,
+    headers: sameOriginHeaders,
+  })
 
   console.log('Smoke: websocket /api/rpc handshake')
   await checkWebSocketHandshake()

--- a/apps/backend/scripts/smoke.ts
+++ b/apps/backend/scripts/smoke.ts
@@ -429,15 +429,12 @@ async function main() {
   }
   const owner = { ownerType: 'USER', ownerId: profileJson.id }
 
-  console.log('Smoke: user profile patch covers image + properties')
+  console.log('Smoke: user profile patch covers image')
   await requestUser('PATCH', '/api/me/profile', {
     expectedStatus: 204,
     headers: jsonHeaders,
     json: {
       image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=',
-      properties: {
-        [`smoke-${runId}`]: `value-${runId}`,
-      },
     },
   })
 

--- a/apps/backend/scripts/smoke.ts
+++ b/apps/backend/scripts/smoke.ts
@@ -383,20 +383,10 @@ async function main() {
   const runId = `${Date.now()}-${Math.floor(Math.random() * 100000)}`
   const email = `smoke-${runId}@example.com`
   const password = 'SmokePassw0rd!'
-
-  console.log('Smoke: signup + login')
-  await requestUser('POST', '/api/auth/join', {
-    expectedStatus: 201,
-    headers: jsonHeaders,
-    json: { name: 'Smoke User', email, password },
-  })
-  await requestUser('POST', '/api/auth/login', {
-    expectedStatus: 204,
-    headers: jsonHeaders,
-    json: { email, password },
-  })
   const adminEmail = `smoke-admin-${runId}@example.com`
   const adminPassword = 'SmokePassw0rd!'
+
+  console.log('Smoke: create admin and regular user sessions')
   await requestAdmin('POST', '/api/auth/join', {
     expectedStatus: 201,
     headers: jsonHeaders,
@@ -406,6 +396,26 @@ async function main() {
     expectedStatus: 204,
     headers: jsonHeaders,
     json: { email: adminEmail, password: adminPassword },
+  })
+
+  await requestAdmin('POST', '/api/users', {
+    expectedStatus: 201,
+    headers: jsonHeaders,
+    json: {
+      name: 'Smoke User',
+      email,
+      password,
+      role: 'USER',
+      ssoUser: false,
+      preferences: '{}',
+      image: null,
+      properties: {},
+    },
+  })
+  await requestUser('POST', '/api/auth/login', {
+    expectedStatus: 204,
+    headers: jsonHeaders,
+    json: { email, password },
   })
 
   console.log('Smoke: authenticated profile read')


### PR DESCRIPTION
## Summary
Convert the Postgres timestamp-like columns to real `timestamp` types and expand the backend smoke test to cover the major API surfaces through two separate sessions: one admin and one regular user.

## Details
- Adds a Postgres-only migration for the timestamp columns, including `JacksonStore`.
- Updates the smoke test to use separate admin and non-admin sessions.
- Covers API paths for profile, folders, workspaces, files, assistants, conversations, prompts, API keys, secrets, satellites, and tools/tool sharing.
- Keeps the smoke flow local-only; no remote server access is required.

## Tests
- `pnpm exec tsc --pretty --noEmit --project apps/backend/tsconfig.json`