### PR TITLE
Hard-reload once when a stale route chunk fails to load

### DIFF
--- a/apps/frontend-vite/src/main.tsx
+++ b/apps/frontend-vite/src/main.tsx
@@ -2,12 +2,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
 import { router } from './router'
+import { installChunkErrorReload } from './reloadOnChunkError'
 // Real global stylesheet (Tailwind base/components/utilities + CSS custom
 // properties every component's className relies on) — apps/frontend/app/
 // layout.tsx used to import this the same way. Processed through Vite's
 // built-in PostCSS support via tailwind.config.cjs/postcss.config.cjs
 // alongside this file.
 import '../../frontend/styles/globals.css'
+
+installChunkErrorReload()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/apps/frontend-vite/src/reloadOnChunkError.ts
+++ b/apps/frontend-vite/src/reloadOnChunkError.ts
@@ -16,39 +16,77 @@
 // try to detect a new deploy while the user sits on one page — that is
 // deliberately out of scope.
 
-// Guard against a reload loop: if a chunk is genuinely missing or broken (a
-// bad build, not a stale tab) the reload won't fix it, so only retry once
-// per cooldown window and otherwise let the error surface via the route's
-// errorElement.
+// Loop protection. If a chunk is genuinely missing or broken (a bad build,
+// not a stale tab) the reload won't fix it, so we must never reload more
+// than once for it within a short window. Two independent guards, OR'd
+// together — a reload loop needs BOTH to fail at the same time — and both
+// self-re-arm after RELOAD_COOLDOWN_MS so a later, unrelated deploy is still
+// handled by the same long-lived tab:
+//
+//  1. A sessionStorage timestamp. Survives the reload; the primary guard.
+//  2. Navigation Timing. `location.reload()` makes the next load's
+//     navigation type `"reload"` (per spec), so a freshly-reloaded document
+//     has already spent its attempt. Needs no storage — this is what stops
+//     a loop when sessionStorage is blocked entirely (locked-down browser,
+//     partitioned context). Only counted while the load is still fresh
+//     (`performance.now() < cooldown`) so a tab reloaded long ago isn't
+//     permanently barred from recovering.
 const LAST_RELOAD_KEY = 'logicle:chunk-error-reload-at'
 const RELOAD_COOLDOWN_MS = 15_000
 
