### PR TITLE
Require satellite connection ownership before wiring up its tools

### DIFF
--- a/apps/backend/lib/tools/satellite/__tests__/implementation.test.ts
+++ b/apps/backend/lib/tools/satellite/__tests__/implementation.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test, vi } from 'vitest'
+import type { ToolParams } from '@/lib/chat/tools'
+
+const connections = new Map<string, any>()
+
+vi.mock('@/lib/satellite/hub', () => ({
+  connections,
+}))
+
+const toolParams: ToolParams = {
+  id: 'sat-1',
+  provisioned: false,
+  promptFragment: '',
+  name: 'My Satellite',
+}
+
+describe('SatelliteTool.functions', () => {
+  test('returns callable functions for the satellite connection owner', async () => {
+    connections.clear()
+    connections.set('sat-1', {
+      satelliteId: 'sat-1',
+      userId: 'owner',
+      kind: 'registered',
+      tools: [{ name: 'do_thing', description: 'does a thing' }],
+    })
+
+    const { SatelliteTool } = await import('@/backend/lib/tools/satellite/implementation')
+    const tool = new SatelliteTool(toolParams, 'sat-1')
+
+    const fns = await tool.functions({} as any, { userId: 'owner' })
+    expect(Object.keys(fns)).toEqual(['do_thing'])
+  })
+
+  test('rejects a user who does not own the satellite connection', async () => {
+    connections.clear()
+    connections.set('sat-1', {
+      satelliteId: 'sat-1',
+      userId: 'owner',
+      kind: 'registered',
+      tools: [{ name: 'do_thing', description: 'does a thing' }],
+    })
+
+    const { SatelliteTool } = await import('@/backend/lib/tools/satellite/implementation')
+    const tool = new SatelliteTool(toolParams, 'sat-1')
+
+    await expect(tool.functions({} as any, { userId: 'attacker' })).rejects.toThrow(
+      /currently offline/
+    )
+  })
+
+  test('rejects when the satellite is not connected at all', async () => {
+    connections.clear()
+
+    const { SatelliteTool } = await import('@/backend/lib/tools/satellite/implementation')
+    const tool = new SatelliteTool(toolParams, 'sat-1')
+
+    await expect(tool.functions({} as any, { userId: 'owner' })).rejects.toThrow(
+      /currently offline/
+    )
+  })
+})

--- a/apps/backend/lib/tools/satellite/implementation.ts
+++ b/apps/backend/lib/tools/satellite/implementation.ts
@@ -115,10 +115,10 @@ export class SatelliteTool extends SatelliteInterface implements ToolImplementat
 
   supportedMedia = []
 
-  functions = async (_model: LlmModel, _context: ToolFunctionContext): Promise<ToolFunctions> => {
+  functions = async (_model: LlmModel, context: ToolFunctionContext): Promise<ToolFunctions> => {
     const { connections } = await import('@/lib/satellite/hub')
     const conn = connections.get(this.satelliteId)
-    if (!conn) {
+    if (!conn || conn.userId !== context.userId) {
       throw new UserVisibleError(`Satellite "${this.toolParams.name}" is currently offline`)
     }
 


### PR DESCRIPTION
## Summary
`SatelliteTool.functions` resolved a live satellite connection purely by `satelliteId` and built callable functions from it with no check that the connection actually belonged to the invoking user. Ephemeral satellites (auto-injected into a chat run for the current user) were already filtered by `userId` upstream in `ChatAssistant`, so they were never exploitable — but a satellite reachable via a *registered* `Tool` DB row (attached to an assistant's tool list, and now gated by tool-visibility sharing in #1055/#1061) bypassed that filter entirely. A tool's own `public`/`workspace`/`private` sharing controls who can *see* it, not who owns the physical satellite connection it drives — so any user who could get such a tool attached to an assistant they use could invoke another user's satellite connection just by knowing its tool ID.

`functions()` now denies with the same `"currently offline"` error already used for a genuinely disconnected satellite whenever `conn.userId` doesn't match the invoking user's id, so a connection-ownership mismatch and a missing connection are indistinguishable to the caller (no existence/ownership info leaked).

## Tests
- `npm run check-types` — passes
- `npx vitest run` — all 110 test files / 998 tests pass, including a new `apps/backend/lib/tools/satellite/__tests__/implementation.test.ts` covering: the owner gets working tool functions, a different user is rejected with the same generic error, and a genuinely offline satellite is still rejected the same way