### PR TITLE
Document coverage strategy and unit-test the mock pipeline's pure logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ The frontend builds with `output: 'export'` (see `apps/frontend/next.config.ts`)
 
 - If you notice missing, outdated, or incomplete instructions here, propose specific additions or edits to the user.
 - To verify type correctness, run `npm run check-types`.
+- Two different layers own coverage: `apps/backend/scripts/smoke.ts`/`integration-baseline.ts` (real Docker deploy, CI) prove routes/auth/DB wiring end-to-end and should stay scoped to that, not be used to chase statement coverage; `vitest` unit tests under `__tests__/` are where statement coverage on pure logic (`packages/core/src/**`, `apps/backend/lib/**`) should be pushed up. See [`docs/testing-strategy.md`](docs/testing-strategy.md) before adding either kind — it lists what's legitimately untestable (type-only files, generated code, process bootstraps) versus the prioritized backlog of real gaps.
 - DTO naming convention: prefer `Entity`, `InsertableEntity`, `UpdateableEntity` in `packages/core/src/types/dto/**`.
 - Avoid upsert endpoints unless explicitly requested; prefer create + update with explicit errors on duplicates.
 - Use `PATCH` for update endpoints.

--- a/apps/backend/lib/chat/__tests__/echo-language-model.test.ts
+++ b/apps/backend/lib/chat/__tests__/echo-language-model.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from 'vitest'
+import type { LanguageModelV3CallOptions, LanguageModelV3FunctionTool } from '@ai-sdk/provider'
+import { EchoLanguageModel } from '../echo-language-model'
+
+function userPrompt(text: string): LanguageModelV3CallOptions['prompt'] {
+  return [{ role: 'user', content: [{ type: 'text', text }] }]
+}
+
+function options(overrides: Partial<LanguageModelV3CallOptions> = {}): LanguageModelV3CallOptions {
+  return { prompt: userPrompt('hello'), ...overrides } as LanguageModelV3CallOptions
+}
+
+const weatherTool: LanguageModelV3FunctionTool = {
+  type: 'function',
+  name: 'get_weather',
+  inputSchema: {
+    type: 'object',
+    properties: { city: { type: 'string' }, days: { type: 'number' }, exact: { type: 'boolean' } },
+    required: ['city', 'days', 'exact'],
+  },
+}
+
+async function collectStream(stream: ReadableStream<unknown>): Promise<unknown[]> {
+  const reader = stream.getReader()
+  const parts: unknown[] = []
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    parts.push(value)
+  }
+  return parts
+}
+
+describe('EchoLanguageModel', () => {
+  test('doGenerate echoes the last user message when no tools are offered', async () => {
+    const model = new EchoLanguageModel()
+    const result = await model.doGenerate(options({ prompt: userPrompt('hello integration') }))
+    expect(result.content).toEqual([{ type: 'text', text: 'Echo: hello integration' }])
+    expect(result.finishReason).toEqual({ unified: 'stop', raw: 'stop' })
+  })
+
+  test('doGenerate picks the last user message when the prompt has multiple turns', async () => {
+    const model = new EchoLanguageModel()
+    const result = await model.doGenerate(
+      options({
+        prompt: [
+          { role: 'user', content: [{ type: 'text', text: 'first' }] },
+          { role: 'assistant', content: [{ type: 'text', text: 'reply' }] },
+          { role: 'user', content: [{ type: 'text', text: 'second' }] },
+        ],
+      })
+    )
+    expect(result.content).toEqual([{ type: 'text', text: 'Echo: second' }])
+  })
+
+  test('doGenerate calls the first function tool instead of answering when tools are offered', async () => {
+    const model = new EchoLanguageModel()
+    const result = await model.doGenerate(options({ tools: [weatherTool] }))
+    expect(result.finishReason).toEqual({ unified: 'tool-calls', raw: 'tool_calls' })
+    expect(result.content).toHaveLength(1)
+    const [call] = result.content
+    expect(call).toMatchObject({ type: 'tool-call', toolName: 'get_weather' })
+    if (call.type !== 'tool-call') throw new Error('expected a tool-call')
+    expect(JSON.parse(call.input as string)).toEqual({ city: 'mock', days: 0, exact: true })
+  })
+
+  test('doGenerate ignores non-function provider tools', async () => {
+    const model = new EchoLanguageModel()
+    const result = await model.doGenerate(
+      options({ tools: [{ type: 'provider-defined', id: 'x.y', name: 'y', args: {} } as never] })
+    )
+    expect(result.content).toEqual([{ type: 'text', text: 'Echo: hello' }])
+  })
+
+  test('doGenerate echoes the tool result once one is present in the prompt', async () => {
+    const model = new EchoLanguageModel()
+    const result = await model.doGenerate(
+      options({
+        tools: [weatherTool],
+        prompt: [
+          ...userPrompt('what is the weather'),
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call-1',
+                toolName: 'get_weather',
+                output: { type: 'text', value: 'sunny' },
+              },
+            ],
+          },
+        ],
+      })
+    )
+    expect(result.content).toEqual([
+      { type: 'text', text: 'Echo: what is the weather [tool result: sunny]' },
+    ])
+    expect(result.finishReason).toEqual({ unified: 'stop', raw: 'stop' })
+  })
+
+  test('doGenerate stringifies a json tool result', async () => {
+    const model = new EchoLanguageModel()
+    const result = await model.doGenerate(
+      options({
+        tools: [weatherTool],
+        prompt: [
+          ...userPrompt('what is the weather'),
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call-1',
+                toolName: 'get_weather',
+                output: { type: 'json', value: { temp: 22 } },
+              },
+            ],
+          },
+        ],
+      })
+    )
+    expect(result.content).toEqual([
+      { type: 'text', text: 'Echo: what is the weather [tool result: {"temp":22}]' },
+    ])
+  })
+
+  test('doStream emits a plain echo when no tools are offered', async () => {
+    const model = new EchoLanguageModel()
+    const { stream } = await model.doStream(options({ prompt: userPrompt('stream me') }))
+    const parts = await collectStream(stream)
+    expect(parts).toContainEqual({ type: 'text-delta', id: 'text-0', delta: 'Echo: stream me' })
+    expect(parts.some((p) => (p as { type: string }).type === 'tool-call')).toBe(false)
+  })
+
+  test('doStream emits a tool-call when tools are offered and no result is present yet', async () => {
+    const model = new EchoLanguageModel()
+    const { stream } = await model.doStream(options({ tools: [weatherTool] }))
+    const parts = await collectStream(stream)
+    const toolCall = parts.find((p) => (p as { type: string }).type === 'tool-call') as {
+      toolName: string
+      input: string
+    }
+    expect(toolCall).toBeDefined()
+    expect(toolCall.toolName).toBe('get_weather')
+    const finish = parts.find((p) => (p as { type: string }).type === 'finish') as {
+      finishReason: { unified: string }
+    }
+    expect(finish.finishReason.unified).toBe('tool-calls')
+  })
+
+  test('doStream emits the tool result echo once a result is present in the prompt', async () => {
+    const model = new EchoLanguageModel()
+    const { stream } = await model.doStream(
+      options({
+        tools: [weatherTool],
+        prompt: [
+          ...userPrompt('what is the weather'),
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call-1',
+                toolName: 'get_weather',
+                output: { type: 'text', value: 'sunny' },
+              },
+            ],
+          },
+        ],
+      })
+    )
+    const parts = await collectStream(stream)
+    expect(parts).toContainEqual({
+      type: 'text-delta',
+      id: 'text-0',
+      delta: 'Echo: what is the weather [tool result: sunny]',
+    })
+  })
+})

