### PR TITLE
Require assistant access to read its system prompt

### DIFF
--- a/__tests__/assistantSystemPromptRoute.test.ts
+++ b/__tests__/assistantSystemPromptRoute.test.ts
@@ -1,0 +1,150 @@
+import { beforeAll, beforeEach, describe, expect, test } from 'vitest'
+import { Kysely, Migrator, type Migration, PostgresAdapter, SqliteAdapter } from 'kysely'
+import { db } from '@/db/database'
+import { migrationModules } from '@/db/migrations.generated'
+import { SESSION_COOKIE_NAME } from '@/lib/auth/session'
+import { createSession } from '@/models/session'
+import { createUser } from '@/models/user'
+import { createAssistant } from '@/models/assistant'
+import * as dto from '@/types/dto'
+import * as systemPromptRoute from '@/api/me/assistants/[assistantId]/systemPrompt/route'
+
+function getDialectName(client: Kysely<any>) {
+  if (client.getExecutor().adapter instanceof SqliteAdapter) return 'sqlite'
+  if (client.getExecutor().adapter instanceof PostgresAdapter) return 'postgresql'
+  return undefined
+}
+
+async function migrateTestDb() {
+  const dialectName = getDialectName(db)
+  const migrator = new Migrator({
+    db,
+    provider: {
+      getMigrations: async () =>
+        Object.fromEntries(
+          Object.entries(migrationModules).map(([name, migration]) => [
+            name,
+            {
+              up: async (client: Kysely<any>) => {
+                await (
+                  migration as { up: (db: Kysely<any>, dialect?: string) => Promise<void> }
+                ).up(client, dialectName)
+              },
+            } satisfies Migration,
+          ])
+        ),
+    },
+  })
+  const { error } = await migrator.migrateToLatest()
+  if (error) throw error
+}
+
+async function resetTables() {
+  await db.deleteFrom('AssistantVersion').execute()
+  await db.deleteFrom('AssistantSharing').execute()
+  await db.deleteFrom('Assistant').execute()
+  await db.deleteFrom('Backend').execute()
+  await db.deleteFrom('Session').execute()
+  await db.deleteFrom('User').execute()
+}
+
+async function insertBackend(id: string) {
+  await db
+    .insertInto('Backend')
+    .values({
+      id,
+      name: `Backend ${id}`,
+      providerType: 'openai',
+      configuration: '{}',
+      provisioned: 0,
+    })
+    .execute()
+}
+
+const makeDraft = (backendId: string, systemPrompt: string): dto.InsertableAssistantDraft => ({
+  backendId,
+  description: 'desc',
+  model: 'gpt-4o-mini',
+  name: 'assistant',
+  versionName: null,
+  systemPrompt,
+  temperature: 0,
+  tokenLimit: 4096,
+  reasoning_effort: null,
+  contextCompression: null,
+  tags: [],
+  prompts: [],
+  tools: [],
+  files: [],
+  iconUri: null,
+  subAssistants: [],
+})
+
+let ownerId: string
+let strangerCookie: string
+let ownerCookie: string
+let assistantId: string
+
+beforeAll(async () => {
+  await migrateTestDb()
+})
+
+beforeEach(async () => {
+  await resetTables()
+  await insertBackend('b1')
+
+  const owner = await createUser({ name: 'Owner', email: 'owner@example.com', ssoUser: 0 })
+  ownerId = owner.id
+  const ownerSession = await createSession(owner.id, new Date(Date.now() + 60_000), 'password', null)
+  ownerCookie = `${SESSION_COOKIE_NAME}=${ownerSession.id}`
+
+  const stranger = await createUser({ name: 'Stranger', email: 'stranger@example.com', ssoUser: 0 })
+  const strangerSession = await createSession(
+    stranger.id,
+    new Date(Date.now() + 60_000),
+    'password',
+    null
+  )
+  strangerCookie = `${SESSION_COOKIE_NAME}=${strangerSession.id}`
+
+  const created = await createAssistant(makeDraft('b1', 'You are a secret private assistant'), ownerId)
+  assistantId = created.assistantId
+})
+
+describe('GET /api/me/assistants/:assistantId/systemPrompt', () => {
+  test('returns 403 for a user with no access to the assistant', async () => {
+    const response = await systemPromptRoute.GET(
+      new Request(`http://localhost/api/me/assistants/${assistantId}/systemPrompt`, {
+        headers: { cookie: strangerCookie },
+      }),
+      { params: Promise.resolve({ assistantId }) }
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  test('returns the system prompt for the owner', async () => {
+    const response = await systemPromptRoute.GET(
+      new Request(`http://localhost/api/me/assistants/${assistantId}/systemPrompt`, {
+        headers: { cookie: ownerCookie },
+      }),
+      { params: Promise.resolve({ assistantId }) }
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      systemPrompt: 'You are a secret private assistant',
+    })
+  })
+
+  test('returns 403 for an assistant that does not exist', async () => {
+    const response = await systemPromptRoute.GET(
+      new Request('http://localhost/api/me/assistants/missing/systemPrompt', {
+        headers: { cookie: ownerCookie },
+      }),
+      { params: Promise.resolve({ assistantId: 'missing' }) }
+    )
+
+    expect(response.status).toBe(403)
+  })
+})

--- a/__tests__/enumerateToolVisibility.test.ts
+++ b/__tests__/enumerateToolVisibility.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const assistantVersionToolsMock = vi.fn()
+const canUserAccessAssistantMock = vi.fn()
+const getPublishedAssistantVersionMock = vi.fn()
+const filterVisibleToolIdsMock = vi.fn()
+const getToolsFilteredMock = vi.fn()
+const getBuildableToolsMock = vi.fn()
+
+vi.mock('@/models/assistant', () => ({
+  assistantVersionTools: assistantVersionToolsMock,
+  canUserAccessAssistant: canUserAccessAssistantMock,
+  getPublishedAssistantVersion: getPublishedAssistantVersionMock,
+}))
+
+vi.mock('@/models/tool', () => ({
+  filterVisibleToolIds: filterVisibleToolIdsMock,
+  getToolsFiltered: getToolsFilteredMock,
+  getBuildableTools: getBuildableToolsMock,
+}))
+
+const executeTakeFirstMock = vi.fn()
+vi.mock('db/database', () => ({
+  db: {
+    selectFrom: () => ({
+      select: () => ({
+        where: () => ({
+          executeTakeFirst: executeTakeFirstMock,
+        }),
+      }),
+    }),
+  },
+}))
+
+function makeTool(id: string, type: string) {
+  return {
+    id,
+    name: id,
+    type,
+    configuration: {},
+    promptFragment: '',
+    provisioned: false,
+    satelliteId: null,
+  }
+}
+
+describe('enumerate.ts tool visibility filtering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    executeTakeFirstMock.mockResolvedValue(undefined)
+    getToolsFilteredMock.mockResolvedValue([])
+  })
+
+  test('availableToolsForAssistantVersion never builds a tool the principal cannot see', async () => {
+    assistantVersionToolsMock.mockResolvedValue([makeTool('t-visible', 'dummy'), makeTool('t-hidden', 'dummy')])
+    filterVisibleToolIdsMock.mockResolvedValue(new Set(['t-visible']))
+
+    const { availableToolsForAssistantVersion } = await import('@/backend/lib/tools/enumerate')
+    const tools = await availableToolsForAssistantVersion('av1', 'gpt-4o', { userId: 'u1' })
+
+    expect(filterVisibleToolIdsMock).toHaveBeenCalledWith({ userId: 'u1' }, ['t-visible', 't-hidden'])
+    expect(tools).toHaveLength(1)
+    expect(tools[0].toolParams.id).toBe('t-visible')
+  })
+
+  test('availableToolsFiltered filters ids through visibility before resolving them', async () => {
+    filterVisibleToolIdsMock.mockResolvedValue(new Set(['t-visible']))
+    getToolsFilteredMock.mockResolvedValue([makeTool('t-visible', 'dummy')])
+
+    const { availableToolsFiltered } = await import('@/backend/lib/tools/enumerate')
+    const tools = await availableToolsFiltered(['t-visible', 't-hidden'], 'gpt-4o', { userId: 'u1' })
+
+    expect(filterVisibleToolIdsMock).toHaveBeenCalledWith({ userId: 'u1' }, ['t-visible', 't-hidden'])
+    expect(getToolsFilteredMock).toHaveBeenCalledWith(['t-visible'])
+    expect(tools).toHaveLength(1)
+  })
+
+  test('buildSubAssistantTool drops a sub-assistant the principal cannot access, and never leaks its name', async () => {
+    canUserAccessAssistantMock.mockImplementation(
+      async (_userId: string, id: string) => id === 'assistant-visible'
+    )
+    getPublishedAssistantVersionMock.mockImplementation(async (id: string) => ({
+      name: id === 'assistant-visible' ? 'Visible Assistant' : 'SECRET PRIVATE ASSISTANT',
+      description: '',
+    }))
+
+    const { buildSubAssistantTool } = await import('@/backend/lib/tools/enumerate')
+    const tool = await buildSubAssistantTool(['assistant-visible', 'assistant-hidden'], {
+      userId: 'u1',
+    })
+
+    expect(canUserAccessAssistantMock).toHaveBeenCalledWith('u1', 'assistant-visible')
+    expect(canUserAccessAssistantMock).toHaveBeenCalledWith('u1', 'assistant-hidden')
+    // getPublishedAssistantVersion (which would reveal the name) is never even
+    // called for the inaccessible sub-assistant.
+    expect(getPublishedAssistantVersionMock).not.toHaveBeenCalledWith('assistant-hidden')
+    expect(tool?.toolParams.promptFragment).toContain('Visible Assistant')
+    expect(tool?.toolParams.promptFragment).not.toContain('SECRET PRIVATE ASSISTANT')
+    expect(tool?.toolParams.promptFragment).not.toContain('assistant-hidden')
+  })
+
+  test('buildSubAssistantTool returns undefined when no sub-assistant is accessible', async () => {
+    canUserAccessAssistantMock.mockResolvedValue(false)
+
+    const { buildSubAssistantTool } = await import('@/backend/lib/tools/enumerate')
+    const tool = await buildSubAssistantTool(['assistant-hidden'], { userId: 'u1' })
+
+    expect(tool).toBeUndefined()
+    expect(getPublishedAssistantVersionMock).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/toolVisibility.test.ts
+++ b/__tests__/toolVisibility.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+type Row = Record<string, unknown>
+
+const selectFromMock = vi.fn()
+const getUserWorkspaceMembershipsMock = vi.fn()
+
+const tables: Record<string, Row[]> = {
+  Tool: [],
+  ToolSharing: [],
+  User: [],
+}
+
+vi.mock('db/database', () => ({
+  db: {
+    selectFrom: selectFromMock,
+  },
+}))
+
+vi.mock('@/models/user', () => ({
+  getUserWorkspaceMemberships: getUserWorkspaceMembershipsMock,
+}))
+
+function matches(row: Row, whereClauses: Array<{ column: string; op: string; value: unknown }>) {
+  return whereClauses.every(({ column, op, value }) => {
+    if (op === '=') return row[column] === value
+    if (op === 'in') return Array.isArray(value) && value.includes(row[column])
+    throw new Error(`Unsupported operator in test double: ${op}`)
+  })
+}
+
+function mockDbQueries() {
+  selectFromMock.mockImplementation((table: string) => {
+    const whereClauses: Array<{ column: string; op: string; value: unknown }> = []
+    const builder = {
+      select: vi.fn(() => builder),
+      selectAll: vi.fn(() => builder),
+      where: vi.fn((column: string, op: string, value: unknown) => {
+        whereClauses.push({ column, op, value })
+        return builder
+      }),
+      executeTakeFirst: vi.fn(async () => tables[table].find((row) => matches(row, whereClauses))),
+      execute: vi.fn(async () => tables[table].filter((row) => matches(row, whereClauses))),
+    }
+    return builder
+  })
+}
+
+describe('tool visibility', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    for (const key of Object.keys(tables)) {
+      tables[key] = []
+    }
+    mockDbQueries()
+    getUserWorkspaceMembershipsMock.mockResolvedValue([])
+  })
+
+  test('filterVisibleToolIds includes public tools for any user', async () => {
+    tables.Tool.push({ id: 't-public', sharing: 'public' })
+    const { filterVisibleToolIds } = await import('@/models/tool')
+    const visible = await filterVisibleToolIds({ userId: 'u-any' }, ['t-public'])
+    expect(visible.has('t-public')).toBe(true)
+  })
+
+  test('filterVisibleToolIds includes workspace tools only for members of a sharing workspace', async () => {
+    tables.Tool.push({ id: 't-workspace', sharing: 'workspace' })
+    tables.ToolSharing.push({ id: 'ts1', toolId: 't-workspace', workspaceId: 'w1' })
+
+    const { filterVisibleToolIds } = await import('@/models/tool')
+
+    getUserWorkspaceMembershipsMock.mockResolvedValueOnce([{ id: 'w1', name: 'W1', role: 'MEMBER' }])
+    const visibleMember = await filterVisibleToolIds({ userId: 'u-member' }, ['t-workspace'])
+    expect(visibleMember.has('t-workspace')).toBe(true)
+
+    getUserWorkspaceMembershipsMock.mockResolvedValueOnce([])
+    const visibleOutsider = await filterVisibleToolIds({ userId: 'u-outsider' }, ['t-workspace'])
+    expect(visibleOutsider.has('t-workspace')).toBe(false)
+  })
+
+  test('filterVisibleToolIds excludes private tools for a regular user', async () => {
+    tables.Tool.push({ id: 't-private', sharing: 'private' })
+    tables.User.push({ id: 'u-user', role: 'USER' })
+
+    const { filterVisibleToolIds } = await import('@/models/tool')
+    const visible = await filterVisibleToolIds({ userId: 'u-user' }, ['t-private'])
+    expect(visible.has('t-private')).toBe(false)
+  })
+
+  test('filterVisibleToolIds includes private tools for an admin, using the userRole hint', async () => {
+    tables.Tool.push({ id: 't-private', sharing: 'private' })
+
+    const { filterVisibleToolIds } = await import('@/models/tool')
+    const visible = await filterVisibleToolIds(
+      { userId: 'u-admin', userRole: 'ADMIN' as never },
+      ['t-private']
+    )
+    expect(visible.has('t-private')).toBe(true)
+  })
+
+  test('filterVisibleToolIds falls back to a DB role lookup when userRole is not provided', async () => {
+    tables.Tool.push({ id: 't-private', sharing: 'private' })
+    tables.User.push({ id: 'u-admin-no-hint', role: 'ADMIN' })
+
+    const { filterVisibleToolIds } = await import('@/models/tool')
+    const visible = await filterVisibleToolIds({ userId: 'u-admin-no-hint' }, ['t-private'])
+    expect(visible.has('t-private')).toBe(true)
+  })
+
+  test('filterVisibleToolIds drops ids for tools that do not exist', async () => {
+    const { filterVisibleToolIds } = await import('@/models/tool')
+    const visible = await filterVisibleToolIds({ userId: 'u-any' }, ['missing-tool'])
+    expect(visible.size).toBe(0)
+  })
+
+  test('canUserAccessTool delegates to filterVisibleToolIds for a single id', async () => {
+    tables.Tool.push({ id: 't-public', sharing: 'public' })
+    tables.Tool.push({ id: 't-private', sharing: 'private' })
+    tables.User.push({ id: 'u-user', role: 'USER' })
+
+    const { canUserAccessTool } = await import('@/models/tool')
+    await expect(canUserAccessTool({ userId: 'u-user' }, 't-public')).resolves.toBe(true)
+    await expect(canUserAccessTool({ userId: 'u-user' }, 't-private')).resolves.toBe(false)
+  })
+})

