### PR TITLE
fix: abort S3 download stream when client disconnects

### DIFF
--- a/__tests__/fileUploadRoutes.test.ts
+++ b/__tests__/fileUploadRoutes.test.ts
@@ -482,6 +482,7 @@ describe('GET /api/files/:fileId/content', () => {
       expectedSizeBytes: 100,
       rangeStart: 10,
       rangeEnd: 19,
+      signal: expect.any(AbortSignal),
     })
   })
 
@@ -518,6 +519,7 @@ describe('GET /api/files/:fileId/content', () => {
       expectedSizeBytes: 100,
       rangeStart: 0,
       rangeEnd: 9,
+      signal: expect.any(AbortSignal),
     })
   })
 
@@ -535,6 +537,9 @@ describe('GET /api/files/:fileId/content', () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get('accept-ranges')).toBe('none')
-    expect(mocks.readStream).toHaveBeenCalledWith('pgp.txt', 'pgp', { expectedSizeBytes: 100 })
+    expect(mocks.readStream).toHaveBeenCalledWith('pgp.txt', 'pgp', {
+      expectedSizeBytes: 100,
+      signal: expect.any(AbortSignal),
+    })
   })
 })

--- a/__tests__/routerAbortSignal.test.ts
+++ b/__tests__/routerAbortSignal.test.ts
@@ -1,0 +1,113 @@
+import { EventEmitter } from 'node:events'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { describe, expect, test, vi } from 'vitest'
+
+const streamingPathname = '/api/__test-probe-streaming__'
+const instantPathname = '/api/__test-probe-instant__'
+let capturedSignal: AbortSignal | undefined
+
+vi.mock('@/lib/router/routes.generated', () => ({
+  backendRouteModules: [
+    {
+      pathname: streamingPathname,
+      load: async () => ({
+        GET: async ({ signal }: { signal: AbortSignal }) => {
+          capturedSignal = signal
+          let streamController: ReadableStreamDefaultController<Uint8Array> | undefined
+          const stream = new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamController = controller
+            },
+          })
+          // Mirrors the pattern used by real streaming routes (e.g. file
+          // download -> S3Storage): close the stream when the caller aborts.
+          signal.addEventListener('abort', () => {
+            streamController?.close()
+          })
+          return new Response(stream, { status: 200 })
+        },
+      }),
+    },
+    {
+      pathname: instantPathname,
+      load: async () => ({
+        GET: async ({ signal }: { signal: AbortSignal }) => {
+          capturedSignal = signal
+          return new Response(null, { status: 204 })
+        },
+      }),
+    },
+  ],
+}))
+
+const { handleApiRequest } = await import('@/lib/router')
+
+class FakeIncomingMessage extends EventEmitter {
+  method = 'GET'
+  headers = { host: 'localhost' }
+  socket = { encrypted: false }
+  constructor(public url: string) {
+    super()
+  }
+}
+
+class FakeServerResponse extends EventEmitter {
+  statusCode = 0
+  statusMessage = ''
+  writableEnded = false
+  private headers: Record<string, string> = {}
+
+  setHeader(key: string, value: string) {
+    this.headers[key] = value
+  }
+
+  write(_chunk: unknown, cb?: (err?: Error | null) => void) {
+    cb?.()
+    return true
+  }
+
+  end(cb?: () => void) {
+    this.writableEnded = true
+    cb?.()
+    this.emit('finish')
+  }
+}
+
+describe('handleApiRequest abort wiring', () => {
+  test('aborts the request signal when the client disconnects before the response finishes', async () => {
+    capturedSignal = undefined
+    const req = new FakeIncomingMessage(streamingPathname)
+    const res = new FakeServerResponse()
+
+    // Fire-and-forget: this stays pending until the fake stream ends, which
+    // only happens once the abort fires below. We only care about the
+    // signal's state, not about the handler promise settling.
+    void handleApiRequest(req as unknown as IncomingMessage, res as unknown as ServerResponse).catch(
+      () => {}
+    )
+
+    // Let the handler run far enough to register its 'abort' listener and
+    // start streaming, then simulate the client disconnecting mid-response.
+    await vi.waitFor(() => expect(capturedSignal).toBeDefined())
+    expect(capturedSignal!.aborted).toBe(false)
+    expect(res.writableEnded).toBe(false)
+
+    res.emit('close')
+
+    expect(capturedSignal!.aborted).toBe(true)
+  })
+
+  test('does not abort the request signal on a normal, completed response', async () => {
+    capturedSignal = undefined
+    const req = new FakeIncomingMessage(instantPathname)
+    const res = new FakeServerResponse()
+
+    await handleApiRequest(req as unknown as IncomingMessage, res as unknown as ServerResponse)
+
+    // A normal completion still emits 'close' after 'finish'; that must not
+    // be mistaken for a client disconnect.
+    res.emit('close')
+
+    expect(capturedSignal!.aborted).toBe(false)
+  })
+})

