### PR TITLE
Bump mcp-file-analyzer to 0.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.5
 
 # Pin this to a released analyzer version (or digest) when updating it.
-ARG FILE_ANALYZER_IMAGE=ghcr.io/logicleai/mcp-file-analyzer:0.8.0
+ARG FILE_ANALYZER_IMAGE=ghcr.io/logicleai/mcp-file-analyzer:0.10.0
 
 # ---------------------
 # Stage 1: File analyzer


### PR DESCRIPTION
## Summary
Pins `Dockerfile`'s `FILE_ANALYZER_IMAGE` to `ghcr.io/logicleai/mcp-file-analyzer:0.10.0` (was `0.8.0`), pulling in [mcp-file-analyzer#26](https://github.com/logicleai/mcp-file-analyzer/pull/26): `downloadUrl` restricted to `https` by default with a `MCP_DOWNLOAD_DISABLED` escape hatch, plus a dependency bump closing reachable `excelize`/`golang.org/x/image`/`golang.org/x/net`/`golang.org/x/text` vulnerabilities.

## Details
- No behavior change on Logicle's side — `mcp-file-analyzer` stays embedded as a stdio subprocess exactly as before, just at a newer, hardened version.
- The new `MCP_DOWNLOAD_DISABLED`/`MCP_DOWNLOAD_ALLOWED_SCHEMES` env knobs the binary now supports are reachable via the `env` field added to stdio MCP tool provisioning in #1032, for anyone who wants to lock down `downloadUrl` further — not required for this bump to work.

## Tests
- `docker build` against the new pin succeeds.
- `docker pull ghcr.io/logicleai/mcp-file-analyzer:0.10.0` confirmed published.
- Ran the built image: `/usr/local/bin/mcp-file-analyzer` executes and reports its usage banner, `soffice --version` still resolves — LibreOffice rendering path intact.