### PR TITLE
Add owner and connection status columns to satellites admin table

### DIFF
--- a/apps/backend/api/me/satellites/route.ts
+++ b/apps/backend/api/me/satellites/route.ts
@@ -1,5 +1,6 @@
 import { ok, operation, responseSpec } from '@/lib/routes'
 import { getUserSatellites, createSatellite } from '@/models/satellite'
+import { getUserById } from '@/models/user'
 import { satelliteListItemSchema, satelliteSchema, insertableSatelliteSchema } from '@/types/dto'
 import { hub } from '@/lib/satellite/hub'
 
@@ -14,6 +15,8 @@ export const GET = operation({
     const satellites = await getUserSatellites(session.userId)
     const connections = Array.from(hub.connections.values()).filter((conn) => conn.userId === session.userId)
     const connectionsById = new Map(connections.map((conn) => [conn.satelliteId, conn]))
+    const owner = await getUserById(session.userId)
+    const ownerName = owner?.name ?? null
 
     const registered = satellites.map((satellite) => {
       const connection = connectionsById.get(satellite.id)
@@ -22,6 +25,7 @@ export const GET = operation({
         name: satellite.name,
         kind: 'registered' as const,
         connected: !!connection,
+        ownerName,
         createdAt: satellite.createdAt,
         updatedAt: satellite.updatedAt,
       }
@@ -34,6 +38,7 @@ export const GET = operation({
         name: conn.name,
         kind: 'ephemeral' as const,
         connected: true,
+        ownerName,
         createdAt: conn.connectedAt.toISOString(),
         updatedAt: conn.connectedAt.toISOString(),
       }))

--- a/apps/backend/api/satellites/route.ts
+++ b/apps/backend/api/satellites/route.ts
@@ -1,6 +1,7 @@
 import { ok, operation, responseSpec } from '@/lib/routes'
 import { hub } from '@/lib/satellite/hub'
 import { getAllSatellites } from '@/models/satellite'
+import { getUsers } from '@/models/user'
 import { satelliteListItemSchema } from '@/types/dto'
 
 export const dynamic = 'force-dynamic'
@@ -12,6 +13,8 @@ export const GET = operation({
   responses: [responseSpec(200, satelliteListItemSchema.array())] as const,
   implementation: async () => {
     const satellites = await getAllSatellites()
+    const users = await getUsers()
+    const userNameById = new Map(users.map((user) => [user.id, user.name]))
     const connectionsById = new Map(
       Array.from(hub.connections.values()).map((conn) => [conn.satelliteId, conn])
     )
@@ -21,6 +24,7 @@ export const GET = operation({
       name: satellite.name,
       kind: 'registered' as const,
       connected: connectionsById.has(satellite.id),
+      ownerName: userNameById.get(satellite.userId) ?? null,
       createdAt: satellite.createdAt,
       updatedAt: satellite.updatedAt,
     }))
@@ -32,6 +36,7 @@ export const GET = operation({
         name: conn.name,
         kind: 'ephemeral' as const,
         connected: true,
+        ownerName: userNameById.get(conn.userId) ?? null,
         createdAt: conn.connectedAt.toISOString(),
         updatedAt: conn.connectedAt.toISOString(),
       }))

--- a/apps/frontend/app/admin/satellites/page.tsx
+++ b/apps/frontend/app/admin/satellites/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useTranslation } from 'react-i18next'
 import { useState } from 'react'
-import { Column, SimpleTable, column } from '@/components/ui/tables'
+import { Column, SimpleTable } from '@/components/ui/tables'
 import { SearchBarWithButtonsOnRight } from '@/components/app/SearchBarWithButtons'
 import { AdminPage } from '../components/AdminPage'
 import { useAdminSatellites } from '@/hooks/satellites'
@@ -24,19 +24,57 @@ const AdminSatellitesPage = () => {
   const ephemeralSatellites = filteredSatellites.filter((s) => s.kind === 'ephemeral')
 
   const columns: Column<dto.SatelliteListItem>[] = [
-    column(t('name'), (satellite) => (
-      <Link variant="ghost" href={`/admin/satellites/${satellite.id}`}>
-        {satellite.name}
-      </Link>
-    )),
-    column('Type', (satellite) => (
-      <span className="text-xs px-2 py-1 rounded-full bg-blue-100 text-blue-700">
-        {satellite.kind === 'ephemeral' ? 'Personal Bridge' : 'Registered'}
-      </span>
-    )),
-    column(t('created'), (satellite) => (
-      <span>{satellite.createdAt ? new Date(satellite.createdAt).toLocaleDateString() : 'Live only'}</span>
-    )),
+    {
+      name: t('name'),
+      headerClass: 'text-center',
+      renderer: (satellite) => (
+        <div className="text-center">
+          <Link variant="ghost" href={`/admin/satellites/${satellite.id}`}>
+            {satellite.name}
+          </Link>
+        </div>
+      ),
+    },
+    {
+      name: t('owner'),
+      headerClass: 'text-center',
+      renderer: (satellite) => <div className="text-center">{satellite.ownerName ?? '-'}</div>,
+    },
+    {
+      name: 'Type',
+      headerClass: 'text-center',
+      renderer: (satellite) => (
+        <div className="text-center">
+          <span className="text-xs px-2 py-1 rounded-full bg-blue-100 text-blue-700">
+            {satellite.kind === 'ephemeral' ? 'Personal Bridge' : 'Registered'}
+          </span>
+        </div>
+      ),
+    },
+    {
+      name: t('created'),
+      headerClass: 'text-center',
+      renderer: (satellite) => (
+        <div className="text-center">
+          {satellite.createdAt ? new Date(satellite.createdAt).toLocaleDateString() : 'Live only'}
+        </div>
+      ),
+    },
+    {
+      name: t('connected'),
+      headerClass: 'text-center',
+      renderer: (satellite) => (
+        <div className="text-center">
+          <span
+            className={`text-xs px-2 py-1 rounded-full ${
+              satellite.connected ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'
+            }`}
+          >
+            {satellite.connected ? `● ${t('connected')}` : `○ ${t('disconnected')}`}
+          </span>
+        </div>
+      ),
+    },
   ]
 
   return (

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -5993,6 +5993,10 @@ components:
             - ephemeral
         connected:
           type: boolean
+        ownerName:
+          anyOf:
+            - type: string
+            - type: "null"
         createdAt:
           anyOf:
             - type: string
@@ -6010,6 +6014,7 @@ components:
         - name
         - kind
         - connected
+        - ownerName
         - createdAt
         - updatedAt
       additionalProperties: false

--- a/packages/core/src/types/dto/satellite.ts
+++ b/packages/core/src/types/dto/satellite.ts
@@ -15,6 +15,7 @@ export const satelliteListItemSchema = z.object({
   name: z.string(),
   kind: z.enum(['registered', 'ephemeral']),
   connected: z.boolean(),
+  ownerName: z.string().nullable(),
   createdAt: iso8601UtcDateTimeSchema.nullable(),
   updatedAt: iso8601UtcDateTimeSchema.nullable(),
 }).meta({ id: 'SatelliteListItem' })


### PR DESCRIPTION
## Summary
The admin "Satellites Overview" table now shows the owning user and live connection status for each satellite, and all column content (headers and data) is centered. This applies to both the "Registered Satellites" and "Personal Bridges" sections, which share the same column configuration.

## Details
- Added an `OWNER` column between `Name` and `Type`, showing the owning user's name.
- Added a `CONNECTED` column at the end, showing a green `● Connected` or gray `○ Disconnected` pill, matching the existing badge style used on the personal satellites page.
- Backend: added `ownerName` to `SatelliteListItem` (resolved from `userId` via a user lookup) in both the admin (`/api/satellites`) and per-user (`/api/me/satellites`) list routes.
- Regenerated `apps/frontend/public/openapi.yaml` to reflect the new `ownerName` field.

## Tests
- `npm run check-types` — passes.
- Verified the updated admin route logic (owner resolution + connection status) against the real local dev database via a throwaway script; results matched expectations.
- Could not perform a full browser click-through: Playwright's Chrome binary isn't installed in this environment and I lack root access to install it.