### PR TITLE
Surface chat runs that fail without emitting any event

### DIFF
--- a/__tests__/startServerChatRunFailureEvents.test.ts
+++ b/__tests__/startServerChatRunFailureEvents.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { SimpleSession } from '@/types/session'
+
+const getConversationWithBackendAssistant = vi.fn()
+const createChatRun = vi.fn()
+const finalizeChatRun = vi.fn()
+const getChatRunById = vi.fn()
+const isChatRunAbortError = vi.fn()
+const persistAndPublishChatRunEvent = vi.fn()
+const saveMessage = vi.fn()
+const chatAssistantBuild = vi.fn()
+const extractLinearConversation = vi.fn()
+
+vi.mock('@/models/conversation', () => ({
+  getConversationWithBackendAssistant,
+}))
+vi.mock('@/backend/lib/files/authorization', () => ({
+  canAccessFile: vi.fn(),
+}))
+vi.mock('@/models/file', () => ({
+  reassignUserOwnedFilesToConversation: vi.fn(),
+}))
+vi.mock('@/backend/lib/chat/chatRuns', () => ({
+  createChatRun,
+  finalizeChatRun,
+  getChatRunById,
+  isChatRunAbortError,
+  persistAndPublishChatRunEvent,
+}))
+vi.mock('@/backend/lib/tools/enumerate', () => ({
+  availableToolsForAssistantVersion: vi.fn().mockResolvedValue([]),
+}))
+vi.mock('@/lib/MessageAuditor', () => ({
+  MessageAuditor: class {
+    auditMessage = vi.fn()
+  },
+}))
+vi.mock('@/lib/chat/conversationUtils', () => ({ extractLinearConversation }))
+vi.mock('@/lib/parameters', () => ({ getUserParameters: vi.fn() }))
+vi.mock('@/models/assistant', () => ({
+  assistantVersionFiles: vi.fn().mockResolvedValue([]),
+  canUserAccessAssistant: vi.fn().mockResolvedValue(true),
+}))
+vi.mock('@/models/message', () => ({ getMessages: vi.fn().mockResolvedValue([]), saveMessage }))
+vi.mock('@/models/userSecrets', () => ({ getUserSecretValue: vi.fn() }))
+vi.mock('db/database', () => ({ db: {} }))
+vi.mock('@/backend/lib/chat', () => ({ ChatAssistant: { build: chatAssistantBuild } }))
+vi.mock('@/backend/lib/chat/compression-planner', () => ({ warmCompressionCache: vi.fn() }))
+
+const session: SimpleSession = {
+  userId: 'u1',
+  userRole: 'USER',
+  sessionId: 's1',
+} as SimpleSession
+
+const userMessage = {
+  id: 'm1',
+  conversationId: 'c1',
+  role: 'user' as const,
+  content: 'hello',
+  attachments: [],
+  parent: null,
+  sentAt: new Date().toISOString(),
+  citations: [],
+}
+
+describe('startServerChatRun failure events', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getConversationWithBackendAssistant.mockResolvedValue({
+      conversation: { id: 'c1', ownerId: 'u1' },
+      assistant: { deleted: false, assistantId: 'a1', assistantVersionId: 'av1', model: 'gpt' },
+      backend: { providerType: 'openai', provisioned: 0, configuration: '{}' },
+    })
+    createChatRun.mockReturnValue({
+      ok: true,
+      run: { id: 'run-1', conversationId: 'c1' },
+      abortController: new AbortController(),
+    })
+    extractLinearConversation.mockReturnValue([userMessage])
+    getChatRunById.mockReturnValue(undefined)
+    isChatRunAbortError.mockReturnValue(false)
+  })
+
+  test('publishes an assistant error message when the provider cannot be built', async () => {
+    chatAssistantBuild.mockRejectedValue(new Error('provider exploded'))
+    const { startServerChatRun } = await import('@/backend/lib/chat/startServerChatRun')
+
+    const result = await startServerChatRun({
+      userMessage,
+      headers: new Headers(),
+      session,
+    })
+    expect(result.ok).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(finalizeChatRun).toHaveBeenCalledWith(
+        expect.objectContaining({ runId: 'run-1', status: 'failed' })
+      )
+    })
+
+    const publishedParts = persistAndPublishChatRunEvent.mock.calls.map(
+      ([, part]) => part as { type: string }
+    )
+    expect(publishedParts.some((part) => part.type === 'message')).toBe(true)
+    expect(publishedParts).toContainEqual({
+      type: 'part',
+      part: { type: 'error', error: 'Internal error' },
+    })
+    // The failure message must also be persisted, so it survives a reload
+    expect(saveMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: 'assistant',
+        parts: [{ type: 'error', error: 'Internal error' }],
+      })
+    )
+  })
+
+  test('does not publish an error message when the run was stopped', async () => {
+    chatAssistantBuild.mockRejectedValue(new Error('aborted'))
+    isChatRunAbortError.mockReturnValue(true)
+    const { startServerChatRun } = await import('@/backend/lib/chat/startServerChatRun')
+
+    const result = await startServerChatRun({
+      userMessage,
+      headers: new Headers(),
+      session,
+    })
+    expect(result.ok).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(finalizeChatRun).toHaveBeenCalledWith(
+        expect.objectContaining({ runId: 'run-1', status: 'stopped' })
+      )
+    })
+
+    expect(persistAndPublishChatRunEvent).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/lib/chat/startServerChatRun.ts
+++ b/apps/backend/lib/chat/startServerChatRun.ts
@@ -22,6 +22,8 @@ import { db } from 'db/database'
 import * as dto from '@/types/dto'
 import { userSecretRequiredMessage, userSecretUnreadableMessage } from '@/lib/userSecretMessages'
 import { isUserProvidedApiKey, USER_SECRET_TYPE } from '@/lib/userSecrets/constants'
