### PR TITLE
Handle pg pool idle-client errors to prevent process wedging

### DIFF
--- a/apps/backend/db/dialect.ts
+++ b/apps/backend/db/dialect.ts
@@ -38,16 +38,21 @@ async function createDialect() {
     PG.types.setTypeParser(1114, 'text', (value) => {
       return toIsoTimestamp(value)
     })
-    dialect = new PostgresDialect({
-      pool: new PG.Pool({
-        database: url.pathname.substring(1),
-        host: url.hostname,
-        user: url.username,
-        password: url.password,
-        port: parseInt(url.port, 10),
-        max: 10,
-      }),
+    const pool = new PG.Pool({
+      database: url.pathname.substring(1),
+      host: url.hostname,
+      user: url.username,
+      password: url.password,
+      port: parseInt(url.port, 10),
+      max: 10,
     })
+    // pg emits 'error' on the pool when an idle client's connection dies
+    // (e.g. the server closes it). Without a listener this throws as an
+    // uncaught exception and can wedge the process.
+    pool.on('error', (err) => {
+      logger.error('Postgres pool idle client error', err)
+    })
+    dialect = new PostgresDialect({ pool })
   }
   return dialect
 }


### PR DESCRIPTION
## Summary
- forel.logicle.ai went down today (502s) because the `logicle-app` Node process wedged: 100% CPU, event loop stopped processing I/O, dozens of sockets stuck in `CLOSE-WAIT`.
- Root cause: `apps/backend/db/dialect.ts` creates the `pg.Pool` without a `pool.on('error', ...)` listener. When an idle pooled client's connection dies (Postgres closing the socket, network blip), `pg` emits `'error'` on the pool. With no listener, Node throws it as an uncaught exception — and since there's no `process.on('uncaughtException', ...)` handler either, this appears to corrupt the event loop/socket state instead of cleanly crashing.
- Fix: register a `pool.on('error', ...)` listener that logs the error, per the documented `node-postgres` requirement.

## Test plan
- [ ] CI passes
- [ ] Manually verified forel.logicle.ai is healthy after restarting the affected container (done, prior to this PR)
- [ ] Consider follow-up: add a global `process.on('uncaughtException')` handler for defense in depth (not included in this PR to keep the fix minimal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)