--- a/apps/backend/lib/tools/timeofday/__tests__/implementation.test.ts
+++ b/apps/backend/lib/tools/timeofday/__tests__/implementation.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test, vi } from 'vitest'
+import type { LlmModel } from '@/lib/chat/models'
+import type { ToolFunction, ToolParams } from '@/lib/chat/tools'
+import { TimeOfDay } from '../implementation'
+
+const model = { model: 'gpt-4o-mini' } as unknown as LlmModel
+
+const toolParams: ToolParams = {
+  id: 't1',
+  name: 'timeofday',
+  promptFragment: '',
+  provisioned: false,
+}
+
+describe('TimeOfDay tool', () => {
+  test('builder constructs an instance from raw tool params', () => {
+    const tool = TimeOfDay.builder(toolParams, {}, model.model) as TimeOfDay
+    expect(tool).toBeInstanceOf(TimeOfDay)
+    expect(tool.toolParams).toBe(toolParams)
+    expect(tool.supportedMedia).toEqual([])
+  })
+
+  test('exposes a single timeOfDay function requiring no parameters', async () => {
+    const tool = new TimeOfDay(toolParams)
+    const functions = await tool.functions(model, { userId: 'u1' })
+    expect(Object.keys(functions)).toEqual(['timeOfDay'])
+    const timeOfDay = functions.timeOfDay as ToolFunction
+    expect(timeOfDay.parameters).toEqual({
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    })
+    expect(timeOfDay.requireConfirm).toBe(false)
+  })
+
+  test('invoking timeOfDay returns the current time as an ISO 8601 string', async () => {
+    const tool = new TimeOfDay(toolParams)
+    const functions = await tool.functions(model, { userId: 'u1' })
+    const timeOfDay = functions.timeOfDay as ToolFunction
+    const before = Date.now()
+    const result = await timeOfDay.invoke({
+      llmModel: model,
+      messages: [],
+      assistantId: 'a1',
+      userId: 'u1',
+      params: {},
+      uiLink: { debugMessage: vi.fn(), addCitations: vi.fn(), attachments: [], citations: [] },
+    })
+    const after = Date.now()
+
+    expect(result.type).toBe('text')
+    if (result.type !== 'text') throw new Error('expected a text result')
+    const returned = new Date(result.value).getTime()
+    expect(returned).toBeGreaterThanOrEqual(before)
+    expect(returned).toBeLessThanOrEqual(after)
+  })
+})

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,0 +1,100 @@
+# Testing strategy: where coverage should come from
+
+This repo has two very different kinds of test, and confusing which one
+should cover a given piece of code either wastes effort (reimplementing
+`smoke.ts` at the unit level) or leaves gaps (business logic nobody ever
+calls except in a full docker deploy). This doc records the split, and a
+prioritized backlog for closing gaps in the "should be unit tested" bucket.
+
+## The two layers
+
+**`apps/backend/scripts/smoke.ts`** (run in CI on every push, against a real
+Docker deployment, both sqlite and postgres) and
+**`apps/backend/scripts/integration-baseline.ts`** (main/dispatch only) exist
+to prove that routes, auth, DB persistence, and cross-module side effects
+actually wire together end-to-end. `providerType: 'mock'` (`EchoLanguageModel`,
+gated behind `ALLOW_MOCK_PROVIDER`) stands in for a real LLM so the chat
+pipeline can be driven without external services. Grow *this* layer only for
+things that can't be verified any other way: authn/authz boundaries, DB
+side-effects that span tables (e.g. file ownership reassignment), and
+wiring between routes and the modules behind them. Do not use it to chase
+statement coverage — every extra smoke scenario costs a full server
+build+boot cycle to iterate on, versus milliseconds for a unit test.
+
+**`vitest` unit/integration tests under `__tests__/` and
+`**/__tests__/`** (run via `npm run test:coverage`, coverage scoped to
+`packages/core/src/**` and `apps/backend/lib/**` in `vitest.config.ts`) are
+where statement-coverage percentage should actually be pushed. Most of the
+codebase's real branching logic — validation, transforms, request/response
+shaping, error classification — lives here and needs zero DB or network
+access to exercise.
+
+## What NOT to chase for coverage
+
+A large share of the lowest-covered files in the current report are not
+undertested business logic — they're one of these, and 0% there is expected,
+not a gap:
+
+- **Type-only modules** with no runtime code: `packages/core/src/types/base.ts`,
+  `folder.ts`, `provider.ts`, `session.ts`, `stats.ts`, `compression.ts`,
+  `packages/core/src/chat/tools.ts` / `types.ts`,
+  `packages/core/src/tools/openapi-types.ts`, `apps/backend/lib/chat/ClientSink.ts`,
+  `apps/backend/lib/chat/usage.ts`, `apps/backend/lib/imagegen/types.ts`.
+  There's nothing executable to cover.
+- **Generated code**: `apps/backend/lib/router/*.generated.ts`,
+  `apps/backend/db/migrations.generated.ts`,
+  `apps/backend/lib/backend/routes.generated.ts` — never hand-edited, never
+  hand-tested.
+- **Process entrypoints / worker-thread bootstraps**: `apps/backend/lib/bootstrap.ts`,
+  `apps/backend/lib/provision.ts`, `apps/backend/lib/chat/tokenizer-worker/{runtime,script}.ts`,
+  `apps/backend/lib/search/{runtime,script}.ts`, `apps/backend/lib/satellite/server.ts`,
+  `apps/backend/lib/tracing/telemetry.ts`, `apps/backend/lib/staticFrontendVite.ts`
+  (dev-only Vite middleware, never runs in production). These only make sense
+  exercised by actually booting the process — i.e. smoke.ts already does,
+  implicitly, every time it hits `/api/health`.
+- **Thin external-API wrappers whose only logic is "make the HTTP/SDK call"**:
+  the `invoke()` half of most `apps/backend/lib/tools/*/implementation.ts`
+  tool implementations (calls to a real search/image/transcription provider).
+  These need contract tests against the real provider or nothing at all —
+  unit-testing them means mocking the provider SDK into meaninglessness.
+
+## Where the real gaps are (backlog, roughly prioritized)
+
+These are files with substantial *pure* logic (schema/request shaping,
+branching, calculation) that are currently undertested and are cheap to
+cover with plain vitest unit tests — no DB, no network:
+
+1. `apps/backend/lib/chat/echo-language-model.ts` (~23%) — the mock LLM
+   itself gained real tool-call branching in the smoke-coverage PR; it has
+   zero dedicated unit tests despite being pure and fully deterministic.
+2. `apps/backend/lib/tools/timeofday/implementation.ts` (~25%) and other
+   small `functions()`/schema-building halves of tool implementations —
+   distinct from their `invoke()` halves (see above), the tool-schema
+   construction is pure and worth covering directly rather than only via
+   smoke.ts.
+3. `apps/backend/lib/tools/openapi/implementation.ts` (~7%, 382 lines) —
+   almost entirely request/response shaping from an OpenAPI spec; likely the
+   single highest-value target in the repo by lines-not-covered.
+4. `apps/backend/lib/tools/mcp/implementation.ts` (~17%) and `file-bridge.ts`
+   (~21%) — protocol/message shaping, separate from the actual MCP transport.
+5. `apps/backend/lib/chat/summarizer.ts` (~20%), `startServerChatRun.ts`
+   (~33%, error branches only partially covered), `chat/index.ts` (~61%,
+   large file, worth incremental coverage rather than a single pass).
+6. `apps/backend/lib/chat/litellm/litellm-provider.ts` (~7%) — provider
+   config/factory logic.
+7. `apps/backend/lib/imagegen/metering.ts` (~13%) and
+   `apps/backend/lib/tools/audio_transcription/metering.ts` (~13%) — thin
+   wrappers around the OpenMeter SDK, but the guard clauses (no-op when
+   unconfigured) and the try/catch-and-log-a-warning around the ingest call
+   are pure branching worth covering with the SDK client mocked.
+8. `packages/core/src/bootstrapPlaceholders.ts` (0%, small) — DOM-dependent
+   (`readBootstrapJson` reads `document`), needs a `jsdom` environment via
+   `// @vitest-environment jsdom` (no existing test file uses that pragma
+   yet, so this is also the first one) — quick win once that's set up.
+9. `apps/backend/lib/router.ts` (~71%, branch coverage 50%) and
+   `apps/backend/lib/logging.ts` (~35%, mixed — some pure formatting, some
+   transport wiring) — partial gaps worth closing incrementally.
+
+When picking up an item here: confirm with a quick read that the file is
+still mostly pure logic (code moves), write the unit test, and cross it off
+by deleting the line — this list is a backlog, not a permanent doc.


