### PR TITLE
Require tool visibility before attaching it to an assistant

### DIFF
--- a/__tests__/assistantFileAuthorization.test.ts
+++ b/__tests__/assistantFileAuthorization.test.ts
@@ -3,9 +3,14 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 type Row = Record<string, unknown>
 
 const tables: Record<string, Row[]> = {
+  Assistant: [],
   AssistantVersion: [],
   File: [],
   AssistantVersionFile: [],
+  Tool: [],
+  ToolSharing: [],
+  User: [],
+  AssistantVersionToolAssociation: [],
 }
 
 const insertedInto: Record<string, Row[]> = {}
@@ -81,8 +86,18 @@ vi.mock('db/database', () => ({
 
 vi.mock('./images', () => ({ getOrCreateImageFromDataUri: vi.fn() }))
 vi.mock('@/models/images', () => ({ getOrCreateImageFromDataUri: vi.fn() }))
-vi.mock('./tool', () => ({ dbToolToBuildableTool: vi.fn() }))
-vi.mock('@/models/tool', () => ({ dbToolToBuildableTool: vi.fn() }))
+// Keep the real filterVisibleToolIds so these tests exercise the actual
+// visibility policy (against the same mocked db), only stubbing the
+// unrelated dbToolToBuildableTool export.
+vi.mock('./tool', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/models/tool')>()),
+  dbToolToBuildableTool: vi.fn(),
+}))
+vi.mock('@/models/tool', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/models/tool')>()),
+  dbToolToBuildableTool: vi.fn(),
+}))
+vi.mock('@/models/user', () => ({ getUserWorkspaceMemberships: vi.fn().mockResolvedValue([]) }))
 vi.mock('./backend', () => ({ getBackendsWithModels: vi.fn() }))
 vi.mock('@/models/backend', () => ({ getBackendsWithModels: vi.fn() }))
 vi.mock('./userSecrets', () => ({ listUserSecretStatuses: vi.fn() }))
@@ -160,5 +175,106 @@ describe('updateAssistantVersion file authorization', () => {
     expect(insertedInto.AssistantVersionFile).toEqual([
       { assistantVersionId: 'av1', fileId: 'already-attached', order: 0 },
     ])
+  })
+})
+
+describe('updateAssistantVersion tool authorization', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    for (const key of Object.keys(tables)) tables[key] = []
+    for (const key of Object.keys(insertedInto)) delete insertedInto[key]
+    deletedFrom.length = 0
+    updatedFileRows.length = 0
+  })
+
+  test('rejects and never associates a tool the acting editor cannot see', async () => {
+    tables.AssistantVersion.push({ id: 'av1', assistantId: 'a1' })
+    tables.Tool.push({ id: 'private-tool', sharing: 'private' })
+    tables.User.push({ id: 'editor', role: 'USER' })
+
+    const { updateAssistantVersion } = await import('@/models/assistant')
+
+    await expect(
+      updateAssistantVersion('av1', { tools: ['private-tool'] } as any, 'editor')
+    ).rejects.toThrow(/not accessible/)
+
+    expect(insertedInto.AssistantVersionToolAssociation).toBeUndefined()
+    expect(deletedFrom).not.toContain('AssistantVersionToolAssociation')
+  })
+
+  test('allows a public tool', async () => {
+    tables.AssistantVersion.push({ id: 'av1', assistantId: 'a1' })
+    tables.Tool.push({ id: 'public-tool', sharing: 'public' })
+
+    const { updateAssistantVersion } = await import('@/models/assistant')
+
+    await expect(
+      updateAssistantVersion('av1', { tools: ['public-tool'] } as any, 'editor')
+    ).resolves.not.toThrow()
+
+    expect(insertedInto.AssistantVersionToolAssociation).toEqual([
+      { assistantVersionId: 'av1', toolId: 'public-tool' },
+    ])
+  })
+
+  test('allows a private tool for an admin editor', async () => {
+    tables.AssistantVersion.push({ id: 'av1', assistantId: 'a1' })
+    tables.Tool.push({ id: 'private-tool', sharing: 'private' })
+    tables.User.push({ id: 'admin-editor', role: 'ADMIN' })
+
+    const { updateAssistantVersion } = await import('@/models/assistant')
+
+    await expect(
+      updateAssistantVersion('av1', { tools: ['private-tool'] } as any, 'admin-editor')
+    ).resolves.not.toThrow()
+
+    expect(insertedInto.AssistantVersionToolAssociation).toEqual([
+      { assistantVersionId: 'av1', toolId: 'private-tool' },
+    ])
+  })
+})
+
+describe('createAssistantWithId tool authorization', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    for (const key of Object.keys(tables)) tables[key] = []
+    for (const key of Object.keys(insertedInto)) delete insertedInto[key]
+    deletedFrom.length = 0
+    updatedFileRows.length = 0
+  })
+
+  test('rejects creation and never associates a tool the acting owner cannot see', async () => {
+    tables.Tool.push({ id: 'private-tool', sharing: 'private' })
+    tables.User.push({ id: 'owner', role: 'USER' })
+
+    const { createAssistantWithId } = await import('@/models/assistant')
+
+    await expect(
+      createAssistantWithId(
+        'a1',
+        {
+          backendId: 'b1',
+          description: 'desc',
+          model: 'gpt-4o-mini',
+          name: 'assistant',
+          versionName: null,
+          systemPrompt: 'hi',
+          temperature: 0,
+          tokenLimit: 4096,
+          reasoning_effort: null,
+          contextCompression: null,
+          tags: [],
+          prompts: [],
+          tools: ['private-tool'],
+          files: [],
+          iconUri: null,
+          subAssistants: [],
+        } as any,
+        'owner',
+        false
+      )
+    ).rejects.toThrow(/not accessible/)
+
+    expect(insertedInto.AssistantVersionToolAssociation).toBeUndefined()
   })
 })