--- a/apps/backend/api/assistants/evaluate/route.ts
+++ b/apps/backend/api/assistants/evaluate/route.ts
@@ -33,7 +33,12 @@ export const POST = operation({
         ? messages
         : messages.map((msg) => (msg.conversationId ? msg : { ...msg, conversationId }))
 
-    const availableTools = await availableToolsFiltered(assistant.tools, assistant.model, assistant.subAssistants)
+    const availableTools = await availableToolsFiltered(
+      assistant.tools,
+      assistant.model,
+      { userId: session.userId, userRole: session.userRole },
+      assistant.subAssistants
+    )
 
     if ('apiKey' in backend && isUserProvidedApiKey(backend.apiKey)) {
       const resolution = await getUserSecretValue(session.userId, backend.id, USER_SECRET_TYPE)

--- a/apps/backend/api/assistants/tokens/estimate/route.ts
+++ b/apps/backend/api/assistants/tokens/estimate/route.ts
@@ -35,7 +35,10 @@ export const POST = operation({
         : messages[0].conversationId === conversationId
         ? messages
         : messages.map((msg) => (msg.conversationId ? msg : { ...msg, conversationId }))
-    const availableTools = await availableToolsFiltered(assistant.tools, assistant.model)
+    const availableTools = await availableToolsFiltered(assistant.tools, assistant.model, {
+      userId: session.userId,
+      userRole: session.userRole,
+    })
     const collector = query?.detail ? createTokenDetailCollector() : undefined
     const result = await estimateConversationWindowTokens(
       {

--- a/apps/backend/api/me/assistants/[assistantId]/route.ts
+++ b/apps/backend/api/me/assistants/[assistantId]/route.ts
@@ -64,7 +64,10 @@ export const GET = operation({
     let toolSupportedMedia: string[] = []
     try {
       toolSupportedMedia = (
-        await availableToolsForAssistantVersion(assistant.versionId, assistant.model)
+        await availableToolsForAssistantVersion(assistant.versionId, assistant.model, {
+          userId: session.userId,
+          userRole: session.userRole,
+        })
       ).flatMap((t) => t.supportedMedia)
     } catch (error) {
       logger.error('Failed loading assistant tools for user assistant route', {

--- a/apps/backend/api/me/assistants/[assistantId]/systemPrompt/route.ts
+++ b/apps/backend/api/me/assistants/[assistantId]/systemPrompt/route.ts
@@ -1,5 +1,5 @@
-import { notFound, ok, operation, responseSpec, errorSpec } from '@/lib/routes'
-import { getPublishedAssistantVersion } from 'models/assistant'
+import { forbidden, notFound, ok, operation, responseSpec, errorSpec } from '@/lib/routes'
+import { canUserAccessAssistant, getPublishedAssistantVersion } from 'models/assistant'
 import { z } from 'zod'
 
 export const dynamic = 'force-dynamic'
@@ -8,9 +8,16 @@ export const GET = operation({
   name: 'Get assistant system prompt',
   description: 'Fetch the system prompt for a published assistant.',
   authentication: 'user',
-  responses: [responseSpec(200, z.object({ systemPrompt: z.string() })), errorSpec(404)] as const,
-  implementation: async ({ params }) => {
+  responses: [
+    responseSpec(200, z.object({ systemPrompt: z.string() })),
+    errorSpec(403),
+    errorSpec(404),
+  ] as const,
+  implementation: async ({ params, session }) => {
     const assistantId = params.assistantId
+    if (!(await canUserAccessAssistant(session.userId, assistantId))) {
+      return forbidden()
+    }
     const assistant = await getPublishedAssistantVersion(assistantId)
     if (!assistant) {
       return notFound()

--- a/apps/backend/api/me/assistants/[assistantId]/tokens/estimate/route.ts
+++ b/apps/backend/api/me/assistants/[assistantId]/tokens/estimate/route.ts
@@ -80,7 +80,8 @@ export const POST = operation({
     const files = await assistantVersionFiles(assistantVersion.id)
     const availableTools = await availableToolsForAssistantVersion(
       assistantVersion.id,
-      assistantVersion.model
+      assistantVersion.model,
+      { userId: session.userId, userRole: session.userRole }
     )
     const collector = query?.detail ? createTokenDetailCollector() : undefined
     const result = await estimateInputTokens(

--- a/apps/backend/api/v1/responses/route.ts
+++ b/apps/backend/api/v1/responses/route.ts
@@ -143,7 +143,8 @@ export const POST = operation({
     const linearThread = extractLinearConversation(dbMessages, dtoUserMessage)
     const availableTools = await availableToolsForAssistantVersion(
       assistant.assistantVersionId,
-      assistant.model
+      assistant.model,
+      { userId: session.userId, userRole: session.userRole }
     )
 
     const updateChatTitle = async (title: string) => {

--- a/apps/backend/lib/chat/startServerChatRun.ts
+++ b/apps/backend/lib/chat/startServerChatRun.ts
@@ -128,7 +128,8 @@ export const startServerChatRun = async ({
   const linearThread = extractLinearConversation(dbMessages, userMessage)
   const availableTools = await availableToolsForAssistantVersion(
     assistant.assistantVersionId,
-    assistant.model
+    assistant.model,
+    { userId: session.userId }
   )
 
   const updateChatTitle = async (title: string) => {

--- a/apps/backend/lib/files/authorization.ts
+++ b/apps/backend/lib/files/authorization.ts
@@ -1,8 +1,7 @@
 import { db } from '@/db/database'
 import type * as schema from '@/db/schema'
 import { canUserAccessAssistant } from '@/models/assistant'
-import { getUserWorkspaceMemberships } from '@/models/user'
-import { UserRole } from '@/types/dto'
+import { canUserAccessTool } from '@/models/tool'
 
 /**
  * File ownership and authorization model
@@ -37,15 +36,6 @@ type AccessUser = {
   userRole?: schema.UserRole
 }
 
-const isAdminUser = async (userId: string, userRoleHint?: schema.UserRole): Promise<boolean> => {
-  if (userRoleHint) {
-    return userRoleHint === UserRole.ADMIN
-  }
-
-  const row = await db.selectFrom('User').select('role').where('id', '=', userId).executeTakeFirst()
-  return row?.role === UserRole.ADMIN
-}
-
 export const canAccess = async (
   user: AccessUser,
   ownerType: schema.FileOwnerType,
@@ -76,37 +66,8 @@ export const canAccess = async (
     }
     case 'ASSISTANT':
       return await canUserAccessAssistant(userId, ownerId)
-    case 'TOOL': {
-      const tool = await db
-        .selectFrom('Tool')
-        .select('sharing')
-        .where('id', '=', ownerId)
-        .executeTakeFirst()
-      if (!tool) {
-        return false
-      }
-
-      if (tool.sharing === 'public') {
-        return true
-      }
-
-      if (tool.sharing === 'workspace') {
-        const memberships = await getUserWorkspaceMemberships(userId)
-        if (memberships.length === 0) {
-          return false
-        }
-        const workspaceIds = memberships.map((m) => m.id)
-        const shared = await db
-          .selectFrom('ToolSharing')
-          .select('id')
-          .where('toolId', '=', ownerId)
-          .where('workspaceId', 'in', workspaceIds)
-          .executeTakeFirst()
-        return !!shared
-      }
-
-      return await isAdminUser(userId, user.userRole)
-    }
+    case 'TOOL':
+      return await canUserAccessTool(user, ownerId)
   }
 }
 

--- a/apps/backend/lib/tools/enumerate.ts
+++ b/apps/backend/lib/tools/enumerate.ts
@@ -1,7 +1,13 @@
-import { assistantVersionTools, getPublishedAssistantVersion } from '@/models/assistant'
+import { assistantVersionTools, canUserAccessAssistant, getPublishedAssistantVersion } from '@/models/assistant'
 import { ToolBuilder, ToolImplementation } from '@/lib/chat/tools'
 import { TimeOfDay } from './timeofday/implementation'
-import { getToolsFiltered, getBuildableTools, BuildableTool } from '@/models/tool'
+import {
+  getToolsFiltered,
+  getBuildableTools,
+  BuildableTool,
+  filterVisibleToolIds,
+  ToolAccessPrincipal,
+} from '@/models/tool'
 import { OpenApiPlugin } from './openapi/implementation'
 import { ImageGeneratorPlugin } from './imagegenerator/implementation'
 import {
@@ -72,14 +78,18 @@ export const availableTools = async (model: string) => {
 
 export const availableToolsForAssistantVersion = async (
   assistantVersionId: string,
-  model: string
+  model: string,
+  principal: ToolAccessPrincipal
 ) => {
   const tools = await assistantVersionTools(assistantVersionId)
+  const visibleToolIds = await filterVisibleToolIds(principal, tools.map((t) => t.id))
   const implementations = (
     await Promise.all(
-      tools.map((t) => {
-        return buildTool(t, model)
-      })
+      tools
+        .filter((t) => visibleToolIds.has(t.id))
+        .map((t) => {
+          return buildTool(t, model)
+        })
     )
   ).filter((t) => !(t === undefined)) as ToolImplementation[]
 
@@ -92,7 +102,7 @@ export const availableToolsForAssistantVersion = async (
 
   if (assistantVersionRow?.subAssistants) {
     const subAssistantIds: string[] = JSON.parse(assistantVersionRow.subAssistants)
-    const subTool = await buildSubAssistantTool(subAssistantIds)
+    const subTool = await buildSubAssistantTool(subAssistantIds, principal)
     if (subTool) implementations.push(subTool)
   }
 
@@ -100,11 +110,13 @@ export const availableToolsForAssistantVersion = async (
 }
 
 export const buildSubAssistantTool = async (
-  subAssistantIds: string[]
+  subAssistantIds: string[],
+  principal: ToolAccessPrincipal
 ): Promise<SubAssistantTool | undefined> => {
   const entries = (
     await Promise.all(
       subAssistantIds.map(async (id) => {
+        if (!(await canUserAccessAssistant(principal.userId, id))) return undefined
         const version = await getPublishedAssistantVersion(id)
         if (!version) return undefined
         return { id, name: version.name, description: version.description ?? '' }
@@ -133,15 +145,17 @@ export const buildSubAssistantTool = async (
 export const availableToolsFiltered = async (
   ids: string[],
   model: string,
+  principal: ToolAccessPrincipal,
   subAssistantIds?: string[]
 ) => {
-  const tools = await getToolsFiltered(ids)
+  const visibleToolIds = await filterVisibleToolIds(principal, ids)
+  const tools = await getToolsFiltered([...visibleToolIds])
   const implementations = (await Promise.all(tools.map((t) => buildTool(t, model)))).filter(
     (t) => t !== undefined
   ) as ToolImplementation[]
 
   if (subAssistantIds && subAssistantIds.length > 0) {
-    const subTool = await buildSubAssistantTool(subAssistantIds)
+    const subTool = await buildSubAssistantTool(subAssistantIds, principal)
     if (subTool) implementations.push(subTool)
   }
 

--- a/apps/backend/lib/tools/subassistant/implementation.ts
+++ b/apps/backend/lib/tools/subassistant/implementation.ts
@@ -106,7 +106,9 @@ export class SubAssistantTool implements ToolImplementation {
             }
 
             const [tools, files, parameters] = await Promise.all([
-              availableToolsForAssistantVersion(assistantVersion.id, assistantVersion.model),
+              availableToolsForAssistantVersion(assistantVersion.id, assistantVersion.model, {
+                userId,
+              }),
               assistantVersionFiles(assistantVersion.id),
               getUserParameters(userId),
             ])

--- a/apps/backend/models/tool.ts
+++ b/apps/backend/models/tool.ts
@@ -3,6 +3,8 @@ import * as dto from '@/types/dto'
 import { nanoid } from 'nanoid'
 import * as schema from '@/db/schema'
 import { getOrCreateImageFromDataUri } from './images'
+import { getUserWorkspaceMemberships } from './user'
+import { UserRole } from '@/types/dto'
 
 export interface BuildableTool {
   id: string
@@ -49,6 +51,69 @@ const toolWorkspaceSharingData = async (toolIds: string[]): Promise<Map<string, 
 
   // Turn the plain object into a Map<string, dto.Sharing[]>
   return new Map(Object.entries(grouped))
+}
+
+export type ToolAccessPrincipal = { userId: string; userRole?: schema.UserRole }
+
+const isAdminUser = async (user: ToolAccessPrincipal): Promise<boolean> => {
+  if (user.userRole) {
+    return user.userRole === UserRole.ADMIN
+  }
+  const row = await db.selectFrom('User').select('role').where('id', '=', user.userId).executeTakeFirst()
+  return row?.role === UserRole.ADMIN
+}
+
+/** Which of the given tool ids are visible to this user: public tools to
+ * anyone, workspace tools to members of a sharing workspace, private tools
+ * to admins only. Tools attached to an assistant/sub-assistant/evaluate
+ * request must always be filtered through this before being built or
+ * exposed to a run, since a tool a user can't see may hold server-side
+ * credentials or reach another user's satellite connection. */
+export const filterVisibleToolIds = async (
+  user: ToolAccessPrincipal,
+  toolIds: string[]
+): Promise<Set<string>> => {
+  const uniqueIds = [...new Set(toolIds)]
+  if (uniqueIds.length === 0) {
+    return new Set()
+  }
+  const tools = await db
+    .selectFrom('Tool')
+    .select(['id', 'sharing'])
+    .where('id', 'in', uniqueIds)
+    .execute()
+  const isAdmin = await isAdminUser(user)
+  const visible = new Set(
+    tools
+      .filter((t) => t.sharing === 'public' || (t.sharing === 'private' && isAdmin))
+      .map((t) => t.id)
+  )
+  const workspaceToolIds = tools.filter((t) => t.sharing === 'workspace').map((t) => t.id)
+  if (workspaceToolIds.length === 0) {
+    return visible
+  }
+  const memberships = await getUserWorkspaceMemberships(user.userId)
+  if (memberships.length === 0) {
+    return visible
+  }
+  const workspaceIds = memberships.map((m) => m.id)
+  const shared = await db
+    .selectFrom('ToolSharing')
+    .select('toolId')
+    .where('toolId', 'in', workspaceToolIds)
+    .where('workspaceId', 'in', workspaceIds)
+    .execute()
+  for (const row of shared) {
+    visible.add(row.toolId)
+  }
+  return visible
+}
+
+export const canUserAccessTool = async (
+  user: ToolAccessPrincipal,
+  toolId: string
+): Promise<boolean> => {
+  return (await filterVisibleToolIds(user, [toolId])).has(toolId)
 }
 
 export const makeSharing = (type: string, workspaces: string[]): dto.Sharing2 => {

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -2068,6 +2068,8 @@ paths:
                 required:
                   - systemPrompt
                 additionalProperties: false
+        "403":
+          $ref: "#/components/responses/Error"
         "404":
           $ref: "#/components/responses/Error"
       parameters:


### PR DESCRIPTION
## Summary
`GET /api/me/assistants/{assistantId}/systemPrompt` only required a logged-in session and loaded the assistant version by ID directly, with no ownership or sharing check — any authenticated user could read the system prompt of any assistant, private or not, just by knowing (or guessing) its ID. Now gated by `canUserAccessAssistant`, matching how the sibling `GET /api/me/assistants/{assistantId}` route is already scoped.

(Re-opened against `main` directly — the original PR #1056 was auto-closed when its stacked base branch was deleted on merge of #1055.)

## Tests
- `npm run check-types` — passes
- `npx vitest run __tests__/assistantSystemPromptRoute.test.ts` — all 3 tests pass: a user with no access gets 403, the owner gets the prompt, and a nonexistent assistant id returns 403 (not a distinguishing 404)