### PR TITLE
Add GPT-5.6 Terra model and set as OpenAI latest alias

### DIFF
--- a/packages/core/src/models/logicle.ts
+++ b/packages/core/src/models/logicle.ts
@@ -36,6 +36,7 @@ import {
   gptChatLatestModel,
   gpt52Model,
   gpt54Model,
+  gpt56TerraModel,
 } from './openai'
 import { perplexityModels } from './perplexity'
 import {
@@ -65,6 +66,7 @@ export const logicleModels: LlmModel[] = [
   gpt51Model,
   gpt52Model,
   gpt54Model,
+  gpt56TerraModel,
   gptChatLatestModel,
   o1Model,
   o1MiniModel,

--- a/packages/core/src/models/openai.ts
+++ b/packages/core/src/models/openai.ts
@@ -471,6 +471,24 @@ export const gpt54Model: LlmModel = {
   defaultReasoning: 'low',
 }
 
+export const gpt56TerraModel: LlmModel = {
+  id: 'gpt-5.6-terra',
+  model: 'gpt-5.6-terra',
+  name: 'GPT-5.6 Terra',
+  description: 'GPT-5.6 Terra, available via Chat Completions and Responses APIs',
+  provider: 'openai',
+  owned_by: 'openai',
+  context_length: 400000,
+  capabilities: {
+    vision: true,
+    function_calling: true,
+    supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
+    promptCaching: false, // caching is automatic and non-configurable on this model
+  },
+  supportedReasoningEfforts: ['none', 'low', 'medium', 'high', 'xhigh'],
+  defaultReasoning: 'low',
+}
+
 export const gptChatLatestModel: LlmModel = {
   ...gpt52ChatModel,
   id: 'chatgpt-5-latest',
@@ -479,9 +497,9 @@ export const gptChatLatestModel: LlmModel = {
 }
 
 export const gptLatest: LlmModel = {
-  ...gpt54Model,
+  ...gpt56TerraModel,
   id: 'gpt-5-latest',
-  name: 'Gpt latest (5.4)',
+  name: 'Gpt latest (5.6 Terra)',
   tags: ['latest'],
 }
 
@@ -507,6 +525,7 @@ export const openaiModels: LlmModel[] = [
   gpt54Model,
   gpt55Model,
   gpt55ProModel,
+  gpt56TerraModel,
   o1Model,
   o1MiniModel,
   o3Model,


### PR DESCRIPTION
## Summary
Adds a new OpenAI model card for GPT-5.6 Terra to the model catalog, exposes it under both the direct OpenAI provider and the logiclecloud provider, and repoints the gpt-5-latest alias to it, so newly created assistants using the "latest" OpenAI model now default to GPT-5.6 Terra instead of GPT-5.4.

## Details
- New gpt56TerraModel entry (id: gpt-5.6-terra) with the same capability profile as GPT-5.5 (400k context, vision, function calling, reasoning efforts none-xhigh, no manual prompt caching).
- gptLatest (id: gpt-5-latest, tags: ['latest']) now spreads from gpt56TerraModel instead of gpt54Model.
- gpt56TerraModel added to the logicleModels catalog (logicle.ts), alongside the other OpenAI models re-exposed under the logiclecloud provider.
- gpt-5.4 remains available as a standalone model card (unchanged); the chat-tuned chatgpt-5-latest alias still points at GPT-5.2 Chat (unchanged).

## Tests
- npm run check-types — no errors.