### PR TITLE
Restyle satellite detail pages and add admin rename support

### DIFF
--- a/apps/backend/api/satellites/[id]/route.ts
+++ b/apps/backend/api/satellites/[id]/route.ts
@@ -1,6 +1,6 @@
 import { ok, noBody, operation, responseSpec, errorSpec, notFound } from '@/lib/routes'
-import { getSatellite, deleteSatellite } from '@/models/satellite'
-import { satelliteSchema } from '@/types/dto'
+import { getSatellite, deleteSatellite, updateSatellite } from '@/models/satellite'
+import { satelliteSchema, updateableSatelliteSchema } from '@/types/dto'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,6 +15,22 @@ export const GET = operation({
       return notFound()
     }
     return ok({ ...satellite, secret: satellite.secret ? '<hidden>' : null })
+  },
+})
+
+export const PATCH = operation({
+  name: 'Update satellite',
+  description: 'Admin: rename any satellite.',
+  authentication: 'admin',
+  requestBodySchema: updateableSatelliteSchema,
+  responses: [responseSpec(200, satelliteSchema), errorSpec(404)] as const,
+  implementation: async ({ params, body }) => {
+    const satellite = await getSatellite(params.id)
+    if (!satellite) {
+      return notFound()
+    }
+    const updated = await updateSatellite(params.id, satellite.userId, body)
+    return ok({ ...updated, secret: updated.secret ? '<hidden>' : null })
   },
 })
 

--- a/apps/frontend/app/admin/satellites/[id]/page.tsx
+++ b/apps/frontend/app/admin/satellites/[id]/page.tsx
@@ -1,63 +1,56 @@
 'use client'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'next/navigation'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Prop, PropList } from '@/components/ui/proplist'
+import { useAdminSatellite } from '@/hooks/satellites'
 import { AdminPage } from '../../components/AdminPage'
