### PR TITLE
Add a Content-Security-Policy to the SPA shell

### DIFF
--- a/__tests__/cspHeader.test.ts
+++ b/__tests__/cspHeader.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { applyCspHeaders, CSP_DIRECTIVES } from '@/backend/lib/staticFrontendVite'
+
+const ENV_KEYS = ['CSP_DISABLE', 'CSP_REPORT_ONLY'] as const
+
+afterEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k]
+})
+
+describe('SPA shell Content-Security-Policy', () => {
+  test('locks down the framing / script / object surface', () => {
+    expect(CSP_DIRECTIVES).toContain("default-src 'self'")
+    expect(CSP_DIRECTIVES).toContain("base-uri 'self'")
+    expect(CSP_DIRECTIVES).toContain("frame-ancestors 'none'")
+    expect(CSP_DIRECTIVES).toContain("frame-src 'none'")
+    expect(CSP_DIRECTIVES).toContain("object-src 'none'")
+    // no 'unsafe-eval' — Zod's allowsEval probe is guarded and falls back
+    expect(CSP_DIRECTIVES).toContain("script-src 'self'")
+    expect(CSP_DIRECTIVES).not.toContain('unsafe-eval')
+  })
+
+  test('enforces by default', () => {
+    const h: Record<string, string> = {}
+    applyCspHeaders(h)
+    expect(h['Content-Security-Policy']).toBe(CSP_DIRECTIVES)
+    expect(h['Content-Security-Policy-Report-Only']).toBeUndefined()
+  })
+
+  test('CSP_REPORT_ONLY=1 observes without enforcing', () => {
+    process.env.CSP_REPORT_ONLY = '1'
+    const h: Record<string, string> = {}
+    applyCspHeaders(h)
+    expect(h['Content-Security-Policy']).toBeUndefined()
+    expect(h['Content-Security-Policy-Report-Only']).toBe(CSP_DIRECTIVES)
+  })
+
+  test('CSP_DISABLE=1 emits nothing', () => {
+    process.env.CSP_DISABLE = '1'
+    const h: Record<string, string> = {}
+    applyCspHeaders(h)
+    expect(Object.keys(h)).toHaveLength(0)
+  })
+})

--- a/apps/backend/lib/staticFrontendVite.ts
+++ b/apps/backend/lib/staticFrontendVite.ts
@@ -34,6 +34,52 @@ const PUBLIC_EXACT_PATHS = new Set(['/favicon.ico', '/openapi.yaml', '/robots.tx
 const isPubliclyServable = (pathname: string) =>
   PUBLIC_EXACT_PATHS.has(pathname) || PUBLIC_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix))
 
+// Content-Security-Policy for the SPA shell. Verified against the built
+// frontend with a headless-browser sweep of chat (KaTeX / mermaid / code
+// highlighting / rich HTML), the recharts analytics dashboards, the Zod-heavy
+// admin tool/backend/SSO forms and the styleguide: the only violation is a
+// single guarded `Function("")` capability probe in Zod's `allowsEval`, which
+// catches, reports once, and falls back to non-JIT validation with identical
+// results — so `script-src 'self'` (no `'unsafe-eval'`) is functionally safe.
+//
+//  - style-src needs 'unsafe-inline': the head has an inline <style>, the
+//    per-deployment brand CSS is injected as a <style> element, and KaTeX /
+//    Prism / mermaid all set inline styles at runtime. Inline styles cannot
+//    execute, and assistant-authored ones are already filtered in Markdown.tsx.
+//  - Google Fonts: stylesheet from fonts.googleapis.com, files from
+//    fonts.gstatic.com (see apps/frontend-vite/index.html).
+//  - img-src keeps https:: model/provider logos are currently hotlinked from
+//    www.cdnlogo.com, and assistants embed external images. Tightening this to
+//    'self' data: blob: additionally closes chat-image exfiltration but needs
+//    those logos self-hosted first — tracked separately.
+//  - connect-src 'self' covers the same-origin API, chat streaming and the
+//    satellite WebSocket (/api/rpc).
+export const CSP_DIRECTIVES = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "frame-ancestors 'none'",
+  "frame-src 'none'",
+  "object-src 'none'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src 'self' https://fonts.gstatic.com data:",
+  "img-src 'self' data: blob: https:",
+  "media-src 'self' blob: data:",
+  "connect-src 'self'",
+  "worker-src 'self' blob:",
+].join('; ')
+
+// `CSP_DISABLE=1` opts out entirely; `CSP_REPORT_ONLY=1` observes without
+// enforcing (useful for the first rollout on an unfamiliar deployment).
+export function applyCspHeaders(headers: Record<string, string>) {
+  if (process.env.CSP_DISABLE === '1') return
+  const name =
+    process.env.CSP_REPORT_ONLY === '1'
+      ? 'Content-Security-Policy-Report-Only'
+      : 'Content-Security-Policy'
+  headers[name] = CSP_DIRECTIVES
+}
+
 function escapeForScriptTag(json: string): string {
   return json.replace(/</g, '\\u003c')
 }
