### PR TITLE
Add Gemini 3.6/3.7 Flash models and flash-latest alias

### DIFF
--- a/packages/core/src/models/gemini.ts
+++ b/packages/core/src/models/gemini.ts
@@ -6,6 +6,9 @@ import {
   gemini31FlashLite,
   gemini31ProModel,
   gemini35FlashModel,
+  gemini36FlashModel,
+  gemini37FlashModel,
+  geminiFlashLatest,
   geminiProLatest,
 } from './vertex'
 
@@ -35,7 +38,19 @@ export const geminiModels: LlmModel[] = [
     provider: 'google-ai-studio',
   },
   {
+    ...gemini36FlashModel,
+    provider: 'google-ai-studio',
+  },
+  {
+    ...gemini37FlashModel,
+    provider: 'google-ai-studio',
+  },
+  {
     ...geminiProLatest,
+    provider: 'google-ai-studio',
+  },
+  {
+    ...geminiFlashLatest,
     provider: 'google-ai-studio',
   },
 ]

--- a/packages/core/src/models/logicle.ts
+++ b/packages/core/src/models/logicle.ts
@@ -47,11 +47,14 @@ import {
   gemini20ProModel,
   gemini25ProModel,
   gemini25FlashModel,
+  geminiFlashLatest,
   geminiProLatest,
   gemini30ProModel,
   gemini31FlashLite,
   gemini31ProModel,
   gemini35FlashModel,
+  gemini36FlashModel,
+  gemini37FlashModel,
 } from './vertex'
 
 export const logicleModels: LlmModel[] = [
@@ -99,9 +102,12 @@ export const logicleModels: LlmModel[] = [
   gemini25FlashModel,
   gemini30ProModel,
   geminiProLatest,
+  geminiFlashLatest,
   gemini31FlashLite,
   gemini31ProModel,
   gemini35FlashModel,
+  gemini36FlashModel,
+  gemini37FlashModel,
   ...perplexityModels,
 ].map((model) => {
   return {

--- a/packages/core/src/models/vertex.ts
+++ b/packages/core/src/models/vertex.ts
@@ -176,6 +176,40 @@ export const gemini35FlashModel: LlmModel = {
   supportedReasoningEfforts: ['minimal', 'low', 'medium', 'high'],
 }
 
+export const gemini36FlashModel: LlmModel = {
+  id: 'gemini-3.6-flash',
+  model: 'gemini-3.6-flash',
+  name: 'Gemini 3.6 Flash',
+  description:
+    "Google's most intelligent model family to date, built on a foundation of state-of-the-art reasoning",
+  provider: 'gcp-vertex',
+  owned_by: 'google',
+  context_length: 1000000,
+  capabilities: {
+    vision: true,
+    function_calling: true,
+    web_search: true,
+  },
+  supportedReasoningEfforts: ['minimal', 'low', 'medium', 'high'],
+}
+
+export const gemini37FlashModel: LlmModel = {
+  id: 'gemini-3.7-flash',
+  model: 'gemini-3.7-flash',
+  name: 'Gemini 3.7 Flash',
+  description:
+    "Google's most intelligent model family to date, built on a foundation of state-of-the-art reasoning",
+  provider: 'gcp-vertex',
+  owned_by: 'google',
+  context_length: 1000000,
+  capabilities: {
+    vision: true,
+    function_calling: true,
+    web_search: true,
+  },
+  supportedReasoningEfforts: ['minimal', 'low', 'medium', 'high'],
+}
+
 export const geminiProLatest: LlmModel = {
   ...gemini31ProModel,
   id: 'gemini-pro-latest',
@@ -183,8 +217,16 @@ export const geminiProLatest: LlmModel = {
   tags: ['latest'],
 }
 
+export const geminiFlashLatest: LlmModel = {
+  ...gemini37FlashModel,
+  id: 'gemini-flash-latest',
+  name: 'Gemini flash latest (3.7)',
+  tags: ['latest'],
+}
+
 export const vertexModels: LlmModel[] = [
   geminiProLatest,
+  geminiFlashLatest,
   gemini15ProModel,
   gemini15FlashModel,
   gemini20ProModel,
@@ -196,4 +238,6 @@ export const vertexModels: LlmModel[] = [
   gemini31FlashLite,
   gemini31ProModel,
   gemini35FlashModel,
+  gemini36FlashModel,
+  gemini37FlashModel,
 ]


### PR DESCRIPTION
## Summary
Adds `gemini-3.6-flash` and `gemini-3.7-flash` to the Gemini model catalog, plus a `geminiFlashLatest` model (aliasing 3.7 Flash) analogous to the existing `geminiProLatest`. All three are available under both the `google-ai-studio` and `logiclecloud` providers, in addition to `gcp-vertex`.

## Tests
- `npm run check-types` — passes