### PR TITLE
Unit-test the OpenAPI tool's spec conversion and request/response handling

### DIFF
--- a/apps/backend/lib/tools/openapi/__tests__/implementation.test.ts
+++ b/apps/backend/lib/tools/openapi/__tests__/implementation.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { ToolFunction, ToolInvokeParams, ToolParams } from '@/lib/chat/tools'
+
+const mockFetch = vi.fn()
+const mockSaveFile = vi.fn()
+const mockResolveToolSecretReference = vi.fn(async (_toolId: string, template: string) => template)
+const mockExpandEnv = vi.fn((template: string) => template)
+
+vi.mock('undici', () => ({
+  fetch: (...args: unknown[]) => mockFetch(...args),
+  Agent: class {
+    close() {
+      return Promise.resolve()
+    }
+  },
+}))
+
+vi.mock('@/backend/lib/tools/file-output-normalization', () => ({
+  saveFile: (...args: unknown[]) => mockSaveFile(...args),
+}))
+
+vi.mock('templates', () => ({
+  expandEnv: (...args: [string]) => mockExpandEnv(...args),
+  resolveToolSecretReference: (...args: [string, string]) => mockResolveToolSecretReference(...args),
+}))
+
+import { OpenApiPlugin } from '@/backend/lib/tools/openapi/implementation'
+
+const yamlSpec = `
+openapi: 3.0.0
+info:
+  title: Test API
+  version: '1.0'
+servers:
+  - url: https://api.example.com
+paths:
+  /items/{id}:
+    get:
+      operationId: getItem
+      description: Get an item
+      security:
+        - apiKeyAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: verbose
+          in: query
+          required: false
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: OK
+  /items:
+    post:
+      operationId: createItem
+      description: Create an item
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+      responses:
+        '200':
+          description: OK
+  /unsupported:
+    put:
+      operationId: unsupportedOp
+      requestBody:
+        required: true
+        content:
+          application/xml:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: OK
+components:
+  securitySchemes:
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-Api-Key
+    bearerAuth:
+      type: http
+      scheme: bearer
+`
+
+const toolParams: ToolParams = {
+  id: 'tool-1',
+  name: 'testapi',
+  promptFragment: '',
+  provisioned: false,
+}
+
+const uiLink = { debugMessage: vi.fn(), addCitations: vi.fn(), attachments: [], citations: [] }
+
+function invokeParams(overrides: Partial<ToolInvokeParams> = {}): ToolInvokeParams {
+  return {
+    llmModel: {} as never,
+    messages: [],
+    assistantId: 'a1',
+    userId: 'u1',
+    params: {},
+    uiLink,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  mockSaveFile.mockReset()
+  mockResolveToolSecretReference.mockClear()
+  mockExpandEnv.mockClear()
+  uiLink.debugMessage.mockClear()
+})
+
+// computeSecurityHeaders resolves every scheme declared under
+// components.securitySchemes for every call, regardless of which operation's
+// `security` list references it — so both schemes need a value configured.
+async function buildPlugin(config: Record<string, unknown> = {}) {
+  return (await OpenApiPlugin.builder(
+    toolParams,
+    { spec: yamlSpec, apiKeyAuth: 'k', bearerAuth: 't', ...config },
+    'gpt-4o-mini'
+  )) as OpenApiPlugin
+}
+
+describe('OpenApiPlugin spec conversion', () => {
+  it('builds one tool function per operation, merging path/query params into the schema', async () => {
+    const plugin = await buildPlugin()
+    const functions = await plugin.functions({} as never, { userId: 'u1' })
+
+    expect(functions.getItem).toBeDefined()
+    const getItem = functions.getItem as ToolFunction
+    expect(getItem.description).toBe('Get an item')
+    expect(getItem.parameters).toEqual({
+      type: 'object',
+      properties: { id: { type: 'string' }, verbose: { type: 'boolean' } },
+      required: ['id'],
+      additionalProperties: false,
+    })
+  })
+
+  it('merges the request body schema in as a required "body" property', async () => {
+    const plugin = await buildPlugin()
+    const functions = await plugin.functions({} as never, { userId: 'u1' })
+
+    const createItem = functions.createItem as ToolFunction
+    expect(createItem.parameters).toMatchObject({
+      required: ['body'],
+      properties: {
+        body: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] },
+      },
+    })
+  })
+
+  it('skips an operation whose request body media type is unsupported', async () => {
+    const plugin = await buildPlugin()
+    const functions = await plugin.functions({} as never, { userId: 'u1' })
+
+    expect(functions.unsupportedOp).toBeUndefined()
+  })
+
+  it('returns no functions and does not throw for an unparseable spec', async () => {
+    const plugin = await buildPlugin({ spec: 'not: [valid, openapi' })
+    const functions = await plugin.functions({} as never, { userId: 'u1' })
+
+    expect(functions).toEqual({})
+  })
+})
+
+function jsonResponse(body: unknown, status = 200, extraHeaders: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...extraHeaders },
+  })
+}
+
+describe('OpenApiPlugin invoke: request building', () => {
+  it('substitutes path params, sets query params, and resolves an apiKey security header', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ ok: true }))
+    const plugin = await buildPlugin({ apiKeyAuth: 'my-api-key' })
+    const functions = await plugin.functions({} as never, { userId: 'u1' })
+
+    await (functions.getItem as ToolFunction).invoke(
+      invokeParams({ params: { id: 'abc 123', verbose: true } })
+    )
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [url, requestInit] = mockFetch.mock.calls[0]
+    expect(url).toBe('https://api.example.com/items/abc%20123?verbose=true')
+    expect(requestInit.method).toBe('GET')
+    expect(requestInit.headers['X-Api-Key']).toBe('my-api-key')
+    expect(mockResolveToolSecretReference).toHaveBeenCalledWith('tool-1', 'my-api-key')
+  })
+
+  it('builds a JSON body and a bearer Authorization header, prefixing "Bearer " when missing', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ id: 1 }))
+    const plugin = await buildPlugin({ bearerAuth: 'token123' })
+    const functions = await plugin.functions({} as never, { userId: 'u1' })
+
+    await (functions.createItem as ToolFunction).invoke(
+      invokeParams({ params: { body: { name: 'widget' } } })
+    )
+
+    const [url, requestInit] = mockFetch.mock.calls[0]
+    expect(url).toBe('https://api.example.com/items')
+    expect(requestInit.method).toBe('POST')
+    expect(requestInit.body).toBe(JSON.stringify({ name: 'widget' }))
+    expect(requestInit.headers['content-type']).toBe('application/json')
+    expect(requestInit.headers.Authorization).toBe('Bearer token123')
+  })
+
+  it('does not double-prefix an already-Bearer-prefixed token', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}))
+    const plugin = await buildPlugin({ bearerAuth: 'Bearer already-prefixed' })
+    const functions = await plugin.functions({} as never, { userId: 'u1' })
+
+    await (functions.createItem as ToolFunction).invoke(
+      invokeParams({ params: { body: { name: 'x' } } })
+    )
+
+    const [, requestInit] = mockFetch.mock.calls[0]
+    expect(requestInit.headers.Authorization).toBe('Bearer already-prefixed')
+  })
+
+  it('reports HTTP request details through uiLink.debugMessage when debug is set', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}))
+    const plugin = await buildPlugin({ bearerAuth: 'token123' })
+    const functions = await plugin.functions({} as never, { userId: 'u1' })
+
+    await (functions.createItem as ToolFunction).invoke(
+      invokeParams({ params: { body: { name: 'x' } }, debug: true })
+    )
+
+    expect(uiLink.debugMessage).toHaveBeenCalledTimes(1)
+    const [message, details] = uiLink.debugMessage.mock.calls[0]
+    expect(message).toBe('HTTP POST https://api.example.com/items')
+    expect(details.headers.Authorization).toBe('<hidden>')
+  })
+
+  it('throws when a configured security parameter is missing', async () => {
+    const plugin = (await OpenApiPlugin.builder(
+      toolParams,
+      { spec: yamlSpec },
+      'gpt-4o-mini'
+    )) as OpenApiPlugin
+    const functions = await plugin.functions({} as never, { userId: 'u1' })
+
+    await expect(
+      (functions.getItem as ToolFunction).invoke(invokeParams({ params: { id: '1' } }))
+    ).rejects.toThrow(/apiKeyAuth not configured/)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('OpenApiPlugin invoke: response handling', () => {
+  it('parses a JSON response', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ id: 42 }))
+    const plugin = await buildPlugin({ apiKeyAuth: 'k' })
+    const functions = await plugin.functions({} as never, { userId: 'u1' })
+
+    const result = await (functions.getItem as ToolFunction).invoke(
+      invokeParams({ params: { id: '1' } })
+    )
+    expect(result).toEqual({ type: 'json', value: { id: 42 } })
+  })
+
+  it('returns plain text for a text/plain response', async () => {
+    mockFetch.mockResolvedValue(
+      new Response('hello world', { status: 200, headers: { 'content-type': 'text/plain' } })
+    )
+    const plugin = await buildPlugin({ apiKeyAuth: 'k' })
+    const functions = await plugin.functions({} as never, { userId: 'u1' })
+
+    const result = await (functions.getItem as ToolFunction).invoke(
+      invokeParams({ params: { id: '1' } })
+    )
+    expect(result).toEqual({ type: 'text', value: 'hello world' })
+  })
+
+  it('returns an error-text result for a non-2xx status, without throwing', async () => {
+    mockFetch.mockResolvedValue(
+      new Response('not found', { status: 404, headers: { 'content-type': 'text/plain' } })
+    )
+    const plugin = await buildPlugin({ apiKeyAuth: 'k' })
+    const functions = await plugin.functions({} as never, { userId: 'u1' })
+
+    const result = await (functions.getItem as ToolFunction).invoke(
+      invokeParams({ params: { id: '1' } })
+    )
+    expect(result).toEqual({
+      type: 'error-text',
+      value: 'Http request failed with status 404: not found',
+    })
+  })
+
+  it('persists a Content-Disposition: attachment response as a file', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: {
+          'content-type': 'application/octet-stream',
+          'content-disposition': 'attachment; filename="report.bin"',
+        },
+      })
+    )
+    mockSaveFile.mockResolvedValue({
+      type: 'file',
+      id: 'file-1',
+      mimetype: 'application/octet-stream',
+      name: 'report.bin',
+      size: 3,
+    })
+    const plugin = await buildPlugin({ apiKeyAuth: 'k' })
+    const functions = await plugin.functions({} as never, { userId: 'u1' })
+
+    const result = await (functions.getItem as ToolFunction).invoke(
+      invokeParams({ params: { id: '1' } })
+    )
+    expect(result.type).toBe('content')
+    if (result.type !== 'content') throw new Error('expected content result')
+    expect(result.value).toHaveLength(2)
+    expect(result.value[1]).toEqual({
+      type: 'file',
+      id: 'file-1',
+      mimetype: 'application/octet-stream',
+      name: 'report.bin',
+      size: 3,
+    })
+    expect(mockSaveFile).toHaveBeenCalledWith(
+      expect.objectContaining({ mimeType: 'application/octet-stream', nameHint: 'report.bin' })
+    )
+  })
+
+  it('persists a binary response with no Content-Disposition as a file', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { 'content-type': 'image/png' },
+      })
+    )
+    mockSaveFile.mockResolvedValue({
+      type: 'file',
+      id: 'file-2',
+      mimetype: 'image/png',
+      name: 'response.bin',
+      size: 3,
+    })
+    const plugin = await buildPlugin({ apiKeyAuth: 'k' })
+    const functions = await plugin.functions({} as never, { userId: 'u1' })
+
+    const result = await (functions.getItem as ToolFunction).invoke(
+      invokeParams({ params: { id: '1' } })
+    )
+    expect(result).toEqual({ type: 'content', value: [{
+      type: 'file',
+      id: 'file-2',
+      mimetype: 'image/png',
+      name: 'response.bin',
+      size: 3,
+    }] })
+  })
+})

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -64,36 +64,34 @@ These are files with substantial *pure* logic (schema/request shaping,
 branching, calculation) that are currently undertested and are cheap to
 cover with plain vitest unit tests — no DB, no network:
 
