### PR TITLE
Enforce file authorization in cloneFilesForOwner

### DIFF
--- a/__tests__/cloneRoutes.test.ts
+++ b/__tests__/cloneRoutes.test.ts
@@ -269,4 +269,91 @@ describe('clone routes duplicate files', () => {
     expect(clonedFile.ownerId).toBe(clonedConversationId)
     expect(clonedFile.fileBlobId).toBe(sourceFile.fileBlobId)
   })
+
+  test('shared chat clone does not duplicate a file id planted in the conversation that the cloning user cannot access', async () => {
+    const sourceOwner = await createUser({
+      name: 'Source User 2',
+      email: 'clone-source-2@example.com',
+      ssoUser: 0,
+    })
+    const victim = await createUser({
+      name: 'Victim User',
+      email: 'clone-victim@example.com',
+      ssoUser: 0,
+    })
+    const targetUser = await createUser({
+      name: 'Target User 2',
+      email: 'clone-target-2@example.com',
+      ssoUser: 0,
+    })
+    const targetSession = await createSession(
+      targetUser.id,
+      new Date(Date.now() + 60_000),
+      'password',
+      null
+    )
+    const targetCookie = `${SESSION_COOKIE_NAME}=${targetSession.id}`
+
+    const assistant = await createAssistant(makeDraft('b1', []), targetUser.id)
+    const sourceConversation = await createConversation(sourceOwner.id, {
+      assistantId: assistant.assistantId,
+      name: 'Shared conversation with a planted attachment',
+    })
+
+    // Simulates a malicious/legacy message that references a file the sender never
+    // owned — a file privately owned by a third, unrelated user.
+    await insertUploadedFile({
+      id: 'f-victim-private',
+      ownerType: 'USER',
+      ownerId: victim.id,
+      name: 'private.txt',
+    })
+
+    const sourceMessage: dto.UserMessage = {
+      id: 'm-source-user-2',
+      conversationId: sourceConversation.id,
+      parent: null,
+      sentAt: new Date().toISOString(),
+      role: 'user',
+      content: 'hello',
+      attachments: [
+        {
+          id: 'f-victim-private',
+          mimetype: 'text/plain',
+          name: 'private.txt',
+          size: 123,
+        },
+      ],
+    }
+    await saveMessage(sourceMessage)
+
+    await db
+      .insertInto('ConversationSharing')
+      .values({ id: 'share-2', lastMessageId: sourceMessage.id })
+      .execute()
+
+    const response = await sharedConversationCloneRoute.POST(
+      new Request('http://localhost/api/share/share-2/clone', {
+        method: 'POST',
+        headers: { cookie: targetCookie },
+      }),
+      { params: Promise.resolve({ shareId: 'share-2' }) }
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as dto.ConversationWithMessages
+    const clonedUserMessage = body.messages.find((message) => message.role === 'user') as dto.UserMessage
+    expect(clonedUserMessage).toBeTruthy()
+    // The unauthorized attachment id is left unmapped, not duplicated into a new
+    // CHAT-owned row the cloning user could then read directly.
+    expect(clonedUserMessage.attachments[0]?.id).toBe('f-victim-private')
+
+    const clonedRows = await db
+      .selectFrom('File')
+      .select(['id'])
+      .where('ownerType', '=', 'CHAT')
+      .where('ownerId', '=', body.conversation.id)
+      .execute()
+    expect(clonedRows).toHaveLength(0)
+  })
 })

--- a/apps/backend/api/assistants/[assistantId]/clone/route.ts
+++ b/apps/backend/api/assistants/[assistantId]/clone/route.ts
@@ -51,6 +51,7 @@ export const POST = operation({
     const clonedFileIds = await cloneFilesForOwner({
       fileIds: originalFiles.map((file) => file.id),
       owner: { ownerType: 'ASSISTANT', ownerId: newAssistantId },
+      userId: session.userId,
     })
     const clonedFiles = originalFiles.map((file) => ({
       ...file,

--- a/apps/backend/api/share/[shareId]/clone/route.ts
+++ b/apps/backend/api/share/[shareId]/clone/route.ts
@@ -118,6 +118,7 @@ export const POST = operation({
     const clonedFileIds = await cloneFilesForOwner({
       fileIds: linear.flatMap((message) => collectFileIdsFromMessage(message)),
       owner: { ownerType: 'CHAT', ownerId: newConversation.id },
+      userId: session.userId,
     })
     const linearWithClonedFiles = linear.map((message) => remapMessageFileIds(message, clonedFileIds))
     const idMap = new Map(linear.map((m) => [m.id, nanoid()]))

--- a/apps/backend/models/file.ts
+++ b/apps/backend/models/file.ts
@@ -2,6 +2,7 @@ import * as dto from '@/types/dto'
 import { db } from 'db/database'
 import { nanoid } from 'nanoid'
 import { isFileEncrypted, type StoredFileEncryption } from '@/lib/storage/encryption'
+import { canAccessFile } from '@/backend/lib/files/authorization'
 
 export interface FileDbRow {
   id: string
@@ -89,11 +90,17 @@ export const reassignUserOwnedFilesToConversation = async ({
 export const cloneFilesForOwner = async ({
   fileIds,
   owner,
+  userId,
 }: {
   fileIds: string[]
   owner: dto.FileOwner
+  userId: string
 }): Promise<Map<string, string>> => {
-  const uniqueIds = [...new Set(fileIds)]
+  const dedupedIds = [...new Set(fileIds)]
+  const accessible = await Promise.all(
+    dedupedIds.map(async (id) => ((await canAccessFile({ userId }, id)) ? id : null))
+  )
+  const uniqueIds = accessible.filter((id): id is string => id != null)
   if (uniqueIds.length === 0) {
     return new Map()
   }


### PR DESCRIPTION
## Summary
`cloneFilesForOwner` took no principal and cloned any file id it was given, purely by id. The assistant-clone path only ever passes server-derived, already-vetted file ids (an assistant's own `assistantVersionFiles`), so it isn't directly exploitable there. The shared-conversation clone path, though, derives its ids from the conversation's own stored messages via `collectFileIdsFromMessage` — if a message contains an attachment id the sender never actually had access to (e.g. planted through the chat-ingestion gaps closed in #1047/#1048, or simply predating those fixes), cloning it would create a brand-new `CHAT`-owned copy that the cloning user could then read directly. That turns a "the file content only ever got sent to the LLM as text" issue into a full raw-binary-read primitive.

`cloneFilesForOwner` now takes the acting user's id and filters every file id through `canAccessFile` before cloning. An inaccessible id is simply left out of the returned clone map, so the cloned message keeps referencing the original (still-inaccessible) file id instead of gaining a fresh, readable copy — every existing legitimate case (cloning your own assistant's knowledge files, cloning a shared conversation's own attachments) is unaffected since those ids are already accessible to the cloning user.

## Tests
- `npm run check-types` — passes
- `npx vitest run __tests__/cloneRoutes.test.ts` — all 3 tests pass, including a new regression test confirming a file id planted in a shared conversation that the cloning user cannot access is never cloned into a new readable row