### PR TITLE
Allow safe combined inline HTML styles

### DIFF
--- a/__tests__/markdownSanitization.test.ts
+++ b/__tests__/markdownSanitization.test.ts
@@ -11,6 +11,8 @@ describe('Markdown HTML sanitization', () => {
     const html = renderMarkdown(`
 <mark>highlight</mark> <u>underline</u>
 
+<sub>subscript</sub> <sup>superscript</sup> <del>deleted</del> <ins>inserted</ins>
+
 <a href="https://example.com/docs">docs</a>
 
 <img src="https://example.com/image.png" alt="example">
@@ -18,6 +20,10 @@ describe('Markdown HTML sanitization', () => {
 
     expect(html).toContain('<mark>highlight</mark>')
     expect(html).toContain('<u>underline</u>')
+    expect(html).toContain('<sub>subscript</sub>')
+    expect(html).toContain('<sup>superscript</sup>')
+    expect(html).toContain('<del>deleted</del>')
+    expect(html).toContain('<ins>inserted</ins>')
     expect(html).toContain('<a href="https://example.com/docs"')
     expect(html).toContain('target="_blank"')
     expect(html).toContain('rel="noopener noreferrer"')
@@ -27,13 +33,14 @@ describe('Markdown HTML sanitization', () => {
 
   test('allows only presentation-safe inline text styles', () => {
     const html = renderMarkdown(
-      '<span style="color: red">styled</span>\n\n' +
-        '<span style="position: fixed; inset: 0">unsafe</span>'
+      '<span style="color:green;font-weight:bold">styled</span>\n\n' +
+        '<span style="color: red; position: fixed; inset: 0">partially safe</span>'
     )
 
-    expect(html).toContain('<span style="color:red">styled</span>')
-    expect(html).toContain('<span>unsafe</span>')
+    expect(html).toContain('<span style="color:green;font-weight:bold">styled</span>')
+    expect(html).toContain('<span style="color:red">partially safe</span>')
     expect(html).not.toContain('position')
+    expect(html).not.toContain('inset')
   })
 
   test('removes executable markup and unsafe URLs', () => {

--- a/apps/frontend/app/chat/components/Markdown.tsx
+++ b/apps/frontend/app/chat/components/Markdown.tsx
@@ -10,6 +10,7 @@ import React, { memo, MutableRefObject, Suspense } from 'react'
 
 import { visit } from 'unist-util-visit'
 import type { Root, Code } from 'mdast'
+import type { Element, Root as HastRoot } from 'hast'
 import { Table } from './Table'
 
 // Lazy: `react-syntax-highlighter`'s Prism build bundles ~250 language
@@ -24,23 +25,49 @@ const MermaidDiagram = React.lazy(() =>
   import('./MermaidDiagram').then((m) => ({ default: m.MermaidDiagram }))
 )
 
-const safeColorStyle =
-  /^(?:color|background-color)\s*:\s*(?:#[\da-f]{3,8}|(?:rgb|hsl)a?\([\d\s.,%+-]+\)|[a-z]+)\s*;?$/i
-const safeTextDecorationStyle = /^text-decoration\s*:\s*(?:underline|line-through)\s*;?$/i
+const safeInlineStyleValues: Record<string, RegExp> = {
+  color: /^(?:#[\da-f]{3,8}|(?:rgb|hsl)a?\([\d\s.,%+-]+\)|[a-z]+)$/i,
+  'background-color': /^(?:#[\da-f]{3,8}|(?:rgb|hsl)a?\([\d\s.,%+-]+\)|[a-z]+)$/i,
+  'font-style': /^(?:italic|normal|oblique)$/i,
+  'font-weight': /^(?:bold|bolder|lighter|normal|[1-9]00)$/i,
+  'text-decoration': /^(?:line-through|underline)$/i,
+}
+
+const sanitizeInlineStyle = (style: string) =>
+  style
+    .split(';')
+    .map((declaration) => {
+      const separator = declaration.indexOf(':')
+      if (separator === -1) return undefined
+      const property = declaration.slice(0, separator).trim().toLowerCase()
+      const value = declaration.slice(separator + 1).trim()
+      return safeInlineStyleValues[property]?.test(value) ? `${property}: ${value}` : undefined
+    })
+    .filter((declaration): declaration is string => declaration !== undefined)
+    .join('; ')
+
+export function rehypeFilterInlineStyles() {
+  return (tree: HastRoot) => {
+    visit(tree, 'element', (node: Element) => {
+      const style = node.properties.style
+      if (typeof style !== 'string') return
+      const sanitizedStyle = sanitizeInlineStyle(style)
+      if (sanitizedStyle) {
+        node.properties.style = sanitizedStyle
+      } else {
+        delete node.properties.style
+      }
+    })
+  }
+}
 
 export const markdownSanitizeSchema = {
   ...defaultSchema,
   tagNames: [...(defaultSchema.tagNames ?? []), 'mark', 'u'],
   attributes: {
     ...defaultSchema.attributes,
-    mark: [
-      ...(defaultSchema.attributes?.mark ?? []),
-      ['style', safeColorStyle, safeTextDecorationStyle],
-    ],
-    span: [
-      ...(defaultSchema.attributes?.span ?? []),
-      ['style', safeColorStyle, safeTextDecorationStyle],
-    ],
+    mark: [...(defaultSchema.attributes?.mark ?? []), 'style'],
+    span: [...(defaultSchema.attributes?.span ?? []), 'style'],
   },
 }
 
@@ -164,6 +191,7 @@ export const Markdown: React.FC<{
         remarkPlugins={[remarkGfm, remarkMath, [remarkAddBlockCodeFlag]]}
         rehypePlugins={[
           rehypeRaw,
+          rehypeFilterInlineStyles,
           [rehypeSanitize, markdownSanitizeSchema],
           rehypeKatex,
           [rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] }],


### PR DESCRIPTION
## Summary

Allows sanitized HTML spans to combine safe presentation styles such as `color:green;font-weight:bold`, while retaining supported semantic tags and continuing to remove unsafe CSS declarations.

## Details

- Filters individual inline CSS declarations before applying the HTML sanitizer.
- Allows color, background color, font style, font weight, and text decoration values.
- Keeps safe declarations when the same style attribute also contains blocked layout properties.
- Adds coverage for `sub`, `sup`, `del`, and `ins`.

## Tests

- `pnpm vitest run __tests__/markdownSanitization.test.ts` — 3 tests passed.
- `pnpm run check-types` — passed.
- `pnpm exec biome check apps/frontend/app/chat/components/Markdown.tsx __tests__/markdownSanitization.test.ts` — passed.