### PR TITLE
feat: run file analyzer as sandboxed stdio MCP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,13 @@ jobs:
           SHORT_SHA="${GITHUB_SHA::8}"
           echo "version=${DATE}.${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build production image (local)
         uses: docker/build-push-action@v5
         with:
@@ -186,6 +193,14 @@ jobs:
           build-args: APP_VERSION=${{ steps.buildver.outputs.version }}
           cache-from: type=gha,scope=nextjs-build
           cache-to: type=gha,mode=max,scope=nextjs-build
+
+      - name: Verify bundled file analyzer
+        run: |
+          docker run --rm --entrypoint sh "${SMOKE_IMAGE}" -c '
+            mcp-file-analyzer -help >/dev/null
+            command -v soffice
+            command -v pdftoppm
+          '
 
       - name: Run smoke and baseline integration checks
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.5
 
 # Pin this to a released analyzer version (or digest) when updating it.
-ARG FILE_ANALYZER_IMAGE=ghcr.io/logicleai/mcp-file-analyzer:0.5.0
+ARG FILE_ANALYZER_IMAGE=ghcr.io/logicleai/mcp-file-analyzer:0.6.0
 
 # ---------------------
 # Stage 1: File analyzer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,29 @@
+# syntax=docker/dockerfile:1.5
+
+# Pin this to a released analyzer version (or digest) when updating it.
+ARG FILE_ANALYZER_IMAGE=ghcr.io/logicleai/mcp-file-analyzer:0.5.0
+
 # ---------------------
-# Stage 1: Builder
+# Stage 1: File analyzer
+# ---------------------
+FROM ${FILE_ANALYZER_IMAGE} AS file-analyzer
+
+# ---------------------
+# Stage 2: Builder
 # ---------------------
 # This is the build stage where we build the NextJS application.
-# syntax directive enables --mount support
-# syntax=docker/dockerfile:1.5
-FROM node:24-alpine AS builder
+FROM node:24-bookworm-slim AS builder
 
 # Accept optional version at build time: --build-arg APP_VERSION=1.2.3
 ARG APP_VERSION
 
-RUN apk add --no-cache \
-    python3 make g++ py3-pip py3-setuptools \
-    pkgconf \
-    cairo-dev pango-dev giflib-dev pixman-dev libjpeg-turbo-dev librsvg-dev \
-    vips-dev \
-    && ln -sf python3 /usr/bin/python
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 make g++ python3-pip python3-setuptools \
+    pkg-config \
+    libcairo2-dev libpango1.0-dev libgif-dev libpixman-1-dev libjpeg62-turbo-dev librsvg2-dev \
+    libvips-dev \
+    && ln -sf python3 /usr/bin/python \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g node-gyp pnpm@10.10.0
 
@@ -56,18 +65,28 @@ RUN --mount=type=cache,id=next-cache,target=/app/.next/cache \
 
 
 # ---------------------
-# Final Stage: Runtime
+# Stage 3: Runtime
 # ---------------------
-FROM node:24-alpine
+FROM node:24-bookworm-slim
 
 WORKDIR /app
 
 # Install kysely globally to enable database migrations at app startup
 RUN npm install -g kysely
 
-# Runtime libs for native modules (sharp/canvas)
-RUN apk add --no-cache \
-    cairo pango giflib pixman libjpeg-turbo librsvg vips vips-cpp
+# Runtime libraries for native modules (sharp/canvas), plus the renderer used by
+# mcp-file-analyzer for Office document previews.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libcairo2 libpango-1.0-0 libgif7 libpixman-1-0 libjpeg62-turbo librsvg2-2 libvips42 \
+    libreoffice-core-nogui \
+    libreoffice-impress-nogui \
+    libreoffice-writer-nogui \
+    libreoffice-calc-nogui \
+    fonts-liberation \
+    fonts-dejavu-core \
+    fonts-noto-core \
+    poppler-utils \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create and set permissions for directories
 RUN mkdir -p apps/frontend/.next/cache /data/sqlite /data/files \
@@ -79,6 +98,7 @@ COPY --from=builder /app/apps/frontend/.next/standalone ./
 COPY --from=builder /app/apps/frontend/.next/static ./apps/frontend/.next/static
 COPY --from=builder /app/dist-server ./dist-server
 COPY --from=builder /app/.env ./.env
+COPY --from=file-analyzer /mcp-file-analyzer /usr/local/bin/mcp-file-analyzer
 
 # Switch to the non-root 'node' for security reasons
 USER node

