### PR TITLE
Return 400 for invalid login credentials, not 401

### DIFF
--- a/__tests__/authRoutes.test.ts
+++ b/__tests__/authRoutes.test.ts
@@ -238,7 +238,7 @@ describe('password auth routes', () => {
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(401)
+    expect(response.status).toBe(400)
     await expect(response.json()).resolves.toEqual({
       error: { message: 'invalid-credentials', values: {} },
     })
@@ -260,7 +260,7 @@ describe('password auth routes', () => {
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(401)
+    expect(response.status).toBe(400)
     await expect(response.json()).resolves.toEqual({
       error: { message: 'authentication method not supported for this user', values: {} },
     })
@@ -278,7 +278,7 @@ describe('password auth routes', () => {
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(401)
+    expect(response.status).toBe(400)
     await expect(response.json()).resolves.toEqual({
       error: { message: 'invalid-credentials', values: {} },
     })

--- a/apps/backend/api/auth/login/route.ts
+++ b/apps/backend/api/auth/login/route.ts
@@ -47,17 +47,17 @@ export const POST = operation({
   implementation: async ({ headers, cookies, body }) => {
     const user = await getUserByEmail(body.email)
     if (!user) {
-      return error(401, 'invalid-credentials')
+      return error(400, 'invalid-credentials')
     }
     if (!user.password) {
-      return error(401, 'authentication method not supported for this user')
+      return error(400, 'authentication method not supported for this user')
     }
     if (!user.enabled) {
       return error(403, 'user-disabled')
     }
     const hasValidPassword = await verifyPassword(body.password, user.password)
     if (!hasValidPassword) {
-      return error(401, 'invalid-credentials')
+      return error(400, 'invalid-credentials')
     }
     await addSessionCookie(user, cookies, undefined, { headers })
     return noBody()


### PR DESCRIPTION
## Summary
`POST /api/auth/login` now returns `400` for invalid credentials or an unsupported auth method, instead of `401`. This reserves `401` exclusively for "no valid session" across the API, matching the convention `operation()` already enforces via its CSRF and authentication checks. It also removes the need for a future client-side 401-handler to special-case the login page.

## Tests
- `npx vitest run __tests__/authRoutes.test.ts` — 35/35 pass (3 assertions updated from 401 to 400)
- `npm run check-types` — clean
- `npm run generate:openapi` — no diff (`400` was already declared in the route's `responses`)
- Verified `LoginPanel.tsx` branches on `!res.ok` and maps the error body's message via i18n, never on the numeric status code — UI-facing error messages are unchanged