-1. `apps/backend/lib/chat/echo-language-model.ts` (~23%) — the mock LLM
-   itself gained real tool-call branching in the smoke-coverage PR; it has
-   zero dedicated unit tests despite being pure and fully deterministic.
-2. `apps/backend/lib/tools/timeofday/implementation.ts` (~25%) and other
-   small `functions()`/schema-building halves of tool implementations —
-   distinct from their `invoke()` halves (see above), the tool-schema
-   construction is pure and worth covering directly rather than only via
-   smoke.ts.
-3. `apps/backend/lib/tools/openapi/implementation.ts` (~7%, 382 lines) —
-   almost entirely request/response shaping from an OpenAPI spec; likely the
-   single highest-value target in the repo by lines-not-covered.
-4. `apps/backend/lib/tools/mcp/implementation.ts` (~17%) and `file-bridge.ts`
+1. `apps/backend/lib/tools/mcp/implementation.ts` (~17%) and `file-bridge.ts`
    (~21%) — protocol/message shaping, separate from the actual MCP transport.
-5. `apps/backend/lib/chat/summarizer.ts` (~20%), `startServerChatRun.ts`
+2. `apps/backend/lib/chat/summarizer.ts` (~20%), `startServerChatRun.ts`
    (~33%, error branches only partially covered), `chat/index.ts` (~61%,
    large file, worth incremental coverage rather than a single pass).