-function tryHardReload(): boolean {
-  let lastReloadAt = 0
+let installed = false
+
+function reloadedRecentlyPerStorage(): boolean {
   try {
-    lastReloadAt = Number(window.sessionStorage.getItem(LAST_RELOAD_KEY)) || 0
+    const last = Number(window.sessionStorage.getItem(LAST_RELOAD_KEY)) || 0
+    return last > 0 && Date.now() - last < RELOAD_COOLDOWN_MS
   } catch {
-    // sessionStorage can throw (privacy mode, storage disabled) — fall
-    // through and reload anyway; one extra reload is acceptable.
+    // sessionStorage blocked (privacy mode, storage disabled, partitioned
+    // context) — guard #2 takes over.
+    return false
   }
-  if (Date.now() - lastReloadAt < RELOAD_COOLDOWN_MS) return false
+}
+
+function reloadedRecentlyPerNavigationTiming(): boolean {
+  try {
+    if (performance.now() >= RELOAD_COOLDOWN_MS) return false
+    const [nav] = performance.getEntriesByType('navigation') as PerformanceNavigationTiming[]
+    if (nav) return nav.type === 'reload'
+    // Deprecated Navigation Timing L1, but present in browsers too old for
+    // the L2 entry type above (e.g. Safari < 15). type 1 === TYPE_RELOAD.
+    const legacyNav = (performance as { navigation?: { type: number } }).navigation
+    return legacyNav?.type === 1
+  } catch {
+    return false
+  }
+}
+
+function alreadyReloadedForThis(): boolean {
+  return reloadedRecentlyPerStorage() || reloadedRecentlyPerNavigationTiming()
+}
+
+function tryHardReload(): boolean {
+  if (alreadyReloadedForThis()) return false
   try {
     window.sessionStorage.setItem(LAST_RELOAD_KEY, String(Date.now()))
   } catch {
-    // ignore — see above
+    // ignore — guard #2 (Navigation Timing) still applies after the reload
   }
   window.location.reload()
   return true
 }
 
 export function installChunkErrorReload(): void {
+  if (installed) return
+  installed = true
   window.addEventListener('vite:preloadError', (event) => {
     if (tryHardReload()) {
       // Suppress Vite's default re-throw so React Router doesn't paint the
       // error page for a frame before the reload takes over.
       event.preventDefault()
     }
-    // Otherwise we're inside the cooldown: a genuinely broken chunk. Let
-    // Vite re-throw so the route's errorElement shows instead of looping.
+    // Otherwise we've already reloaded once for this: a genuinely broken
+    // chunk. Let Vite re-throw so the route's errorElement shows instead of
+    // looping.
   })
 }

--- a/apps/frontend-vite/src/reloadOnChunkError.ts
+++ b/apps/frontend-vite/src/reloadOnChunkError.ts
@@ -1,0 +1,54 @@
+// A browser tab loaded before a deploy still holds the previous build's
+// HTML, which references content-hashed chunk filenames
+// (/assets/UsersPage-a1b2c3.js). Every route here is lazy-loaded (see
+// router.tsx), so the first time that tab navigates to a route it hadn't
+// already loaded, the chunk request 404s and the user lands on the error
+// page.
+//
+// The fix is the standard Vite recipe: listen for `vite:preloadError` — the
+// event Vite fires when a dynamically imported chunk fails to load — and
+// hard-reload. index.html is served with `Cache-Control: no-cache`, so the
+// reload fetches the fresh shell with the new asset hashes and the
+// navigation then succeeds.
+// https://vite.dev/guide/build.html#load-error-handling
+//
+// Scope: this only covers "the tab navigates after a deploy". It does not
+// try to detect a new deploy while the user sits on one page — that is
+// deliberately out of scope.
+
+// Guard against a reload loop: if a chunk is genuinely missing or broken (a
+// bad build, not a stale tab) the reload won't fix it, so only retry once
+// per cooldown window and otherwise let the error surface via the route's
+// errorElement.
+const LAST_RELOAD_KEY = 'logicle:chunk-error-reload-at'
+const RELOAD_COOLDOWN_MS = 15_000
+
+function tryHardReload(): boolean {
+  let lastReloadAt = 0
+  try {
+    lastReloadAt = Number(window.sessionStorage.getItem(LAST_RELOAD_KEY)) || 0
+  } catch {
+    // sessionStorage can throw (privacy mode, storage disabled) — fall
+    // through and reload anyway; one extra reload is acceptable.
+  }
+  if (Date.now() - lastReloadAt < RELOAD_COOLDOWN_MS) return false
+  try {
+    window.sessionStorage.setItem(LAST_RELOAD_KEY, String(Date.now()))
+  } catch {
+    // ignore — see above
+  }
+  window.location.reload()
+  return true
+}
+
+export function installChunkErrorReload(): void {
+  window.addEventListener('vite:preloadError', (event) => {
+    if (tryHardReload()) {
+      // Suppress Vite's default re-throw so React Router doesn't paint the
+      // error page for a frame before the reload takes over.
+      event.preventDefault()
+    }
+    // Otherwise we're inside the cooldown: a genuinely broken chunk. Let
+    // Vite re-throw so the route's errorElement shows instead of looping.
+  })
+}


### PR DESCRIPTION
"## Summary\n\nA browser tab left open across a deploy keeps running the previous build and 404s the first time it lazy-loads a route chunk whose content hash changed, dropping the user on the generic error page. This adds the standard Vite `vite:preloadError` handler that hard-reloads the tab onto the fresh build, restoring roughly what Next's router did automatically.\n\n## Details\n\n- `apps/frontend-vite/src/reloadOnChunkError.ts` — installs a `window` listener for `vite:preloadError` (fired by Vite when a dynamically imported chunk fails to load). On the first failure it calls `window.location.reload()`; `index.html` is served `Cache-Control: no-cache` and `/assets/*` are `immutable` + hashed, so the reload lands on the new build and the navigation then succeeds.\n- `apps/frontend-vite/src/main.tsx` calls `installChunkErrorReload()` (idempotent) before mounting the router.\n\n### Loop protection\n\nTwo independent guards, OR'd together — a reload loop needs both to fail at once — each self-re-arming after a 15s cooldown so the same long-lived tab still handles a *later* deploy:\n\n1. **sessionStorage timestamp** — primary guard, survives the reload.\n2. **Navigation Timing type** — `location.reload()` makes the next load's navigation type `\"reload\"` (per spec), so a freshly-reloaded document has already spent its attempt. Needs no storage, so it's what stops a loop when sessionStorage is blocked entirely (locked-down browser, partitioned context). Only honored while `performance.now() < cooldown`; falls back to the deprecated L1 `performance.navigation` API for pre-2021 browsers.\n\nWhen a guard trips, the handler stops calling `preventDefault()` and lets Vite re-throw into the route's `errorElement` instead of reloading.\n\nResidual: if sessionStorage is blocked **and** `vite:preloadError` consistently fires only after the 15s window on every load, reloads can recur at most once per 15s — a slow loop, not a CPU-pegging one, and only against a genuinely broken deployment.\n\n## Scope\n\n- Covers \"the tab navigates after a deploy\". Does **not** detect a new deploy while the user stays on one page — no version polling, no coupling between API responses and the HTML build. That case is knowingly left uncovered.\n- The reload reloads the current URL (the pending navigation hasn't committed when the chunk import fails), so the user stays on the page they were on and re-clicks.\n\n## Tests\n\n- `npm run check-types` — passes.\n- End-to-end against the production server (`npm run build` + `npm start`):\n  - Loaded `/auth/login`, rebuilt the frontend with a changed `SignUpPanel` (new chunk hash, old chunk removed from `dist/`), clicked \"Sign up\" in the open tab → `GET /assets/SignUpPanel-<oldhash>.js` 404 → `vite:preloadError` → tab hard-reloaded onto the new entry chunk → re-clicking \"Sign up\" rendered `/auth/join` normally, no second reload.\n- Loop guards, driven in-browser via synthetic `vite:preloadError` on the prod server:\n  - fresh page (nav type `navigate`, no key) → reloads;\n  - second event <15s later with the key present → no reload;\n  - second event <15s later with the key deleted (simulating blocked storage) → still no reload (Navigation Timing guard);\n  - after the 15s cooldown, a new event with no key → reloads again (feature re-arms).\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n"
