### PR TITLE
Pass provisioner-supplied env through to stdio MCP tools

### DIFF
--- a/__tests__/mcpStdio.test.ts
+++ b/__tests__/mcpStdio.test.ts
@@ -7,6 +7,7 @@ const stdioConfig = {
   url: 'stdio://local' as const,
   command: 'mcp-file-analyzer',
   args: ['--example'],
+  env: {},
   authentication: { type: 'none' as const },
 }
 

--- a/apps/backend/lib/tools/mcp/implementation.ts
+++ b/apps/backend/lib/tools/mcp/implementation.ts
@@ -103,8 +103,12 @@ const createTransport = (
 ) => {
   if (isMcpStdioPluginParams(params)) {
     logger.info(`Create MCP stdio transport for command ${params.command}`)
+    // Provisioner-supplied env comes first so the fixed sandbox keys below
+    // always win — a provisioned tool can tune its own behavior (e.g.
+    // disabling a capability) but can't use `env` to escape the sandbox.
     const env = sandbox
       ? {
+          ...params.env,
           PATH: process.env.PATH ?? '',
           LANG: process.env.LANG ?? 'C.UTF-8',
           HOME: `${sandbox.workspaceDir}/home`,
@@ -125,8 +129,8 @@ const createTransport = (
       })
     }
     const discoveryEnv = params.sandbox
-      ? { ...process.env, LOGICLE_MCP_SANDBOX: '1' }
-      : undefined
+      ? { ...process.env, ...params.env, LOGICLE_MCP_SANDBOX: '1' }
+      : { ...params.env }
     return new StdioClientTransport({
       command: params.command,
       args: params.args,

--- a/examples/provisioning/mcp-file-analyzer.yaml
+++ b/examples/provisioning/mcp-file-analyzer.yaml
@@ -40,6 +40,15 @@ tools:
       url: stdio://local
       command: /usr/local/bin/mcp-file-analyzer
       args: []
+      # Extra env vars for the spawned process. Security posture for what
+      # this specific tool binary can do is the provisioner's call, not
+      # Logicle's — e.g. mcp-file-analyzer supports disabling its own
+      # outbound-download capability entirely:
+      #   env:
+      #     MCP_DOWNLOAD_DISABLED: "1"
+      # These cannot override Logicle's own sandbox env keys (HOME, TMPDIR,
+      # MCP_SANDBOX_DIR, LOGICLE_MCP_SANDBOX, PATH, LANG).
+      env: {}
       sandbox:
         mode: conversation
         root: /data/mcp-file-analyzer

--- a/packages/core/src/tools/schemas.ts
+++ b/packages/core/src/tools/schemas.ts
@@ -134,6 +134,12 @@ export const mcpStdioPluginSchema = z.object({
   url: z.literal('stdio://local').default('stdio://local'),
   command: z.string().min(1),
   args: z.array(z.string()).default([]),
+  // Extra environment variables passed to the spawned process, e.g. to tune
+  // security-relevant behavior the tool itself exposes (disabling network
+  // access, restricting allowed schemes, etc). Only reachable via
+  // provisioning — stdio tools cannot be edited through the app, so this is
+  // the provisioner's knob, not an application user's.
+  env: z.record(z.string(), z.string()).default({}),
   sandbox: mcpConversationSandboxSchema.optional(),
   authentication: z.object({ type: z.literal('none') }).default({ type: 'none' }),
 })


### PR DESCRIPTION
## Summary
Stdio MCP tool configs gain a generic `env` field so a provisioner can pass extra environment variables to the spawned process — e.g. the newly-added `MCP_DOWNLOAD_DISABLED` for `mcp-file-analyzer` (see logicleai/mcp-file-analyzer#26). Logicle stays a generic pipe for whatever env a provisioner wants to set rather than special-casing individual tools' env vars in application code.

## Details
- `packages/core/src/tools/schemas.ts`: `mcpStdioPluginSchema` gains `env: z.record(z.string(), z.string()).default({})`.
- `apps/backend/lib/tools/mcp/implementation.ts` (`createTransport`): provisioner `env` is merged in for both the sandboxed spawn and the discovery/non-sandboxed spawn paths, with provisioner env spread *first* and Logicle's own fixed sandbox keys (`HOME`, `TMPDIR`, `MCP_SANDBOX_DIR`, `LOGICLE_MCP_SANDBOX`, `PATH`, `LANG`) spread *last* — a provisioner can tune tool behavior but can't use `env` to override what keeps the sandbox contained.
- `examples/provisioning/mcp-file-analyzer.yaml`: documents the field in place with `MCP_DOWNLOAD_DISABLED` as the worked example.
- Stdio tools are provisioning-only already (`api/tools/[toolId]/route.ts` forbids editing a provisioned tool through the app), so this field is only ever reachable via the provisioning YAML — not exposed to application users.

## Tests
- `npm run check-types` — passes.
- `npx vitest run __tests__/mcpStdio.test.ts __tests__/configSecrets.test.ts` — passes.