--- a/__tests__/mcpStdio.test.ts
+++ b/__tests__/mcpStdio.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest'
+import { McpPlugin } from '@/backend/lib/tools/mcp/implementation'
+import { mcpPluginSchema } from '@/lib/tools/schemas'
+
+const stdioConfig = {
+  transport: 'stdio' as const,
+  url: 'stdio://local' as const,
+  command: 'mcp-file-analyzer',
+  args: ['--example'],
+  authentication: { type: 'none' as const },
+}
+
+describe('stdio MCP tools', () => {
+  test('accepts a command and argument list', () => {
+    expect(mcpPluginSchema.parse(stdioConfig)).toEqual(stdioConfig)
+  })
+
+  test('does not expose an unprovisioned stdio tool', async () => {
+    const plugin = new McpPlugin(
+      {
+        id: 'local-mcp',
+        name: 'Local MCP',
+        promptFragment: '',
+        provisioned: false,
+      },
+      stdioConfig
+    )
+
+    await expect(plugin.functions({} as any, { userId: 'user-1' })).resolves.toEqual({})
+  })
+})

--- a/apps/backend/lib/tools/file-output-normalization.ts
+++ b/apps/backend/lib/tools/file-output-normalization.ts
@@ -114,7 +114,7 @@ export const normalizeMcpToolResult = async (
         ...params,
         content: Buffer.from(item.resource.blob, 'base64'),
         mimeType: item.resource.mimeType ?? defaultMimeType,
-        nameHint: item.resource.name,
+        nameHint: item.resource.name ?? item.resource.uri,
         source: 'MCP',
       })
       contentParts.push(persisted)

--- a/apps/backend/lib/tools/mcp/file-bridge.ts
+++ b/apps/backend/lib/tools/mcp/file-bridge.ts
@@ -1,0 +1,100 @@
+import type { Duplex } from 'node:stream'
+import { canAccessFile } from '@/backend/lib/files/authorization'
+import { getFileWithId } from '@/models/file'
+import { storage } from '@/lib/storage'
+
+export type McpPublishedArtifact = { name: string; mimeType: string; data: Buffer }
+
+const safeFileId = (value: unknown): value is string =>
+  typeof value === 'string' && /^[A-Za-z0-9_-]+$/.test(value)
+const safeSize = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 100 * 1024 * 1024
+
+const write = async (channel: Duplex, data: string | Buffer) => {
+  if (channel.write(data)) return
+  await new Promise<void>((resolve, reject) => {
+    channel.once('drain', resolve)
+    channel.once('error', reject)
+  })
+}
+
+/** A private, ordered protocol over FD 3. Headers are newline-delimited JSON;
+ * publish-artifact headers are followed by exactly `size` raw bytes. */
+export class McpFileBridge {
+  private buffer = Buffer.alloc(0)
+  private pendingArtifact?: { requestId?: string; name: string; mimeType: string; size: number }
+  private queue = Promise.resolve()
+  private artifacts: McpPublishedArtifact[] = []
+
+  constructor(
+    private readonly channel: Duplex,
+    private readonly scope: { conversationId: string; userId: string }
+  ) {
+    channel.on('data', (chunk: Buffer) => this.receive(Buffer.from(chunk)))
+  }
+
+  takeArtifacts(): McpPublishedArtifact[] {
+    const artifacts = this.artifacts
+    this.artifacts = []
+    return artifacts
+  }
+
+  private receive(chunk: Buffer) {
+    this.buffer = Buffer.concat([this.buffer, chunk])
+    while (true) {
+      if (this.pendingArtifact) {
+        if (this.buffer.length < this.pendingArtifact.size) return
+        const artifact = this.pendingArtifact
+        const data = this.buffer.subarray(0, artifact.size)
+        this.buffer = this.buffer.subarray(artifact.size)
+        this.pendingArtifact = undefined
+        this.enqueue(async () => {
+          this.artifacts.push({ name: artifact.name, mimeType: artifact.mimeType, data })
+          await write(this.channel, JSON.stringify({ type: 'artifact', requestId: artifact.requestId }) + '\n')
+        })
+        continue
+      }
+      const newline = this.buffer.indexOf(0x0a)
+      if (newline < 0) return
+      const line = this.buffer.subarray(0, newline).toString('utf8')
+      this.buffer = this.buffer.subarray(newline + 1)
+      let request: Record<string, unknown>
+      try { request = JSON.parse(line) } catch {
+        this.enqueue(() => write(this.channel, JSON.stringify({ type: 'error', message: 'Invalid bridge request' }) + '\n'))
+        continue
+      }
+      if (request.type === 'publish-artifact' && typeof request.name === 'string' && typeof request.mimeType === 'string' && safeSize(request.size)) {
+        this.pendingArtifact = { requestId: typeof request.requestId === 'string' ? request.requestId : undefined, name: request.name, mimeType: request.mimeType, size: request.size }
+        continue
+      }
+      this.enqueue(() => this.handleRequest(request))
+    }
+  }
+
+  private enqueue(task: () => Promise<void>) {
+    this.queue = this.queue.then(task).catch(() => { this.channel.destroy() })
+  }
+
+  private async handleRequest(request: Record<string, unknown>) {
+    const requestId = typeof request.requestId === 'string' ? request.requestId : undefined
+    if (request.type !== 'read-file' || !safeFileId(request.id)) {
+      await write(this.channel, JSON.stringify({ type: 'error', requestId, message: 'Invalid file request' }) + '\n')
+      return
+    }
+    if (!(await canAccessFile({ userId: this.scope.userId }, request.id))) {
+      await write(this.channel, JSON.stringify({ type: 'error', requestId, message: 'File access denied' }) + '\n')
+      return
+    }
+    const file = await getFileWithId(request.id)
+    if (!file) {
+      await write(this.channel, JSON.stringify({ type: 'error', requestId, message: 'File not found' }) + '\n')
+      return
+    }
+    const data = await storage.readBuffer(file.path, file.encryption)
+    await write(this.channel, JSON.stringify({ type: 'file', requestId, name: file.name, mimeType: file.type, size: data.length }) + '\n')
+    await write(this.channel, data)
+  }
+}
+
+export const attachMcpFileBridge = (channel: Duplex, scope: { conversationId: string; userId: string }) =>
+  new McpFileBridge(channel, scope)

