### PR TITLE
Upgrade to TypeScript 7

### DIFF
--- a/apps/backend/scripts/i18n/check-i18n-keys.ts
+++ b/apps/backend/scripts/i18n/check-i18n-keys.ts
@@ -1,12 +1,17 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import ts from 'typescript'
+import { API } from 'typescript/unstable/sync'
+import * as ts from 'typescript/unstable/ast'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const repoRoot = path.resolve(__dirname, '../../../..')
 const localesRoot = path.join(repoRoot, 'apps/frontend/locales')
+const tsApi = new API()
+const tsSnapshot = tsApi.updateSnapshot({
+  openProjects: [path.join(repoRoot, 'tsconfig.json')],
+})
 
 const ignoredDirs = new Set(['node_modules', '.next', 'dist', 'dist-server', 'coverage', 'locales'])
 
@@ -75,11 +80,9 @@ function loadLocales(): LocaleMap {
 }
 
 function collectKeysFromSource(filePath: string): Set<string> {
-  const text = fs.readFileSync(filePath, 'utf-8')
-  const ext = path.extname(filePath)
-  const kind = ext === '.tsx' || ext === '.jsx' ? ts.ScriptKind.TSX : ts.ScriptKind.TS
-  const sourceFile = ts.createSourceFile(filePath, text, ts.ScriptTarget.Latest, true, kind)
   const keys = new Set<string>()
+  const sourceFile = tsSnapshot.getDefaultProjectForFile(filePath)?.program.getSourceFile(filePath)
+  if (!sourceFile) return keys
 
   function addKeyFromArg(arg?: ts.Expression) {
     if (!arg) return
@@ -107,7 +110,7 @@ function collectKeysFromSource(filePath: string): Set<string> {
         addKeyFromArg(node.arguments[0])
       }
     }
-    ts.forEachChild(node, visit)
+    node.forEachChild(visit)
   }
 
   visit(sourceFile)

