### PR TITLE
Cover chat attachments and tool invocation in the mock smoke test

### DIFF
--- a/apps/backend/lib/chat/echo-language-model.ts
+++ b/apps/backend/lib/chat/echo-language-model.ts
@@ -1,6 +1,7 @@
 import {
   LanguageModelV3,
   LanguageModelV3CallOptions,
+  LanguageModelV3FunctionTool,
   LanguageModelV3GenerateResult,
   LanguageModelV3StreamResult,
 } from '@ai-sdk/provider'
@@ -16,13 +17,61 @@ function extractLastUserText(options: LanguageModelV3CallOptions): string {
   return ''
 }
 
+/** Text of the most recent tool result in the prompt, if a tool has already run. */
+function extractToolResultText(options: LanguageModelV3CallOptions): string | undefined {
+  for (let i = options.prompt.length - 1; i >= 0; i--) {
+    const message = options.prompt[i]
+    if (message.role !== 'tool') continue
+    for (const part of message.content) {
+      if (part.type !== 'tool-result') continue
+      const output = part.output
+      if (output.type === 'text') return output.value
+      if (output.type === 'json') return JSON.stringify(output.value)
+      return undefined
+    }
+  }
+  return undefined
+}
+
+function firstFunctionTool(
+  options: LanguageModelV3CallOptions
+): LanguageModelV3FunctionTool | undefined {
+  return options.tools?.find(
+    (tool): tool is LanguageModelV3FunctionTool => tool.type === 'function'
+  )
+}
+
+/** Fills every required property of the tool's input schema with a fixed dummy value. */
+function dummyToolInput(tool: LanguageModelV3FunctionTool): string {
+  const schema = tool.inputSchema as {
+    properties?: Record<string, { type?: string }>
+    required?: string[]
+  }
+  const args: Record<string, unknown> = {}
+  for (const key of schema.required ?? []) {
+    const type = schema.properties?.[key]?.type
+    args[key] = type === 'number' || type === 'integer' ? 0 : type === 'boolean' ? true : 'mock'
+  }
+  return JSON.stringify(args)
+}
+
 const MOCK_USAGE = Object.freeze({
   inputTokens: Object.freeze({ total: 1, noCache: 1, cacheRead: undefined, cacheWrite: undefined }),
   outputTokens: Object.freeze({ total: 1, text: 1, reasoning: undefined }),
 })
 
 const MOCK_FINISH_REASON = Object.freeze({ unified: 'stop' as const, raw: 'stop' })
+const MOCK_TOOL_CALL_FINISH_REASON = Object.freeze({ unified: 'tool-calls' as const, raw: 'tool_calls' })
+const MOCK_TOOL_CALL_ID = 'mock-tool-call-1'
 
+/**
+ * Deterministic fake LLM used by `providerType: 'mock'` (gated behind
+ * ALLOW_MOCK_PROVIDER). Echoes the last user message back, except:
+ * - if the call includes function tools and no tool result is in the prompt
+ *   yet, it calls the first tool instead of answering, so the mock pipeline
+ *   also exercises real tool invocation.
+ * - once a tool result is present, it echoes the user text plus the result.
+ */
 export class EchoLanguageModel implements LanguageModelV3 {
   readonly specificationVersion = 'v3' as const
   readonly provider = 'mock'
@@ -30,6 +79,24 @@ export class EchoLanguageModel implements LanguageModelV3 {
   readonly supportedUrls = {}
 
   async doGenerate(options: LanguageModelV3CallOptions): Promise<LanguageModelV3GenerateResult> {
+    const toolResultText = extractToolResultText(options)
+    if (toolResultText !== undefined) {
+      const text = `Echo: ${extractLastUserText(options)} [tool result: ${toolResultText}]`
+      return { content: [{ type: 'text', text }], finishReason: MOCK_FINISH_REASON, usage: MOCK_USAGE, warnings: [] }
+    }
+
+    const tool = firstFunctionTool(options)
+    if (tool) {
+      return {
+        content: [
+          { type: 'tool-call', toolCallId: MOCK_TOOL_CALL_ID, toolName: tool.name, input: dummyToolInput(tool) },
+        ],
+        finishReason: MOCK_TOOL_CALL_FINISH_REASON,
+        usage: MOCK_USAGE,
+        warnings: [],
+      }
+    }
+
     const text = `Echo: ${extractLastUserText(options)}`
     return {
       content: [{ type: 'text', text }],
@@ -40,17 +107,47 @@ export class EchoLanguageModel implements LanguageModelV3 {
   }
 
   async doStream(options: LanguageModelV3CallOptions): Promise<LanguageModelV3StreamResult> {
+    const toolResultText = extractToolResultText(options)
+    if (toolResultText !== undefined) {
+      const text = `Echo: ${extractLastUserText(options)} [tool result: ${toolResultText}]`
+      return { stream: textStream(text) }
+    }
+
+    const tool = firstFunctionTool(options)
+    if (tool) {
+      return { stream: toolCallStream(tool) }
+    }
+
     const text = `Echo: ${extractLastUserText(options)}`
-    const stream = new ReadableStream({
-      start(controller) {
-        controller.enqueue({ type: 'stream-start', warnings: [] })
-        controller.enqueue({ type: 'text-start', id: 'text-0' })
-        controller.enqueue({ type: 'text-delta', id: 'text-0', delta: text })
-        controller.enqueue({ type: 'text-end', id: 'text-0' })
-        controller.enqueue({ type: 'finish', finishReason: MOCK_FINISH_REASON, usage: MOCK_USAGE })
-        controller.close()
-      },
-    })
-    return { stream }
+    return { stream: textStream(text) }
   }
+}
+
+function textStream(text: string) {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'stream-start', warnings: [] })
+      controller.enqueue({ type: 'text-start', id: 'text-0' })
+      controller.enqueue({ type: 'text-delta', id: 'text-0', delta: text })
+      controller.enqueue({ type: 'text-end', id: 'text-0' })
+      controller.enqueue({ type: 'finish', finishReason: MOCK_FINISH_REASON, usage: MOCK_USAGE })
+      controller.close()
+    },
+  })
+}
+
+function toolCallStream(tool: LanguageModelV3FunctionTool) {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'stream-start', warnings: [] })
+      controller.enqueue({
+        type: 'tool-call',
+        toolCallId: MOCK_TOOL_CALL_ID,
+        toolName: tool.name,
+        input: dummyToolInput(tool),
+      })
+      controller.enqueue({ type: 'finish', finishReason: MOCK_TOOL_CALL_FINISH_REASON, usage: MOCK_USAGE })
+      controller.close()
+    },
+  })
 }

