### PR TITLE
Loosen chat inline-style sanitization to a safe blocklist

### DIFF
--- a/__tests__/markdownSanitization.test.ts
+++ b/__tests__/markdownSanitization.test.ts
@@ -31,16 +31,37 @@ describe('Markdown HTML sanitization', () => {
     expect(html).toContain('<img src="https://example.com/image.png" alt="example"/>')
   })
 
-  test('allows only presentation-safe inline text styles', () => {
+  test('allows presentation styles but strips overlay/clickjacking properties', () => {
     const html = renderMarkdown(
       '<span style="color:green;font-weight:bold">styled</span>\n\n' +
-        '<span style="color: red; position: fixed; inset: 0">partially safe</span>'
+        '<span style="color: red; position: fixed; inset: 0; z-index: 99">partially safe</span>\n\n' +
+        '<p style="font-size:20px;text-align:center;font-family:Georgia,serif">rich</p>\n\n' +
+        '<span style="transform:translateY(-200px)">shifted</span>\n\n' +
+        '<div style="background:red;border-radius:16px;padding:14px 20px;color:white">box</div>'
     )
 
     expect(html).toContain('<span style="color:green;font-weight:bold">styled</span>')
     expect(html).toContain('<span style="color:red">partially safe</span>')
     expect(html).not.toContain('position')
     expect(html).not.toContain('inset')
+    expect(html).not.toContain('z-index')
+    expect(html).not.toContain('transform')
+    expect(html).toContain('font-size:20px')
+    expect(html).toContain('text-align:center')
+    expect(html).toContain('border-radius:16px')
+  })
+
+  test('strips style values that can fetch or execute', () => {
+    const html = renderMarkdown(
+      '<div style="background-image:url(https://evil.example/track.png)">tracked</div>\n\n' +
+        '<span style="color:red;background:url(javascript:alert(1))">x</span>\n\n' +
+        '<p style="width:@import url(x)">y</p>'
+    )
+
+    expect(html).not.toContain('evil.example')
+    expect(html).not.toContain('url(')
+    expect(html).not.toContain('@import')
+    expect(html).toContain('<span style="color:red">x</span>')
   })
 
   test('removes executable markup and unsafe URLs', () => {

--- a/apps/frontend/app/chat/components/Markdown.tsx
+++ b/apps/frontend/app/chat/components/Markdown.tsx
@@ -25,13 +25,30 @@ const MermaidDiagram = React.lazy(() =>
   import('./MermaidDiagram').then((m) => ({ default: m.MermaidDiagram }))
 )
 
-const safeInlineStyleValues: Record<string, RegExp> = {
-  color: /^(?:#[\da-f]{3,8}|(?:rgb|hsl)a?\([\d\s.,%+-]+\)|[a-z]+)$/i,
-  'background-color': /^(?:#[\da-f]{3,8}|(?:rgb|hsl)a?\([\d\s.,%+-]+\)|[a-z]+)$/i,
-  'font-style': /^(?:italic|normal|oblique)$/i,
-  'font-weight': /^(?:bold|bolder|lighter|normal|[1-9]00)$/i,
-  'text-decoration': /^(?:line-through|underline)$/i,
-}
+// Inline styles from assistant output are allowed broadly — the product
+// deliberately supports rich HTML formatting — with two carve-outs that keep
+// the surface safe without an ever-growing property allowlist:
+//
+//  1. Properties that let an element escape the message flow and overlay the
+//     rest of the page (clickjacking) are dropped.
+//  2. Any value that can trigger a network fetch or code execution is dropped:
+//     `url(...)`, `image-set(...)`, `expression(...)`, `@import`, `javascript:`.
+//     This is the cheap equivalent of "strip attributes that carry URLs" —
+//     `background-image`, `list-style-image`, `cursor`, `content`, `mask`, …
+//     all funnel through `url()`, so one value check covers them.
+const blockedStyleProperties = new Set([
+  'position',
+  'inset',
+  'top',
+  'right',
+  'bottom',
+  'left',
+  'z-index',
+  'transform',
+  'pointer-events',
+])
+
+const unsafeStyleValue = /url\(|image-set\(|expression\(|@import|javascript:|[<>]/i
 
 const sanitizeInlineStyle = (style: string) =>
   style
@@ -41,7 +58,11 @@ const sanitizeInlineStyle = (style: string) =>
       if (separator === -1) return undefined
       const property = declaration.slice(0, separator).trim().toLowerCase()
       const value = declaration.slice(separator + 1).trim()
-      return safeInlineStyleValues[property]?.test(value) ? `${property}: ${value}` : undefined
+      if (!property || !value) return undefined
+      if (property.startsWith('--')) return undefined
+      if (blockedStyleProperties.has(property)) return undefined
+      if (unsafeStyleValue.test(value)) return undefined
+      return `${property}: ${value}`
     })
     .filter((declaration): declaration is string => declaration !== undefined)
     .join('; ')
@@ -63,11 +84,17 @@ export function rehypeFilterInlineStyles() {
 
 export const markdownSanitizeSchema = {
   ...defaultSchema,
+  // `defaultSchema` (GitHub's list) already covers the tags assistants actually
+  // emit for display — headings, lists, tables, `blockquote`, `details`/
+  // `summary`, `a`, `img`, `sub`/`sup`/`del`/`ins`, … — so this only adds the
+  // two inline-formatting tags GitHub omits. `<iframe>`, `<style>`, `<script>`,
+  // `<object>`, `<form>` and friends stay excluded.
   tagNames: [...(defaultSchema.tagNames ?? []), 'mark', 'u'],
   attributes: {
     ...defaultSchema.attributes,
-    mark: [...(defaultSchema.attributes?.mark ?? []), 'style'],
-    span: [...(defaultSchema.attributes?.span ?? []), 'style'],
+    // `style` is allowed on every element; its declarations are already
+    // filtered by `rehypeFilterInlineStyles` (runs before `rehypeSanitize`).
+    '*': [...(defaultSchema.attributes?.['*'] ?? []), 'style'],
   },
 }
 


### PR DESCRIPTION
## Problem

The chat Markdown renderer filters inline `style` through a **5-property allowlist** (`color`, `background-color`, `font-style`, `font-weight`, `text-decoration`). Everything else — `font-size`, `font-family`, `text-align`, `padding`/`margin`, `border`, `border-radius`, `background`, `line-height`, … — is silently stripped.

Assistants that format replies with rich HTML (e.g. a "GPT with HTML" style assistant) lose most of their styling on render: a `font-size: 20px` paragraph renders at body size, a red rounded callout box renders as plain text, a custom font is ignored.

## Data

Fleet-wide survey of stored messages (29 dedicated tenants, ~815k messages, ~17k with markup):

- Genuinely-used inline-style properties: ~25 presentation properties (`color`, `font-*`, `text-align`, `text-decoration`, `line-height`, `vertical-align`, `padding*`, `margin*`, `border*`, `border-radius`, `width`/`max-width`/`min-width`, `height`, `display`, `white-space`, `box-shadow`, `opacity`, `background`, …).
- Positioning (`position`, `top`, `left`, `z-index`) appears ~600× fleet-wide — almost entirely inside **pasted third-party email CSS**, plus a handful of deliberate clickjacking test probes.
- `url()` / `@import` in inline styles: ~690×, **exclusively** in pasted email CSS — never a real rendered vector.

## Change

Replace the property allowlist with a **blocklist**:

- **Drop** overlay / clickjacking properties: `position`, `inset`, `top`, `right`, `bottom`, `left`, `z-index`, `transform`, `pointer-events`.
- **Drop** any declaration whose value can fetch or execute: `url(`, `image-set(`, `expression(`, `@import`, `javascript:`, or angle brackets. This is the cheap equivalent of "strip attributes carrying URLs" — `background-image`, `cursor`, `list-style-image`, `mask`, … all funnel through `url()`.
- **Drop** CSS custom properties (`--*`).
- Allow `style` on all elements (`'*'`) instead of only `mark`/`span`.
- Keep `mark` + `u`; no other tags added. `<iframe>`, `<style>`, `<script>`, `<object>`, `<form>` remain excluded by the GitHub default schema.

Net effect: **zero regression against observed assistant output**, positioning + CSS-fetch vectors closed, rich-formatting bug fixed.

## Explicitly out of scope (tracked separately)

- No Content-Security-Policy is added (there is currently none in the app or the proxy).
- External `<img>`/`<audio>`/`<video>` still load from any `http(s)` host — the exfiltration / browser-side-SSRF concern needs an image proxy or click-to-load gate.
- No hard tag allowlist (still relies on the `rehype-sanitize` GitHub default list).

## Tests

`__tests__/markdownSanitization.test.ts` updated: presentation styles pass; `position`/`inset`/`z-index`/`transform` stripped; `url()`/`@import`/`javascript:` values stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)