### PR TITLE
Always create uploaded files as USER-owned by the uploader

### DIFF
--- a/__tests__/fileUploadRoutes.test.ts
+++ b/__tests__/fileUploadRoutes.test.ts
@@ -318,7 +318,7 @@ describe('PUT /api/files/:fileId/content', () => {
 // ── POST /api/files ──────────────────────────────────────────────────────────
 
 describe('POST /api/files', () => {
-  test('creates chat upload metadata with CHAT ownership', async () => {
+  test('always creates metadata as USER-owned by the uploader, ignoring the requested owner', async () => {
     await insertConversation({ id: 'chat-1', ownerId: testUserId })
 
     const response = await filesRoute.POST(
@@ -345,10 +345,10 @@ describe('POST /api/files', () => {
       .select(['ownerType', 'ownerId'])
       .where('id', '=', body.id)
       .executeTakeFirstOrThrow()
-    expect(file).toEqual({ ownerType: 'CHAT', ownerId: 'chat-1' })
+    expect(file).toEqual({ ownerType: 'USER', ownerId: testUserId })
   })
 
-  test('returns 403 when creating metadata for an owner the user cannot access', async () => {
+  test('ignores a client-supplied owner pointing at another user', async () => {
     const response = await filesRoute.POST(
       new Request('http://localhost/api/files', {
         method: 'POST',
@@ -357,7 +357,7 @@ describe('POST /api/files', () => {
           'content-type': 'application/json',
         },
         body: JSON.stringify({
-          name: 'private.txt',
+          name: 'spoofed.txt',
           type: 'text/plain',
           size: 12,
           owner: { ownerType: 'USER', ownerId: 'other-user' },
@@ -366,7 +366,14 @@ describe('POST /api/files', () => {
       { params: Promise.resolve({}) }
     )
 
-    expect(response.status).toBe(403)
+    expect(response.status).toBe(201)
+    const body = await response.json()
+    const file = await db
+      .selectFrom('File')
+      .select(['ownerType', 'ownerId'])
+      .where('id', '=', body.id)
+      .executeTakeFirstOrThrow()
+    expect(file).toEqual({ ownerType: 'USER', ownerId: testUserId })
   })
 })
 

--- a/apps/backend/api/files/route.ts
+++ b/apps/backend/api/files/route.ts
@@ -1,6 +1,5 @@
 
-import { forbidden, ok, operation, responseSpec, errorSpec } from '@/lib/routes'
-import { canAccess } from '@/backend/lib/files/authorization'
+import { ok, operation, responseSpec, errorSpec } from '@/lib/routes'
 import { addFile } from '@/models/file'
 import * as dto from '@/types/dto'
 import { nanoid } from 'nanoid'
@@ -11,14 +10,15 @@ export const POST = operation({
   description: 'Create file metadata entry.',
   authentication: 'user',
   requestBodySchema: dto.insertableFileSchema,
-  responses: [responseSpec(201, dto.fileSchema), errorSpec(400), errorSpec(403)] as const,
+  responses: [responseSpec(201, dto.fileSchema), errorSpec(400)] as const,
   implementation: async ({ body, session }) => {
     const id = nanoid()
     const path = `${id}-${body.name.replace(/(\W+)/gi, '-')}`
-    const { owner, ...bodyWithoutOwner } = body
-    if (!(await canAccess({ userId: session.userId, userRole: session.userRole }, owner.ownerType, owner.ownerId))) {
-      return forbidden()
-    }
+    // Uploads always create the File row as USER-owned by the uploader — the client-supplied
+    // `owner` is ignored. Ownership transfers to its final owner (CHAT/ASSISTANT/TOOL) happens
+    // server-side afterward, as a side effect of saving the entity the file is attached to.
+    const { owner: _clientSuppliedOwner, ...bodyWithoutOwner } = body
+    const owner: dto.FileOwner = { ownerType: 'USER', ownerId: session.userId }
     const fileEncryption = getConfiguredFileEncryption()
     const created = await addFile(bodyWithoutOwner, path, fileEncryption, owner)
     return ok(

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -1889,8 +1889,6 @@ paths:
                 $ref: "#/components/schemas/File"
         "400":
           $ref: "#/components/responses/Error"
-        "403":
-          $ref: "#/components/responses/Error"
       security:
         - bearerAuth: []
       requestBody:


### PR DESCRIPTION
## Summary
`POST /api/files` let the client supply an arbitrary `owner` and gated creation with `canAccess` — a **read** permission — instead of requiring `USER`-ownership as documented in `docs/file-ownership-and-upload-security.md`. Concretely, a caller with only read access to a shared conversation, a public/workspace tool, or a shared assistant (any non-owner `canAccess` branch) could create a `File` row directly owned by that `CHAT`/`ASSISTANT`/`TOOL`, without ever owning it — contradicting the "uploads always create `USER`-owned rows" invariant the rest of the file-authorization model depends on (ownership is only ever supposed to transfer to its final owner server-side, as a side effect of saving the entity the file gets attached to).

The endpoint now ignores the client-supplied `owner` entirely and always creates the row as `USER`-owned by the authenticated session — matching every legitimate frontend caller, which already only ever requested self-ownership (`ChatInput.tsx`, `ToolKnowledgeSection.tsx`, `KnowledgeTabPanel.tsx` all pass `{ ownerType: 'USER', ownerId: userProfile.id }`). Regenerated `apps/frontend/public/openapi.yaml` since the route no longer returns 403.

## Tests
- `npm run check-types` — passes
- `npx vitest run __tests__/fileUploadRoutes.test.ts` — all 17 tests pass, including an updated test confirming metadata creation now always lands as `USER`-owned regardless of the requested owner, and a new test confirming a client-supplied owner pointing at another user is ignored rather than honored