### PR TITLE
Re-verify assistant access on every run, not just conversation ownership

### DIFF
--- a/__tests__/startServerChatRunAttachmentAuthorization.test.ts
+++ b/__tests__/startServerChatRunAttachmentAuthorization.test.ts
@@ -28,7 +28,8 @@ vi.mock('@/backend/lib/tools/enumerate', () => ({
 vi.mock('@/lib/MessageAuditor', () => ({ MessageAuditor: vi.fn() }))
 vi.mock('@/lib/chat/conversationUtils', () => ({ extractLinearConversation: vi.fn() }))
 vi.mock('@/lib/parameters', () => ({ getUserParameters: vi.fn() }))
-vi.mock('@/models/assistant', () => ({ assistantVersionFiles: vi.fn() }))
+const canUserAccessAssistant = vi.fn()
+vi.mock('@/models/assistant', () => ({ assistantVersionFiles: vi.fn(), canUserAccessAssistant }))
 vi.mock('@/models/message', () => ({ getMessages: vi.fn(), saveMessage: vi.fn() }))
 vi.mock('@/models/userSecrets', () => ({ getUserSecretValue: vi.fn() }))
 vi.mock('db/database', () => ({ db: {} }))
@@ -59,6 +60,26 @@ describe('startServerChatRun attachment authorization', () => {
       conversation: { id: 'c1', ownerId: 'attacker' },
       assistant: { deleted: false, assistantId: 'a1', assistantVersionId: 'av1', model: 'gpt' },
       backend: {},
+    })
+    canUserAccessAssistant.mockResolvedValue(true)
+  })
+
+  test('rejects the message when the user no longer has access to the assistant', async () => {
+    canUserAccessAssistant.mockResolvedValue(false)
+    const { startServerChatRun } = await import('@/backend/lib/chat/startServerChatRun')
+
+    const result = await startServerChatRun({
+      userMessage: { ...baseUserMessage, attachments: [] },
+      headers: new Headers(),
+      session,
+    })
+
+    expect(canUserAccessAssistant).toHaveBeenCalledWith('attacker', 'a1')
+    expect(createChatRun).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      message: 'You no longer have access to this assistant',
     })
   })
 

--- a/__tests__/v1ResponsesAssistantAccess.test.ts
+++ b/__tests__/v1ResponsesAssistantAccess.test.ts
@@ -82,6 +82,7 @@ const makeDraft = (backendId: string): dto.InsertableAssistantDraft => ({
 })
 
 let requesterCookie: string
+let requesterId: string
 let privateAssistantId: string
 
 beforeAll(async () => {
@@ -105,6 +106,7 @@ beforeEach(async () => {
     email: 'v1resp-requester@example.com',
     ssoUser: 0,
   })
+  requesterId = requester.id
   const requesterSession = await createSession(
     requester.id,
     new Date(Date.now() + 60_000),
@@ -132,5 +134,41 @@ describe('POST /api/v1/responses', () => {
       .where('assistantId', '=', privateAssistantId)
       .execute()
     expect(conversations).toHaveLength(0)
+  })
+
+  test('returns 403 when continuing a run on a conversation whose assistant is no longer accessible', async () => {
+    await db
+      .insertInto('Conversation')
+      .values({
+        id: 'c-revoked',
+        assistantId: privateAssistantId,
+        name: 'revoked',
+        ownerId: requesterId,
+        createdAt: new Date().toISOString(),
+      })
+      .execute()
+    await db
+      .insertInto('Message')
+      .values({
+        id: 'm-first',
+        content: 'hello',
+        conversationId: 'c-revoked',
+        parent: null,
+        role: 'user',
+        sentAt: new Date().toISOString(),
+        version: null,
+      })
+      .execute()
+
+    const response = await responsesRoute.POST(
+      new Request('http://localhost/api/v1/responses', {
+        method: 'POST',
+        headers: { cookie: requesterCookie, 'content-type': 'application/json' },
+        body: JSON.stringify({ content: 'follow up', previous_response: 'm-first' }),
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(403)
   })
 })

--- a/apps/backend/api/v1/responses/route.ts
+++ b/apps/backend/api/v1/responses/route.ts
@@ -117,6 +117,9 @@ export const POST = operation({
     if (conversation.ownerId !== session.userId) {
       return forbidden('Trying to add a message to a non owned conversation')
     }
+    if (!(await canUserAccessAssistant(session.userId, assistant.assistantId))) {
+      return forbidden('You no longer have access to this assistant')
+    }
     if (userMessage.attachments && userMessage.attachments.length > 0) {
       const accessChecks = await Promise.all(
         userMessage.attachments.map((id) => canAccessFile({ userId: session.userId }, id))

--- a/apps/backend/lib/chat/startServerChatRun.ts
+++ b/apps/backend/lib/chat/startServerChatRun.ts
@@ -12,7 +12,7 @@ import { MessageAuditor } from '@/lib/MessageAuditor'
 import { extractLinearConversation } from '@/lib/chat/conversationUtils'
 import { setRootSpanAttrs } from '@/lib/tracing/root-registry'
 import { getUserParameters } from '@/lib/parameters'
-import { assistantVersionFiles } from '@/models/assistant'
+import { assistantVersionFiles, canUserAccessAssistant } from '@/models/assistant'
 import { getConversationWithBackendAssistant } from '@/models/conversation'
 import { reassignUserOwnedFilesToConversation } from '@/models/file'
 import { canAccessFile } from '@/backend/lib/files/authorization'
@@ -87,6 +87,14 @@ export const startServerChatRun = async ({
       ok: false,
       status: 403,
       message: 'This assistant has been deleted',
+    }
+  }
+
+  if (!(await canUserAccessAssistant(session.userId, assistant.assistantId))) {
+    return {
+      ok: false,
+      status: 403,
+      message: 'You no longer have access to this assistant',
     }
   }
 


### PR DESCRIPTION
## Summary
Both `startServerChatRun` (the main chat send path) and the continuation path of `POST /api/v1/responses` only checked that the requester owned the conversation — neither re-checked whether the requester still has access to the conversation's *assistant*. Once a conversation existed, revoking the assistant's sharing (removed from a workspace, un-shared, etc.) had no effect: the conversation's owner could keep sending messages to it and consuming backend/LLM cost indefinitely. Both paths now call `canUserAccessAssistant` on every run/continuation, not just once at conversation-creation time.

Stacked on #1058 (targets that branch, not `main`).

## Tests
- `npm run check-types` — passes
- `npx vitest run` — all 109 test files / 995 tests pass, including a new test in `startServerChatRunAttachmentAuthorization.test.ts` (revoked assistant access rejects the run) and a new test in `v1ResponsesAssistantAccess.test.ts` (continuing a run via `previous_response` on a conversation whose assistant is no longer accessible returns 403)