### PR TITLE
Block SSRF in DOCX export image fetches

### DIFF
--- a/apps/backend/lib/docx/export.ts
+++ b/apps/backend/lib/docx/export.ts
@@ -3,6 +3,7 @@ import type { IRunOptions } from 'docx'
 import { getFileWithId } from '@/models/file'
 import { canAccessFile } from '@/backend/lib/files/authorization'
 import { storage } from '@/lib/storage'
+import { safeFetch } from '@/backend/lib/net/safeFetch'
 import type * as schema from '@/db/schema'
 import type { Image as MdastImage, InlineCode as MdastInlineCode, Root, RootContent, Text as MdastText } from 'mdast'
 import docx from 'remark-docx'
@@ -286,11 +287,7 @@ function createLoadImageData(principal: AccessPrincipal) {
       return Uint8Array.from(data).buffer
     }
 
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`Failed to load image: ${url}`)
-    }
-    return await response.arrayBuffer()
+    return await safeFetch(url)
   }
 }
 

--- a/apps/backend/lib/net/__tests__/safeFetch.test.ts
+++ b/apps/backend/lib/net/__tests__/safeFetch.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+
+const undiciFetchMock = vi.fn()
+
+vi.mock('undici', () => ({
+  Agent: vi.fn().mockImplementation(() => ({})),
+  fetch: undiciFetchMock,
+}))
+
+describe('IP range blocking', () => {
+  test('blocks loopback, private, link-local and cloud-metadata IPv4 addresses', async () => {
+    const { __testing } = await import('../safeFetch')
+    const blocked = [
+      '127.0.0.1',
+      '10.0.0.5',
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.1.1',
+      '169.254.169.254', // cloud metadata
+      '0.0.0.0',
+      '100.64.0.1',
+      '224.0.0.1',
+      '255.255.255.255',
+    ]
+    for (const ip of blocked) {
+      expect(__testing.isBlockedIPv4(ip)).toBe(true)
+    }
+  })
+
+  test('allows ordinary public IPv4 addresses', async () => {
+    const { __testing } = await import('../safeFetch')
+    expect(__testing.isBlockedIPv4('8.8.8.8')).toBe(false)
+    expect(__testing.isBlockedIPv4('1.1.1.1')).toBe(false)
+  })
+
+  test('blocks loopback, unique-local, link-local and IPv4-mapped private IPv6 addresses', async () => {
+    const { __testing } = await import('../safeFetch')
+    expect(__testing.isBlockedIPv6('::1')).toBe(true)
+    expect(__testing.isBlockedIPv6('fe80::1')).toBe(true)
+    expect(__testing.isBlockedIPv6('fc00::1')).toBe(true)
+    expect(__testing.isBlockedIPv6('::ffff:127.0.0.1')).toBe(true)
+    expect(__testing.isBlockedIPv6('::ffff:169.254.169.254')).toBe(true)
+  })
+
+  test('allows an ordinary public IPv6 address', async () => {
+    const { __testing } = await import('../safeFetch')
+    expect(__testing.isBlockedIPv6('2606:4700:4700::1111')).toBe(false)
+  })
+})
+
+describe('safeFetch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('rejects non-http(s) protocols before making any request', async () => {
+    const { safeFetch } = await import('../safeFetch')
+    await expect(safeFetch('file:///etc/passwd')).rejects.toThrow(/non-http/)
+    expect(undiciFetchMock).not.toHaveBeenCalled()
+  })
+
+  test('rejects a literal loopback IP before making any request', async () => {
+    const { safeFetch } = await import('../safeFetch')
+    await expect(safeFetch('http://127.0.0.1/secret')).rejects.toThrow(/non-public/)
+    expect(undiciFetchMock).not.toHaveBeenCalled()
+  })
+
+  test('rejects a literal cloud-metadata IP before making any request', async () => {
+    const { safeFetch } = await import('../safeFetch')
+    await expect(safeFetch('http://169.254.169.254/latest/meta-data')).rejects.toThrow(/non-public/)
+    expect(undiciFetchMock).not.toHaveBeenCalled()
+  })
+
+  test('enforces the maximum response size and cancels the stream', async () => {
+    const cancel = vi.fn()
+    const chunk = new Uint8Array(1024)
+    let reads = 0
+    const reader = {
+      read: vi.fn(async () => {
+        reads += 1
+        if (reads > 3) return { done: true, value: undefined }
+        return { done: false, value: chunk }
+      }),
+      cancel,
+    }
+    undiciFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: { getReader: () => reader },
+    })
+
+    const { safeFetch } = await import('../safeFetch')
+    await expect(safeFetch('http://example.com/big', { maxBytes: 2000 })).rejects.toThrow(
+      /exceeded the maximum allowed size/
+    )
+    expect(cancel).toHaveBeenCalled()
+  })
+
+  test('returns the concatenated body when under the size limit', async () => {
+    const part1 = new Uint8Array([1, 2, 3])
+    const part2 = new Uint8Array([4, 5])
+    let reads = 0
+    const reader = {
+      read: vi.fn(async () => {
+        reads += 1
+        if (reads === 1) return { done: false, value: part1 }
+        if (reads === 2) return { done: false, value: part2 }
+        return { done: true, value: undefined }
+      }),
+      cancel: vi.fn(),
+    }
+    undiciFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: { getReader: () => reader },
+    })
+
+    const { safeFetch } = await import('../safeFetch')
+    const result = await safeFetch('http://example.com/small')
+    expect(new Uint8Array(result)).toEqual(new Uint8Array([1, 2, 3, 4, 5]))
+  })
+
+  test('throws when the response is not ok', async () => {
+    undiciFetchMock.mockResolvedValue({ ok: false, status: 404 })
+    const { safeFetch } = await import('../safeFetch')
+    await expect(safeFetch('http://example.com/missing')).rejects.toThrow(/HTTP 404/)
+  })
+})

