### PR TITLE
Require ownership before attaching a file to an assistant's knowledge set

### DIFF
--- a/__tests__/assistantFileAuthorization.test.ts
+++ b/__tests__/assistantFileAuthorization.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+type Row = Record<string, unknown>
+
+const tables: Record<string, Row[]> = {
+  AssistantVersion: [],
+  File: [],
+  AssistantVersionFile: [],
+}
+
+const insertedInto: Record<string, Row[]> = {}
+const deletedFrom: string[] = []
+const updatedFileRows: Array<{ set: Row; where: Array<{ column: string; op: string; value: unknown }> }> = []
+
+function matches(row: Row, whereClauses: Array<{ column: string; op: string; value: unknown }>) {
+  return whereClauses.every(({ column, op, value }) => {
+    if (op === '=') return row[column] === value
+    if (op === 'in') return Array.isArray(value) && value.includes(row[column])
+    throw new Error(`Unsupported operator in test double: ${op}`)
+  })
+}
+
+vi.mock('db/database', () => ({
+  db: {
+    selectFrom: (table: string) => {
+      const whereClauses: Array<{ column: string; op: string; value: unknown }> = []
+      const builder = {
+        select: () => builder,
+        selectAll: () => builder,
+        where: (column: string, op: string, value: unknown) => {
+          whereClauses.push({ column, op, value })
+          return builder
+        },
+        execute: async () => tables[table].filter((row) => matches(row, whereClauses)),
+        executeTakeFirst: async () => tables[table].find((row) => matches(row, whereClauses)),
+        executeTakeFirstOrThrow: async () => {
+          const row = tables[table].find((row) => matches(row, whereClauses))
+          if (!row) throw new Error(`No row found in ${table}`)
+          return row
+        },
+      }
+      return builder
+    },
+    insertInto: (table: string) => ({
+      values: (values: Row | Row[]) => ({
+        execute: async () => {
+          insertedInto[table] = insertedInto[table] ?? []
+          insertedInto[table].push(...(Array.isArray(values) ? values : [values]))
+        },
+        executeTakeFirstOrThrow: async () => {
+          insertedInto[table] = insertedInto[table] ?? []
+          insertedInto[table].push(...(Array.isArray(values) ? values : [values]))
+          return { insertId: 1 }
+        },
+      }),
+    }),
+    updateTable: (table: string) => ({
+      set: (set: Row) => {
+        const whereClauses: Array<{ column: string; op: string; value: unknown }> = []
+        const builder = {
+          where: (column: string, op: string, value: unknown) => {
+            whereClauses.push({ column, op, value })
+            return builder
+          },
+          execute: async () => {
+            if (table === 'File') updatedFileRows.push({ set, where: [...whereClauses] })
+          },
+        }
+        return builder
+      },
+    }),
+    deleteFrom: (table: string) => ({
+      where: () => ({
+        execute: async () => {
+          deletedFrom.push(table)
+        },
+      }),
+    }),
+  },
+}))
+
+vi.mock('./images', () => ({ getOrCreateImageFromDataUri: vi.fn() }))
+vi.mock('@/models/images', () => ({ getOrCreateImageFromDataUri: vi.fn() }))
+vi.mock('./tool', () => ({ dbToolToBuildableTool: vi.fn() }))
+vi.mock('@/models/tool', () => ({ dbToolToBuildableTool: vi.fn() }))
+vi.mock('./backend', () => ({ getBackendsWithModels: vi.fn() }))
+vi.mock('@/models/backend', () => ({ getBackendsWithModels: vi.fn() }))
+vi.mock('./userSecrets', () => ({ listUserSecretStatuses: vi.fn() }))
+vi.mock('@/models/userSecrets', () => ({ listUserSecretStatuses: vi.fn() }))
+vi.mock('@/lib/tools/schemas', () => ({ getMcpToolAvailability: vi.fn() }))
+
+describe('updateAssistantVersion file authorization', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    for (const key of Object.keys(tables)) tables[key] = []
+    for (const key of Object.keys(insertedInto)) delete insertedInto[key]
+    deletedFrom.length = 0
+    updatedFileRows.length = 0
+  })
+
+  test('rejects and never associates a file the acting user does not own', async () => {
+    tables.AssistantVersion.push({ id: 'av1', assistantId: 'a1' })
+    tables.File.push({ id: 'victim-file', ownerType: 'USER', ownerId: 'victim' })
+
+    const { updateAssistantVersion } = await import('@/models/assistant')
+
+    await expect(
+      updateAssistantVersion(
+        'av1',
+        { files: [{ id: 'victim-file', name: 'x', type: 'text/plain', size: 1 }] } as any,
+        'attacker'
+      )
+    ).rejects.toThrow(/cannot be attached/)
+
+    expect(insertedInto.AssistantVersionFile).toBeUndefined()
+    expect(updatedFileRows).toHaveLength(0)
+  })
+
+  test('allows and transfers a file the acting user owns', async () => {
+    tables.AssistantVersion.push({ id: 'av1', assistantId: 'a1' })
+    tables.File.push({ id: 'own-file', ownerType: 'USER', ownerId: 'editor' })
+
+    const { updateAssistantVersion } = await import('@/models/assistant')
+
+    await updateAssistantVersion(
+      'av1',
+      { files: [{ id: 'own-file', name: 'x', type: 'text/plain', size: 1 }] } as any,
+      'editor'
+    )
+
+    expect(insertedInto.AssistantVersionFile).toEqual([
+      { assistantVersionId: 'av1', fileId: 'own-file', order: 0 },
+    ])
+    expect(updatedFileRows).toEqual([
+      {
+        set: { ownerType: 'ASSISTANT', ownerId: 'a1' },
+        where: [
+          { column: 'id', op: 'in', value: ['own-file'] },
+          { column: 'ownerType', op: '=', value: 'USER' },
+          { column: 'ownerId', op: '=', value: 'editor' },
+        ],
+      },
+    ])
+  })
+
+  test('allows re-saving a file already owned by this same assistant', async () => {
+    tables.AssistantVersion.push({ id: 'av1', assistantId: 'a1' })
+    tables.File.push({ id: 'already-attached', ownerType: 'ASSISTANT', ownerId: 'a1' })
+
+    const { updateAssistantVersion } = await import('@/models/assistant')
+
+    await expect(
+      updateAssistantVersion(
+        'av1',
+        { files: [{ id: 'already-attached', name: 'x', type: 'text/plain', size: 1 }] } as any,
+        'editor'
+      )
+    ).resolves.not.toThrow()
+
+    expect(insertedInto.AssistantVersionFile).toEqual([
+      { assistantVersionId: 'av1', fileId: 'already-attached', order: 0 },
+    ])
+  })
+})

