### PR TITLE
feat: surface real token usage as a chat stream event

### DIFF
--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -1101,6 +1101,14 @@ export class ChatAssistant {
         const updatedAssistantResponse =
           chatState.getLastMessageAssert<dto.AssistantMessage>('assistant')
         await this.saveMessage(updatedAssistantResponse, usage)
+        if (usage) {
+          clientSink.enqueue({
+            type: 'usage',
+            inputTokens: usage.inputTokens,
+            outputTokens: usage.outputTokens,
+            totalTokens: usage.totalTokens,
+          })
+        }
       }
 
       const functions = this.functions

--- a/packages/core/src/chat/streamApply.ts
+++ b/packages/core/src/chat/streamApply.ts
@@ -103,7 +103,7 @@ export function applyStreamPartToMessages(
   if (streamPart.type === 'message') {
     return [...messages, streamPart.msg]
   }
-  if (streamPart.type === 'summary') {
+  if (streamPart.type === 'summary' || streamPart.type === 'usage') {
     return messages
   }
   const lastIndex = messages.length - 1

--- a/packages/core/src/types/dto/chat.ts
+++ b/packages/core/src/types/dto/chat.ts
@@ -351,6 +351,16 @@ interface TextStreamPartSummary extends TextStreamPartGeneric {
   summary: string
 }
 
+/** Emitted once per assistant turn, right after the LLM call finishes — carries the same token
+ * counts already computed for DB persistence (see apps/backend/lib/chat/usage.ts's `Usage`), just
+ * surfaced to the stream consumer too. Never mutates message history (see streamApply.ts). */
+interface TextStreamPartUsage extends TextStreamPartGeneric {
+  type: 'usage'
+  inputTokens: number
+  outputTokens: number
+  totalTokens: number
+}
+
 export type TextStreamPart =
   | TextStreamPartNewMessage
   | TextStreamPartNewPart
@@ -360,6 +370,7 @@ export type TextStreamPart =
   | TextStreamPartCitations
   | TextStreamPartUserRequest
   | TextStreamPartSummary
+  | TextStreamPartUsage
 
 export const messageSchema = z.record(z.string(), z.unknown()) as unknown as z.ZodType<Message>
 


### PR DESCRIPTION
## Summary
Assistant chat/evaluate streams now emit a `usage` event (`inputTokens`/`outputTokens`/`totalTokens`) right after each turn finishes, using the same token counts already computed internally for DB persistence. This lets any stream consumer — including the assistant playground/`evaluate` endpoint — see the real cost of a turn, which previously was computed and immediately discarded for that endpoint.

## Details
- Added `TextStreamPartUsage` (`type: 'usage'`) to the shared `dto.TextStreamPart` union.
- `applyStreamPartToMessages` treats `usage` as a no-op on message history (same as `summary`), so existing frontend/backend consumers don't throw on the new event type.
- `ChatAssistant` emits the event immediately after `saveMessage(assistantResponse, usage)`.

## Tests
- `npm run check-types` — clean
- `npx biome check` on the changed files — clean
- Full `npx vitest run` — 950 passed, 30 skipped, no regressions