--- a/apps/backend/models/assistant.ts
+++ b/apps/backend/models/assistant.ts
@@ -2,7 +2,7 @@ import * as dto from '@/types/dto'
 import { db } from 'db/database'
 import * as schema from '@/db/schema'
 import { nanoid } from 'nanoid'
-import { BuildableTool, dbToolToBuildableTool } from './tool'
+import { BuildableTool, dbToolToBuildableTool, filterVisibleToolIds } from './tool'
 import { Expression, SqlBool, SqliteAdapter, sql } from 'kysely'
 import { getOrCreateImageFromDataUri } from './images'
 import { getBackendsWithModels } from './backend'
@@ -78,6 +78,25 @@ const assertFilesAttachableToAssistant = async (
         (row.ownerType === 'ASSISTANT' && row.ownerId === assistantId))
     if (!allowed) {
       throw new Error(`File ${id} cannot be attached to assistant ${assistantId}`)
+    }
+  }
+}
+
+/** A tool not visible to the acting editor (private tool they're not an admin
+ * for, or a workspace tool outside their workspaces) must never be attached
+ * to an assistant — the tool's own visibility rules are the only thing that
+ * decides who can ever invoke it, so an assistant referencing an invisible
+ * tool would otherwise let it slip into a run undetected. */
+const assertToolsAttachableToAssistant = async (
+  toolIds: string[],
+  editorId: string
+): Promise<void> => {
+  const uniqueIds = [...new Set(toolIds)]
+  if (uniqueIds.length === 0) return
+  const visible = await filterVisibleToolIds({ userId: editorId }, uniqueIds)
+  for (const id of uniqueIds) {
+    if (!visible.has(id)) {
+      throw new Error(`Tool ${id} is not accessible and cannot be attached to an assistant`)
     }
   }
 }
@@ -518,6 +537,7 @@ export const createAssistantWithId = async (
     .execute()
   const tools = toAssistantToolAssociation(id, dtoTools)
   if (tools.length !== 0) {
+    await assertToolsAttachableToAssistant(dtoTools, owner)
     await db.insertInto('AssistantVersionToolAssociation').values(tools).execute()
   }
   const files = toAssistantFileAssociation(id, dtoFiles)
@@ -676,9 +696,12 @@ export const updateAssistantVersion = async (
     }
   }
   if (assistant.tools) {
+    const tools = toAssistantToolAssociation(assistantVersionId, assistant.tools)
+    if (tools.length !== 0) {
+      await assertToolsAttachableToAssistant(assistant.tools, userId)
+    }
     // TODO: delete all and insert all might be replaced by differential logic
     await deleteAssistantVersionToolAssociations(assistantVersionId)
-    const tools = toAssistantToolAssociation(assistantVersionId, assistant.tools)
     if (tools.length !== 0) {
       await db.insertInto('AssistantVersionToolAssociation').values(tools).execute()
     }


### PR DESCRIPTION
## Summary
`createAssistantWithId` and `updateAssistantVersion` associated any given tool ID with an assistant with no check that the tool was actually visible to the acting editor. Files got exactly this treatment (`assertFilesAttachableToAssistant`) in an earlier fix; tools didn't. Since assistant tools are wired up and invoked for any user of the assistant with no further per-viewer check at the point of use (that read-side gap was closed separately in #1055), attaching an invisible tool at save time was enough to smuggle it into a run regardless of its own public/workspace/private sharing — an editor could reference a tool ID they can't see and have it run for every user of the assistant.

Adds `assertToolsAttachableToAssistant`, mirroring the files check: every tool ID is validated against `filterVisibleToolIds` before any `AssistantVersionToolAssociation` row is written, on both the create and update paths. On update, validation runs before the destructive delete-then-reinsert of existing associations, so a rejected save leaves the assistant's current tools untouched rather than leaving it with none.

## Tests
- `npm run check-types` — passes
- `npx vitest run` — all 109 test files / 999 tests pass, including 4 new tests in `assistantFileAuthorization.test.ts` covering: rejection of an invisible tool on update (no association written), a public tool succeeding, a private tool succeeding for an admin editor, and rejection on create