### PR TITLE
Disable hover-prefetch on links to dynamic-segment routes

### DIFF
--- a/apps/frontend/app/admin/backends/BackendsPage.tsx
+++ b/apps/frontend/app/admin/backends/BackendsPage.tsx
@@ -55,7 +55,7 @@ export const BackendsPage = () => {
 
   const columns: Column<dto.Backend>[] = [
     column(t('table-column-name'), (backend) => (
-      <Link variant="ghost" href={`/admin/backends/${backend.id}`}>
+      <Link variant="ghost" href={`/admin/backends/${backend.id}`} prefetch={false}>
         {backend.name}
       </Link>
     )),

--- a/apps/frontend/app/admin/satellites/page.tsx
+++ b/apps/frontend/app/admin/satellites/page.tsx
@@ -29,7 +29,7 @@ const AdminSatellitesPage = () => {
       headerClass: 'text-center',
       renderer: (satellite) => (
         <div className="text-center">
-          <Link variant="ghost" href={`/admin/satellites/${satellite.id}`}>
+          <Link variant="ghost" href={`/admin/satellites/${satellite.id}`} prefetch={false}>
             {satellite.name}
           </Link>
         </div>

--- a/apps/frontend/app/admin/sso/SSOPage.tsx
+++ b/apps/frontend/app/admin/sso/SSOPage.tsx
@@ -52,7 +52,7 @@ const SSOPage = () => {
 
   const columns: Column<IdpConnection>[] = [
     column(t('table-column-name'), (ssoConnection) => (
-      <Link variant="ghost" href={`/admin/sso/${ssoConnection.id}`}>
+      <Link variant="ghost" href={`/admin/sso/${ssoConnection.id}`} prefetch={false}>
         {ssoConnection.name}
       </Link>
     )),

--- a/apps/frontend/app/admin/tools/page.tsx
+++ b/apps/frontend/app/admin/tools/page.tsx
@@ -90,7 +90,7 @@ const AllTools = () => {
 
   const columns: Column<dto.Tool>[] = [
     column(t('table-column-name'), (tool) => (
-      <Link variant="ghost" href={`/admin/tools/${tool.id}`}>
+      <Link variant="ghost" href={`/admin/tools/${tool.id}`} prefetch={false}>
         {tool.name}
       </Link>
     )),

--- a/apps/frontend/app/admin/users/UsersPage.tsx
+++ b/apps/frontend/app/admin/users/UsersPage.tsx
@@ -63,7 +63,7 @@ const UsersPage = () => {
 
   const columns: Column<dto.AdminUser>[] = [
     column(t('table-column-name'), (user) => (
-      <Link variant="ghost" href={`/admin/users/${user.id}`}>
+      <Link variant="ghost" href={`/admin/users/${user.id}`} prefetch={false}>
         {user.name}
       </Link>
     )),

--- a/apps/frontend/app/admin/workspaces/components/WorkspacesPage.tsx
+++ b/apps/frontend/app/admin/workspaces/components/WorkspacesPage.tsx
@@ -41,7 +41,7 @@ const WorkspacesPage = () => {
 
   const columns: Column<dto.WorkspaceWithMemberCount>[] = [
     column(t('table-column-name'), (workspace: dto.WorkspaceWithMemberCount) => (
-      <Link variant="ghost" href={`/admin/workspaces/${workspace.id}`}>
+      <Link variant="ghost" href={`/admin/workspaces/${workspace.id}`} prefetch={false}>
         {workspace.name}
       </Link>
     )),

--- a/apps/frontend/app/assistants/components/UsageTabPanel.tsx
+++ b/apps/frontend/app/assistants/components/UsageTabPanel.tsx
@@ -28,7 +28,9 @@ export const UsageTabPanel = ({ visible, className, assistantId }: Props) => {
             <ul className="flex flex-col gap-2">
               {parents.map((parent) => (
                 <li key={parent.id}>
-                  <Link href={`/assistants/${parent.id}`}>{parent.name}</Link>
+                  <Link href={`/assistants/${parent.id}`} prefetch={false}>
+                    {parent.name}
+                  </Link>
                 </li>
               ))}
             </ul>

--- a/apps/frontend/app/chat/components/ChatFolder.tsx
+++ b/apps/frontend/app/chat/components/ChatFolder.tsx
@@ -25,6 +25,7 @@ export const ChatFolder: React.FC<Params> = ({ folder }) => {
   return (
     <Link
       href={`/chat/folders/${folder.id}`}
+      prefetch={false}
       className="text-h3 p-2"
       key={folder.id}
       onDrop={handleDrop}

--- a/apps/frontend/app/satellites/page.tsx
+++ b/apps/frontend/app/satellites/page.tsx
@@ -107,7 +107,7 @@ const MySatellitesPage = () => {
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   {satellite.kind === 'registered' ? (
-                    <Link variant="ghost" href={`/satellites/${satellite.id}`}>
+                    <Link variant="ghost" href={`/satellites/${satellite.id}`} prefetch={false}>
                       {satellite.name}
                     </Link>
                   ) : (

--- a/apps/frontend/components/ui/link.tsx
+++ b/apps/frontend/components/ui/link.tsx
@@ -32,21 +32,33 @@ interface Params extends VariantProps<typeof linkVariants> {
   iconSize?: number
   children: string
   className?: string
+  // Under static export, a link to a dynamic segment (an id only known at
+  // runtime) can never have a pre-baked prefetch payload — Next's default
+  // hover-prefetch just 404s harmlessly but noisily. Pass `false` for those.
+  prefetch?: boolean
 }
 
-const Link = ({ href, children, variant, size, className, icon, iconSize }: Params) => {
+const Link = ({ href, children, variant, size, className, icon, iconSize, prefetch }: Params) => {
   const Icon = icon
   return (
-    <NextLink href={href} className={`${linkVariants({ variant, size })} ${className ?? ''}`}>
+    <NextLink
+      href={href}
+      prefetch={prefetch}
+      className={`${linkVariants({ variant, size })} ${className ?? ''}`}
+    >
       {Icon && <Icon size={iconSize ?? 18} />}
       {children}
     </NextLink>
   )
 }
 
-const AvatarLink = ({ href, children, variant, size }: Params) => {
+const AvatarLink = ({ href, children, variant, size, prefetch }: Params) => {
   return (
-    <NextLink href={href} className={cn(linkVariants({ variant, size }), 'items-center gap-2')}>
+    <NextLink
+      href={href}
+      prefetch={prefetch}
+      className={cn(linkVariants({ variant, size }), 'items-center gap-2')}
+    >
       <LetterAvatar name={children} />
       <span className="justify-center">{children}</span>
     </NextLink>


### PR DESCRIPTION
## Summary
Removes the remaining console 404 noise on admin list pages (users, tools, backends, workspaces, sso, satellites) and elsewhere: row links to a dynamic id route were still using Next's default hover-prefetch, which under static export can never succeed for a runtime-only id and was 404ing on every hover.

## Details
- `components/ui/link.tsx`'s `Link`/`AvatarLink` wrapper now accepts and forwards a `prefetch` prop (previously silently dropped).
- Set `prefetch={false}` on the row links in `admin/users`, `admin/tools`, `admin/backends`, `admin/workspaces`, `admin/sso`, `admin/satellites`, `satellites`, `assistants` usage panel, and `chat/folders`.
- Click-triggered navigation is unaffected — it still falls back to a full page load exactly as before; this only stops the wasted, noisy speculative hover fetch.

## Tests
- `npm run check-types` and `pnpm build` — clean.
- Verified live: `admin/users` list previously logged one `__next._tree.txt 404` per row on hover; after the fix, 0 console errors on load and after clicking into a user (navigation still works).