### PR TITLE
Restore Red Hat Display as the app font

### DIFF
--- a/apps/frontend/tailwind.config.cjs
+++ b/apps/frontend/tailwind.config.cjs
@@ -94,6 +94,9 @@ module.exports = {
       xl: ['24px', '32px'],
     },
     extend: {
+      fontFamily: {
+        sans: ['"Red Hat Display"', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+      },
       transitionProperty: {
         width: 'width',
         opacity: 'opacity',


### PR DESCRIPTION
## Summary

After the Vite + React Router migration the app was rendering in the OS default sans-serif instead of Red Hat Display. This restores the intended typeface across the whole app by declaring it in the shared Tailwind theme, so it applies through Tailwind Preflight itself.

## Details

- Before the migration, `apps/frontend/app/layout.tsx` loaded the font with `next/font/google`'s `Red_Hat_Display(...)` and applied it as a generated **class** on `<html>` (specificity `0,1,0`), which beat Tailwind Preflight's `html { font-family }` rule regardless of cascade order.
- Its replacement in `apps/frontend-vite/index.html` sets the font with an **element selector** (`html { font-family: 'Red Hat Display', … }`) of equal specificity to Preflight. `globals.css` (`@tailwind base`) is imported from `main.tsx` and injected after the inline `<style>`, so Preflight's default `ui-sans-serif, system-ui, …` won and Red Hat Display never took effect.
- Fix: add `theme.extend.fontFamily.sans = ['"Red Hat Display"', 'ui-sans-serif', 'system-ui', 'sans-serif']` in `apps/frontend/tailwind.config.cjs` (shared by both `apps/frontend` and `apps/frontend-vite`). Preflight now emits Red Hat Display on `html`, and the `font-sans` utility resolves to it too.
- The inline `<style>` in `index.html` is now redundant but harmless as a pre-CSS-load fallback; left in place.

## Risks

- The font is still fetched from the Google Fonts CDN (a pre-existing consequence of the migration away from `next/font`'s self-hosting). Networks that block Google Fonts fall back to the system sans stack. Re-self-hosting would mean a new dependency and is out of scope here.

## Tests

- `npm run build-ci` (Vite production build) — succeeds; built `assets/index-*.css` Preflight rule is `html{…font-family:Red Hat Display,ui-sans-serif,system-ui,sans-serif…}`.
- Ran the app (`npm run dev`) and checked `/auth/login` and `/auth/join` in Chromium via Playwright:
  - `getComputedStyle(document.documentElement).fontFamily` → `"Red Hat Display", ui-sans-serif, system-ui, sans-serif`
  - `document.fonts.check('16px "Red Hat Display"')` → `true` (face actually loaded)
  - sampled `label` / `button` / `input` computed font → Red Hat Display
- Verified the static-frontend serving is unaffected: `/` → `307 /chat`, `/chat` and `/admin/users` → `307 /auth/login?callbackUrl=…` when unauthenticated, `__logicle_env__` bootstrap JSON injected into the served HTML, `/api/health` → `200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)