### PR TITLE
Fix OpenAI chat latest routing

### DIFF
--- a/apps/backend/lib/chat/provider-factory.ts
+++ b/apps/backend/lib/chat/provider-factory.ts
@@ -108,7 +108,7 @@ export function createLanguageModelBasic(
             headers: options.user ? { 'x-litellm-customer-id': options.user } : undefined,
             fetch,
           })
-          .responses(model.model)
+          .responses(`openai/${model.model}`)
       } else if (model.owned_by === 'anthropic') {
         return anthropic
           .createAnthropic({

--- a/packages/core/src/models/openai.ts
+++ b/packages/core/src/models/openai.ts
@@ -493,7 +493,7 @@ export const gptChatLatestModel: LlmModel = {
   ...gpt52ChatModel,
   model: 'chat-latest',
   id: 'chatgpt-5-latest',
-  name: 'Gpt chat latest (5.2)',
+  name: 'Gpt chat latest',
   tags: ['latest'],
 }
 

--- a/packages/core/src/models/openai.ts
+++ b/packages/core/src/models/openai.ts
@@ -491,6 +491,7 @@ export const gpt56TerraModel: LlmModel = {
 
 export const gptChatLatestModel: LlmModel = {
   ...gpt52ChatModel,
+  model: 'chat-latest',
   id: 'chatgpt-5-latest',
   name: 'Gpt chat latest (5.2)',
   tags: ['latest'],


### PR DESCRIPTION
## Summary

Routes OpenAI models through the LiteLLM OpenAI provider namespace and assigns `chat-latest` as the concrete model ID for the ChatGPT latest model entry. This ensures requests use the intended provider and model.

## Tests

- `npm run check-types`