+import { UserVisibleError } from '@/backend/lib/chat/exceptions'
+import { logger } from '@/lib/logging'
 import { type SimpleSession } from '@/types/session'
 import { type Usage } from '@/backend/lib/chat/usage'
 import { warmCompressionCache } from '@/backend/lib/chat/compression-planner'
@@ -102,7 +104,8 @@ export const startServerChatRun = async ({
     return {
       ok: false,
       status: 400,
-      message: 'A chat run can only be started with a user message or a response to a pending request',
+      message:
+        'A chat run can only be started with a user message or a response to a pending request',
     }
   }
 
@@ -205,26 +208,35 @@ export const startServerChatRun = async ({
 
   const sink = publishQueuedEvents()
 
+  // Persist and publish an assistant message carrying only an error part, so
+  // that a failed run is visible both to live subscribers and after a reload.
+  const publishAssistantErrorMessage = async (errorText: string) => {
+    const chatState = new ChatState(linearThread)
+    const assistantMessage = chatState.appendMessage(chatState.createEmptyAssistantMsg())
+    const errorPart: dto.ErrorPart = { type: 'error', error: errorText }
+    chatState.applyStreamPart({ type: 'part', part: errorPart })
+    const updatedAssistantMessage =
+      chatState.getLastMessageAssert<dto.AssistantMessage>('assistant')
+    await saveAndAuditMessage(updatedAssistantMessage)
+    sink.enqueue({ type: 'message', msg: assistantMessage })
+    sink.enqueue({ type: 'part', part: errorPart })
+    await sink.drain()
+  }
+
   const execute = async () => {
     try {
       let resolvedProviderConfig = providerConfig
-      if ('apiKey' in resolvedProviderConfig && isUserProvidedApiKey(resolvedProviderConfig.apiKey)) {
+      if (
+        'apiKey' in resolvedProviderConfig &&
+        isUserProvidedApiKey(resolvedProviderConfig.apiKey)
+      ) {
         const resolution = await getUserSecretValue(session.userId, backend.id, USER_SECRET_TYPE)
         if (resolution.status !== 'ok') {
           const errorText =
             resolution.status === 'unreadable'
               ? userSecretUnreadableMessage
               : userSecretRequiredMessage()
-          const chatState = new ChatState(linearThread)
-          const assistantMessage = chatState.appendMessage(chatState.createEmptyAssistantMsg())
-          const errorPart: dto.ErrorPart = { type: 'error', error: errorText }
-          chatState.applyStreamPart({ type: 'part', part: errorPart })
-          const updatedAssistantMessage =
-            chatState.getLastMessageAssert<dto.AssistantMessage>('assistant')
-          await saveAndAuditMessage(updatedAssistantMessage)
-          sink.enqueue({ type: 'message', msg: assistantMessage })
-          sink.enqueue({ type: 'part', part: errorPart })
-          await sink.drain()
+          await publishAssistantErrorMessage(errorText)
           finalizeChatRun({ runId: run.id, status: 'failed' })
           return
         }
@@ -263,12 +275,20 @@ export const startServerChatRun = async ({
       })
     } catch (error) {
       await sink.drain().catch(() => undefined)
+      const stopped =
+        isChatRunAbortError(error, abortController.signal) ||
+        !!getChatRunById(run.id)?.stopRequestedAt
+      if (!stopped) {
+        // Failures reaching this point (e.g. provider construction) have not
+        // published any event: without a terminal error event subscribers
+        // would just see the stream close and report nothing at all.
+        logger.error('Chat run failed', error)
+        const errorText = error instanceof UserVisibleError ? error.message : 'Internal error'
+        await publishAssistantErrorMessage(errorText).catch(() => undefined)
+      }
       finalizeChatRun({
         runId: run.id,
-        status:
-          isChatRunAbortError(error, abortController.signal) || getChatRunById(run.id)?.stopRequestedAt
-            ? 'stopped'
-            : 'failed',
+        status: stopped ? 'stopped' : 'failed',
         error: error instanceof Error ? error.message : String(error),
       })
     }

--- a/apps/frontend/app/chat/components/ChatPageContextProvider.tsx
+++ b/apps/frontend/app/chat/components/ChatPageContextProvider.tsx
@@ -243,11 +243,26 @@ export const ChatPageContextProvider: FC<Props> = ({ children }) => {
         },
         onFinished() {
           if (subscriptionNonceRef.current !== nonce) return
+          const machineState = chatRunMachineRef.current
+          const stopRequested =
+            isRunAttachedToConversation(machineState, conversationId, runId) &&
+            'stopRequested' in machineState &&
+            machineState.stopRequested
           const currentConversation = selectedConversationRef.current
           if (currentConversation?.id === conversationId) {
             const cleaned = removePlaceholderIfPresent(currentConversation)
             if (cleaned !== currentConversation) {
-              setSelectedConversationState(cleaned)
+              // The run finished without ever producing an assistant message.
+              // Unless the user stopped it, that's a failure the backend could
+              // not report: show it instead of silently dropping the placeholder.
+              setSelectedConversationState(
+                stopRequested
+                  ? cleaned
+                  : applyChatRunFailureToConversation({
+                      conversation: currentConversation,
+                      error: t('chat-response-failure'),
+                    })
+              )
             }
           }
           setChatRunMachineState(


### PR DESCRIPTION
## Summary

A chat run that failed before the provider streamed anything (for example when the provider could not be built) was finalized as `failed` without publishing a single event: the client saw the SSE stream close, found no active run, silently dropped the thinking placeholder, and the user got no reply and no error. The failure is now visible: the backend publishes and persists an error message, and the client shows a failure for any run that ends without ever producing an assistant message.

## Details

- `startServerChatRun`: the `execute()` catch now persists and publishes an assistant message carrying an error part (reusing the pattern of the user-secret failure path, extracted into a `publishAssistantErrorMessage` helper) before finalizing the run as `failed`; `UserVisibleError` messages are shown as-is, anything else as `Internal error`. Stopped runs (`stopRequestedAt`/abort) are unaffected. The failure is also logged server-side.
- Because the error message is persisted via `saveMessage`, the failure remains visible after a reload instead of the conversation showing an unanswered user message.
- Client (`ChatPageContextProvider`): if a run finishes while the thinking placeholder is still the last message — i.e. no assistant message was ever received — the placeholder is converted into a visible `chat-response-failure` error instead of being silently removed, unless the user requested the stop.

## Tests

- New `__tests__/startServerChatRunFailureEvents.test.ts`: provider-construction failure publishes a `message` event plus an `error` part and persists the error message; a stopped run publishes nothing.
- `npx vitest run` — full suite, 1079 passed / 21 skipped
- `npm run check-types`, `biome check`, `prettier` on touched files — clean
- Verified in the browser (Playwright, local dev server): a run that ends with zero events now renders the error banner with Retry instead of leaving the user message with no reply and no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)