### PR TITLE
Enforce file authorization in KnowledgePlugin's GetFile tool

### DIFF
--- a/apps/backend/lib/tools/knowledge/__tests__/implementation.test.ts
+++ b/apps/backend/lib/tools/knowledge/__tests__/implementation.test.ts
@@ -5,6 +5,7 @@ import type { ToolFunction, ToolInvokeParams, ToolParams } from '@/lib/chat/tool
 const mockExecuteTakeFirst = vi.fn()
 const mockExtractFromFile = vi.fn()
 const mockDtoFileToLlmFilePart = vi.fn()
+const mockCanAccessFile = vi.fn()
 const envMock = vi.hoisted(() => ({ knowledge: { alwaysConvertToText: false } }))
 
 vi.mock('@/db/database', () => ({
@@ -31,10 +32,16 @@ vi.mock('@/backend/lib/chat/conversion', () => ({
   dtoFileToLlmFilePart: (...args: unknown[]) => mockDtoFileToLlmFilePart(...args),
 }))
 
+vi.mock('@/backend/lib/files/authorization', () => ({
+  canAccessFile: (...args: unknown[]) => mockCanAccessFile(...args),
+}))
+
 beforeEach(() => {
   mockExecuteTakeFirst.mockReset()
   mockExtractFromFile.mockReset()
   mockDtoFileToLlmFilePart.mockReset()
+  mockCanAccessFile.mockReset()
+  mockCanAccessFile.mockResolvedValue(true)
   envMock.knowledge.alwaysConvertToText = false
 })
 
@@ -74,6 +81,19 @@ describe('KnowledgePlugin GetFile', () => {
 
     const result = await fns.GetFile.invoke(makeInvokeParams('missing'))
 
+    expect(result).toEqual({ type: 'error-text', value: 'File not found' })
+  })
+
+  it('returns an error without reading file metadata when the user cannot access the file', async () => {
+    mockCanAccessFile.mockResolvedValue(false)
+    mockExecuteTakeFirst.mockResolvedValue(fileEntry)
+    const plugin = new KnowledgePlugin(toolParams, {})
+    const fns = (await plugin.functions({} as any, { userId: 'user-1' })) as Record<string, ToolFunction>
+
+    const result = await fns.GetFile.invoke(makeInvokeParams('other-tenant-file'))
+
+    expect(mockCanAccessFile).toHaveBeenCalledWith({ userId: 'user-1' }, 'other-tenant-file')
+    expect(mockExecuteTakeFirst).not.toHaveBeenCalled()
     expect(result).toEqual({ type: 'error-text', value: 'File not found' })
   })
 

--- a/apps/backend/lib/tools/knowledge/implementation.ts
+++ b/apps/backend/lib/tools/knowledge/implementation.ts
@@ -15,6 +15,7 @@ import * as dto from '@/types/dto'
 import * as ai from 'ai'
 import { LlmModel } from '@/lib/chat/models'
 import { dtoFileToLlmFilePart } from '@/backend/lib/chat/conversion'
+import { canAccessFile } from '@/backend/lib/files/authorization'
 import { cachingExtractor } from '@/lib/textextraction/cache'
 import type { FileDbRow } from '@/backend/models/file'
 
@@ -78,8 +79,12 @@ export class KnowledgePlugin extends KnowledgePluginInterface implements ToolImp
         additionalProperties: false,
         required: ['id'],
       },
-      invoke: async ({ llmModel, params }): Promise<dto.ToolCallResultOutput> => {
-        const fileEntry = await fetchFileEntry(`${params.id}`)
+      invoke: async ({ llmModel, params, userId }): Promise<dto.ToolCallResultOutput> => {
+        const fileId = `${params.id}`
+        if (!(await canAccessFile({ userId }, fileId))) {
+          return { type: 'error-text', value: 'File not found' }
+        }
+        const fileEntry = await fetchFileEntry(fileId)
         if (!fileEntry) {
           return { type: 'error-text', value: 'File not found' }
         }


### PR DESCRIPTION
## Summary
`KnowledgePlugin.GetFile` (the builtin tool that lets the model fetch a knowledge file's content on demand) resolved the LLM-supplied file id directly against the database with no ownership or sharing check — a crafted tool call could pull the content of any file in the system into the model's context, regardless of tenant. `GetFile.invoke` now calls `canAccessFile` with the calling user's id before resolving the file, matching the authorization model already used by every other file-serving code path in the app. Both a missing file and an inaccessible one return the same generic `File not found` error, so the tool doesn't leak which case occurred. Legitimate use — the model fetching a file the user's conversation/assistant actually exposes — is unaffected.

## Tests
- `npm run check-types` — passes
- `npx vitest run apps/backend/lib/tools/knowledge/__tests__/implementation.test.ts` — all 8 tests pass, including a new regression test confirming an inaccessible file is rejected before any metadata is even read from the database