### PR TITLE
Redact gcp-vertex credentials from backend API responses

### DIFF
--- a/packages/core/src/types/secure.ts
+++ b/packages/core/src/types/secure.ts
@@ -1,5 +1,7 @@
 import * as dto from '@/types/dto'
 
+export const PROTECTED_CREDENTIALS = '<redacted>'
+
 export function protect(str: string) {
   const len = str.length
   const clearText = Math.min(12, Math.max(0, (len >> 1) - 4))
@@ -18,6 +20,11 @@ export function protectApiKey(backend: dto.Backend): dto.Backend {
     return {
       ...backend,
       apiKey: backend.apiKey === undefined ? undefined : protect(backend.apiKey),
+    } as dto.Backend
+  } else if ('credentials' in backend) {
+    return {
+      ...backend,
+      credentials: backend.credentials === undefined ? undefined : PROTECTED_CREDENTIALS,
     } as dto.Backend
   } else {
     return backend


### PR DESCRIPTION
## Summary
`GET /api/backends` (any authenticated user) and `GET /api/backends/{id}` (admin) returned the full, unredacted `credentials` field for `gcp-vertex` backends — including the GCP service-account private key when configured that way. `protectApiKey` only redacted the `apiKey` field, which `gcp-vertex` backends don't have (they use `credentials` instead), so the secret passed straight through. `protectApiKey` now redacts `credentials` to a fixed placeholder the same way it protects `apiKey`.

## Tests
- `npm run check-types`