### PR TITLE
Fix file upload integration baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,8 +249,7 @@ jobs:
           run_smoke "sqlite" "file:///data/sqlite/logicle.sqlite"
           run_smoke "postgres" "postgresql://admin:admin@host.docker.internal:5432/logicle"
 
-      - name: Run integration baseline checks (main/dispatch)
-        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+      - name: Run integration baseline checks
         run: |
           set -euo pipefail
           trap 'status=$?; if [ "$status" -ne 0 ]; then echo "Baseline test failed; dumping container logs"; docker logs logicle-smoke || true; fi' EXIT

--- a/apps/backend/scripts/integration-baseline.ts
+++ b/apps/backend/scripts/integration-baseline.ts
@@ -437,16 +437,32 @@ async function main() {
     json: { name: `integration-${runId}.txt`, type: 'text/plain', size: 1 },
     allowStatus: [400],
   })
-  await request('POST', '/api/files', {
+  console.log('Integration: file creation ignores a client-supplied owner')
+  const forgedOwnerFileCreated = await request('POST', '/api/files', {
+    expectedStatus: 201,
     headers: jsonHeaders,
     json: {
-      name: `integration-${runId}-forbidden.txt`,
+      name: `integration-${runId}-client-owner-ignored.txt`,
       type: 'text/plain',
       size: 1,
       owner: { ownerType: 'USER', ownerId: adminUserId },
     },
-    allowStatus: [403],
   })
+  const forgedOwnerFileId = parseJson(
+    forgedOwnerFileCreated.text,
+    '/api/files POST (client owner ignored)'
+  ).id as string
+  const forgedOwnerFileDetails = await request('GET', `/api/files/${forgedOwnerFileId}`, {
+    expectedStatus: 200,
+    headers: sameOriginHeaders,
+  })
+  const forgedOwner = parseJson(
+    forgedOwnerFileDetails.text,
+    `/api/files/${forgedOwnerFileId} GET (client owner ignored)`
+  ).owner as { ownerType?: string; ownerId?: string }
+  if (forgedOwner.ownerType !== 'USER' || forgedOwner.ownerId !== profileJson.id) {
+    throw new Error(`Client-supplied file owner was not ignored: ${forgedOwnerFileDetails.text}`)
+  }
   const ownedFileCreated = await request('POST', '/api/files', {
     expectedStatus: 201,
     headers: jsonHeaders,


### PR DESCRIPTION
## Summary

Updates the integration baseline for the secure file-upload ownership flow and runs the baseline on branch CI, preventing stale main-only assertions from surfacing after merge.

## Details

- Assert that client-supplied file ownership is ignored and the authenticated uploader remains the owner.
- Run integration baseline checks on every CI branch execution.

## Tests

- `pnpm run check-types`
- `pnpm run build:smoke`
- `pnpm vitest run __tests__/fileUploadRoutes.test.ts` — 19 tests passed
- `pnpm exec prettier --check apps/backend/scripts/integration-baseline.ts .github/workflows/ci.yml`
- `pnpm exec biome check apps/backend/scripts/integration-baseline.ts`
- Parsed `.github/workflows/ci.yml` with the repository's `yaml` package
- `git diff --check`