--- a/apps/backend/lib/net/safeFetch.ts
+++ b/apps/backend/lib/net/safeFetch.ts
@@ -1,0 +1,144 @@
+import { Agent, fetch as undiciFetch } from 'undici'
+import dns from 'node:dns'
+import net from 'node:net'
+
+/**
+ * Blocks fetches that resolve to loopback, private, link-local (including the
+ * 169.254.169.254 cloud metadata address), or otherwise non-public IP ranges. The
+ * check runs inside the connector's `lookup`, so it applies to every redirect hop and
+ * to the actual TCP connection undici makes — not just to a DNS lookup done up front
+ * that a DNS-rebinding attacker could bypass by resolving differently a moment later.
+ */
+
+function isBlockedIPv4(ip: string): boolean {
+  const parts = ip.split('.').map(Number)
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p))) return true
+  const [a, b] = parts
+  if (a === 0) return true // 0.0.0.0/8
+  if (a === 10) return true // 10.0.0.0/8
+  if (a === 100 && b >= 64 && b <= 127) return true // 100.64.0.0/10 (CGNAT)
+  if (a === 127) return true // 127.0.0.0/8 (loopback)
+  if (a === 169 && b === 254) return true // 169.254.0.0/16 (link-local incl. cloud metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true // 172.16.0.0/12
+  if (a === 192 && b === 0 && parts[2] === 0) return true // 192.0.0.0/24
+  if (a === 192 && b === 0 && parts[2] === 2) return true // 192.0.2.0/24 (TEST-NET-1)
+  if (a === 192 && b === 88 && parts[2] === 99) return true // 192.88.99.0/24
+  if (a === 192 && b === 168) return true // 192.168.0.0/16
+  if (a === 198 && (b === 18 || b === 19)) return true // 198.18.0.0/15
+  if (a === 198 && b === 51 && parts[2] === 100) return true // 198.51.100.0/24 (TEST-NET-2)
+  if (a === 203 && b === 0 && parts[2] === 113) return true // 203.0.113.0/24 (TEST-NET-3)
+  if (a >= 224) return true // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved + broadcast
+  return false
+}
+
+function isBlockedIPv6(ip: string): boolean {
+  const normalized = ip.toLowerCase()
+  if (normalized === '::1' || normalized === '::') return true
+  const v4Mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/.exec(normalized)
+  if (v4Mapped) return isBlockedIPv4(v4Mapped[1])
+  const firstGroup = normalized.split(':')[0]
+  const firstHextet = parseInt(firstGroup || '0', 16) || 0
+  if ((firstHextet & 0xfe00) === 0xfc00) return true // fc00::/7 unique local
+  if ((firstHextet & 0xffc0) === 0xfe80) return true // fe80::/10 link-local
+  if ((firstHextet & 0xff00) === 0xff00) return true // ff00::/8 multicast
+  if (normalized.startsWith('2001:db8:')) return true // documentation range
+  if (normalized.startsWith('100::')) return true // discard-only prefix
+  return false
+}
+
+function isBlockedIp(address: string, family: number): boolean {
+  return family === 6 ? isBlockedIPv6(address) : isBlockedIPv4(address)
+}
+
+export const __testing = { isBlockedIPv4, isBlockedIPv6 }
+
+const safeLookup: typeof dns.lookup = ((hostname: string, options: unknown, callback: unknown) => {
+  const cb = (typeof options === 'function' ? options : callback) as (
+    err: NodeJS.ErrnoException | null,
+    address: string | dns.LookupAddress[],
+    family?: number
+  ) => void
+  const opts = typeof options === 'function' ? {} : ((options ?? {}) as dns.LookupOptions)
+
+  dns.lookup(hostname, { ...opts, all: true }, (err, addresses) => {
+    if (err) return cb(err, [] as never)
+    const list = addresses as dns.LookupAddress[]
+    const allowed = list.filter((a) => !isBlockedIp(a.address, a.family))
+    if (allowed.length === 0) {
+      cb(new Error(`Refusing to connect to a non-public address for host ${hostname}`), [] as never)
+      return
+    }
+    if (opts.all) {
+      cb(null, allowed as never)
+    } else {
+      cb(null, allowed[0].address, allowed[0].family)
+    }
+  })
+}) as typeof dns.lookup
+
+const safeAgent = new Agent({
+  connect: { lookup: safeLookup },
+})
+
+const DEFAULT_TIMEOUT_MS = 10_000
+const DEFAULT_MAX_BYTES = 25 * 1024 * 1024
+
+/**
+ * Fetch that only follows http(s), pins DNS resolution (including every redirect
+ * hop) to public IP addresses, times out, and caps the response body size. Use this
+ * instead of the global `fetch` for any URL that isn't already known to be safe
+ * (e.g. taken from user-controlled content) and whose response is read server-side.
+ */
+export async function safeFetch(
+  url: string,
+  options: { timeoutMs?: number; maxBytes?: number } = {}
+): Promise<ArrayBuffer> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES
+
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error(`Invalid URL: ${url}`)
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Refusing to fetch a non-http(s) URL: ${url}`)
+  }
+  if (net.isIP(parsed.hostname) && isBlockedIp(parsed.hostname, net.isIP(parsed.hostname))) {
+    throw new Error(`Refusing to connect to a non-public address: ${parsed.hostname}`)
+  }
+
+  const response = await undiciFetch(parsed, {
+    dispatcher: safeAgent,
+    redirect: 'follow',
+    signal: AbortSignal.timeout(timeoutMs),
+  } as never)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`)
+  }
+
+  const reader = response.body?.getReader()
+  if (!reader) {
+    return new ArrayBuffer(0)
+  }
+  const chunks: Uint8Array[] = []
+  let total = 0
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    total += value.byteLength
+    if (total > maxBytes) {
+      await reader.cancel()
+      throw new Error(`Response for ${url} exceeded the maximum allowed size of ${maxBytes} bytes`)
+    }
+    chunks.push(value)
+  }
+  const result = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    result.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return result.buffer
+}


