### PR TITLE
Enforce file authorization in DOCX export

### DIFF
--- a/__tests__/docxExport.test.ts
+++ b/__tests__/docxExport.test.ts
@@ -15,7 +15,7 @@ const problematicMarkdown = `**ISTRUZIONE OPERATIVA**
 `
 
 async function renderDocx(markdown: string) {
-  const out = await renderDocxFromMarkdown(markdown)
+  const out = await renderDocxFromMarkdown(markdown, { userId: 'test-user' })
   return Buffer.from(out)
 }
 

--- a/__tests__/docxExportAuthorization.test.ts
+++ b/__tests__/docxExportAuthorization.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const getFileWithIdMock = vi.fn()
+const canAccessFileMock = vi.fn()
+const readBufferMock = vi.fn()
+
+vi.mock('@/models/file', () => ({
+  getFileWithId: getFileWithIdMock,
+}))
+vi.mock('@/backend/lib/files/authorization', () => ({
+  canAccessFile: canAccessFileMock,
+}))
+vi.mock('@/lib/storage', () => ({
+  storage: { readBuffer: readBufferMock },
+}))
+
+// Minimal valid 1x1 transparent PNG.
+const PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+
+describe('DOCX export authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('does not resolve or read content for a file the principal cannot access', async () => {
+    canAccessFileMock.mockResolvedValue(false)
+    const { renderDocxFromMarkdown } = await import('../apps/backend/lib/docx/export')
+
+    await renderDocxFromMarkdown('![img](/api/files/secret-file/content)', { userId: 'attacker' })
+
+    expect(canAccessFileMock).toHaveBeenCalledWith({ userId: 'attacker' }, 'secret-file')
+    expect(getFileWithIdMock).not.toHaveBeenCalled()
+    expect(readBufferMock).not.toHaveBeenCalled()
+  })
+
+  test('does not turn an inaccessible non-image file into a link', async () => {
+    canAccessFileMock.mockResolvedValue(false)
+    const { renderDocxFromMarkdown } = await import('../apps/backend/lib/docx/export')
+
+    await renderDocxFromMarkdown('![doc](/api/files/secret-doc/content)', { userId: 'attacker' })
+
+    expect(getFileWithIdMock).not.toHaveBeenCalled()
+  })
+
+  test('reads content for a file the principal can access', async () => {
+    canAccessFileMock.mockResolvedValue(true)
+    getFileWithIdMock.mockResolvedValue({
+      id: 'ok-file',
+      path: 'some/path.png',
+      encryption: null,
+      type: 'image/png',
+      name: 'a.png',
+    })
+    readBufferMock.mockResolvedValue(Buffer.from(PNG_BASE64, 'base64'))
+    const { renderDocxFromMarkdown } = await import('../apps/backend/lib/docx/export')
+
+    await renderDocxFromMarkdown('![img](/api/files/ok-file/content)', { userId: 'owner' })
+
+    expect(canAccessFileMock).toHaveBeenCalledWith({ userId: 'owner' }, 'ok-file')
+    expect(readBufferMock).toHaveBeenCalledWith('some/path.png', null)
+  })
+})