-6. `apps/backend/lib/chat/litellm/litellm-provider.ts` (~7%) — provider
+3. `apps/backend/lib/chat/litellm/litellm-provider.ts` (~7%) — provider
    config/factory logic.
-7. `apps/backend/lib/imagegen/metering.ts` (~13%) and
+4. `apps/backend/lib/imagegen/metering.ts` (~13%) and
    `apps/backend/lib/tools/audio_transcription/metering.ts` (~13%) — thin
    wrappers around the OpenMeter SDK, but the guard clauses (no-op when
    unconfigured) and the try/catch-and-log-a-warning around the ingest call
    are pure branching worth covering with the SDK client mocked.
-8. `packages/core/src/bootstrapPlaceholders.ts` (0%, small) — DOM-dependent
+5. `packages/core/src/bootstrapPlaceholders.ts` (0%, small) — DOM-dependent
    (`readBootstrapJson` reads `document`), needs a `jsdom` environment via
    `// @vitest-environment jsdom` (no existing test file uses that pragma
    yet, so this is also the first one) — quick win once that's set up.
-9. `apps/backend/lib/router.ts` (~71%, branch coverage 50%) and
+6. `apps/backend/lib/router.ts` (~71%, branch coverage 50%) and
    `apps/backend/lib/logging.ts` (~35%, mixed — some pure formatting, some
    transport wiring) — partial gaps worth closing incrementally.