@@ -236,14 +282,16 @@ export async function serveStaticFrontendVite(
   const htmlFile = path.join(outDir, 'index.html')
   const html = await fs.promises.readFile(htmlFile, 'utf-8')
   const withBootstrap = await injectBootstrapData(html)
-  res.writeHead(200, {
+  const shellHeaders: Record<string, string> = {
     'Content-Type': 'text/html; charset=utf-8',
     'X-Robots-Tag': 'noindex, nofollow, noarchive',
     // Never cache the shell itself — it's what references the hashed
     // /assets/* filenames above, so a cached stale index.html would keep
     // pointing at assets a new deploy has already deleted.
     'Cache-Control': 'no-cache',
-  })
+  }
+  applyCspHeaders(shellHeaders)
+  res.writeHead(200, shellHeaders)
   res.end(withBootstrap)
   return true
 }


### PR DESCRIPTION
## Why

The app served **no CSP**. The `rehype-sanitize` allowlist in `Markdown.tsx` was the entire client-side security boundary — no backstop if it regressed (a dep bump, a schema edit), and nothing constraining where a rendered page could send data. Follow-up to #1078.

## What

A CSP on the **prod static shell response** (`serveStaticFrontendVite`), scoped so the Vite dev middleware is untouched:

```
default-src 'self';
base-uri 'self';
frame-ancestors 'none';
frame-src 'none';
object-src 'none';
script-src 'self';
style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
font-src 'self' https://fonts.gstatic.com data:;
img-src 'self' data: blob: https:;
media-src 'self' blob: data:;
connect-src 'self';
worker-src 'self' blob:
```

`CSP_REPORT_ONLY=1` observes without enforcing; `CSP_DISABLE=1` is the break-glass.

## How it was verified

Headless-browser sweep of the built frontend with the policy applied, asserting `securitypolicyviolation` events, across:

| Surface | Result |
|---|---|
| Chat boot | clean |
| Chat render: KaTeX (inline + display), syntax-highlighted code, rich sanitized HTML (styled box, `mark`/`u`/colour), external image, table | clean |
| `/admin/analytics` — recharts dashboards | clean |
| `/admin/tools/create`, `/admin/backends`, `/admin/sso` — Zod-heavy forms | clean |
| `/admin/settings`, `/internals/styleguide`, `/auth/login` | clean |

**The only violation, anywhere:** one `script-src <- eval` from Zod v4's `allowsEval` capability probe (`schemas-*.js`):

```js
export const allowsEval = cached(() => {
  try { const F = Function; new F(""); return true }
  catch (_) { return false }        // ← CSP path
})
```

It is guarded, cached (fires once), and Zod falls back to interpreted validation with identical results. Adding `'unsafe-eval'` makes it zero violations but defeats the point — so `script-src 'self'` ships as-is and that one recurring report is **expected and harmless**. Worth a filter rule if a `report-to` collector is wired up.

## Deliberately out of scope

- **`img-src` stays permissive (`https:`)** — provider/model logos are currently hotlinked from `www.cdnlogo.com` and assistants embed external images. Tightening to `'self' data: blob:` additionally closes chat-image exfiltration but needs those logos self-hosted first.
- **`form-action`** omitted — would risk SAML POST-binding SSO; needs a test tenant.
- No `report-to` / `report-uri` endpoint.
- Dev-mode CSP.

## Rollout

Testing supports shipping this **enforcing**. For a cautious first fleet rollout, set `CSP_REPORT_ONLY=1`, confirm the only report is the known Zod one, then unset.

## Tests

`__tests__/cspHeader.test.ts` — policy shape + `CSP_REPORT_ONLY` / `CSP_DISABLE` behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)