### PR DESCRIPTION
## Summary
Closes an SSRF in DOCX export: `renderDocxFromMarkdown` fetched arbitrary image URLs from client-supplied markdown with the bare global `fetch()`, with no protocol/host restriction, no check against loopback/private/link-local addresses, no timeout, and no response size cap — so any authenticated user exporting a conversation to DOCX could point an `![img](...)` reference at an internal service or the cloud metadata endpoint and get the response bytes embedded back into the file they download.

## Details
- New `apps/backend/lib/net/safeFetch.ts`: a hardened fetch for URLs taken from user-controlled content. Only `http`/`https` are allowed; DNS resolution is pinned to public addresses via a custom `undici` connector `lookup`, which is invoked by undici at actual connect time for every redirect hop — not just once up front, which is what makes it hold up against DNS-rebinding rather than just a naive pre-check. Adds a request timeout (10s default) and a response size cap (25MB default) enforced while streaming the body.
- `apps/backend/lib/docx/export.ts`'s `loadImageData` now calls `safeFetch` instead of the raw `fetch` for non-`/api/files` image URLs. The already-authorized `/api/files/{id}/content` path (fixed in a prior PR) is unchanged.

## Risks
- `safeFetch` is scoped to the DOCX export path in this PR. Other outbound calls the original findings flagged (OpenAPI tool remotes, MCP OAuth/discovery, OIDC discovery) are a separate, broader effort and not touched here.
- Verified manually against a real local HTTP server: a literal `127.0.0.1` target and a `localhost` hostname target were both blocked even though something was actually listening (not just refused because nothing was there), while a real public HTTPS URL succeeded.

## Tests
- `npm run check-types` — clean
- `npx vitest run` — 1014 passed, 21 skipped (full suite)
- `npx biome check` on the changed files — clean
- Added `apps/backend/lib/net/__tests__/safeFetch.test.ts` (10 tests: IPv4/IPv6 blocking table, protocol rejection, literal private/metadata IP rejection, size cap enforcement + stream cancellation, non-ok response handling)
- Manual smoke test with a real listening server on `127.0.0.1` (both by literal IP and by `localhost` hostname) confirming the block engages before any data is read, plus a successful fetch of a real public HTTPS URL