--- a/apps/backend/api/assistants/[assistantId]/route.ts
+++ b/apps/backend/api/assistants/[assistantId]/route.ts
@@ -90,7 +90,7 @@ export const PATCH = operation({
     ) {
       return forbidden(`You're not authorized to modify assistant ${params.assistantId}`)
     }
-    await updateAssistantDraft(params.assistantId, body)
+    await updateAssistantDraft(params.assistantId, body, userId)
     return noBody()
   },
 })

--- a/apps/backend/lib/provision.ts
+++ b/apps/backend/lib/provision.ts
@@ -229,7 +229,7 @@ const provisionAssistants = async (assistants: Record<string, ProvisionableAssis
 
     if (existing) {
       // Update the version with same id of the assistant...
-      await updateAssistantVersion(id, insertableAssistantDraft)
+      await updateAssistantVersion(id, insertableAssistantDraft, owner)
       // TODO: handle owner / deleted changes
     } else {
       await createAssistantWithId(id, insertableAssistantDraft, owner, true)

--- a/apps/backend/models/assistant.ts
+++ b/apps/backend/models/assistant.ts
@@ -52,15 +52,48 @@ function toAssistantToolAssociation(
   })
 }
 
+/** Only a file the acting user currently owns, or one already belonging to this
+ * same assistant (kept across an edit), may be attached to an assistant's
+ * knowledge set — assistant knowledge files are trusted server-side and sent
+ * to the LLM for any user of the assistant without a further per-viewer
+ * access check, so anything else must be rejected before it is associated. */
+const assertFilesAttachableToAssistant = async (
+  assistantId: string,
+  fileIds: string[],
+  userId: string
+): Promise<void> => {
+  const uniqueIds = [...new Set(fileIds)]
+  if (uniqueIds.length === 0) return
+  const rows = await db
+    .selectFrom('File')
+    .select(['id', 'ownerType', 'ownerId'])
+    .where('id', 'in', uniqueIds)
+    .execute()
+  const rowById = new Map(rows.map((r) => [r.id, r]))
+  for (const id of uniqueIds) {
+    const row = rowById.get(id)
+    const allowed =
+      row !== undefined &&
+      ((row.ownerType === 'USER' && row.ownerId === userId) ||
+        (row.ownerType === 'ASSISTANT' && row.ownerId === assistantId))
+    if (!allowed) {
+      throw new Error(`File ${id} cannot be attached to assistant ${assistantId}`)
+    }
+  }
+}
+
 const transferFilesToAssistantOwner = async (
   assistantId: string,
-  fileIds: string[]
+  fileIds: string[],
+  userId: string
 ): Promise<void> => {
   if (fileIds.length === 0) return
   await db
     .updateTable('File')
     .set({ ownerType: 'ASSISTANT', ownerId: assistantId })
     .where('id', 'in', fileIds)
+    .where('ownerType', '=', 'USER')
+    .where('ownerId', '=', userId)
     .execute()
 }
 
