### PR TITLE
Enforce file authorization when resolving chat attachments for the LLM

### DIFF
--- a/__tests__/chatTruncation.test.ts
+++ b/__tests__/chatTruncation.test.ts
@@ -75,6 +75,8 @@ const fakeLanguageModel = {
   provider: 'openai.responses',
 } as LanguageModelV3
 
+const fakePrincipal = { userId: 'test-user' }
+
 // --- buildHistorySegments tests ---
 
 describe('buildHistorySegments', () => {
@@ -92,7 +94,8 @@ describe('buildHistorySegments', () => {
     const segments = await ChatAssistant.buildHistorySegments(
       [msg1, msg2],
       fakeLlmModel,
-      fakeLanguageModel
+      fakeLanguageModel,
+      fakePrincipal
     )
 
     expect(segments).toHaveLength(2)
@@ -109,6 +112,7 @@ describe('buildHistorySegments', () => {
       [msg],
       fakeLlmModel,
       fakeLanguageModel,
+      fakePrincipal,
       'm1'
     )
 
@@ -123,7 +127,8 @@ describe('buildHistorySegments', () => {
     const segments = await ChatAssistant.buildHistorySegments(
       [msg1, msg2],
       fakeLlmModel,
-      fakeLanguageModel
+      fakeLanguageModel,
+      fakePrincipal
     )
 
     expect(segments).toHaveLength(1)
@@ -143,6 +148,7 @@ describe('buildHistorySegments', () => {
       [msg1, msg2, msg3],
       fakeLlmModel,
       fakeLanguageModel,
+      fakePrincipal,
       undefined,
       cache
     )
@@ -151,6 +157,7 @@ describe('buildHistorySegments', () => {
       [msg2, msg3],
       fakeLlmModel,
       fakeLanguageModel,
+      fakePrincipal,
       undefined,
       cache
     )
@@ -163,8 +170,8 @@ describe('buildHistorySegments', () => {
     const msg = makeMessage('m1')
     mockDtoMessageToLlmMessage.mockImplementation(async (m: dto.Message) => makeLlmMessage(m.id))
 
-    await ChatAssistant.buildHistorySegments([msg], fakeLlmModel, fakeLanguageModel)
-    await ChatAssistant.buildHistorySegments([msg], fakeLlmModel, fakeLanguageModel)
+    await ChatAssistant.buildHistorySegments([msg], fakeLlmModel, fakeLanguageModel, fakePrincipal)
+    await ChatAssistant.buildHistorySegments([msg], fakeLlmModel, fakeLanguageModel, fakePrincipal)
 
     expect(mockDtoMessageToLlmMessage).toHaveBeenCalledTimes(2)
   })

--- a/__tests__/conversion.test.ts
+++ b/__tests__/conversion.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { LlmModelCapabilities } from '@/lib/chat/models'
 import type * as dto from '@/types/dto'
 import { fileDescriptorText } from '@/backend/lib/chat/message-projection'
@@ -7,11 +7,16 @@ const ensureFileAnalysis = vi.fn()
 const readBuffer = vi.fn()
 const extractFromFile = vi.fn()
 const getFileWithId = vi.fn()
+const canAccessFile = vi.fn(async () => true)
 const warn = vi.fn()
 const info = vi.fn()
 
 vi.mock('@/models/file', () => ({
   getFileWithId,
+}))
+
+vi.mock('@/backend/lib/files/authorization', () => ({
+  canAccessFile,
 }))
 
 vi.mock('@/lib/file-analysis', () => ({
@@ -48,6 +53,7 @@ const pdfCapabilities: LlmModelCapabilities = {
 
 const openaiLanguageModel = { provider: 'openai.responses' } as any
 const litellmLanguageModel = { provider: 'litellm.chat' } as any
+const testPrincipal = { userId: 'test-user' }
 
 const pdfFile = {
   fileBlobId: 'blob-1',
@@ -226,7 +232,8 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
         ],
       },
       pdfCapabilities,
-      openaiLanguageModel.provider
+      openaiLanguageModel.provider,
+      testPrincipal
     )
 
     expect(message).toEqual({
@@ -241,9 +248,20 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
             value: [
               {
                 type: 'text',
-                text: fileDescriptorText(pdfFile.name, pdfFile.id, pdfFile.type, pdfFile.size, 1, 'Attachment'),
+                text: fileDescriptorText(
+                  pdfFile.name,
+                  pdfFile.id,
+                  pdfFile.type,
+                  pdfFile.size,
+                  1,
+                  'Attachment'
+                ),
               },
-              { type: 'file-data', data: Buffer.from('pdf-bytes').toString('base64'), mediaType: pdfFile.type },
+              {
+                type: 'file-data',
+                data: Buffer.from('pdf-bytes').toString('base64'),
+                mediaType: pdfFile.type,
+              },
             ],
           },
         },
@@ -307,7 +325,8 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
         ],
       },
       pdfCapabilities,
-      openaiLanguageModel.provider
+      openaiLanguageModel.provider,
+      testPrincipal
     )
 
     expect(message).toEqual({
@@ -322,7 +341,14 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
             value: [
               {
                 type: 'text',
-                text: fileDescriptorText(pdfFile.name, pdfFile.id, pdfFile.type, pdfFile.size, 1, 'Attachment'),
+                text: fileDescriptorText(
+                  pdfFile.name,
+                  pdfFile.id,
+                  pdfFile.type,
+                  pdfFile.size,
+                  1,
+                  'Attachment'
+                ),
               },
               {
                 type: 'file-data',
@@ -391,7 +417,8 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
         ],
       },
       pdfCapabilities,
-      litellmLanguageModel.provider
+      litellmLanguageModel.provider,
+      testPrincipal
     )
 
     expect(message).toEqual({
@@ -406,7 +433,14 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
             value: [
               {
                 type: 'text',
-                text: fileDescriptorText(pdfFile.name, pdfFile.id, pdfFile.type, pdfFile.size, 1, 'Attachment'),
+                text: fileDescriptorText(
+                  pdfFile.name,
+                  pdfFile.id,
+                  pdfFile.type,
+                  pdfFile.size,
+                  1,
+                  'Attachment'
+                ),
               },
               {
                 type: 'text',
@@ -455,7 +489,8 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
         ],
       },
       { vision: false, function_calling: true, supportedMedia: [] },
-      openaiLanguageModel.provider
+      openaiLanguageModel.provider,
+      testPrincipal
     )
 
     expect(message).toEqual({
@@ -470,7 +505,14 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
             value: [
               {
                 type: 'text',
-                text: fileDescriptorText(pdfFile.name, pdfFile.id, pdfFile.type, pdfFile.size, 1, 'Attachment'),
+                text: fileDescriptorText(
+                  pdfFile.name,
+                  pdfFile.id,
+                  pdfFile.type,
+                  pdfFile.size,
+                  1,
+                  'Attachment'
+                ),
               },
               {
                 type: 'text',
@@ -527,7 +569,8 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
         ],
       },
       { ...pdfCapabilities, vision: true, supportedMedia: ['image/png'] },
-      litellmLanguageModel.provider
+      litellmLanguageModel.provider,
+      testPrincipal
     )
 
     expect(message).toEqual({
@@ -542,7 +585,14 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
             value: [
               {
                 type: 'text',
-                text: fileDescriptorText(imageFile.name, imageFile.id, imageFile.type, imageFile.size, 1, 'Attachment'),
+                text: fileDescriptorText(
+                  imageFile.name,
+                  imageFile.id,
+                  imageFile.type,
+                  imageFile.size,
+                  1,
+                  'Attachment'
+                ),
               },
               {
                 type: 'text',
@@ -556,6 +606,88 @@ describe('dtoMessageToLlmMessage tool file conversion', () => {
     expect(getFileWithId).toHaveBeenCalledWith(imageFile.id)
     expect(readBuffer).not.toHaveBeenCalled()
     expect(ensureFileAnalysis).not.toHaveBeenCalled()
+  })
+})
+
+describe('dtoMessageToLlmMessage authorization', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    canAccessFile.mockResolvedValue(true)
+  })
+
+  test('skips a user attachment the principal cannot access instead of resolving its content', async () => {
+    canAccessFile.mockResolvedValue(false)
+
+    const { dtoMessageToLlmMessage } = await import('@/backend/lib/chat/conversion')
+    const message = await dtoMessageToLlmMessage(
+      {
+        id: 'u-auth-1',
+        conversationId: 'c1',
+        parent: null,
+        sentAt: new Date().toISOString(),
+        citations: [],
+        role: 'user',
+        content: 'hello',
+        attachments: [{ id: 'other-tenant-file', name: 'secret.pdf', mimetype: 'application/pdf', size: 10 }],
+      },
+      { vision: false, function_calling: true, supportedMedia: ['application/pdf'] },
+      openaiLanguageModel.provider,
+      testPrincipal
+    )
+
+    expect(canAccessFile).toHaveBeenCalledWith(testPrincipal, 'other-tenant-file')
+    expect(getFileWithId).not.toHaveBeenCalled()
+    // The descriptor text below only echoes name/mimetype/size the client supplied in its own
+    // request — not anything looked up server-side — so skipping the attachment part itself is
+    // what matters: no file content or server-verified metadata is ever resolved or sent.
+    expect(message).toEqual({
+      role: 'user',
+      content: [
+        { type: 'text', text: 'hello' },
+        {
+          type: 'text',
+          text: 'Attachment 1: secret.pdf (id other-tenant-file, application/pdf, 10 bytes)',
+        },
+      ],
+    })
+  })
+
+  test('throws instead of resolving a tool-result file the principal cannot access', async () => {
+    canAccessFile.mockResolvedValue(false)
+
+    const { dtoMessageToLlmMessage } = await import('@/backend/lib/chat/conversion')
+    await expect(
+      dtoMessageToLlmMessage(
+        {
+          id: 't-auth-1',
+          conversationId: 'c1',
+          parent: null,
+          sentAt: new Date().toISOString(),
+          citations: [],
+          role: 'tool',
+          parts: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call1',
+              toolName: 'some_tool',
+              result: {
+                type: 'content',
+                value: [{ type: 'file', id: 'other-tenant-file', mimetype: 'application/pdf', name: 'secret.pdf', size: 10 }],
+              },
+            },
+          ],
+        },
+        pdfCapabilities,
+        openaiLanguageModel.provider,
+        testPrincipal
+      )
+    ).rejects.toThrow(/Not authorized/)
+
+    expect(getFileWithId).not.toHaveBeenCalled()
   })
 })
 
@@ -579,7 +711,8 @@ describe('dtoMessageToLlmMessage contract', () => {
         attachments: [],
       },
       { vision: false, function_calling: true, supportedMedia: [] },
-      openaiLanguageModel.provider
+      openaiLanguageModel.provider,
+      testPrincipal
     )
 
     expect(message).toEqual({ role: 'user', content: 'hello' })
@@ -608,10 +741,18 @@ describe('dtoMessageToLlmMessage contract', () => {
         role: 'user',
         content: 'hello',
         metadata: { locale: 'en-US' },
-        attachments: [{ id: imageFile.id, name: imageFile.name, mimetype: imageFile.type, size: imageFile.size }],
+        attachments: [
+          {
+            id: imageFile.id,
+            name: imageFile.name,
+            mimetype: imageFile.type,
+            size: imageFile.size,
+          },
+        ],
       },
       { vision: true, function_calling: true, supportedMedia: ['image/png'] },
-      openaiLanguageModel.provider
+      openaiLanguageModel.provider,
+      testPrincipal
     )
 
     expect(message).toEqual({
@@ -621,7 +762,14 @@ describe('dtoMessageToLlmMessage contract', () => {
         { type: 'text', text: 'hello' },
         {
           type: 'text',
-          text: fileDescriptorText(imageFile.name, imageFile.id, imageFile.type, imageFile.size, 1, 'Attachment'),
+          text: fileDescriptorText(
+            imageFile.name,
+            imageFile.id,
+            imageFile.type,
+            imageFile.size,
+            1,
+            'Attachment'
+          ),
         },
         {
           type: 'image',
@@ -648,7 +796,8 @@ describe('dtoMessageToLlmMessage contract', () => {
         ],
       },
       { vision: false, function_calling: true, supportedMedia: [] },
-      openaiLanguageModel.provider
+      openaiLanguageModel.provider,
+      testPrincipal
     )
 
     expect(message).toEqual({

--- a/__tests__/fileMetadataInterspersing.test.ts
+++ b/__tests__/fileMetadataInterspersing.test.ts
@@ -25,10 +25,12 @@ const ensureFileAnalysis = vi.fn()
 const readBuffer = vi.fn()
 const extractFromFile = vi.fn()
 const getFileWithId = vi.fn()
+const canAccessFile = vi.fn(async () => true)
 const warn = vi.fn()
 const info = vi.fn()
 
 vi.mock('@/models/file', () => ({ getFileWithId }))
+vi.mock('@/backend/lib/files/authorization', () => ({ canAccessFile }))
 vi.mock('@/lib/file-analysis', () => ({
   ensureFileAnalysis,
   isReadyFileAnalysis: (analysis: dto.FileAnalysis | undefined) =>
@@ -281,7 +283,8 @@ describe('dtoMessageToLlmMessage', () => {
         attachments: [{ id: pngFile.id, name: pngFile.name, mimetype: pngFile.type, size: pngFile.size }],
       },
       visionCapabilities,
-      'openai.chat'
+      'openai.chat',
+      { userId: 'test-user' }
     )
 
     expect(msg).toBeDefined()
@@ -318,7 +321,8 @@ describe('dtoMessageToLlmMessage', () => {
         ],
       },
       visionCapabilities,
-      'openai.chat'
+      'openai.chat',
+      { userId: 'test-user' }
     )
 
     const parts = msg!.content as Array<{ type: string; text?: string }>
@@ -349,7 +353,8 @@ describe('dtoMessageToLlmMessage', () => {
         attachments: [{ id: pdfFile.id, name: pdfFile.name, mimetype: pdfFile.type, size: pdfFile.size }],
       },
       noVisionCapabilities, // no PDF support → text fallback
-      'openai.chat'
+      'openai.chat',
+      { userId: 'test-user' }
     )
 
     const parts = msg!.content as Array<{ type: string; text?: string }>
@@ -384,7 +389,8 @@ describe('dtoMessageToLlmMessage', () => {
         ],
       },
       visionCapabilities,
-      'openai.chat'
+      'openai.chat',
+      { userId: 'test-user' }
     )
 
     const parts = msg!.content as Array<{ type: string }>

--- a/__tests__/parallelToolCalls.test.ts
+++ b/__tests__/parallelToolCalls.test.ts
@@ -40,6 +40,10 @@ vi.mock('@/models/file', () => ({
   addFile: vi.fn(),
 }))
 
+vi.mock('@/backend/lib/files/authorization', () => ({
+  canAccessFile: vi.fn().mockResolvedValue(true),
+}))
+
 vi.mock('@/lib/logging', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), log: vi.fn() },
   loggingFetch: vi.fn(),

--- a/__tests__/promptTokenCounter.test.ts
+++ b/__tests__/promptTokenCounter.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
-const { mockEstimateNativeImageTokens, mockGetFileWithId } = vi.hoisted(() => ({
+const { mockEstimateNativeImageTokens, mockGetFileWithId, mockCanAccessFile } = vi.hoisted(() => ({
   mockEstimateNativeImageTokens: vi.fn(),
   mockGetFileWithId: vi.fn(),
+  mockCanAccessFile: vi.fn(async () => true),
 }))
 
 vi.mock('@/backend/lib/chat/image-token-estimator', () => ({
@@ -11,6 +12,10 @@ vi.mock('@/backend/lib/chat/image-token-estimator', () => ({
 
 vi.mock('@/models/file', () => ({
   getFileWithId: mockGetFileWithId,
+}))
+
+vi.mock('@/backend/lib/files/authorization', () => ({
+  canAccessFile: mockCanAccessFile,
 }))
 
 import {
@@ -105,7 +110,8 @@ describe('countModelMessageTokens', () => {
         ],
       },
       fakeModel.capabilities,
-      'litellm.chat'
+      'litellm.chat',
+      { userId: 'test-user' }
     )
 
     expect(llmMessage).toBeDefined()

--- a/apps/backend/lib/chat/__tests__/compression-planner.test.ts
+++ b/apps/backend/lib/chat/__tests__/compression-planner.test.ts
@@ -34,6 +34,10 @@ vi.mock('@/models/file', () => ({
   }),
 }))
 
+vi.mock('@/backend/lib/files/authorization', () => ({
+  canAccessFile: vi.fn(async () => true),
+}))
+
 vi.mock('@/models/compressed-message', () => ({
   getCompressedMessage: mockGetCompressedMessage,
   saveCompressedMessage: mockSaveCompressedMessage,
@@ -293,7 +297,7 @@ describe('applyCompressionPlan', () => {
 
     const { compressed } = await compress(makeGeneratedDocxHistory())
 
-    const segments = await buildHistorySegments(compressed, modelWithoutDocxNativeSupport, languageModel)
+    const segments = await buildHistorySegments(compressed, modelWithoutDocxNativeSupport, languageModel, { userId: 'test-user' })
     const promptText = JSON.stringify(segments.map((segment) => segment.message))
 
     expect(promptText).toContain('File available on demand: documento_semplice.docx')
@@ -312,7 +316,7 @@ describe('applyCompressionPlan', () => {
   test('uncompressed generated DOCX tool result is still converted through text extraction when not natively supported', async () => {
     mockExtractFromFile.mockResolvedValueOnce('EXTRACTED DOCX CONTENT')
 
-    const segments = await buildHistorySegments(makeGeneratedDocxHistory(), modelWithoutDocxNativeSupport, languageModel)
+    const segments = await buildHistorySegments(makeGeneratedDocxHistory(), modelWithoutDocxNativeSupport, languageModel, { userId: 'test-user' })
     const promptText = JSON.stringify(segments.map((segment) => segment.message))
 
     expect(promptText).toContain('Attachment 1: documento_semplice.docx')
@@ -323,7 +327,7 @@ describe('applyCompressionPlan', () => {
   test('compressed generated image tool result never upgrades to image-data / native bytes, and never calls a model to describe it', async () => {
     const { compressed } = await compress(makeGeneratedHorseImageHistory())
 
-    const segments = await buildHistorySegments(compressed, modelWithoutDocxNativeSupport, languageModel)
+    const segments = await buildHistorySegments(compressed, modelWithoutDocxNativeSupport, languageModel, { userId: 'test-user' })
     const promptText = JSON.stringify(segments.map((segment) => segment.message))
 
     expect(promptText).toContain('File available on demand: horse.png')
@@ -341,7 +345,7 @@ describe('applyCompressionPlan', () => {
   test('uncompressed generated image tool result still sends image bytes (provider adapters do not change full-policy semantics)', async () => {
     mockReadBuffer.mockResolvedValueOnce(Buffer.from('horse-image-bytes'))
 
-    const segments = await buildHistorySegments(makeGeneratedHorseImageHistory(), modelWithoutDocxNativeSupport, languageModel)
+    const segments = await buildHistorySegments(makeGeneratedHorseImageHistory(), modelWithoutDocxNativeSupport, languageModel, { userId: 'test-user' })
     const promptText = JSON.stringify(segments.map((segment) => segment.message))
 
     expect(promptText).toContain('Attachment 1: horse.png')

--- a/apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
+++ b/apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts
@@ -32,6 +32,10 @@ vi.mock('@/models/file', () => ({
   },
 }))
 
+vi.mock('@/backend/lib/files/authorization', () => ({
+  canAccessFile: async () => true,
+}))
+
 vi.mock('@/lib/storage', () => ({
   storage: {
     readBuffer: async () => Buffer.from(ONE_BY_ONE_PNG_BASE64, 'base64'),
@@ -272,9 +276,15 @@ describe('message projection parity', () => {
     const assistantLlm = await dtoMessageToLlmMessage(
       assistantMessage,
       approxModel.capabilities,
-      approxModel.provider
+      approxModel.provider,
+      { userId: 'test-user' }
     )
-    const toolLlm = await dtoMessageToLlmMessage(toolMessage, approxModel.capabilities, approxModel.provider)
+    const toolLlm = await dtoMessageToLlmMessage(
+      toolMessage,
+      approxModel.capabilities,
+      approxModel.provider,
+      { userId: 'test-user' }
+    )
 
     expect(assistantLlm?.role).toBe('assistant')
     expect(toolLlm?.role).toBe('tool')
@@ -326,7 +336,12 @@ describe('message projection parity', () => {
       ])
     )
 
-    const llm = await dtoMessageToLlmMessage(toolMessage, approxModel.capabilities, 'litellm')
+    const llm = await dtoMessageToLlmMessage(
+      toolMessage,
+      approxModel.capabilities,
+      'litellm',
+      { userId: 'test-user' }
+    )
     expect(llm?.role).toBe('tool')
     if (llm?.role !== 'tool') return
     const content = llm.content
@@ -405,7 +420,9 @@ describe('token invariant for non-file history', () => {
     const llmMessages = (
       await Promise.all(
         history.map((message) =>
-          dtoMessageToLlmMessage(message, approxModel.capabilities, approxModel.provider)
+          dtoMessageToLlmMessage(message, approxModel.capabilities, approxModel.provider, {
+            userId: 'test-user',
+          })
         )
       )
     ).filter((m): m is NonNullable<typeof m> => Boolean(m))
@@ -465,7 +482,9 @@ describe('token invariant for non-file history', () => {
     const llmMessages = (
       await Promise.all(
         history.map((message) =>
-          dtoMessageToLlmMessage(message, approxModel.capabilities, approxModel.provider)
+          dtoMessageToLlmMessage(message, approxModel.capabilities, approxModel.provider, {
+            userId: 'test-user',
+          })
         )
       )
     ).filter((m): m is NonNullable<typeof m> => Boolean(m))
@@ -501,7 +520,12 @@ describe('token invariant for non-file history', () => {
       history,
       draft: null,
     })
-    const llm = await dtoMessageToLlmMessage(history[0]!, parityMediaModel.capabilities as any, 'openai')
+    const llm = await dtoMessageToLlmMessage(
+      history[0]!,
+      parityMediaModel.capabilities as any,
+      'openai',
+      { userId: 'test-user' }
+    )
     expect(llm?.role).toBe('user')
     const runtimeTokens = llm ? await countModelMessageTokens(parityMediaModel as any, llm) : 0
     expect(estimate.estimate.history).toBe(runtimeTokens)
@@ -541,7 +565,12 @@ describe('token invariant for non-file history', () => {
       history,
       draft: null,
     })
-    const llm = await dtoMessageToLlmMessage(history[0]!, parityMediaModel.capabilities as any, 'openai')
+    const llm = await dtoMessageToLlmMessage(
+      history[0]!,
+      parityMediaModel.capabilities as any,
+      'openai',
+      { userId: 'test-user' }
+    )
     expect(llm?.role).toBe('user')
     const runtimeTokens = llm ? await countModelMessageTokens(parityMediaModel as any, llm) : 0
     expect(estimate.estimate.history).toBe(runtimeTokens)

--- a/apps/backend/lib/chat/conversion.ts
+++ b/apps/backend/lib/chat/conversion.ts
@@ -1,6 +1,7 @@
 import * as ai from 'ai'
 import { type FileDbRow } from '@/backend/models/file'
 import { getFileWithId } from '@/models/file'
+import { canAccessFile } from '@/backend/lib/files/authorization'
 import * as dto from '@/types/dto'
 import { ensureFileAnalysis } from '@/lib/file-analysis'
 import { UserVisibleError } from '@/backend/lib/chat'
@@ -155,10 +156,13 @@ const dtoFileToToolResultOutputPart = async (
   return dtoFileToTextPart(fileEntry)
 }
 
+export type ConversionPrincipal = { userId: string }
+
 export const dtoMessageToLlmMessage = async (
   m: dto.Message,
   capabilities: LlmModelCapabilities,
-  providerName: string
+  providerName: string,
+  principal: ConversionPrincipal
 ): Promise<ai.ModelMessage | undefined> => {
   const projected = projectMessageForEstimationCached(m)
   if (projected.role === 'ignored') return undefined
@@ -180,6 +184,9 @@ export const dtoMessageToLlmMessage = async (
               if (v.type === 'text') {
                 parts.push(v)
               } else {
+                if (!(await canAccessFile(principal, v.id))) {
+                  throw new Error(`Not authorized to access attachment ${v.id}`)
+                }
                 const fileEntry = await getFileWithId(v.id)
                 if (!fileEntry) {
                   throw new Error(`Can't find entry for attachment ${v.id}`)
@@ -267,6 +274,10 @@ export const dtoMessageToLlmMessage = async (
       if (item.kind === 'text') {
         parts.push({ type: 'text', text: item.text })
       } else if (item.kind === 'attachment') {
+        if (!(await canAccessFile(principal, item.attachment.id))) {
+          logger.warn(`Not authorized to access attachment ${item.attachment.id}`)
+          continue
+        }
         const fileEntry = await getFileWithId(item.attachment.id)
         if (!fileEntry) {
           logger.warn(`Can't find entry for attachment ${item.attachment.id}`)

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -209,13 +209,9 @@ export class ChatAssistant {
   }
 
   static async buildHistorySegments(
-    messages: dto.Message[],
-    llmModel: LlmModel,
-    languageModel: LanguageModelV3,
-    draftMessageId?: string,
-    cache?: Map<string, ai.ModelMessage>
+    ...args: Parameters<typeof buildHistorySegments>
   ): Promise<PromptSegment[]> {
-    return buildHistorySegments(messages, llmModel, languageModel, draftMessageId, cache)
+    return buildHistorySegments(...args)
   }
 
   static async buildPromptSegments(
@@ -549,6 +545,7 @@ export class ChatAssistant {
       parameters: this.parameters,
       knowledge: this.knowledge,
       messages,
+      principal: { userId: this.options.user },
     })
     return segments.map((segment) => segment.message)
   }
@@ -608,7 +605,8 @@ export class ChatAssistant {
     const historySegments = await buildHistorySegments(
       truncatedChat,
       this.llmModel,
-      this.languageModel
+      this.languageModel,
+      { userId: this.options.user }
     )
 
     const isAnthropic = this.languageModel.provider === 'anthropic.messages'

--- a/apps/backend/lib/chat/preamble.ts
+++ b/apps/backend/lib/chat/preamble.ts
@@ -5,7 +5,11 @@ import env from '@/lib/env'
 import { LlmModel } from '@/lib/chat/models'
 import { ToolImplementation } from '@/lib/chat/tools'
 import type { ParameterValueAndDescription } from '@/models/user'
-import { dtoMessageToLlmMessage, sanitizeOrphanToolCalls } from '@/backend/lib/chat/conversion'
+import {
+  dtoMessageToLlmMessage,
+  sanitizeOrphanToolCalls,
+  type ConversionPrincipal,
+} from '@/backend/lib/chat/conversion'
 import { fileDescriptorText } from '@/backend/lib/chat/message-projection'
 
 async function mapWithConcurrency<T, R>(
@@ -237,6 +241,7 @@ export async function buildHistorySegments(
   messages: dto.Message[],
   llmModel: LlmModel,
   languageModel: LanguageModelV3,
+  principal: ConversionPrincipal,
   draftMessageId?: string,
   cache?: Map<string, ai.ModelMessage>
 ): Promise<PromptSegment[]> {
@@ -246,8 +251,12 @@ export async function buildHistorySegments(
         let converted = cache?.get(message.id)
         if (!converted) {
           converted =
-            (await dtoMessageToLlmMessage(message, llmModel.capabilities, languageModel.provider)) ??
-            undefined
+            (await dtoMessageToLlmMessage(
+              message,
+              llmModel.capabilities,
+              languageModel.provider,
+              principal
+            )) ?? undefined
           if (converted && cache) cache.set(message.id, converted)
         }
         return converted
@@ -278,6 +287,7 @@ export async function buildPromptSegments({
   parameters,
   knowledge,
   messages,
+  principal,
   draftMessageId,
 }: {
   assistantParams: AssistantParamsLike
@@ -287,9 +297,10 @@ export async function buildPromptSegments({
   parameters: Record<string, ParameterValueAndDescription>
   knowledge: dto.AssistantFile[]
   messages: dto.Message[]
+  principal: ConversionPrincipal
   draftMessageId?: string
 }): Promise<PromptSegment[]> {
   const preamble = await buildPreambleSegments({ assistantParams, llmModel, tools, parameters, knowledge })
-  const history = await buildHistorySegments(messages, llmModel, languageModel, draftMessageId)
+  const history = await buildHistorySegments(messages, llmModel, languageModel, principal, draftMessageId)
   return [...preamble, ...history]
 }


### PR DESCRIPTION
## Summary
`dtoMessageToLlmMessage` resolved user-attachment and tool-result file IDs directly via `getFileWithId`, with no ownership or sharing check — a crafted message (or a tool result carrying an attacker-influenced file ID) referencing another tenant's file could have that file's content read from storage and sent straight to the LLM. The conversion path now takes the sending user's principal and calls `canAccessFile` before resolving any file: an inaccessible user attachment is silently skipped from the LLM payload (matching the existing behavior for a missing file — only the client-supplied name/size in the message itself is echoed back, nothing server-verified), while an inaccessible tool-result file throws, since a trusted tool should never legitimately return an ID the caller can't access. The principal is threaded through `buildHistorySegments`/`buildPromptSegments`/`ChatAssistant` using the same session user already passed to `ChatAssistant.build`, so normal chat history, attachments, and tool results for a user's own or legitimately shared conversations are unaffected.

## Tests
- `npm run check-types` — passes
- `npx vitest run __tests__/conversion.test.ts __tests__/chatTruncation.test.ts __tests__/fileMetadataInterspersing.test.ts __tests__/promptTokenCounter.test.ts apps/backend/lib/chat/__tests__/compression-planner.test.ts apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts __tests__/chatAssistant.test.ts __tests__/chatRuns.test.ts __tests__/subassistantTool.test.ts __tests__/contextRetrieveTool.test.ts` — all 158 tests pass, including two new regression tests confirming an inaccessible attachment is skipped (not resolved) and an inaccessible tool-result file throws instead of being read