--- a/apps/backend/scripts/smoke.ts
+++ b/apps/backend/scripts/smoke.ts
@@ -621,6 +621,25 @@ async function main() {
     throw new Error(`User tools did not include the shared tool: ${visibleTools.text}`)
   }
 
+  console.log('Smoke: create a real function-calling tool for the chat run below')
+  const timeOfDayToolCreated = await requestAdmin('POST', '/api/tools', {
+    expectedStatus: 201,
+    headers: jsonHeaders,
+    json: {
+      type: 'timeofday',
+      name: `Smoke TimeOfDay Tool ${runId}`,
+      description: 'Smoke time of day tool',
+      configuration: {},
+      tags: ['smoke'],
+      icon: null,
+      sharing: { type: 'workspace', workspaces: [workspaceJson.id] },
+      promptFragment: 'smoke-timeofday',
+    },
+  })
+  const timeOfDayToolId = (
+    parseJson(timeOfDayToolCreated.text, '/api/tools POST (timeofday)') as { id: string }
+  ).id
+
   console.log('Smoke: file upload baseline')
   const fileCreated = await requestUser('POST', '/api/files', {
     expectedStatus: 201,
@@ -867,6 +886,120 @@ async function main() {
   const errorEvent = chatEvents.find((event) => event.part?.type === 'error')
   if (errorEvent?.part?.error) {
     throw new Error(`Chat response contained error part: ${errorEvent.part.error}`)
+  }
+
+  console.log('Smoke: chat message with a file attachment reassigns file ownership to the conversation')
+  const attachmentChat = await requestUser('POST', '/api/chat', {
+    expectedStatus: 200,
+    headers: { ...jsonHeaders, accept: 'text/event-stream' },
+    json: {
+      id: `msg-attach-${runId}`,
+      conversationId,
+      parent: chatMessageId,
+      role: 'user',
+      content: 'here is a file',
+      attachments: [{ id: fileId, name: `smoke-${runId}.txt`, mimetype: 'text/plain', size: 11 }],
+    },
+  })
+  const attachmentChatEvents = parseSseData(
+    attachmentChat.text,
+    '/api/chat SSE (attachment)'
+  ) as Array<{ type?: string; text?: string; part?: { type?: string; error?: string } }>
+  const attachmentStreamedText = attachmentChatEvents
+    .filter((event) => event.type === 'text')
+    .map((event) => event.text ?? '')
+    .join('')
+  if (attachmentStreamedText !== 'Echo: here is a file') {
+    throw new Error(`Chat response with attachment did not echo as expected: ${attachmentChat.text}`)
+  }
+  const attachmentErrorEvent = attachmentChatEvents.find((event) => event.part?.type === 'error')
+  if (attachmentErrorEvent?.part?.error) {
+    throw new Error(`Chat response with attachment contained error part: ${attachmentErrorEvent.part.error}`)
+  }
+  const attachedFileDetails = await requestUser('GET', `/api/files/${fileId}`, {
+    expectedStatus: 200,
+    headers: sameOriginHeaders,
+  })
+  const attachedFileJson = parseJson(attachedFileDetails.text, `/api/files/${fileId} after attach`) as {
+    owner: { ownerType: string; ownerId: string }
+  }
+  if (attachedFileJson.owner.ownerType !== 'CHAT' || attachedFileJson.owner.ownerId !== conversationId) {
+    throw new Error(`Attached file was not reassigned to the conversation: ${attachedFileDetails.text}`)
+  }
+
+  console.log('Smoke: chat run actually invokes a real function-calling tool')
+  const toolAssistantCreated = await requestUser('POST', '/api/assistants', {
+    expectedStatus: 201,
+    headers: jsonHeaders,
+    json: {
+      backendId,
+      description: 'Smoke tool-calling assistant',
+      model: 'mock-echo',
+      name: 'Smoke Tool Assistant',
+      systemPrompt: 'You are a smoke test assistant with tool access.',
+      temperature: 0.2,
+      tokenLimit: 4096,
+      reasoning_effort: null,
+      tags: [],
+      prompts: [],
+      tools: [timeOfDayToolId],
+      files: [],
+      iconUri: null,
+    },
+  })
+  const toolAssistantId = (
+    parseJson(toolAssistantCreated.text, '/api/assistants POST (tools)') as { assistantId: string }
+  ).assistantId
+  await requestUser('POST', `/api/assistants/${toolAssistantId}/sharing`, {
+    expectedStatus: 200,
+    headers: jsonHeaders,
+    json: [{ type: 'workspace', workspaceId: workspaceJson.id, workspaceName: workspaceJson.name }],
+  })
+  await requestUser('POST', `/api/assistants/${toolAssistantId}/publish`, {
+    expectedStatus: 200,
+    headers: jsonHeaders,
+    json: { versionName: `Smoke Tool Publish ${runId}` },
+  })
+  const toolConversationCreated = await requestUser('POST', '/api/conversations', {
+    expectedStatus: 201,
+    headers: jsonHeaders,
+    json: { assistantId: toolAssistantId, name: 'Smoke Tool Conversation' },
+  })
+  const toolConversationId = (
+    parseJson(toolConversationCreated.text, '/api/conversations POST (tools)') as { id: string }
+  ).id
+
+  const toolChat = await requestUser('POST', '/api/chat', {
+    expectedStatus: 200,
+    headers: { ...jsonHeaders, accept: 'text/event-stream' },
+    json: {
+      id: `msg-tool-${runId}`,
+      conversationId: toolConversationId,
+      parent: null,
+      role: 'user',
+      content: 'what time is it',
+      attachments: [],
+    },
+  })
+  const toolChatEvents = parseSseData(toolChat.text, '/api/chat SSE (tools)') as Array<{
+    type?: string
+    text?: string
+    part?: { type?: string; toolName?: string; error?: string }
+  }>
+  const toolCallEvent = toolChatEvents.find((event) => event.part?.type === 'tool-call')
+  if (!toolCallEvent?.part?.toolName?.endsWith('timeOfDay')) {
+    throw new Error(`Chat run did not invoke the timeOfDay tool: ${toolChat.text}`)
+  }
+  const toolStreamedText = toolChatEvents
+    .filter((event) => event.type === 'text')
+    .map((event) => event.text ?? '')
+    .join('')
+  if (!toolStreamedText.startsWith('Echo: what time is it [tool result:')) {
+    throw new Error(`Chat run final answer did not include the tool result: ${toolChat.text}`)
+  }
+  const toolErrorEvent = toolChatEvents.find((event) => event.part?.type === 'error')
+  if (toolErrorEvent?.part?.error) {
+    throw new Error(`Tool chat response contained error part: ${toolErrorEvent.part.error}`)
   }
 
   console.log('Smoke: conversation share and feedback')

--- a/packages/core/src/models/mock.ts
+++ b/packages/core/src/models/mock.ts
@@ -10,7 +10,7 @@ export const mockEchoModel: LlmModel = {
   context_length: 128000,
   capabilities: {
     vision: false,
-    function_calling: false,
+    function_calling: true,
   },
 }
 


### PR DESCRIPTION
## Summary
Extends the mock-LLM smoke test (`apps/backend/scripts/smoke.ts`, run in CI on every push against a real Docker deployment) to exercise two happy-path flows that had no coverage: attaching a file to a chat message, and a real tool being invoked mid chat-run. `EchoLanguageModel` (the fake LLM behind `providerType: 'mock'`) now supports deterministic function-calling — it calls the first available tool when one is offered and no tool result is in the prompt yet, then echoes the tool result back on the following turn.

## Details
- `EchoLanguageModel.doGenerate`/`doStream` detect available function tools and a pending tool result in the prompt, and branch between: plain echo, emitting a tool-call, or echoing `Echo: <text> [tool result: <result>]`.
- `mock-echo`'s catalog entry now declares `function_calling: true` (was `false`), otherwise tools are stripped before reaching the model.
- `smoke.ts` now: (1) sends a second chat message with a file attachment and asserts the file is reassigned to the conversation (`ownerType: 'CHAT'`), exercising `canAccessFile`/`reassignUserOwnedFilesToConversation` for real; (2) creates a `timeofday` tool (deterministic, no external service), attaches it to a dedicated assistant, and asserts the chat run's SSE stream contains a real tool-call and a final answer that includes the tool's result.

## Tests
- `npm run check-types` — clean.
- `npx vitest run` — 112 files, 1014 tests passing, 0 failures.
- Built `smoke.ts` (`npm run build:smoke`) and ran it against a locally started server (fresh sqlite DB, `ALLOW_MOCK_PROVIDER=1`) — full smoke suite passes end-to-end, including the two new scenarios.