### PR TITLE
Keep assistant preview scrolling within the editor

### DIFF
--- a/apps/frontend-vite/index.html
+++ b/apps/frontend-vite/index.html
@@ -35,7 +35,7 @@
     <title>Logicle</title>
   </head>
   <body class="overflow-hidden h-full">
-    <div id="root"></div>
+    <div id="root" class="h-full"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Restores the Vite root height constraint so assistant preview chat scrolling remains inside its panel instead of shifting the prompt editor and left-side form.

## Tests

- `pnpm run check-types` — passed.
- `pnpm run build-ci` — production frontend build passed.