--- a/apps/backend/api/conversations/[conversationId]/export/docx/route.ts
+++ b/apps/backend/api/conversations/[conversationId]/export/docx/route.ts
@@ -19,7 +19,10 @@ export const POST = operation({
       return forbidden()
     }
 
-    const doc = await renderDocxFromMarkdown(body.markdown)
+    const doc = await renderDocxFromMarkdown(body.markdown, {
+      userId: session.userId,
+      userRole: session.userRole,
+    })
     return new Response(Buffer.from(doc), {
       status: 200,
       headers: {

--- a/apps/backend/api/share/[shareId]/export/docx/route.ts
+++ b/apps/backend/api/share/[shareId]/export/docx/route.ts
@@ -10,7 +10,7 @@ export const POST = operation({
   authentication: 'user',
   requestBodySchema: dto.conversationDocxExportRequestSchema,
   responses: [responseSpec(200, z.any()), errorSpec(404)] as const,
-  implementation: async ({ params, body }) => {
+  implementation: async ({ params, body, session }) => {
     const sharedConversation = await db
       .selectFrom('ConversationSharing')
       .select('id')
@@ -21,7 +21,10 @@ export const POST = operation({
       return notFound(`No shared conversation with id ${params.shareId}`)
     }
 
-    const doc = await renderDocxFromMarkdown(body.markdown)
+    const doc = await renderDocxFromMarkdown(body.markdown, {
+      userId: session.userId,
+      userRole: session.userRole,
+    })
     return new Response(Buffer.from(doc), {
       status: 200,
       headers: {

--- a/apps/backend/lib/docx/export.ts
+++ b/apps/backend/lib/docx/export.ts
@@ -1,7 +1,9 @@
 import { TextRun } from 'docx'
 import type { IRunOptions } from 'docx'
 import { getFileWithId } from '@/models/file'
+import { canAccessFile } from '@/backend/lib/files/authorization'
 import { storage } from '@/lib/storage'
+import type * as schema from '@/db/schema'
 import type { Image as MdastImage, InlineCode as MdastInlineCode, Root, RootContent, Text as MdastText } from 'mdast'
 import docx from 'remark-docx'
 import { htmlPlugin } from 'remark-docx/plugins/html'
@@ -201,7 +203,12 @@ export const coloredHtmlPlugin = (): RemarkDocxPlugin => {
 
 const FILE_URL_PATTERN = /^\/api\/files\/([^/]+)\/content$/
 
-const remarkNonImageFileLinks: Plugin<[string], Root> = (baseUrl: string) => {
+type AccessPrincipal = { userId: string; userRole?: schema.UserRole }
+
+const remarkNonImageFileLinks: Plugin<[string, AccessPrincipal], Root> = (
+  baseUrl: string,
+  principal: AccessPrincipal
+) => {
   return async (tree: Root) => {
       type Replacement = { parent: { children: RootContent[] }; index: number; text: string; url: string }
       const replacements: Replacement[] = []
@@ -216,7 +223,9 @@ const remarkNonImageFileLinks: Plugin<[string], Root> = (baseUrl: string) => {
         const idx = index
 
         tasks.push(
-          getFileWithId(fileId).then((file) => {
+          canAccessFile(principal, fileId).then(async (allowed) => {
+            if (!allowed) return
+            const file = await getFileWithId(fileId)
             if (!file?.type.startsWith('image/')) {
               replacements.push({
                 parent: p,
@@ -248,56 +257,65 @@ function dataUrlToArrayBuffer(url: string): ArrayBuffer {
   return Uint8Array.from(buffer).buffer
 }
 
-async function loadImageData(url: string): Promise<ArrayBuffer> {
-  if (url.startsWith('data:')) {
-    return dataUrlToArrayBuffer(url)
-  }
-
-  const pathname = (() => {
-    if (url.startsWith('/')) return url
-    try {
-      return new URL(url).pathname
-    } catch {
-      return url
+function createLoadImageData(principal: AccessPrincipal) {
+  return async function loadImageData(url: string): Promise<ArrayBuffer> {
+    if (url.startsWith('data:')) {
+      return dataUrlToArrayBuffer(url)
     }
-  })()
 
-  const fileMatch = pathname.match(/^\/api\/files\/([^/]+)\/content$/)
-  if (fileMatch) {
-    const file = await getFileWithId(fileMatch[1])
-    if (!file) {
-      throw new Error(`Missing file for DOCX export image: ${fileMatch[1]}`)
+    const pathname = (() => {
+      if (url.startsWith('/')) return url
+      try {
+        return new URL(url).pathname
+      } catch {
+        return url
+      }
+    })()
+
+    const fileMatch = pathname.match(/^\/api\/files\/([^/]+)\/content$/)
+    if (fileMatch) {
+      const fileId = fileMatch[1]
+      if (!(await canAccessFile(principal, fileId))) {
+        throw new Error(`Not authorized to access file for DOCX export image: ${fileId}`)
+      }
+      const file = await getFileWithId(fileId)
+      if (!file) {
+        throw new Error(`Missing file for DOCX export image: ${fileId}`)
+      }
+      const data = await storage.readBuffer(file.path, file.encryption)
+      return Uint8Array.from(data).buffer
     }
-    const data = await storage.readBuffer(file.path, file.encryption)
-    return Uint8Array.from(data).buffer
-  }
 
-  const response = await fetch(url)
-  if (!response.ok) {
-    throw new Error(`Failed to load image: ${url}`)
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`Failed to load image: ${url}`)
+    }
+    return await response.arrayBuffer()
   }
-  return await response.arrayBuffer()
 }
 
 async function fallbackSvgToBuffer({ buffer }: { buffer: ArrayBuffer }) {
   return buffer
 }
 
-export async function renderDocxFromMarkdown(markdown: string): Promise<Uint8Array> {
+export async function renderDocxFromMarkdown(
+  markdown: string,
+  principal: AccessPrincipal
+): Promise<Uint8Array> {
   const baseUrl = process.env.APP_URL ?? ''
   const processor = unified()
     .use(remarkParse)
     .use(remarkGfm)
     .use(remarkMath)
     .use(remarkColoredSpans)
-    .use(remarkNonImageFileLinks, baseUrl)
+    .use(remarkNonImageFileLinks, baseUrl, principal)
     .use(docx, {
       thematicBreak: 'line',
       plugins: [
         coloredHtmlPlugin(),
         latexPlugin(),
         shikiPlugin({ theme: 'github-light' }),
-        imagePlugin({ load: loadImageData, fallbackSvg: fallbackSvgToBuffer }),
+        imagePlugin({ load: createLoadImageData(principal), fallbackSvg: fallbackSvgToBuffer }),
       ],
     })
 


### PR DESCRIPTION
## Summary
The DOCX export endpoints (`POST /api/conversations/{id}/export/docx` and `POST /api/share/{shareId}/export/docx`) resolved `/api/files/{id}/content` references found in the client-supplied markdown directly against storage, with no ownership or sharing check. Any authenticated user could export a DOCX embedding the raw content of an arbitrary file ID belonging to another tenant. `renderDocxFromMarkdown` now takes the caller's principal and gates every file resolution — both the embedded-image path and the non-image file-link path — through `canAccessFile` before touching file metadata or content, so exporting your own or a legitimately shared conversation is unaffected while cross-tenant file IDs are silently dropped from the export.

## Tests
- `npm run check-types` — passes
- `npx vitest run __tests__/docxExport.test.ts __tests__/docxExportAuthorization.test.ts` — all 10 tests pass, including new regression tests confirming inaccessible file IDs are neither embedded nor turned into links, while accessible ones still render correctly