### PR TITLE
Enforce file authorization on the assistant evaluate endpoint

### DIFF
--- a/__tests__/evaluateRouteFileAuthorization.test.ts
+++ b/__tests__/evaluateRouteFileAuthorization.test.ts
@@ -1,0 +1,184 @@
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { Kysely, Migrator, type Migration, PostgresAdapter, SqliteAdapter } from 'kysely'
+import { db } from '@/db/database'
+import { migrationModules } from '@/db/migrations.generated'
+import { SESSION_COOKIE_NAME } from '@/lib/auth/session'
+import { createSession } from '@/models/session'
+import { createUser } from '@/models/user'
+
+const canAccessFileMock = vi.fn()
+const getBackendMock = vi.fn()
+const availableToolsFilteredMock = vi.fn()
+const getUserParametersMock = vi.fn()
+const getUserSecretValueMock = vi.fn()
+const chatAssistantBuildMock = vi.fn()
+const assistantParamsFromMock = vi.fn()
+
+vi.mock('@/backend/lib/files/authorization', () => ({
+  canAccessFile: canAccessFileMock,
+}))
+vi.mock('@/models/backend', () => ({ getBackend: getBackendMock }))
+vi.mock('@/backend/lib/tools/enumerate', () => ({
+  availableToolsFiltered: availableToolsFilteredMock,
+}))
+vi.mock('@/lib/parameters', () => ({ getUserParameters: getUserParametersMock }))
+vi.mock('@/models/userSecrets', () => ({ getUserSecretValue: getUserSecretValueMock }))
+vi.mock('@/backend/lib/chat', () => ({
+  ChatAssistant: {
+    build: chatAssistantBuildMock,
+    assistantParamsFrom: assistantParamsFromMock,
+  },
+}))
+
+function getDialectName(client: Kysely<any>) {
+  if (client.getExecutor().adapter instanceof SqliteAdapter) return 'sqlite'
+  if (client.getExecutor().adapter instanceof PostgresAdapter) return 'postgresql'
+  return undefined
+}
+
+async function migrateTestDb() {
+  const dialectName = getDialectName(db)
+  const migrator = new Migrator({
+    db,
+    provider: {
+      getMigrations: async () =>
+        Object.fromEntries(
+          Object.entries(migrationModules).map(([name, migration]) => [
+            name,
+            {
+              up: async (client: Kysely<any>) => {
+                await (
+                  migration as { up: (db: Kysely<any>, dialect?: string) => Promise<void> }
+                ).up(client, dialectName)
+              },
+            } satisfies Migration,
+          ])
+        ),
+    },
+  })
+  const { error } = await migrator.migrateToLatest()
+  if (error) throw error
+}
+
+async function resetTables() {
+  await db.deleteFrom('Session').execute()
+  await db.deleteFrom('User').execute()
+}
+
+const now = new Date().toISOString()
+
+const makeAssistantDraft = (fileIds: string[]) => ({
+  id: 'a1',
+  assistantId: 'a1',
+  backendId: 'b1',
+  description: '',
+  model: 'gpt-4o-mini',
+  name: 'assistant',
+  versionName: null,
+  systemPrompt: 'hi',
+  temperature: 0,
+  tokenLimit: 4096,
+  reasoning_effort: null,
+  contextCompression: null,
+  createdAt: now,
+  updatedAt: now,
+  owner: 'someone',
+  tools: [],
+  files: fileIds.map((id) => ({ id, name: `${id}.txt`, type: 'text/plain', size: 1 })),
+  sharing: [],
+  tags: [],
+  prompts: [],
+  iconUri: null,
+  provisioned: false,
+  hidden: false,
+  pendingChanges: false,
+  subAssistants: [],
+})
+
+let sessionCookie: string
+
+beforeAll(async () => {
+  await migrateTestDb()
+})
+
+beforeEach(async () => {
+  await resetTables()
+  vi.clearAllMocks()
+  getBackendMock.mockResolvedValue({ id: 'b1', providerType: 'openai', configuration: '{}' })
+  availableToolsFilteredMock.mockResolvedValue([])
+  getUserParametersMock.mockResolvedValue({})
+  assistantParamsFromMock.mockReturnValue({})
+
+  const user = await createUser({ name: 'Evaluator', email: 'evaluate-route@example.com', ssoUser: 0 })
+  const session = await createSession(user.id, new Date(Date.now() + 60_000), 'password', null)
+  sessionCookie = `${SESSION_COOKIE_NAME}=${session.id}`
+})
+
+describe('POST /api/assistants/evaluate', () => {
+  test('returns 403 and never builds a run when the draft references an inaccessible file', async () => {
+    canAccessFileMock.mockResolvedValue(false)
+    const { POST } = await import('@/api/assistants/evaluate/route')
+
+    const response = await POST(
+      new Request('http://localhost/api/assistants/evaluate', {
+        method: 'POST',
+        headers: { cookie: sessionCookie, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          assistant: makeAssistantDraft(['other-tenant-file']),
+          messages: [
+            {
+              id: 'm1',
+              conversationId: 'preview',
+              parent: null,
+              sentAt: now,
+              role: 'user',
+              content: 'hi',
+              attachments: [],
+            },
+          ],
+        }),
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(canAccessFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: expect.any(String) }),
+      'other-tenant-file'
+    )
+    expect(response.status).toBe(403)
+    expect(chatAssistantBuildMock).not.toHaveBeenCalled()
+  })
+
+  test('proceeds to build a run when every referenced file is accessible', async () => {
+    canAccessFileMock.mockResolvedValue(true)
+    chatAssistantBuildMock.mockResolvedValue({
+      sendUserMessageAndStreamResponse: vi.fn().mockResolvedValue(new ReadableStream()),
+    })
+    const { POST } = await import('@/api/assistants/evaluate/route')
+
+    const response = await POST(
+      new Request('http://localhost/api/assistants/evaluate', {
+        method: 'POST',
+        headers: { cookie: sessionCookie, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          assistant: makeAssistantDraft(['own-file']),
+          messages: [
+            {
+              id: 'm1',
+              conversationId: 'preview',
+              parent: null,
+              sentAt: now,
+              role: 'user',
+              content: 'hi',
+              attachments: [],
+            },
+          ],
+        }),
+      }),
+      { params: Promise.resolve({}) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(chatAssistantBuildMock).toHaveBeenCalled()
+  })
+})

--- a/apps/backend/api/assistants/evaluate/route.ts
+++ b/apps/backend/api/assistants/evaluate/route.ts
@@ -3,7 +3,8 @@ import { ChatAssistant } from '@/backend/lib/chat'
 import { getBackend } from '@/models/backend'
 import { availableToolsFiltered } from '@/backend/lib/tools/enumerate'
 import { getUserParameters } from '@/lib/parameters'
-import { error, operation, responseSpec, errorSpec } from '@/lib/routes'
+import { canAccessFile } from '@/backend/lib/files/authorization'
+import { error, forbidden, operation, responseSpec, errorSpec } from '@/lib/routes'
 import { z } from 'zod'
 import { getUserSecretValue } from '@/models/userSecrets'
 import { userSecretRequiredMessage, userSecretUnreadableMessage } from '@/lib/userSecretMessages'
@@ -15,7 +16,7 @@ export const POST = operation({
   description: 'Evaluate an assistant draft with a message list.',
   authentication: 'user',
   requestBodySchema: dto.evaluateAssistantRequestSchema,
-  responses: [responseSpec(200, z.any()), errorSpec(400)] as const,
+  responses: [responseSpec(200, z.any()), errorSpec(400), errorSpec(403)] as const,
   implementation: async ({ session, body }) => {
     const { assistant, messages } = body
     const backend = await getBackend(assistant.backendId)
@@ -25,6 +26,13 @@ export const POST = operation({
 
     if (messages.length === 0) {
       return error(400, 'No messages provided')
+    }
+
+    const fileAccessChecks = await Promise.all(
+      assistant.files.map((f) => canAccessFile({ userId: session.userId, userRole: session.userRole }, f.id))
+    )
+    if (fileAccessChecks.some((allowed) => !allowed)) {
+      return forbidden('Assistant references files that are not accessible to the current user')
     }
 
     const conversationId = messages[0].conversationId || assistant.id || 'preview'

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -626,6 +626,8 @@ paths:
               schema: {}
         "400":
           $ref: "#/components/responses/Error"
+        "403":
+          $ref: "#/components/responses/Error"
       security:
         - bearerAuth: []
       requestBody:


### PR DESCRIPTION
## Summary
`POST /api/assistants/evaluate` accepts a fully client-supplied assistant draft — including its knowledge files list — and passed `assistant.files` straight to `ChatAssistant.build` with no ownership check at all, unlike the chat attachment path which already validates every referenced file id. Knowledge files are trusted server-side and their content is loaded directly into the LLM context, so any authenticated user could put an arbitrary file id into the draft's `files` list and have that file's content read into the evaluate run. Every file id in the draft is now checked with `canAccessFile` before the run is built; the request is rejected with 403 if any file isn't accessible to the caller.

The sibling `POST /api/assistants/tokens/estimate` endpoint passes the same client-supplied `files` list into token estimation, but that path only reads file metadata/size for the estimate and doesn't read actual file bytes (per the existing "without loading file bytes" test coverage in `tokenEstimator.test.ts`), so it's out of scope here.

## Tests
- `npm run check-types` — passes
- `npx vitest run` — all 110 test files / 997 tests pass, including a new `evaluateRouteFileAuthorization.test.ts` covering: 403 + no run built when a referenced file is inaccessible, and a normal run proceeding when every file is accessible