-import toast from 'react-hot-toast'
-import { get } from '@/lib/fetch'
-import * as dto from '@/types/dto'
+import { SatelliteDialog } from '@/app/satellites/components/SatelliteDialog'
 
 const SatelliteDetail = () => {
   const { t } = useTranslation()
   const params = useParams()
   const satelliteId = params.id as string
+  const { data: satellite, isLoading, mutate } = useAdminSatellite(satelliteId)
+  const [renamingSatellite, setRenamingSatellite] = useState(false)
 
-  const [satellite, setSatellite] = useState<dto.Satellite | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    void loadSatellite()
-  }, [satelliteId])
-
-  async function loadSatellite() {
-    try {
-      const response = await get(`/api/me/satellites/${satelliteId}`)
-      if (response.error) {
-        toast.error(response.error.message)
-        return
-      }
-      setSatellite(response.data as dto.Satellite)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  if (loading) {
-    return <AdminPage title={t('loading')}>{t('loading')}</AdminPage>
-  }
-
-  if (!satellite) {
-    return <AdminPage title={t('not-found')}>{t('satellite-not-found')}</AdminPage>
+  if (!isLoading && !satellite) {
+    return <AdminPage title={t('satellite-not-found')}>{null}</AdminPage>
   }
 
   return (
-    <AdminPage title={satellite.name}>
-      <div className="border rounded-lg p-4">
-        <h2 className="text-lg font-semibold mb-4">{t('satellite-details')}</h2>
-        <div className="space-y-2">
-          <div>
-            <span className="text-sm font-medium">{t('name')}:</span> {satellite.name}
-          </div>
-          <div>
-            <span className="text-sm font-medium">{t('id')}:</span>
-            <code className="ml-2 bg-gray-100 px-2 py-1 rounded text-xs">{satellite.id}</code>
-          </div>
-          <div>
-            <span className="text-sm font-medium">{t('created')}:</span>{' '}
-            {new Date(satellite.createdAt).toLocaleDateString()}
-          </div>
-        </div>
-      </div>
+    <AdminPage
+      isLoading={isLoading}
+      title={satellite?.name ?? ''}
+      headerActions={
+        <Button variant="secondary" onClick={() => setRenamingSatellite(true)}>
+          {t('rename')}
+        </Button>
+      }
+    >
+      {satellite && (
+        <Card className="p-4 max-w-xl">
+          <h2 className="text-lg font-semibold mb-4">{t('satellite-details')}</h2>
+          <PropList>
+            <Prop label={t('name')}>{satellite.name}</Prop>
+            <Prop label={t('id')}>
+              <code className="bg-muted px-2 py-1 rounded text-xs">{satellite.id}</code>
+            </Prop>
+            <Prop label={t('created')}>{new Date(satellite.createdAt).toLocaleDateString()}</Prop>
+          </PropList>
+        </Card>
+      )}
+      {satellite && renamingSatellite && (
+        <SatelliteDialog
+          mode="rename"
+          scope="admin"
+          satellite={satellite}
+          onClose={() => setRenamingSatellite(false)}
+          onSaved={(updated) => mutate(updated, { revalidate: false })}
+        />
+      )}
     </AdminPage>
   )
 }

--- a/apps/frontend/app/satellites/[id]/page.tsx
+++ b/apps/frontend/app/satellites/[id]/page.tsx
@@ -1,77 +1,61 @@
 'use client'
 import { useTranslation } from 'react-i18next'
-import { useRouter, useParams } from 'next/navigation'
+import { useParams } from 'next/navigation'
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Prop, PropList } from '@/components/ui/proplist'
 import { useSatellite } from '@/hooks/satellites'
+import { AdminPage } from '@/app/admin/components/AdminPage'
 import { SatelliteDialog } from '../components/SatelliteDialog'
 
 const SatelliteDetail = () => {
   const { t } = useTranslation()
   const params = useParams()
-  const router = useRouter()
   const satelliteId = params.id as string
-  const { data: satellite, isLoading: loading } = useSatellite(satelliteId)
+  const { data: satellite, isLoading, mutate } = useSatellite(satelliteId)
   const [renamingSatellite, setRenamingSatellite] = useState(false)
 
-  if (loading) {
-    return (
-      <div className="h-full flex items-center justify-center">
-        <div>{t('loading')}</div>
-      </div>
-    )
-  }
-
-  if (!satellite) {
-    return (
-      <div className="h-full flex flex-col items-center justify-center">
-        <p className="text-gray-500 mb-4">{t('satellite-not-found')}</p>
-        <Button onClick={() => router.back()}>{t('back')}</Button>
-      </div>
-    )
+  if (!isLoading && !satellite) {
+    return <AdminPage title={t('satellite-not-found')}>{null}</AdminPage>
   }
 
   return (
-    <div className="h-full flex flex-col p-6 overflow-y-auto">
-      <div className="mb-6 flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">{satellite.name}</h1>
-          <p className="text-sm text-gray-600 mt-1">Registered Satellite</p>
-        </div>
-        <div className="flex gap-2">
-          <Button variant="secondary" onClick={() => setRenamingSatellite(true)}>
-            {t('rename')}
-          </Button>
-          <Button variant="ghost" onClick={() => router.back()}>
-            {t('back')}
-          </Button>
-        </div>
-      </div>
-
-      <div className="border rounded-lg p-4">
-        <h2 className="text-lg font-semibold mb-4">{t('satellite-details')}</h2>
-        <div className="space-y-2">
-          <div>
-            <span className="text-sm font-medium">{t('name')}:</span> {satellite.name}
-          </div>
-          <div>
-            <span className="text-sm font-medium">{t('id')}:</span>
-            <code className="ml-2 bg-gray-100 px-2 py-1 rounded text-xs">{satellite.id}</code>
-          </div>
-          <div>
-            <span className="text-sm font-medium">{t('created')}:</span>{' '}
-            {new Date(satellite.createdAt).toLocaleDateString()}
-          </div>
-        </div>
-      </div>
-      {renamingSatellite && (
-        <SatelliteDialog
-          mode="rename"
-          satellite={satellite}
-          onClose={() => setRenamingSatellite(false)}
-        />
+    <AdminPage
+      isLoading={isLoading}
+      title={satellite?.name ?? ''}
+      headerActions={
+        <Button variant="secondary" onClick={() => setRenamingSatellite(true)}>
+          {t('rename')}
+        </Button>
+      }
+    >
+      {satellite && (
+        <>
+          <p className="text-sm text-muted-foreground -mt-3 mb-4">{t('registered-satellite')}</p>
+          <Card className="p-4 max-w-xl">
+            <h2 className="text-lg font-semibold mb-4">{t('satellite-details')}</h2>
+            <PropList>
+              <Prop label={t('name')}>{satellite.name}</Prop>
+              <Prop label={t('id')}>
+                <code className="bg-muted px-2 py-1 rounded text-xs">{satellite.id}</code>
+              </Prop>
+              <Prop label={t('created')}>
+                {new Date(satellite.createdAt).toLocaleDateString()}
+              </Prop>
+            </PropList>
+          </Card>
+          {renamingSatellite && (
+            <SatelliteDialog
+              mode="rename"
+              satellite={satellite}
+              onClose={() => setRenamingSatellite(false)}
+              onSaved={(updated) => mutate(updated, { revalidate: false })}
+            />
+          )}
+        </>
       )}
-    </div>
+    </AdminPage>
   )
 }
 

--- a/apps/frontend/app/satellites/components/SatelliteDialog.tsx
+++ b/apps/frontend/app/satellites/components/SatelliteDialog.tsx
@@ -7,18 +7,19 @@ import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { post, patch } from '@/lib/fetch'
-import { mutateSatellites } from '@/hooks/satellites'
+import { mutateSatellites, mutateAdminSatellites } from '@/hooks/satellites'
 import * as dto from '@/types/dto'
 import { SatelliteSecretDialog } from './SatelliteSecretDialog'
 
 type Props = {
   mode: 'create' | 'rename'
+  scope?: 'me' | 'admin'
   satellite?: dto.Satellite | dto.SatelliteListItem
   onClose: () => void
   onSaved?: (satellite: dto.Satellite) => void
 }
 
-export const SatelliteDialog = ({ mode, satellite, onClose, onSaved }: Props) => {
+export const SatelliteDialog = ({ mode, scope = 'me', satellite, onClose, onSaved }: Props) => {
   const { t } = useTranslation()
   const nameId = useId()
   const [name, setName] = useState(satellite?.name ?? '')
@@ -38,7 +39,10 @@ export const SatelliteDialog = ({ mode, satellite, onClose, onSaved }: Props) =>
       const response =
         mode === 'create'
           ? await post<dto.Satellite>('/api/me/satellites', { name: trimmedName })
-          : await patch<dto.Satellite>(`/api/me/satellites/${satellite?.id}`, { name: trimmedName })
+          : await patch<dto.Satellite>(
+              `${scope === 'admin' ? '/api/satellites' : '/api/me/satellites'}/${satellite?.id}`,
+              { name: trimmedName }
+            )
 
       if (response.error) {
         toast.error(response.error.message)
@@ -46,7 +50,7 @@ export const SatelliteDialog = ({ mode, satellite, onClose, onSaved }: Props) =>
       }
 
       const savedSatellite = response.data as dto.Satellite
-      await mutateSatellites()
+      await (scope === 'admin' ? mutateAdminSatellites() : mutateSatellites())
       onSaved?.(savedSatellite)
 
       if (mode === 'create') {

--- a/apps/frontend/hooks/satellites.ts
+++ b/apps/frontend/hooks/satellites.ts
@@ -97,6 +97,26 @@ export function mutateAdminSatellites() {
   return mutate(ADMIN_SATELLITES_URL)
 }
 
+export function useAdminSatellite(id: string) {
+  const { data, error, isLoading, mutate } = useSWR(
+    id ? `${ADMIN_SATELLITES_URL}/${id}` : null,
+    async (url) => {
+      const response = await get(url)
+      if (response.error) {
+        throw new Error(response.error.message)
+      }
+      return response.data as dto.Satellite
+    }
+  )
+
+  return {
+    data,
+    error: error?.message || null,
+    isLoading,
+    mutate,
+  }
+}
+
 export function useSatellite(id: string) {
   const { data, error, isLoading, mutate } = useSWR(
     id ? `/api/me/satellites/${id}` : null,

--- a/apps/frontend/locales/en/logicle.json
+++ b/apps/frontend/locales/en/logicle.json
@@ -89,6 +89,7 @@
   "registered": "Registered",
   "ephemeral": "Ephemeral",
   "registered-satellites": "Registered Satellites",
+  "registered-satellite": "Registered Satellite",
   "personal-bridges": "Personal Bridges",
   "connected": "Connected",
   "disconnected": "Disconnected",

--- a/apps/frontend/locales/it/logicle.json
+++ b/apps/frontend/locales/it/logicle.json
@@ -89,6 +89,7 @@
   "registered": "Registrato",
   "ephemeral": "Effimero",
   "registered-satellites": "Satelliti Registrati",
+  "registered-satellite": "Satellite Registrato",
   "personal-bridges": "Bridge Personali",
   "connected": "Connesso",
   "disconnected": "Disconnesso",

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -2559,6 +2559,36 @@ paths:
             type: string
       security:
         - bearerAuth: []
+    patch:
+      summary: Update satellite
+      description: "Admin: rename any satellite."
+      responses:
+        "200":
+          description: Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Satellite"
+        "404":
+          $ref: "#/components/responses/Error"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+              additionalProperties: false
   /api/satellites:
     get:
       summary: List all satellites


### PR DESCRIPTION
## Summary

The `/satellites/{id}` and `/admin/satellites/{id}` detail pages now render with the shared `Card`/`PropList` components used across the rest of the app instead of ad-hoc bordered divs and inline `<span>` labels, bringing them in line with the styling of the other single-entity admin panels (backends, workspaces, SSO connections, users). Admins can now also rename any satellite from the admin panel.

## Details

- Fixed the admin detail page fetching `GET /api/me/satellites/{id}` (owner-scoped) instead of the intended `GET /api/satellites/{id}` (admin-scoped) endpoint, which caused a 404 for any satellite the admin didn't personally own.
- Added admin `PATCH /api/satellites/{id}` (mirroring the existing admin `DELETE`'s pattern of updating via the satellite's actual owner id) so admins can rename satellites they don't own.
- Fixed a stale-cache bug on the owner-facing detail page: renaming only revalidated the satellite list cache, not the single-satellite cache the detail page reads, so a successful rename showed a "saved" toast but kept displaying the old name until a manual reload.
- Removed a redundant in-page "Back" button; navigation back to the satellite list is already covered by the persistent left-rail satellite icon, matching every other single-entity detail panel in the app.
- Replaced a hardcoded, untranslated "Registered Satellite" subtitle with a proper `registered-satellite` i18n key (added to both `en` and `it` locales).
- Regenerated `apps/frontend/public/openapi.yaml` for the new endpoint.

## Tests

- `npm run check-types` — passes
- Manually exercised both detail pages in the browser: rename on `/satellites/{id}` and `/admin/satellites/{id}`, confirmed immediate UI update and reverted test renames back to the original name