### PR TITLE
Restore sanitized HTML rendering in chat

### DIFF
--- a/__tests__/markdownSanitization.test.ts
+++ b/__tests__/markdownSanitization.test.ts
@@ -1,0 +1,52 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, test } from 'vitest'
+import { Markdown } from '@/frontend/app/chat/components/Markdown'
+
+const renderMarkdown = (markdown: string) =>
+  renderToStaticMarkup(React.createElement(Markdown, { className: '', children: markdown }))
+
+describe('Markdown HTML sanitization', () => {
+  test('renders safe inline formatting, external links, and images', () => {
+    const html = renderMarkdown(`
+<mark>highlight</mark> <u>underline</u>
+
+<a href="https://example.com/docs">docs</a>
+
+<img src="https://example.com/image.png" alt="example">
+`)
+
+    expect(html).toContain('<mark>highlight</mark>')
+    expect(html).toContain('<u>underline</u>')
+    expect(html).toContain('<a href="https://example.com/docs"')
+    expect(html).toContain('target="_blank"')
+    expect(html).toContain('rel="noopener noreferrer"')
+    expect(html).not.toContain('node="')
+    expect(html).toContain('<img src="https://example.com/image.png" alt="example"/>')
+  })
+
+  test('allows only presentation-safe inline text styles', () => {
+    const html = renderMarkdown(
+      '<span style="color: red">styled</span>\n\n' +
+        '<span style="position: fixed; inset: 0">unsafe</span>'
+    )
+
+    expect(html).toContain('<span style="color:red">styled</span>')
+    expect(html).toContain('<span>unsafe</span>')
+    expect(html).not.toContain('position')
+  })
+
+  test('removes executable markup and unsafe URLs', () => {
+    const html = renderMarkdown(`
+<script>alert('xss')</script>
+<iframe src="https://example.com"></iframe>
+<img src="x" onerror="alert('xss')">
+<a href="javascript:alert('xss')">bad link</a>
+`)
+
+    expect(html).not.toContain('<script')
+    expect(html).not.toContain('<iframe')
+    expect(html).not.toContain('onerror')
+    expect(html).not.toContain('javascript:')
+  })
+})

--- a/apps/frontend/app/chat/components/Markdown.tsx
+++ b/apps/frontend/app/chat/components/Markdown.tsx
@@ -1,6 +1,8 @@
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 import ReactMarkdown, { Components } from 'react-markdown'
 import rehypeExternalLinks from 'rehype-external-links'
 import 'katex/dist/katex.min.css' // `rehype-katex` does not import the CSS for you
@@ -21,6 +23,26 @@ const CodeBlock = React.lazy(() =>
 const MermaidDiagram = React.lazy(() =>
   import('./MermaidDiagram').then((m) => ({ default: m.MermaidDiagram }))
 )
+
+const safeColorStyle =
+  /^(?:color|background-color)\s*:\s*(?:#[\da-f]{3,8}|(?:rgb|hsl)a?\([\d\s.,%+-]+\)|[a-z]+)\s*;?$/i
+const safeTextDecorationStyle = /^text-decoration\s*:\s*(?:underline|line-through)\s*;?$/i
+
+export const markdownSanitizeSchema = {
+  ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames ?? []), 'mark', 'u'],
+  attributes: {
+    ...defaultSchema.attributes,
+    mark: [
+      ...(defaultSchema.attributes?.mark ?? []),
+      ['style', safeColorStyle, safeTextDecorationStyle],
+    ],
+    span: [
+      ...(defaultSchema.attributes?.span ?? []),
+      ['style', safeColorStyle, safeTextDecorationStyle],
+    ],
+  },
+}
 
 export function remarkAddBlockCodeFlag() {
   return (tree: Root) => {
@@ -128,7 +150,7 @@ export const Markdown: React.FC<{
       td({ children }) {
         return <td className="break-words px-3 py-1">{children}</td>
       },
-      a({ children, ...props }) {
+      a({ children, node: _node, ...props }) {
         return <CustomAnchor {...props}>{children}</CustomAnchor>
       },
     }),
@@ -141,8 +163,10 @@ export const Markdown: React.FC<{
         className={className}
         remarkPlugins={[remarkGfm, remarkMath, [remarkAddBlockCodeFlag]]}
         rehypePlugins={[
-          [rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] }],
+          rehypeRaw,
+          [rehypeSanitize, markdownSanitizeSchema],
           rehypeKatex,
+          [rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] }],
         ]}
         components={components}
       >

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "rehype-external-links": "^3.0.0",
     "rehype-katex": "^7.0.0",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark": "^15.0.1",
     "remark-docx": "^0.3.26",
     "remark-gfm": "4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,6 +367,9 @@ importers:
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       remark:
         specifier: ^15.0.1
         version: 15.0.1
@@ -5284,6 +5287,9 @@ packages:
   hast-util-raw@9.1.0:
     resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
 
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
@@ -7095,6 +7101,9 @@ packages:
 
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   relative-time-format@1.1.6:
     resolution: {integrity: sha512-aCv3juQw4hT1/P/OrVltKWLlp15eW1GRcwP1XdxHrPdZE9MtgqFpegjnTjLhi2m2WI9MT/hQQtE+tjEWG1hgkQ==}
@@ -13519,6 +13528,12 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      unist-util-position: 5.0.0
+
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -15667,6 +15682,11 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-raw: 9.1.0
       vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   relative-time-format@1.1.6: {}
 


### PR DESCRIPTION
## Summary

Restores safe inline HTML rendering in chat and prompt previews, including highlights, underlines, external links, images, and constrained text colors, while stripping executable markup, unsafe URLs, event handlers, and layout-affecting styles.

## Details

- Parses embedded HTML with `rehype-raw` and sanitizes it through an explicit `rehype-sanitize` schema.
- Allows presentation-safe `color`, `background-color`, and `text-decoration` values on `mark` and `span`.
- Prevents React Markdown metadata from leaking into rendered anchor attributes.

## Tests

- `pnpm vitest run __tests__/markdownSanitization.test.ts` — 3 tests passed.
- `pnpm run check-types` — passed.
- `pnpm exec biome check apps/frontend/app/chat/components/Markdown.tsx __tests__/markdownSanitization.test.ts` — passed.