--- a/apps/backend/lib/tools/mcp/implementation.ts
+++ b/apps/backend/lib/tools/mcp/implementation.ts
@@ -11,6 +11,7 @@ import {
   McpInterface,
   McpPluginAuthentication,
   McpPluginParams,
+  McpStdioPluginParams,
   isMcpStdioPluginParams,
   mcpPluginSchema,
 } from '@/lib/tools/schemas'
@@ -27,14 +28,15 @@ import type { ToolAuthParams } from '@/lib/chat/tools'
 import { LlmModel } from '@/lib/chat/models'
 import { LRUCache } from 'lru-cache'
 import * as dto from '@/types/dto'
-import { normalizeMcpToolResult } from '@/backend/lib/tools/file-output-normalization'
-import { getFileWithId } from '@/models/file'
-import { canAccessFile } from '@/backend/lib/files/authorization'
-import { storage } from '@/lib/storage'
+import { normalizeMcpToolResult, saveFile } from '@/backend/lib/tools/file-output-normalization'
+import { prepareMcpConversationSandbox, type McpConversationSandbox } from './sandbox'
+import { attachMcpFileBridge, type McpFileBridge } from './file-bridge'
+import { SandboxedStdioClientTransport } from './sandboxed-stdio-transport'
 
 interface CacheItem {
   id: string
   client: Client
+  bridge?: McpFileBridge
   keepAlive?: NodeJS.Timeout
 }
 
@@ -93,10 +95,44 @@ const computeHeaders = (
   return {}
 }
 