--- a/apps/backend/scripts/i18n/check-i18n-literals.ts
+++ b/apps/backend/scripts/i18n/check-i18n-literals.ts
@@ -1,11 +1,16 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import ts from 'typescript'
+import { API } from 'typescript/unstable/sync'
+import * as ts from 'typescript/unstable/ast'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const projectRoot = path.resolve(__dirname, '../..')
+const tsApi = new API()
+const tsSnapshot = tsApi.updateSnapshot({
+  openProjects: [path.resolve(projectRoot, '../../tsconfig.json')],
+})
 
 const ignoredDirs = new Set([
   'node_modules',
@@ -73,14 +78,14 @@ function isMeaningfulText(text: string): boolean {
 function collectIssues(filePath: string): Issue[] {
   const issues: Issue[] = []
   const sourceText = fs.readFileSync(filePath, 'utf-8')
-  const ext = path.extname(filePath)
-  const kind = ext === '.tsx' || ext === '.jsx' ? ts.ScriptKind.TSX : ts.ScriptKind.TS
-  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true, kind)
+  const sourceFile = tsSnapshot.getDefaultProjectForFile(filePath)?.program.getSourceFile(filePath)
+  if (!sourceFile) return issues
+  const parsedSourceFile = sourceFile
 
   function addIssue(node: ts.Node, message: string, text: string) {
-    if (hasIgnoreComment(sourceText, sourceFile, node)) return
-    const pos = node.getStart(sourceFile)
-    const { line, character } = sourceFile.getLineAndCharacterOfPosition(pos)
+    if (hasIgnoreComment(sourceText, parsedSourceFile, node)) return
+    const pos = node.getStart(parsedSourceFile)
+    const { line, character } = parsedSourceFile.getLineAndCharacterOfPosition(pos)
     issues.push({
       filePath,
       line: line + 1,
@@ -92,7 +97,7 @@ function collectIssues(filePath: string): Issue[] {
 
   function visit(node: ts.Node) {
     if (ts.isJsxText(node)) {
-      const text = node.getText(sourceFile)
+      const text = node.getText(parsedSourceFile)
       if (isMeaningfulText(text)) {
         addIssue(node, 'JSX text literal should be localized', text.trim())
       }
@@ -113,9 +118,9 @@ function collectIssues(filePath: string): Issue[] {
     }
 
     if (ts.isJsxAttribute(node)) {
-      const name = node.name.getText(sourceFile)
+      const name = node.name.getText(parsedSourceFile)
       if (!localizedAttributeNames.has(name)) {
-        ts.forEachChild(node, visit)
+        node.forEachChild(visit)
         return
       }
       const initializer = node.initializer
@@ -134,7 +139,7 @@ function collectIssues(filePath: string): Issue[] {
       }
     }
 
-    ts.forEachChild(node, visit)
+    node.forEachChild(visit)
   }
 
   visit(sourceFile)

--- a/apps/frontend/locales/en/logicle.json
+++ b/apps/frontend/locales/en/logicle.json
@@ -536,6 +536,7 @@
   "saml-config-updated": "SAML Config updated successfully.",
   "saml-connection-established": "Single Sign-On connection is enabled for your workspace.",
   "save": "Save",
+  "saved": "Saved",
   "no-parameters-available": "No parameters available",
   "save-changes": "Save Changes",
   "save-and-submit": "Save & Submit",

--- a/apps/frontend/locales/it/logicle.json
+++ b/apps/frontend/locales/it/logicle.json
@@ -536,6 +536,7 @@
   "saml-config-updated": "Configurazione SAML modificata con successo.",
   "saml-connection-established": "La connessione Single Sign-On è abilitata per il tuo workspace.",
   "save": "Salva",
+  "saved": "Salvato",
   "no-parameters-available": "Non ci sono parametri disponibili",
   "save-changes": "Salva Modifiche",
   "save-and-submit": "Salva e Invia",

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "tailwindcss": "3.3.3",
     "tsup": "^8.5.1",
     "tsx": "^4.20.5",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vitest": "^3.2.4"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,7 +182,7 @@ importers:
         version: 3.31.0(react@19.2.8)
       '@tailwindcss/typography':
         specifier: 0.5.19
-        version: 0.5.19(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@6.0.3)))
+        version: 0.5.19(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@7.0.2)))
       '@tanstack/react-table':
         specifier: ^8.21.2
         version: 8.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -245,7 +245,7 @@ importers:
         version: 10.6.2
       i18next:
         specifier: ^24.1.0
-        version: 24.2.3(typescript@6.0.3)
+        version: 24.2.3(typescript@7.0.2)
       i18next-resources-to-backend:
         specifier: ^1.1.4
         version: 1.2.1
@@ -338,7 +338,7 @@ importers:
         version: 2.4.1(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-i18next:
         specifier: 12.3.1
-        version: 12.3.1(i18next@24.2.3(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 12.3.1(i18next@24.2.3(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-loader-spinner:
         specifier: ^8.0.0
         version: 8.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -398,7 +398,7 @@ importers:
         version: 2.6.0
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@6.0.3)))
+        version: 1.0.7(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@7.0.2)))
       together-ai:
         specifier: ^0.39.0
         version: 0.39.0
@@ -438,7 +438,7 @@ importers:
         version: 2.5.2
       '@tailwindcss/forms':
         specifier: 0.5.6
-        version: 0.5.6(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@6.0.3)))
+        version: 0.5.6(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@7.0.2)))
       '@trivago/prettier-plugin-sort-imports':
         specifier: 4.2.0
         version: 4.2.0(prettier@3.0.3)
@@ -519,16 +519,16 @@ importers:
         version: 0.5.4(@trivago/prettier-plugin-sort-imports@4.2.0(prettier@3.0.3))(prettier@3.0.3)
       tailwindcss:
         specifier: 3.3.3
-        version: 3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@6.0.3))
+        version: 3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@7.0.2))
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.20.5)(typescript@6.0.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.20.5)(typescript@7.0.2)(yaml@2.7.0)
       tsx:
         specifier: ^4.20.5
         version: 4.20.5
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.2)(jiti@1.21.7)(jsdom@25.0.1(canvas@2.11.2(encoding@0.1.13)))(tsx@4.20.5)(yaml@2.7.0)
@@ -3522,6 +3522,126 @@ packages:
 
   '@types/xml2js@0.4.14':
     resolution: {integrity: sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@uiw/codemirror-extensions-basic-setup@4.23.10':
     resolution: {integrity: sha512-zpbmSeNs3OU/f/Eyd6brFnjsBUYwv2mFjWxlAsIRSwTlW+skIT60rQHFBSfsj/5UVSxSLWVeUYczN7AyXvgTGQ==}
@@ -7131,9 +7251,9 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   ufo@1.6.1:
@@ -10663,15 +10783,15 @@ snapshots:
 
   '@tabler/icons@3.31.0': {}
 
-  '@tailwindcss/forms@0.5.6(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@6.0.3)))':
+  '@tailwindcss/forms@0.5.6(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@7.0.2)))':
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@6.0.3))
+      tailwindcss: 3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@7.0.2))
 
