### PR TITLE
Enforce file authorization for sub-assistant tool attachments

### DIFF
--- a/__tests__/subassistantTool.test.ts
+++ b/__tests__/subassistantTool.test.ts
@@ -10,6 +10,8 @@ const {
   mockAvailableToolsForAssistantVersion,
   mockGetUserParameters,
   mockExecuteTakeFirst,
+  mockGetFileWithId,
+  mockCanAccessFile,
 } = vi.hoisted(() => ({
   mockStreamText: vi.fn(),
   mockCanUserAccessAssistant: vi.fn().mockResolvedValue(true),
@@ -18,6 +20,8 @@ const {
   mockAvailableToolsForAssistantVersion: vi.fn().mockResolvedValue([]),
   mockGetUserParameters: vi.fn().mockResolvedValue({}),
   mockExecuteTakeFirst: vi.fn(),
+  mockGetFileWithId: vi.fn(),
+  mockCanAccessFile: vi.fn().mockResolvedValue(true),
 }))
 
 // ESM modules can't be spied on at runtime — mock the whole module,
@@ -99,6 +103,14 @@ vi.mock('@/backend/lib/tools/enumerate', () => ({
 
 vi.mock('@/lib/parameters', () => ({
   getUserParameters: mockGetUserParameters,
+}))
+
+vi.mock('@/models/file', () => ({
+  getFileWithId: mockGetFileWithId,
+}))
+
+vi.mock('@/backend/lib/files/authorization', () => ({
+  canAccessFile: mockCanAccessFile,
 }))
 
 vi.mock('@/lib/models', () => ({
@@ -203,6 +215,7 @@ describe('SubAssistantTool.invoke_assistant', () => {
     mockCanUserAccessAssistant.mockResolvedValue(true)
     mockGetPublishedAssistantVersion.mockResolvedValue(fakeAssistantVersion)
     mockExecuteTakeFirst.mockResolvedValue(fakeBackend)
+    mockCanAccessFile.mockResolvedValue(true)
 
     const tool = new SubAssistantTool(fakeToolParams, [
       { id: 'asst-1', name: 'Sub Bot', description: 'A sub-assistant for testing' },
@@ -308,6 +321,38 @@ describe('SubAssistantTool.invoke_assistant', () => {
       type: 'error-text',
       value: 'Sub-assistant "Sub Bot" backend not found',
     })
+  })
+
+  test('drops attachments the user cannot access before invoking the sub-assistant', async () => {
+    mockStreamText.mockReturnValue(makeStreamResult('done'))
+    mockCanAccessFile.mockImplementation(async (_user: unknown, id: string) => id === 'own-file')
+    mockGetFileWithId.mockImplementation(async (id: string) => ({
+      id,
+      name: `${id}.txt`,
+      type: 'text/plain',
+      size: 10,
+    }))
+
+    const buildSpy = vi.spyOn(ChatAssistant, 'build')
+
+    await invoke({
+      llmModel: fakeLlmModel,
+      messages: [],
+      assistantId: 'parent',
+      userId: 'user-1',
+      params: {
+        assistantId: 'asst-1',
+        input: 'hello',
+        attachments: [{ id: 'own-file' }, { id: 'other-tenant-file' }],
+      },
+      uiLink: fakeUiLink,
+    })
+
+    expect(mockCanAccessFile).toHaveBeenCalledWith({ userId: 'user-1' }, 'own-file')
+    expect(mockCanAccessFile).toHaveBeenCalledWith({ userId: 'user-1' }, 'other-tenant-file')
+    expect(mockGetFileWithId).toHaveBeenCalledWith('own-file')
+    expect(mockGetFileWithId).not.toHaveBeenCalledWith('other-tenant-file')
+    expect(buildSpy).toHaveBeenCalled()
   })
 
   test('propagates rootOwner to nested chat assistant build', async () => {

--- a/apps/backend/lib/tools/subassistant/implementation.ts
+++ b/apps/backend/lib/tools/subassistant/implementation.ts
@@ -21,6 +21,7 @@ import { ClientSink } from '@/backend/lib/chat/ClientSink'
 import * as dto from '@/types/dto'
 import { nanoid } from 'nanoid'
 import { getFileWithId } from '@/models/file'
+import { canAccessFile } from '@/backend/lib/files/authorization'
 
 export interface SubAssistantEntry {
   id: string
@@ -134,8 +135,13 @@ export class SubAssistantTool implements ToolImplementation {
               rootOwner,
             })
 
+            const accessibleAttachmentIds = (
+              await Promise.all(
+                attachmentIds.map(async ({ id }) => ((await canAccessFile({ userId }, id)) ? id : null))
+              )
+            ).filter((id): id is string => id != null)
             const attachments: dto.Attachment[] = (
-              await Promise.all(attachmentIds.map(({ id }) => getFileWithId(id)))
+              await Promise.all(accessibleAttachmentIds.map((id) => getFileWithId(id)))
             )
               .filter((f): f is NonNullable<typeof f> => f != null)
               .map((f) => ({ id: f.id, mimetype: f.type, name: f.name, size: f.size ?? 0 }))


### PR DESCRIPTION
## Summary
The `invoke_assistant` sub-assistant tool resolved LLM-supplied attachment file IDs via `getFileWithId` with no ownership or sharing check, before handing their metadata (name/mimetype/size) into the nested sub-assistant's conversation — a crafted tool call could reference another tenant's file ID to pull it into scope. Each attachment ID is now filtered through `canAccessFile` for the invoking user before being resolved; an inaccessible ID is silently dropped (consistent with how a missing file ID is already handled) rather than surfacing to the sub-assistant. A user attaching their own files, or files already shared into the current conversation, is unaffected.

## Tests
- `npm run check-types` — passes
- `npx vitest run __tests__/subassistantTool.test.ts` — all 7 tests pass, including a new regression test confirming an inaccessible attachment is filtered out (never resolved) while an accessible one still reaches the sub-assistant