### PR DESCRIPTION
## Summary
(Replaces #1069, which GitHub auto-closed when #1068's base branch was deleted on squash-merge — rebased onto `main` with no content changes.)

Documents the coverage split between `smoke.ts`/`integration-baseline.ts` (route/auth/DB wiring, run against a real Docker deploy) and vitest unit tests (statement coverage on pure logic in `packages/core/src/**` and `apps/backend/lib/**`), including what's legitimately untestable (type-only files, generated code, process/worker-thread bootstraps) so future coverage work isn't spent chasing those. Starts working the resulting backlog on two files that had zero dedicated unit tests despite being pure: `EchoLanguageModel` (the mock LLM's tool-call branching from #1068) and the `timeofday` tool.

## Details
- `docs/testing-strategy.md`: the two-layer split, what not to chase for coverage, and a prioritized backlog of real gaps (ranked roughly by lines-not-covered and how purely-logical the file is). Linked from `AGENTS.md`.
- `apps/backend/lib/chat/__tests__/echo-language-model.test.ts`: covers plain echo, multi-turn "last user message" selection, tool-call emission (including ignoring non-function provider tools), and the tool-result echo branch, for both `doGenerate` and `doStream`. Coverage on the file: 22.72% -> 94.91%.
- `apps/backend/lib/tools/timeofday/__tests__/implementation.test.ts`: covers the builder, the function/schema shape, and `invoke()`'s actual timestamp. Coverage on the file: 25% -> 100%.

## Tests
- `npm run check-types` — clean.
- `npx vitest run` — 113 files, 1016 tests passing, 0 failures.