### PR TITLE
Reject chat messages that reference inaccessible file IDs

### DIFF
--- a/__tests__/startServerChatRunAttachmentAuthorization.test.ts
+++ b/__tests__/startServerChatRunAttachmentAuthorization.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { SimpleSession } from '@/types/session'
+
+const getConversationWithBackendAssistant = vi.fn()
+const canAccessFile = vi.fn()
+const reassignUserOwnedFilesToConversation = vi.fn()
+const createChatRun = vi.fn()
+
+vi.mock('@/models/conversation', () => ({
+  getConversationWithBackendAssistant,
+}))
+vi.mock('@/backend/lib/files/authorization', () => ({
+  canAccessFile,
+}))
+vi.mock('@/models/file', () => ({
+  reassignUserOwnedFilesToConversation,
+}))
+vi.mock('@/backend/lib/chat/chatRuns', () => ({
+  createChatRun,
+  finalizeChatRun: vi.fn(),
+  getChatRunById: vi.fn(),
+  isChatRunAbortError: vi.fn(),
+  persistAndPublishChatRunEvent: vi.fn(),
+}))
+vi.mock('@/backend/lib/tools/enumerate', () => ({
+  availableToolsForAssistantVersion: vi.fn(),
+}))
+vi.mock('@/lib/MessageAuditor', () => ({ MessageAuditor: vi.fn() }))
+vi.mock('@/lib/chat/conversationUtils', () => ({ extractLinearConversation: vi.fn() }))
+vi.mock('@/lib/parameters', () => ({ getUserParameters: vi.fn() }))
+vi.mock('@/models/assistant', () => ({ assistantVersionFiles: vi.fn() }))
+vi.mock('@/models/message', () => ({ getMessages: vi.fn(), saveMessage: vi.fn() }))
+vi.mock('@/models/userSecrets', () => ({ getUserSecretValue: vi.fn() }))
+vi.mock('db/database', () => ({ db: {} }))
+vi.mock('@/backend/lib/chat', () => ({ ChatAssistant: { build: vi.fn() } }))
+vi.mock('@/backend/lib/chat/compression-planner', () => ({ warmCompressionCache: vi.fn() }))
+
+const session: SimpleSession = {
+  userId: 'attacker',
+  userRole: 'USER',
+  sessionId: 's1',
+} as SimpleSession
+
+const baseUserMessage = {
+  id: 'm1',
+  conversationId: 'c1',
+  role: 'user' as const,
+  content: 'hello',
+  attachments: [{ id: 'other-tenant-file', name: 'secret.pdf', mimetype: 'application/pdf', size: 10 }],
+  parent: null,
+  sentAt: new Date().toISOString(),
+  citations: [],
+}
+
+describe('startServerChatRun attachment authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getConversationWithBackendAssistant.mockResolvedValue({
+      conversation: { id: 'c1', ownerId: 'attacker' },
+      assistant: { deleted: false, assistantId: 'a1', assistantVersionId: 'av1', model: 'gpt' },
+      backend: {},
+    })
+  })
+
+  test('rejects the message and never reassigns ownership when an attachment is not accessible', async () => {
+    canAccessFile.mockResolvedValue(false)
+    const { startServerChatRun } = await import('@/backend/lib/chat/startServerChatRun')
+
+    const result = await startServerChatRun({
+      userMessage: baseUserMessage,
+      headers: new Headers(),
+      session,
+    })
+
+    expect(canAccessFile).toHaveBeenCalledWith({ userId: 'attacker' }, 'other-tenant-file')
+    expect(reassignUserOwnedFilesToConversation).not.toHaveBeenCalled()
+    expect(createChatRun).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      message: 'Message references files that are not accessible to the current user',
+    })
+  })
+
+  test('proceeds to reassign ownership when every attachment is accessible', async () => {
+    canAccessFile.mockResolvedValue(true)
+    createChatRun.mockReturnValue({ ok: false, run: { id: 'run-1' } })
+    const { startServerChatRun } = await import('@/backend/lib/chat/startServerChatRun')
+
+    const result = await startServerChatRun({
+      userMessage: baseUserMessage,
+      headers: new Headers(),
+      session,
+    })
+
+    expect(canAccessFile).toHaveBeenCalledWith({ userId: 'attacker' }, 'other-tenant-file')
+    expect(reassignUserOwnedFilesToConversation).toHaveBeenCalledWith({
+      fileIds: ['other-tenant-file'],
+      userId: 'attacker',
+      conversationId: 'c1',
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.status).toBe(409)
+    }
+  })
+})