-  '@tailwindcss/typography@0.5.19(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@6.0.3)))':
+  '@tailwindcss/typography@0.5.19(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@7.0.2)))':
     dependencies:
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@6.0.3))
+      tailwindcss: 3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@7.0.2))
 
   '@tanstack/react-table@8.21.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -10993,6 +11113,66 @@ snapshots:
   '@types/xml2js@0.4.14':
     dependencies:
       '@types/node': 24.12.2
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@uiw/codemirror-extensions-basic-setup@4.23.10(@codemirror/autocomplete@6.18.6)(@codemirror/commands@6.8.0)(@codemirror/language@6.11.0)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.6.0)(@codemirror/view@6.42.0)':
     dependencies:
@@ -12698,11 +12878,11 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.10
 
-  i18next@24.2.3(typescript@6.0.3):
+  i18next@24.2.3(typescript@7.0.2):
     dependencies:
       '@babel/runtime': 7.26.10
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   iconv-lite@0.6.3:
     dependencies:
@@ -14066,13 +14246,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.3
 
-  postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@24.12.2)(typescript@6.0.3)):
+  postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@24.12.2)(typescript@7.0.2)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.7.0
     optionalDependencies:
       postcss: 8.5.3
-      ts-node: 10.9.2(@types/node@24.12.2)(typescript@6.0.3)
+      ts-node: 10.9.2(@types/node@24.12.2)(typescript@7.0.2)
 
   postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.20.5)(yaml@2.7.0):
     dependencies:
@@ -14294,11 +14474,11 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  react-i18next@12.3.1(i18next@24.2.3(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-i18next@12.3.1(i18next@24.2.3(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@babel/runtime': 7.26.10
       html-parse-stringify: 3.0.1
-      i18next: 24.2.3(typescript@6.0.3)
+      i18next: 24.2.3(typescript@7.0.2)
       react: 19.2.8
     optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
@@ -15069,11 +15249,11 @@ snapshots:
 
   tailwind-merge@2.6.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@6.0.3))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@7.0.2))):
     dependencies:
-      tailwindcss: 3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@6.0.3))
+      tailwindcss: 3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@7.0.2))
 
-  tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@6.0.3)):
+  tailwindcss@3.3.3(ts-node@10.9.2(@types/node@24.12.2)(typescript@7.0.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -15092,7 +15272,7 @@ snapshots:
       postcss: 8.5.3
       postcss-import: 15.1.0(postcss@8.5.3)
       postcss-js: 4.0.1(postcss@8.5.3)
-      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@24.12.2)(typescript@6.0.3))
+      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@24.12.2)(typescript@7.0.2))
       postcss-nested: 6.2.0(postcss@8.5.3)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -15218,7 +15398,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@types/node@24.12.2)(typescript@6.0.3):
+  ts-node@10.9.2(@types/node@24.12.2)(typescript@7.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -15232,7 +15412,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 6.0.3
+      typescript: 7.0.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -15241,7 +15421,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.20.5)(typescript@6.0.3)(yaml@2.7.0):
+  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.20.5)(typescript@7.0.2)(yaml@2.7.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.0)
       cac: 6.7.14
@@ -15262,7 +15442,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.23
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -15294,7 +15474,28 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.1
 
-  typescript@6.0.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   ufo@1.6.1: {}
 


### PR DESCRIPTION
## Summary

Upgrades the repository to TypeScript 7 and migrates the i18n validators to TypeScript 7’s supported syntax API. The checks retain their existing coverage, and a missing localized success message is now translated.

## Details

- Upgrade TypeScript to `7.0.2`.
- Migrate i18n AST walking from the retired compiler API to the TypeScript 7 synchronous API and AST surface.
- Add English and Italian translations for the existing `saved` success message.

## Risks

- `i18next` currently declares a TypeScript `^5` peer range, although its runtime is not coupled to the compiler and all repository checks pass.

## Tests

- `npm run check-types`
- `npm run check:i18n`
- `npm run lint:i18n-literals`
- `npm test`
- `npm run build`