### PR TITLE
Bump mcp-file-analyzer to 0.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.5
 
 # Pin this to a released analyzer version (or digest) when updating it.
-ARG FILE_ANALYZER_IMAGE=ghcr.io/logicleai/mcp-file-analyzer:0.10.0
+ARG FILE_ANALYZER_IMAGE=ghcr.io/logicleai/mcp-file-analyzer:0.11.0
 
 # ---------------------
 # Stage 1: File analyzer


### PR DESCRIPTION
## Summary

Upgrades the bundled `mcp-file-analyzer` runtime image to `0.11.0`, adding upstream PDF support for Office scripts and PDF overlay/preview fixes.

## Tests

- `pnpm run check-types`
- Confirmed the `ghcr.io/logicleai/mcp-file-analyzer:0.11.0` Linux/AMD64 manifest exists
- Ran `/mcp-file-analyzer -help` from the `0.11.0` image successfully
- `git diff --check`