@@ -489,11 +522,10 @@ export const createAssistantWithId = async (
   }
   const files = toAssistantFileAssociation(id, dtoFiles)
   if (files.length !== 0) {
+    const fileIds = files.map((f) => f.fileId)
+    await assertFilesAttachableToAssistant(id, fileIds, owner)
     await db.insertInto('AssistantVersionFile').values(files).execute()
-    await transferFilesToAssistantOwner(
-      id,
-      files.map((f) => f.fileId)
-    )
+    await transferFilesToAssistantOwner(id, fileIds, owner)
   }
 
   const created = await getAssistantVersion(id)
@@ -566,7 +598,8 @@ export const cloneAssistantVersion = async (assistantVersionId: string) => {
 
 export const updateAssistantDraft = async (
   assistantId: string,
-  changeSet: dto.UpdateableAssistantDraft
+  changeSet: dto.UpdateableAssistantDraft,
+  userId: string
 ) => {
   const assistant = await getAssistant(assistantId)
   if (!assistant) {
@@ -589,7 +622,7 @@ export const updateAssistantDraft = async (
       .where('Assistant.id', '=', assistantId)
       .execute()
   }
-  return updateAssistantVersion(assistantVersionId, changeSet)
+  return updateAssistantVersion(assistantVersionId, changeSet, userId)
 }
 
 export const updateAssistantHidden = async (assistantId: string, hidden: boolean) => {
@@ -604,7 +637,8 @@ export const updateAssistantHidden = async (assistantId: string, hidden: boolean
 
 export const updateAssistantVersion = async (
   assistantVersionId: string,
-  assistant: dto.UpdateableAssistantDraft
+  assistant: dto.UpdateableAssistantDraft,
+  userId: string
 ) => {
   const {
     files: dtoFiles,
@@ -620,16 +654,24 @@ export const updateAssistantVersion = async (
       .where('id', '=', assistantVersionId)
       .executeTakeFirstOrThrow()
 
+    const fileAssociations = toAssistantFileAssociation(assistantVersionId, assistant.files)
+    if (fileAssociations.length !== 0) {
+      await assertFilesAttachableToAssistant(
+        assistantVersion.assistantId,
+        fileAssociations.map((f) => f.fileId),
+        userId
+      )
+    }
     await db
       .deleteFrom('AssistantVersionFile')
       .where('assistantVersionId', '=', assistantVersionId)
       .execute()
-    const fileAssociations = toAssistantFileAssociation(assistantVersionId, assistant.files)
     if (fileAssociations.length !== 0) {
       await db.insertInto('AssistantVersionFile').values(fileAssociations).execute()
       await transferFilesToAssistantOwner(
         assistantVersion.assistantId,
-        fileAssociations.map((f) => f.fileId)
+        fileAssociations.map((f) => f.fileId),
+        userId
       )
     }
   }


### PR DESCRIPTION
## Summary
`transferFilesToAssistantOwner` transferred ownership of any given file IDs to an assistant with no ownership predicate at all — critically, both callers built the `AssistantVersionFile` association row *before* calling it, and never checked whether the transfer actually succeeded. Since assistant knowledge files are trusted server-side and their content is sent to the LLM for any user of the assistant with no further per-viewer access check, simply getting a foreign file ID associated was enough to leak that file's content to every future user of the (possibly attacker-crafted or attacker-edited) assistant — independent of whether the underlying file's ownership actually got reassigned.

Both assistant-save paths (`createAssistantWithId` and `updateAssistantVersion`, reached via `POST /api/assistants` and `PATCH /api/assistants/{assistantId}`) now verify, before any association or ownership-transfer write happens, that every proposed file id is either currently `USER`-owned by the acting editor or already `ASSISTANT`-owned by this same assistant (kept across an edit, since re-saving an assistant's existing knowledge files must keep working). Anything else raises and the whole save is rejected before touching the database, so no partial/malicious association can land even on failure.

## Tests
- `npm run check-types` — passes
- `npx vitest run __tests__/assistantFileAuthorization.test.ts __tests__/cloneRoutes.test.ts __tests__/fileAuthorization.test.ts __tests__/subassistantTool.test.ts` — all 25 tests pass, including 3 new regression tests covering: rejection (and no association/transfer) of a file owned by another user, successful attach+transfer of a file the editor owns, and successful re-save of a file already belonging to the same assistant