+7. `apps/backend/lib/tools/openapi/implementation.ts`'s multipart-response
+   branch (the file overall went 7% -> 90%, but parsing a
+   `multipart/`-content-type response — `parseMultipart` + per-part
+   text-vs-attachment handling — is still uncovered; needs a hand-built
+   multipart body in the mocked `fetch` response).
+
+Done: `echo-language-model.ts` (23% -> 95%), `tools/timeofday/implementation.ts`
+(25% -> 100%), `tools/openapi/implementation.ts` (7% -> 90%, see the
+multipart caveat above).
 
 When picking up an item here: confirm with a quick read that the file is
 still mostly pure logic (code moves), write the unit test, and cross it off


### PR DESCRIPTION
## Summary
Continues the coverage-driven backlog from `docs/testing-strategy.md` (item 3, the highest-value gap). `apps/backend/lib/tools/openapi/implementation.ts` — the OpenAPI-spec-to-tool-function converter and its request/response handling — had almost no direct coverage despite being mostly pure logic. Adds unit tests with `fetch` (undici) and file persistence mocked; no network or DB access.

## Details
- Spec conversion: path/query params and request-body schema merged into each operation's tool-function schema; an operation with an unsupported request-body media type is skipped rather than failing the whole spec; an unparseable spec yields no functions instead of throwing.
- Request building: path/query substitution (with encoding), apiKey and bearer security headers (including the "don't double-prefix an already-`Bearer `-prefixed token" branch), and the debug-logging path (`uiLink.debugMessage`, with security headers hidden).
- Found and documented (via a code comment, not a behavior change) that `computeSecurityHeaders` resolves every scheme declared under `components.securitySchemes` on every call, not just the ones an operation's own `security` list references — so tests configure both schemes used in the fixture spec.
- Response handling: JSON, plain text, non-2xx (`error-text`, no throw), and persisting a binary response as a file both via `Content-Disposition: attachment` and via a non-text/non-JSON content type with no disposition header.
- Coverage on the file: 7.2% -> 90.2% (multipart-response parsing is the main remaining gap, left for a follow-up per the backlog doc).

## Tests
- `npm run check-types` — clean.
- `npx vitest run --coverage` — 114 files, 1030 tests passing, 0 failures. Overall statement coverage: 71.83% -> 73.49%.