-const createTransport = (params: McpPluginParams, accessToken?: string) => {
+const createTransport = (
+  params: McpPluginParams,
+  accessToken?: string,
+  sandbox?: McpConversationSandbox,
+  bridgeRef?: { value?: McpFileBridge }
+) => {
   if (isMcpStdioPluginParams(params)) {
     logger.info(`Create MCP stdio transport for command ${params.command}`)
-    return new StdioClientTransport({ command: params.command, args: params.args })
+    const env = sandbox
+      ? {
+          PATH: process.env.PATH ?? '',
+          LANG: process.env.LANG ?? 'C.UTF-8',
+          HOME: `${sandbox.workspaceDir}/home`,
+          TMPDIR: `${sandbox.workspaceDir}/tmp`,
+          MCP_SANDBOX_DIR: sandbox.workspaceDir,
+          LOGICLE_MCP_SANDBOX: '1',
+        }
+      : undefined
+    if (sandbox) {
+      return new SandboxedStdioClientTransport({
+        command: params.command,
+        args: params.args,
+        env,
+        cwd: sandbox.workspaceDir,
+        onFileBridge: (channel) => {
+          bridgeRef!.value = attachMcpFileBridge(channel, sandbox)
+        },
+      })
+    }
+    const discoveryEnv = params.sandbox
+      ? { ...process.env, LOGICLE_MCP_SANDBOX: '1' }
+      : undefined
+    return new StdioClientTransport({
+      command: params.command,
+      args: params.args,
+      env: discoveryEnv,
+      cwd: undefined,
+    })
   }
   const { url, authentication } = params
   const headers = {
@@ -129,7 +165,8 @@ const createTransport = (params: McpPluginParams, accessToken?: string) => {
 const getClient = async (
   params: McpPluginParams,
   accessToken?: string,
-  cacheKeySuffix?: string
+  cacheKeySuffix?: string,
+  sandbox?: McpConversationSandbox
 ) => {
   const key = JSON.stringify({ params, accessToken, cacheKeySuffix })
   const cached = clientCache.get(key)
@@ -142,9 +179,15 @@ const getClient = async (
     name: 'example-client',
     version: '1.0.0',
   })
-  const transport = createTransport(params, accessToken)
+  const bridgeRef: { value?: McpFileBridge } = {}
+  const transport = createTransport(params, accessToken, sandbox, bridgeRef)
   transport.onclose = () => {
     logger.info('MCP Transport closed')
+    // A local stdio child can disappear independently, for example after its
+    // binary is restarted. Never retain a client whose transport has closed.
+    if (clientCache.get(key)?.client === client) {
+      clientCache.delete(key)
+    }
   }
   transport.onerror = (error) => {
     logger.error(
@@ -161,65 +204,8 @@ const getClient = async (
     throw e
   }
   const id = nanoid()
-  clientCache.set(key, { id, client, keepAlive: startKeepAlive(key, client) })
+  clientCache.set(key, { id, client, bridge: bridgeRef.value, keepAlive: startKeepAlive(key, client) })
   return client
-}
-
-// Detects a parameter that carries base64-encoded file bytes.
-function isBlobProperty(name: string, schema: JSONSchema7): boolean {
-  if (schema.type !== 'string') return false
-  const lower = name.toLowerCase()
-  if (lower === 'data' || lower === 'blob' || lower === 'content') {
-    const desc = (schema.description ?? '').toLowerCase()
-    if (desc.includes('base64')) return true
-  }
-  const fmt = (schema as Record<string, unknown>).format
-  if (fmt === 'byte' || fmt === 'base64') return true
-  return false
-}
-
-function isMimeTypeProperty(name: string): boolean {
-  const lower = name.toLowerCase()
-  return (
-    lower === 'mimetype' || lower === 'mime_type' || lower === 'mediatype' || lower === 'media_type'
-  )
-}
-
-// Returns the blob and mimeType property names if the schema has a blob+mimeType pair.
-function detectBlobSignature(
-  schema: JSONSchema7
-): { blobProp: string; mimeTypeProp: string } | null {
-  const props = schema.properties
-  if (!props) return null
-  let blobProp: string | null = null
-  let mimeTypeProp: string | null = null
-  for (const [name, propSchema] of Object.entries(props)) {
-    if (typeof propSchema === 'boolean') continue
-    if (isBlobProperty(name, propSchema)) blobProp = name
-    if (isMimeTypeProperty(name)) mimeTypeProp = name
-  }
-  return blobProp && mimeTypeProp ? { blobProp, mimeTypeProp } : null
-}
-
-// Rewrites a blob+mimeType schema to accept a file_id instead.
-function rewriteSchemaForFileId(
-  schema: JSONSchema7,
-  blobProp: string,
-  mimeTypeProp: string
-): JSONSchema7 {
-  const { [blobProp]: _b, [mimeTypeProp]: _m, ...rest } = schema.properties ?? {}
-  const required = (schema.required ?? []).filter((r) => r !== blobProp && r !== mimeTypeProp)
-  return {
-    ...schema,
-    properties: {
-      ...rest,
-      file_id: {
-        type: 'string',
-        description: 'Logicle file ID of the document to import.',
-      },
-    },
-    required: [...required, 'file_id'],
-  }
 }
 
 async function convertMcpSpecToToolFunctions(
@@ -249,26 +235,45 @@ async function convertMcpSpecToToolFunctions(
   const result: ToolFunctions = {}
   for (const tool_ of tools) {
     const tool = tool_ as any
-    const originalSchema = tool.inputSchema as JSONSchema7
-    const blobSig = detectBlobSignature(originalSchema)
-    const exposedSchema = blobSig
-      ? rewriteSchemaForFileId(originalSchema, blobSig.blobProp, blobSig.mimeTypeProp)
-      : originalSchema
-    const exposedDescription = blobSig
-      ? `${
-          tool.description ?? ''
-        }\n\nProvide a Logicle file_id; the file bytes are fetched automatically.`
-      : tool.description ?? ''
 
     result[tool.name] = {
-      description: exposedDescription,
+      description: tool.description ?? '',
       // the code below is highly unsafe... but it's a start
-      parameters: exposedSchema,
+      parameters: tool.inputSchema,
       auth: async () => null,
       invoke: async (invokeParams: ToolInvokeParams) => {
-        const { params, userId } = invokeParams
+        const { params, userId, conversationId } = invokeParams
         let clientToUse = client
         let accessToken: string | undefined
+        if (isMcpStdioPluginParams(toolParams) && toolParams.sandbox) {
+          if (!conversationId) {
+            return {
+              type: 'error-text' as const,
+              value: 'A conversation is required to use this sandboxed MCP tool.',
+            }
+          }
+          try {
+            const sandbox = await prepareMcpConversationSandbox(
+              toolParams as McpStdioPluginParams,
+              conversationId,
+              userId,
+            )
+            if (sandbox) {
+              clientToUse = await getClient(
+                toolParams,
+                undefined,
+                `conversation:${conversationId}`,
+                sandbox
+              )
+            }
+          } catch (error) {
+            logger.warn(`Failed preparing MCP sandbox for conversation ${conversationId}`, error)
+            return {
+              type: 'error-text' as const,
+              value: error instanceof Error ? error.message : 'Failed preparing MCP sandbox.',
+            }
+          }
+        }
         if (toolParams.authentication.type === 'oauth') {
           if (!userId) {
             return {
@@ -296,29 +301,6 @@ async function convertMcpSpecToToolFunctions(
           clientToUse = await getClient(toolParams, accessToken, userId)
         }
 
-        // Resolve file_id → base64 bytes before forwarding to the real MCP tool.
-        let callArgs: Record<string, unknown> = { ...params }
-        if (blobSig) {
-          const fileId = `${params.file_id ?? ''}`
-          if (!fileId) {
-            return { type: 'error-text' as const, value: 'file_id is required' }
-          }
-          if (userId && !(await canAccessFile({ userId }, fileId))) {
-            return { type: 'error-text' as const, value: `Access denied to file: ${fileId}` }
-          }
-          const fileEntry = await getFileWithId(fileId)
-          if (!fileEntry) {
-            return { type: 'error-text' as const, value: `File not found: ${fileId}` }
-          }
-          const fileBytes = await storage.readBuffer(fileEntry.path, fileEntry.encryption)
-          const { file_id: _ignored, ...restParams } = callArgs
-          callArgs = {
-            ...restParams,
-            [blobSig.blobProp]: Buffer.from(fileBytes).toString('base64'),
-            [blobSig.mimeTypeProp]: fileEntry.type,
-          }
-        }
-
         let result: Awaited<ReturnType<Client['callTool']>> | undefined
         const maxAttempts = 1 + Math.max(0, env.tools.mcp.callToolMaxRetries)
         let lastError: unknown
@@ -327,7 +309,7 @@ async function convertMcpSpecToToolFunctions(
           try {
             result = await clientToUse.callTool({
               name: tool.name,
-              arguments: callArgs,
+              arguments: params,
             })
             lastError = undefined
             break
@@ -348,15 +330,23 @@ async function convertMcpSpecToToolFunctions(
             lastError instanceof Error ? lastError.message : 'MCP tool invocation failed'
           return { type: 'error-text' as const, value: errorMessage }
         }
-        return await normalizeMcpToolResult(result!, invokeParams, {
-          resolveResourceLinks: !blobSig,
-          readResource: async (uri) => {
-            const read = await clientToUse.readResource({ uri })
-            return read.contents?.[0] as
-              | { blob?: string; text?: string; mimeType?: string }
-              | undefined
-          },
+        const normalized = await normalizeMcpToolResult(result!, invokeParams, {
+          resolveResourceLinks: false,
         })
+        const bridge = [...clientCache.values()].find((item) => item.client === clientToUse)?.bridge
+        const artifacts = bridge?.takeArtifacts() ?? []
+        if (artifacts.length === 0) return normalized
+        const files = await Promise.all(artifacts.map((artifact) => saveFile({
+          ...invokeParams,
+          content: artifact.data,
+          mimeType: artifact.mimeType,
+          nameHint: artifact.name,
+          source: 'MCP file bridge',
+        })))
+        if (normalized.type === 'content') {
+          return { type: 'content' as const, value: [...normalized.value, ...files] }
+        }
+        return { type: 'content' as const, value: files }
       },
     }
   }

--- a/apps/backend/lib/tools/mcp/implementation.ts
+++ b/apps/backend/lib/tools/mcp/implementation.ts
@@ -11,11 +11,14 @@ import {
   McpInterface,
   McpPluginAuthentication,
   McpPluginParams,
+  isMcpStdioPluginParams,
+  mcpPluginSchema,
 } from '@/lib/tools/schemas'
 import { JSONSchema7 } from 'json-schema'
 import { logger } from '@/lib/logging'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { nanoid } from 'nanoid'
 import env from '@/lib/env'
@@ -90,7 +93,12 @@ const computeHeaders = (
   return {}
 }
 
-const createTransport = ({ url, authentication }: McpPluginParams, accessToken?: string) => {
+const createTransport = (params: McpPluginParams, accessToken?: string) => {
+  if (isMcpStdioPluginParams(params)) {
+    logger.info(`Create MCP stdio transport for command ${params.command}`)
+    return new StdioClientTransport({ command: params.command, args: params.args })
+  }
+  const { url, authentication } = params
   const headers = {
     ...computeHeaders(authentication, accessToken),
     ...(env.tenantId ? { 'x-tenant-id': env.tenantId } : {}),
@@ -128,7 +136,8 @@ const getClient = async (
   if (cached) {
     return cached.client
   }
-  logger.info(`Creating MCP client to ${params.url}`)
+  const endpoint = isMcpStdioPluginParams(params) ? `stdio:${params.command}` : params.url
+  logger.info(`Creating MCP client to ${endpoint}`)
   const client = new Client({
     name: 'example-client',
     version: '1.0.0',
@@ -139,7 +148,7 @@ const getClient = async (
   }
   transport.onerror = (error) => {
     logger.error(
-      `MCP Transport error, closing and removing from cache client for tool at ${params.url}`,
+      `MCP Transport error, closing and removing from cache client for tool at ${endpoint}`,
       error
     )
     void client.close()
@@ -171,7 +180,9 @@ function isBlobProperty(name: string, schema: JSONSchema7): boolean {
 
 function isMimeTypeProperty(name: string): boolean {
   const lower = name.toLowerCase()
-  return lower === 'mimetype' || lower === 'mime_type' || lower === 'mediatype' || lower === 'media_type'
+  return (
+    lower === 'mimetype' || lower === 'mime_type' || lower === 'mediatype' || lower === 'media_type'
+  )
 }
 
 // Returns the blob and mimeType property names if the schema has a blob+mimeType pair.
@@ -244,8 +255,10 @@ async function convertMcpSpecToToolFunctions(
       ? rewriteSchemaForFileId(originalSchema, blobSig.blobProp, blobSig.mimeTypeProp)
       : originalSchema
     const exposedDescription = blobSig
-      ? `${tool.description ?? ''}\n\nProvide a Logicle file_id; the file bytes are fetched automatically.`
-      : (tool.description ?? '')
+      ? `${
+          tool.description ?? ''
+        }\n\nProvide a Logicle file_id; the file bytes are fetched automatically.`
+      : tool.description ?? ''
 
     result[tool.name] = {
       description: exposedDescription,
@@ -331,14 +344,17 @@ async function convertMcpSpecToToolFunctions(
           }
         }
         if (lastError !== undefined) {
-          const errorMessage = lastError instanceof Error ? lastError.message : 'MCP tool invocation failed'
+          const errorMessage =
+            lastError instanceof Error ? lastError.message : 'MCP tool invocation failed'
           return { type: 'error-text' as const, value: errorMessage }
         }
         return await normalizeMcpToolResult(result!, invokeParams, {
           resolveResourceLinks: !blobSig,
           readResource: async (uri) => {
             const read = await clientToUse.readResource({ uri })
-            return read.contents?.[0] as { blob?: string; text?: string; mimeType?: string } | undefined
+            return read.contents?.[0] as
+              | { blob?: string; text?: string; mimeType?: string }
+              | undefined
           },
         })
       },
@@ -350,8 +366,8 @@ async function convertMcpSpecToToolFunctions(
 
 export class McpPlugin extends McpInterface implements ToolImplementation {
   static builder: ToolBuilder = async (toolParams: ToolParams, params: Record<string, unknown>) => {
-    const config = params as McpPluginParams
-    return new McpPlugin(toolParams, config) // TODO: need a better validation
+    const config = mcpPluginSchema.parse(params)
+    return new McpPlugin(toolParams, config)
   }
 
   supportedMedia = []
@@ -370,6 +386,12 @@ export class McpPlugin extends McpInterface implements ToolImplementation {
   }
 
   async functions(_model: LlmModel, context: ToolFunctionContext): Promise<ToolFunctions> {
+    if (isMcpStdioPluginParams(this.config) && !this.toolParams.provisioned) {
+      logger.warn(
+        `Ignoring stdio MCP tool ${this.toolParams.id}: stdio is only available to provisioned tools`
+      )
+      return {}
+    }
     const userId = context?.userId ?? ''
     if (
       this.config.authentication.type === 'oauth' &&

--- a/apps/backend/lib/tools/mcp/sandbox.ts
+++ b/apps/backend/lib/tools/mcp/sandbox.ts
@@ -1,0 +1,30 @@
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
+import type { McpStdioPluginParams } from '@/lib/tools/schemas'
+
+const safeSegment = (value: string, label: string) => {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) throw new Error(`Invalid MCP sandbox ${label}`)
+  return value
+}
+
+export type McpConversationSandbox = {
+  workspaceDir: string
+  conversationId: string
+  userId: string
+}
+
+/** Creates process-local state directories. File bytes stay in Logicle storage and
+ * are fetched on demand over the dedicated file bridge instead of being staged. */
+export const prepareMcpConversationSandbox = async (
+  config: McpStdioPluginParams,
+  conversationId: string,
+  userId: string
+): Promise<McpConversationSandbox | undefined> => {
+  if (!config.sandbox) return undefined
+  const workspaceDir = path.join(config.sandbox.root, safeSegment(conversationId, 'conversation id'))
+  await Promise.all([
+    mkdir(path.join(workspaceDir, 'home'), { recursive: true, mode: 0o700 }),
+    mkdir(path.join(workspaceDir, 'tmp'), { recursive: true, mode: 0o700 }),
+  ])
+  return { workspaceDir, conversationId, userId }
+}

--- a/apps/backend/lib/tools/mcp/sandboxed-stdio-transport.ts
+++ b/apps/backend/lib/tools/mcp/sandboxed-stdio-transport.ts
@@ -1,0 +1,85 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import process from 'node:process'
+import { PassThrough, type Duplex } from 'node:stream'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { ReadBuffer, serializeMessage } from '@modelcontextprotocol/sdk/shared/stdio.js'
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js'
+
+type ServerParameters = {
+  command: string
+  args?: string[]
+  env?: Record<string, string>
+  cwd?: string
+  onFileBridge: (channel: Duplex) => void
+}
+
+const inheritedEnvironment = () => {
+  const keys = process.platform === 'win32' ? ['PATH', 'TEMP', 'USERNAME', 'USERPROFILE'] : ['HOME', 'LOGNAME', 'PATH', 'SHELL', 'TERM']
+  return Object.fromEntries(keys.flatMap((key) => process.env[key] === undefined ? [] : [[key, process.env[key] as string]]))
+}
+
+/** MCP stdio transport with an additional, private duplex FD (3). */
+export class SandboxedStdioClientTransport implements Transport {
+  private child?: ChildProcessWithoutNullStreams
+  private readBuffer = new ReadBuffer()
+  onclose?: () => void
+  onerror?: (error: Error) => void
+  onmessage?: (message: JSONRPCMessage) => void
+
+  constructor(private readonly params: ServerParameters) {}
+
+  async start() {
+    if (this.child) throw new Error('Transport already started')
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn(this.params.command, this.params.args ?? [], {
+        env: { ...inheritedEnvironment(), ...this.params.env, LOGICLE_FILE_BRIDGE_FD: '3' } as unknown as NodeJS.ProcessEnv,
+        cwd: this.params.cwd,
+        shell: false,
+        windowsHide: process.platform === 'win32',
+        stdio: ['pipe', 'pipe', 'inherit', 'pipe'],
+      }) as ChildProcessWithoutNullStreams
+      this.child = child
+      child.once('error', (error) => { reject(error); this.onerror?.(error) })
+      child.once('spawn', () => {
+        const bridge = child.stdio[3]
+        if (!bridge || typeof (bridge as Duplex).write !== 'function') {
+          reject(new Error('MCP file bridge FD is unavailable'))
+          return
+        }
+        this.params.onFileBridge(bridge as Duplex)
+        resolve()
+      })
+      child.once('close', () => { this.child = undefined; this.onclose?.() })
+      child.stdin.on('error', (error) => this.onerror?.(error))
+      child.stdout.on('error', (error) => this.onerror?.(error))
+      child.stdout.on('data', (chunk) => {
+        this.readBuffer.append(chunk)
+        while (true) {
+          try {
+            const message = this.readBuffer.readMessage()
+            if (!message) break
+            this.onmessage?.(message)
+          } catch (error) { this.onerror?.(error as Error); break }
+        }
+      })
+    })
+  }
+
+  async close() {
+    const child = this.child
+    this.child = undefined
+    child?.stdin.end()
+    child?.kill('SIGTERM')
+    this.readBuffer.clear()
+  }
+
+  async send(message: JSONRPCMessage) {
+    if (!this.child) throw new Error('Not connected')
+    const data = serializeMessage(message)
+    if (this.child.stdin.write(data)) return
+    await new Promise<void>((resolve, reject) => {
+      this.child?.stdin.once('drain', resolve)
+      this.child?.stdin.once('error', reject)
+    })
+  }
+}

--- a/examples/provisioning/mcp-file-analyzer.yaml
+++ b/examples/provisioning/mcp-file-analyzer.yaml
@@ -1,0 +1,47 @@
+# Mount this file in the Logicle container and set:
+# PROVISION_PATH=/provision/mcp-file-analyzer.yaml
+#
+# The tool is provisioned by virtue of being declared here. Local stdio MCP
+# tools are intentionally accepted only from provisioning, so application users
+# cannot configure arbitrary commands to run inside the container.
+backends:
+  logiclecloud:
+    name: Logicle Cloud
+    providerType: logiclecloud
+    apiKey: ${LOGICLECLOUD_API_KEY}
+    endPoint: https://llmproxy.eu.logicle.ai
+
+tools:
+  image-generator:
+    type: imagegen.openai
+    name: Image generator
+    description: Generate and edit images with GPT Image 1.5.
+    tags:
+      - images
+      - generation
+    sharing:
+      type: public
+    configuration:
+      model: gpt-image-1.5
+      apiKey: ${OPENAI_API_KEY}
+
+  mcp-file-analyzer:
+    type: mcp
+    name: File analyzer
+    description: Extract text and render previews from files attached to a chat.
+    tags:
+      - files
+      - documents
+    sharing:
+      type: public
+    configuration:
+      transport: stdio
+      # Metadata only: stdio does not open a network connection to this URL.
+      url: stdio://local
+      command: /usr/local/bin/mcp-file-analyzer
+      args: []
+      sandbox:
+        mode: conversation
+        root: /var/lib/logicle/mcp-file-analyzer
+      authentication:
+        type: none

--- a/examples/provisioning/mcp-file-analyzer.yaml
+++ b/examples/provisioning/mcp-file-analyzer.yaml
@@ -42,6 +42,6 @@ tools:
       args: []
       sandbox:
         mode: conversation
-        root: /var/lib/logicle/mcp-file-analyzer
+        root: /data/mcp-file-analyzer
       authentication:
         type: none

--- a/packages/core/src/tools/schemas.ts
+++ b/packages/core/src/tools/schemas.ts
@@ -120,6 +120,13 @@ export const mcpHttpPluginSchema = z.object({
   authentication: mcpAuthenticationSchema,
 })
 
+export const mcpConversationSandboxSchema = z
+  .object({
+    mode: z.literal('conversation'),
+    root: z.string().min(1),
+  })
+  .strict()
+
 export const mcpStdioPluginSchema = z.object({
   transport: z.literal('stdio'),
   // Maintains a URL-shaped endpoint for generic MCP metadata and OAuth call sites.
@@ -127,6 +134,7 @@ export const mcpStdioPluginSchema = z.object({
   url: z.literal('stdio://local').default('stdio://local'),
   command: z.string().min(1),
   args: z.array(z.string()).default([]),
+  sandbox: mcpConversationSandboxSchema.optional(),
   authentication: z.object({ type: z.literal('none') }).default({ type: 'none' }),
 })
 

--- a/packages/core/src/tools/schemas.ts
+++ b/packages/core/src/tools/schemas.ts
@@ -114,12 +114,28 @@ export const mcpAuthenticationSchema = z
   ])
   .default({ type: 'none' })
 
-export const mcpPluginSchema = z.object({
+export const mcpHttpPluginSchema = z.object({
+  transport: z.never().optional(),
   url: z.string().url(),
   authentication: mcpAuthenticationSchema,
 })
+
+export const mcpStdioPluginSchema = z.object({
+  transport: z.literal('stdio'),
+  // Maintains a URL-shaped endpoint for generic MCP metadata and OAuth call sites.
+  // The stdio transport itself never uses this value.
+  url: z.literal('stdio://local').default('stdio://local'),
+  command: z.string().min(1),
+  args: z.array(z.string()).default([]),
+  authentication: z.object({ type: z.literal('none') }).default({ type: 'none' }),
+})
+
+export const mcpPluginSchema = z.union([mcpHttpPluginSchema, mcpStdioPluginSchema])
 export type McpPluginAuthentication = z.infer<typeof mcpAuthenticationSchema>
 export type McpPluginParams = z.infer<typeof mcpPluginSchema>
+export type McpStdioPluginParams = z.infer<typeof mcpStdioPluginSchema>
+export const isMcpStdioPluginParams = (params: McpPluginParams): params is McpStdioPluginParams =>
+  'transport' in params && params.transport === 'stdio'
 export class McpInterface {
   static toolName = 'mcp'
 }


### PR DESCRIPTION
## Summary

Bundle the local file analyzer and run it as a provisioned stdio MCP tool with conversation-scoped file access. Logicle owns input and output files while the analyzer remains a transient worker.

## Details

- Bundle `mcp-file-analyzer` plus LibreOffice/Poppler rendering dependencies in the runtime image.
- Add provisioned-only stdio MCP configuration and a conversation sandbox transport with a private FD 3 bridge.
- Transfer authorized input files and generated documents/previews over the bridge, then persist outputs as Logicle files.
- Remove the base64/import adaptation path and include an example provisioning configuration.

## Tests

- `pnpm run check-types`
- `go test ./...` in `mcp-file-analyzer`
- Built `mcp-file-analyzer` locally.
- Exercised fresh MCP discovery, a sandboxed `office_script` call, bridge artifact persistence, and preview rendering against the local split backend.