--- a/apps/backend/api/v1/responses/route.ts
+++ b/apps/backend/api/v1/responses/route.ts
@@ -10,6 +10,7 @@ import { nanoid } from 'nanoid'
 import { MessageAuditor } from '@/lib/MessageAuditor'
 import { assistantVersionFiles, getAssistant } from '@/models/assistant'
 import { getFileWithId, reassignUserOwnedFilesToConversation } from '@/models/file'
+import { canAccessFile } from '@/backend/lib/files/authorization'
 import { storage } from '@/lib/storage'
 import { getUserParameters } from '@/lib/parameters'
 import { error, forbidden, ok, operation, responseSpec, errorSpec } from '@/lib/routes'
@@ -114,6 +115,12 @@ export const POST = operation({
       return forbidden('Trying to add a message to a non owned conversation')
     }
     if (userMessage.attachments && userMessage.attachments.length > 0) {
+      const accessChecks = await Promise.all(
+        userMessage.attachments.map((id) => canAccessFile({ userId: session.userId }, id))
+      )
+      if (accessChecks.some((allowed) => !allowed)) {
+        return forbidden('Message references files that are not accessible to the current user')
+      }
       await reassignUserOwnedFilesToConversation({
         fileIds: userMessage.attachments,
         userId: session.userId,

--- a/apps/backend/lib/chat/startServerChatRun.ts
+++ b/apps/backend/lib/chat/startServerChatRun.ts
@@ -15,6 +15,7 @@ import { getUserParameters } from '@/lib/parameters'
 import { assistantVersionFiles } from '@/models/assistant'
 import { getConversationWithBackendAssistant } from '@/models/conversation'
 import { reassignUserOwnedFilesToConversation } from '@/models/file'
+import { canAccessFile } from '@/backend/lib/files/authorization'
 import { getMessages, saveMessage } from '@/models/message'
 import { getUserSecretValue } from '@/models/userSecrets'
 import { db } from 'db/database'
@@ -90,8 +91,19 @@ export const startServerChatRun = async ({
   }
 
   if (userMessage.role === 'user' && userMessage.attachments.length > 0) {
+    const attachmentIds = userMessage.attachments.map((attachment) => attachment.id)
+    const accessChecks = await Promise.all(
+      attachmentIds.map((id) => canAccessFile({ userId: session.userId }, id))
+    )
+    if (accessChecks.some((allowed) => !allowed)) {
+      return {
+        ok: false,
+        status: 403,
+        message: 'Message references files that are not accessible to the current user',
+      }
+    }
     await reassignUserOwnedFilesToConversation({
-      fileIds: userMessage.attachments.map((attachment) => attachment.id),
+      fileIds: attachmentIds,
       userId: session.userId,
       conversationId: conversation.id,
     })


### PR DESCRIPTION
## Summary
`reassignUserOwnedFilesToConversation` correctly scoped its ownership transfer with `WHERE ownerType='USER' AND ownerId=userId`, but neither call site checked how many rows it actually affected — if a sent message referenced a file ID the sender didn't own, that ID simply failed to be reassigned while staying referenced in the saved message, with no rejection or error. Both message-send entry points (`startServerChatRun`, used by the main chat flow, and the `POST /api/v1/responses` endpoint) now call `canAccessFile` for every attachment ID up front and reject the whole request with a 403 if any attachment isn't accessible to the sender, instead of silently proceeding. A normal user attaching their own freshly-uploaded files, or re-referencing a file already shared into the same conversation, is unaffected — both remain accessible under the existing `canAccessFile` rules.

This is a companion fix to #1047, which closed the same class of issue further downstream (file content resolution before it reaches the LLM); this PR closes it at the point of ingestion.

## Tests
- `npm run check-types` — passes
- `npx vitest run __tests__/startServerChatRunAttachmentAuthorization.test.ts __tests__/fileOwnershipTransfer.test.ts` — all 4 tests pass, including two new regression tests confirming an inaccessible attachment causes the message to be rejected (and ownership is never reassigned), while an accessible attachment still proceeds normally