### PR TITLE
Close the upload-dedup race between concurrent PUTs on the same file

### DIFF
--- a/__tests__/fileDeduplication.test.ts
+++ b/__tests__/fileDeduplication.test.ts
@@ -66,7 +66,8 @@ describe('finalizeUploadedFile', () => {
     })
 
     const updateExecuteMock = vi.fn().mockResolvedValue(undefined)
-    const updateWhere1 = vi.fn(() => ({ execute: updateExecuteMock }))
+    const updateWhere2 = vi.fn(() => ({ execute: updateExecuteMock }))
+    const updateWhere1 = vi.fn(() => ({ where: updateWhere2 }))
     updateTableMock.mockReturnValueOnce({ set: vi.fn(() => ({ where: updateWhere1 })) })
 
     const { finalizeUploadedFile } = await import('@/backend/lib/files/upload-dedup')
@@ -105,7 +106,8 @@ describe('finalizeUploadedFile', () => {
     })
 
     const updateExecuteMock = vi.fn().mockResolvedValue(undefined)
-    const updateWhere1 = vi.fn(() => ({ execute: updateExecuteMock }))
+    const updateWhere2 = vi.fn(() => ({ execute: updateExecuteMock }))
+    const updateWhere1 = vi.fn(() => ({ where: updateWhere2 }))
     updateTableMock.mockReturnValueOnce({ set: vi.fn(() => ({ where: updateWhere1 })) })
 
     const { finalizeUploadedFile } = await import('@/backend/lib/files/upload-dedup')

--- a/__tests__/fileUploadRoutes.test.ts
+++ b/__tests__/fileUploadRoutes.test.ts
@@ -274,6 +274,60 @@ describe('PUT /api/files/:fileId/content', () => {
     expect(newFile.fileBlobId).toEqual(canonicalFile.fileBlobId)
   })
 