--- a/apps/backend/api/files/[fileId]/content/route.ts
+++ b/apps/backend/api/files/[fileId]/content/route.ts
@@ -173,7 +173,7 @@ export const GET = operation({
   name: 'Download file content',
   authentication: 'user',
   responses: [responseSpec(200, z.any()), errorSpec(403), errorSpec(404)] as const,
-  implementation: async ({ params, headers, session }) => {
+  implementation: async ({ params, headers, session, signal }) => {
     const file = await db
       .selectFrom('File')
       .leftJoin('FileBlob', 'FileBlob.id', 'File.fileBlobId')
@@ -203,6 +203,7 @@ export const GET = operation({
         expectedSizeBytes: file.size,
         rangeStart: start,
         rangeEnd: end,
+        signal,
       })
       return new Response(stream, {
         status: 206,
@@ -217,6 +218,7 @@ export const GET = operation({
 
     const fileContent = await storage.readStream(file.path, file.encryption, {
       expectedSizeBytes: file.size ?? undefined,
+      signal,
     })
     return new Response(fileContent, {
       headers: {

--- a/apps/backend/lib/router.ts
+++ b/apps/backend/lib/router.ts
@@ -29,7 +29,7 @@ const toNodeRequestUrl = (req: IncomingMessage) => {
   return new URL(req.url ?? '/', `${protocol}://${host}`)
 }
 
-const toWebRequest = (req: IncomingMessage) => {
+const toWebRequest = (req: IncomingMessage, signal: AbortSignal) => {
   const url = toNodeRequestUrl(req)
   const headers = new Headers()
 
@@ -54,6 +54,7 @@ const toWebRequest = (req: IncomingMessage) => {
         ? undefined
         : (Readable.toWeb(req) as ReadableStream),
     duplex: 'half',
+    signal,
   } as RequestInit)
 }
 
@@ -129,7 +130,19 @@ const methodNotAllowedForModule = (routeModule: RouteModule) => {
 }
 
 export async function handleApiRequest(req: IncomingMessage, res: ServerResponse) {
-  const request = toWebRequest(req)
+  // Ties the Request's AbortSignal to the real connection lifecycle: if the
+  // client disconnects before we finish writing the response (e.g. a large
+  // file download is cancelled mid-stream), route handlers observing
+  // `signal` can tear down any in-flight upstream work (S3 reads, etc.)
+  // instead of leaving it running until it times out on its own.
+  const abortController = new AbortController()
+  res.on('close', () => {
+    if (!res.writableEnded) {
+      abortController.abort()
+    }
+  })
+
+  const request = toWebRequest(req, abortController.signal)
   const url = new URL(request.url)
   const match = matchRoute(url.pathname)
 

--- a/apps/backend/lib/storage/S3Storage.ts
+++ b/apps/backend/lib/storage/S3Storage.ts
@@ -103,14 +103,20 @@ export class S3Storage extends BaseStorage {
             : undefined,
       }
       const command = new GetObjectCommand(params)
-      const response = await this.s3Client.send(command)
+      // abortSignal keeps the underlying socket tied to the client's request:
+      // if the client disconnects mid-download, the SDK destroys the S3
+      // connection immediately instead of leaving it open (and unreturned to
+      // the agent pool) until S3 itself times it out.
+      const response = await this.s3Client.send(command, { abortSignal: options?.signal })
       const body = response.Body
       if (!body) {
         throw new Error(`Failed reading S3 object ${path}: No body`)
       }
       return body.transformToWebStream()
     } catch (error) {
-      logger.error('Failed reading S3 object', error)
+      if (!options?.signal?.aborted) {
+        logger.error('Failed reading S3 object', error)
+      }
       throw error
     }
   }

--- a/apps/backend/lib/storage/api.ts
+++ b/apps/backend/lib/storage/api.ts
@@ -7,6 +7,7 @@ export interface StorageReadOptions {
   bypassCache?: boolean
   rangeStart?: number
   rangeEnd?: number
+  signal?: AbortSignal
 }
 
 export interface Storage {

--- a/apps/backend/scripts/smoke.ts
+++ b/apps/backend/scripts/smoke.ts
@@ -75,6 +75,7 @@ function createSession() {
       headers = {},
       includeCookies = true,
       allowStatus = null,
+      signal,
     } = opts
     const allHeaders: Record<string, string> = { ...headers }
     if (includeCookies && sessionCookies.size > 0) {
@@ -89,6 +90,7 @@ function createSession() {
       method,
       headers: allHeaders,
       body: payload,
+      signal,
     })
     setCookiesFromResponse(res.headers)
     const text = await res.text()
@@ -115,6 +117,7 @@ type RequestOptions = {
   headers?: Record<string, string>
   includeCookies?: boolean
   allowStatus?: number[] | null
+  signal?: AbortSignal
 }
 
 async function request(method: string, path: string, opts: RequestOptions = {}) {
@@ -580,6 +583,56 @@ async function main() {
     throw new Error(
       `Unexpected ranged accept-ranges header: ${rangedContent.res.headers.get('accept-ranges')}`
     )
+  }
+
+  console.log('Smoke: aborting a download mid-stream does not break the server')
+  {
+    // Large enough that the response is still streaming out when we cut the
+    // client connection below, instead of already having completed.
+    const abortPayload = crypto.randomBytes(4 * 1024 * 1024)
+    const abortFileCreated = await requestUser('POST', '/api/files', {
+      expectedStatus: 201,
+      headers: jsonHeaders,
+      json: {
+        name: `smoke-abort-${runId}.bin`,
+        type: 'application/octet-stream',
+        size: abortPayload.byteLength,
+        owner,
+      },
+    })
+    const abortFileId = (
+      parseJson(abortFileCreated.text, '/api/files POST abort') as { id: string }
+    ).id
+    await requestUser('PUT', `/api/files/${abortFileId}/content`, {
+      expectedStatus: 204,
+      headers: { 'content-type': 'application/octet-stream', ...sameOriginHeaders },
+      body: new Uint8Array(abortPayload),
+    })
+
+    const controller = new AbortController()
+    const downloadPromise = requestUser('GET', `/api/files/${abortFileId}/content`, {
+      headers: sameOriginHeaders,
+      signal: controller.signal,
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    controller.abort()
+
+    let sawAbortError = false
+    try {
+      await downloadPromise
+    } catch (err) {
+      sawAbortError = err instanceof Error && err.name === 'AbortError'
+    }
+    if (!sawAbortError) {
+      throw new Error('Expected the client-aborted download request to reject with AbortError')
+    }
+
+    // The server must stay healthy and keep serving unrelated requests after
+    // a client disconnects mid-download.
+    await requestUser('GET', '/api/me/profile', {
+      expectedStatus: 200,
+      headers: sameOriginHeaders,
+    })
   }
 
   console.log('Smoke: pdf upload analysis preview')


### PR DESCRIPTION
## Summary
Fixes a socket leak on file downloads: `GET /api/files/[fileId]/content` never propagated the request's `AbortSignal` down to `S3Storage.readStream`, so when a client disconnected mid-download, the S3 connection stayed open (held by the shared `NodeHttpHandler` agent, `maxSockets: 500`) until S3's own idle timeout instead of being released immediately. Under sustained traffic this drains the shared pool and queues unrelated S3 requests (uploads/downloads) app-wide.

`StorageReadOptions` now carries an optional `signal`, threaded from the route through the storage layer chain (already transparently forwarded by `CachingStorage`/`PgpEncryptingStorage`/`AeadEncryptingStorage`) down to `S3Storage.readStream`, which passes it as `abortSignal` to `s3Client.send(...)`.

## Details
- Reproduced on `dev.logicle.dev` (v0.32.0-rc3, no fix): 40 downloads of a 259MB file aborted client-side after 1s pushed established S3 connections on the `logicle-app` container from 1 to 51; 41 were still open a minute later.
- Only the plain (non-range) and range-request download paths in the `content` route are affected; both now pass `signal` through.

## Tests
- `npx tsc --noEmit -p .` — clean