+  test('rejects a second concurrent upload for the same file and keeps only one blob', async () => {
+    await insertFile({ id: 'f-race', path: 'f-race.txt' })
+    mocks.writeStream.mockImplementation(
+      async (_path: string, stream: ReadableStream<Uint8Array>) => consumeStream(stream)
+    )
+
+    const makeRequest = () =>
+      contentRoute.PUT(
+        new Request('http://localhost/api/files/f-race/content', {
+          method: 'PUT',
+          headers: { cookie: sessionCookie },
+          body: 'racing content',
+        }),
+        { params: Promise.resolve({ fileId: 'f-race' }) }
+      )
+
+    const [first, second] = await Promise.all([makeRequest(), makeRequest()])
+    const statuses = [first.status, second.status].sort()
+
+    expect(statuses).toEqual([204, 400])
+    const blobs = await db.selectFrom('FileBlob').selectAll().execute()
+    expect(blobs).toHaveLength(1)
+    const file = await db.selectFrom('File').selectAll().where('id', '=', 'f-race').executeTakeFirstOrThrow()
+    expect(file.fileBlobId).toEqual(blobs[0].id)
+  })
+
+  test('lets a retry succeed after a failed upload releases its claim', async () => {
+    await insertFile({ id: 'f-retry', path: 'f-retry.txt' })
+    mocks.writeStream.mockRejectedValueOnce(new Error('disk full'))
+
+    const failed = await contentRoute.PUT(
+      new Request('http://localhost/api/files/f-retry/content', {
+        method: 'PUT',
+        headers: { cookie: sessionCookie },
+        body: 'content',
+      }),
+      { params: Promise.resolve({ fileId: 'f-retry' }) }
+    )
+    expect(failed.status).toBe(500)
+
+    mocks.writeStream.mockImplementation(
+      async (_path: string, stream: ReadableStream<Uint8Array>) => consumeStream(stream)
+    )
+    const retried = await contentRoute.PUT(
+      new Request('http://localhost/api/files/f-retry/content', {
+        method: 'PUT',
+        headers: { cookie: sessionCookie },
+        body: 'content',
+      }),
+      { params: Promise.resolve({ fileId: 'f-retry' }) }
+    )
+    expect(retried.status).toBe(204)
+  })
+
   test('returns 500 Upload failure when storage write throws a server error', async () => {
     await insertFile({ id: 'f1', path: 'f1.txt' })
     mocks.writeStream.mockRejectedValue(new Error('disk full'))

--- a/apps/backend/api/files/[fileId]/content/route.ts
+++ b/apps/backend/api/files/[fileId]/content/route.ts
@@ -1,4 +1,5 @@
 import { db } from '@/db/database'
+import { sql } from 'kysely'
 import { canAccessFile, canWriteFile } from '@/backend/lib/files/authorization'
 import { error, noBody, notFound, forbidden, operation, responseSpec, errorSpec } from '@/lib/routes'
 import { storage } from '@/lib/storage'
@@ -85,8 +86,29 @@ export const PUT = operation({
     if (file.fileBlobId) {
       return error(400, 'File content has already been uploaded')
     }
+    // Atomically claim the row so a second, concurrent PUT for the same file can't also pass
+    // the check above and race this one to write the same storage path / finalize the blob.
+    const claim = await db
+      .updateTable('File')
+      .set({ uploaded: 1 } as never)
+      .where('id', '=', params.fileId)
+      .where('fileBlobId', 'is', null)
+      .where(sql.ref('uploaded'), '=', 0)
+      .executeTakeFirst()
+    if (!claim || Number(claim.numUpdatedRows) !== 1) {
+      return error(400, 'File content has already been uploaded')
+    }
+    const releaseClaim = async () => {
+      await db
+        .updateTable('File')
+        .set({ uploaded: 0 } as never)
+        .where('id', '=', params.fileId)
+        .where('fileBlobId', 'is', null)
+        .execute()
+    }
     const contentLength = headers.get('content-length')
     if (contentLength && (!/^\d+$/.test(contentLength) || Number(contentLength) > env.chat.attachments.maxSize)) {
+      await releaseClaim()
       return error(400, 'File exceeds the maximum upload size')
     }
     let clientDisconnected = false
@@ -96,6 +118,7 @@ export const PUT = operation({
     signal.addEventListener('abort', onAbortLike)
     const requestBodyStream = request.stream
     if (!requestBodyStream) {
+      await releaseClaim()
       return error(400, 'Missing body')
     }
 
@@ -117,6 +140,7 @@ export const PUT = operation({
     try {
       await storage.writeStream(file.path, hashingStream, getConfiguredFileEncryption())
     } catch (e) {
+      await releaseClaim()
       if (clientDisconnected) {
         logger.error('Upload aborted by user')
         return error(500, 'Upload aborted')

--- a/apps/backend/lib/files/upload-dedup.ts
+++ b/apps/backend/lib/files/upload-dedup.ts
@@ -40,7 +40,7 @@ export const finalizeUploadedFile = async (params: {
     .where('contentHash', '=', params.contentHash)
     .executeTakeFirstOrThrow()
 
-  if (blob.id !== createdBlobId) {
+  if (blob.id !== createdBlobId && blob.path !== params.filePath) {
     await storage.rm(params.filePath)
   }
 
@@ -56,6 +56,6 @@ export const finalizeUploadedFile = async (params: {
       encrypted: isFileEncrypted(blob.encryption) ? 1 : 0,
     } as any)
     .where('id', '=', params.fileId)
+    .where('fileBlobId', 'is', null)
     .execute()
-
 }


### PR DESCRIPTION
## Summary
Fixes a race in file content upload where two concurrent `PUT /api/files/{id}/content` requests for the same file could both pass the "not yet uploaded" check, both write to the same storage path, and both race to finalize the content-hash dedup, leaving blob/file linkage in an inconsistent state. The route now atomically claims the row before writing to storage, so only one concurrent upload for a given file id can proceed.

## Details
- `apps/backend/api/files/[fileId]/content/route.ts`: after the existing fast-path check, atomically claim the file row with a conditional `UPDATE ... WHERE fileBlobId IS NULL AND uploaded = 0`. A second concurrent request gets 0 updated rows and is rejected with 400 before ever touching storage. The claim is released (`uploaded` reset to 0) on every failure path (oversized body, missing body, storage write failure) so a legitimate retry isn't permanently blocked.
- `apps/backend/lib/files/upload-dedup.ts`: `finalizeUploadedFile`'s final `File` update now also carries a `WHERE fileBlobId IS NULL` guard as defense in depth, and the redundant-blob cleanup no longer removes a storage path if it happens to equal the canonical blob's path.

## Risks
- Does not change dedup semantics across different file ids uploading identical content (still content-hash based, first writer's MIME/size become canonical) — that's a separate design question, not a race condition, and out of scope here.

## Tests
- `npm run check-types` — clean
- `npx vitest run` — 1006 passed, 21 skipped (full suite)
- Added two tests to `__tests__/fileUploadRoutes.test.ts`: concurrent same-file uploads (one 204, one 400, exactly one `FileBlob` row) and a failed-then-retried upload succeeding after the claim is released
- Updated `__tests__/fileDeduplication.test.ts`'s mock chain for the extra `WHERE` clause