### PR TITLE
Bound chat run reconnect attempts and flatten the retry loop

### DIFF
--- a/__tests__/chatRunSubscription.test.ts
+++ b/__tests__/chatRunSubscription.test.ts
@@ -5,15 +5,15 @@ describe('maintainChatRunSubscription', () => {
   test('reconnects with the latest sequence when the run is still active', async () => {
     const subscribe = vi
       .fn()
-      .mockImplementationOnce(async ({ onEvent, onClose }: any) => {
+      .mockImplementationOnce(async ({ onEvent }: any) => {
         onEvent({ type: 'text', text: 'a' }, 2)
-        onClose()
       })
       .mockImplementationOnce(async ({ afterSequence }: any) => {
         expect(afterSequence).toBe(2)
       })
 
     let lastSequence = 0
+    const onFinished = vi.fn()
 
     await maintainChatRunSubscription({
       conversationId: 'conversation-1',
@@ -21,21 +21,19 @@ describe('maintainChatRunSubscription', () => {
       signal: new AbortController().signal,
       getAfterSequence: () => lastSequence,
       subscribe,
-      getActiveRun: async () =>
-        ({
-          id: 'run-1',
-        }) as any,
+      getActiveRun: vi.fn().mockResolvedValueOnce({ id: 'run-1' }).mockResolvedValue(null),
       waitForReconnect: async () => {},
       onEvent: (_event, sequence) => {
         lastSequence = sequence
       },
       onReconnect: vi.fn(),
-      onFinished: vi.fn(),
+      onFinished,
       onFailed: vi.fn(),
       isCanceled: () => false,
     })
 
     expect(subscribe).toHaveBeenCalledTimes(2)
+    expect(onFinished).toHaveBeenCalledTimes(1)
   })
 
   test('fails instead of hanging when the active-run lookup throws after a subscribe error', async () => {
@@ -73,9 +71,7 @@ describe('maintainChatRunSubscription', () => {
       runId: 'run-1',
       signal: new AbortController().signal,
       getAfterSequence: () => 0,
-      subscribe: vi.fn().mockImplementation(async ({ onClose }: any) => {
-        onClose()
-      }),
+      subscribe: vi.fn().mockResolvedValue(undefined),
       getActiveRun: vi.fn().mockRejectedValue(lookupError),
       waitForReconnect: async () => {},
       onEvent: vi.fn(),
@@ -84,9 +80,6 @@ describe('maintainChatRunSubscription', () => {
       onFailed,
       isCanceled: () => false,
     })
-
-    // onClose kicks off the lookup without awaiting it
-    await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(onFailed).toHaveBeenCalledTimes(1)
     expect(onFailed).toHaveBeenCalledWith(lookupError)
@@ -102,9 +95,7 @@ describe('maintainChatRunSubscription', () => {
       runId: 'run-1',
       signal: new AbortController().signal,
       getAfterSequence: () => 0,
-      subscribe: vi.fn().mockImplementation(async ({ onClose }: any) => {
-        onClose()
-      }),
+      subscribe: vi.fn().mockResolvedValue(undefined),
       getActiveRun: vi.fn().mockResolvedValue(null),
       waitForReconnect: async () => {},
       onEvent: vi.fn(),
@@ -114,10 +105,95 @@ describe('maintainChatRunSubscription', () => {
       isCanceled: () => false,
     })
 
-    // onClose kicks off the lookup without awaiting it
-    await new Promise((resolve) => setTimeout(resolve, 0))
-
     expect(onFinished).toHaveBeenCalledTimes(1)
     expect(onFailed).not.toHaveBeenCalled()
+  })
+
+  test('gives up after too many consecutive reconnect attempts without progress', async () => {
+    const subscribe = vi.fn().mockResolvedValue(undefined)
+    const onReconnect = vi.fn()
+    const onFailed = vi.fn()
+    const onFinished = vi.fn()
+
+    await maintainChatRunSubscription({
+      conversationId: 'conversation-1',
+      runId: 'run-1',
+      signal: new AbortController().signal,
+      getAfterSequence: () => 0,
+      subscribe,
+      getActiveRun: vi.fn().mockResolvedValue({ id: 'run-1' }),
+      waitForReconnect: async () => {},
+      onEvent: vi.fn(),
+      onReconnect,
+      onFinished,
+      onFailed,
+      isCanceled: () => false,
+    })
+
+    expect(subscribe).toHaveBeenCalledTimes(11)
+    expect(onReconnect).toHaveBeenCalledTimes(10)
+    expect(onFailed).toHaveBeenCalledTimes(1)
+    expect(onFinished).not.toHaveBeenCalled()
+  })
+
+  test('resets the attempt counter when a connection makes progress', async () => {
+    const subscribe = vi
+      .fn()
+      .mockImplementationOnce(async ({ onEvent }: any) => {
+        onEvent({ type: 'text', text: 'a' }, 1)
+      })
+      .mockResolvedValue(undefined)
+    const onReconnect = vi.fn()
+    const onFinished = vi.fn()
+    const onFailed = vi.fn()
+
+    await maintainChatRunSubscription({
+      conversationId: 'conversation-1',
+      runId: 'run-1',
+      attempt: 9,
+      signal: new AbortController().signal,
+      getAfterSequence: () => 0,
+      subscribe,
+      getActiveRun: vi.fn().mockResolvedValueOnce({ id: 'run-1' }).mockResolvedValue(null),
+      waitForReconnect: async () => {},
+      onEvent: vi.fn(),
+      onReconnect,
+      onFinished,
+      onFailed,
+      isCanceled: () => false,
+    })
+
+    // Without the reset, starting at attempt 9 plus one no-progress cycle
+    // would already be close to the cap; progress must bring it back to 1.
+    expect(onReconnect).toHaveBeenCalledWith(1)
+    expect(onFinished).toHaveBeenCalledTimes(1)
+    expect(onFailed).not.toHaveBeenCalled()
+  })
+
+  test('stops silently when aborted while waiting to reconnect', async () => {
+    const abortController = new AbortController()
+    const onFailed = vi.fn()
+    const onFinished = vi.fn()
+
+    await maintainChatRunSubscription({
+      conversationId: 'conversation-1',
+      runId: 'run-1',
+      signal: abortController.signal,
+      getAfterSequence: () => 0,
+      subscribe: vi.fn().mockResolvedValue(undefined),
+      getActiveRun: vi.fn().mockResolvedValue({ id: 'run-1' }),
+      waitForReconnect: async () => {
+        abortController.abort()
+        throw new DOMException('Aborted', 'AbortError')
+      },
+      onEvent: vi.fn(),
+      onReconnect: vi.fn(),
+      onFinished,
+      onFailed,
+      isCanceled: () => false,
+    })
+
+    expect(onFailed).not.toHaveBeenCalled()
+    expect(onFinished).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/app/chat/components/chatRunSubscription.ts
+++ b/apps/frontend/app/chat/components/chatRunSubscription.ts
@@ -2,6 +2,18 @@ import * as dto from '@/types/dto'
 
 const reconnectDelayMs = (attempt: number) => Math.min(250 * attempt, 1000)
 
+// Give up after this many consecutive reconnect attempts that make no
+// progress (no event received): an unreachable events endpoint would
+// otherwise be polled forever with the chat stuck in "receiving".
+const maxConsecutiveReconnectAttempts = 10
+
+// Keeps a subscription to a chat run alive until the run is no longer active.
+//
+// The subscribe promise resolving means the stream closed (cleanly or not):
+// as long as the server still reports the run as active we reconnect from the
+// last applied sequence, resetting the attempt counter whenever a connection
+// made progress. Every exit goes through exactly one of onFinished/onFailed,
+// unless the subscription was aborted or superseded.
 export const maintainChatRunSubscription = async ({
   conversationId,
   runId,
@@ -40,7 +52,30 @@ export const maintainChatRunSubscription = async ({
   onFailed: (error: unknown) => void
   isCanceled: () => boolean
 }) => {
-  const reconnectOrFinish = async (error?: unknown) => {
+  let currentAttempt = attempt
+  for (;;) {
+    if (signal.aborted || isCanceled()) {
+      return
+    }
+
+    let subscribeError: unknown
+    let receivedEvent = false
+    try {
+      await subscribe({
+        runId,
+        afterSequence: getAfterSequence(),
+        signal,
+        onOpen,
+        onEvent(event, sequence) {
+          receivedEvent = true
+          onEvent(event, sequence)
+        },
+        onClose() {},
+      })
+    } catch (error) {
+      subscribeError = error
+    }
+
     if (signal.aborted || isCanceled()) {
       return
     }
@@ -52,61 +87,36 @@ export const maintainChatRunSubscription = async ({
     try {
       activeRun = await getActiveRun(conversationId)
     } catch (lookupError) {
-      if (signal.aborted || isCanceled()) {
-        return
+      if (!signal.aborted && !isCanceled()) {
+        onFailed(subscribeError ?? lookupError)
       }
-      onFailed(error ?? lookupError)
       return
     }
     if (signal.aborted || isCanceled()) {
       return
     }
 
-    if (activeRun?.id === runId) {
-      const nextAttempt = attempt + 1
-      onReconnect(nextAttempt)
-      await waitForReconnect(reconnectDelayMs(nextAttempt), signal)
-      if (signal.aborted || isCanceled()) {
-        return
+    if (activeRun?.id !== runId) {
+      if (subscribeError) {
+        onFailed(subscribeError)
+      } else {
+        onFinished()
       }
-      await maintainChatRunSubscription({
-        conversationId,
-        runId,
-        attempt: nextAttempt,
-        signal,
-        getAfterSequence,
-        subscribe,
-        getActiveRun,
-        waitForReconnect,
-        onEvent,
-        onReconnect,
-        onFinished,
-        onFailed,
-        isCanceled,
-      })
       return
     }
 
-    if (error) {
-      onFailed(error)
+    currentAttempt = receivedEvent ? 1 : currentAttempt + 1
+    if (currentAttempt > maxConsecutiveReconnectAttempts) {
+      onFailed(subscribeError ?? new Error('Chat run subscription kept failing'))
       return
     }
 
-    onFinished()
-  }
-
-  try {
-    await subscribe({
-      runId,
-      afterSequence: getAfterSequence(),
-      signal,
-      onOpen,
-      onEvent,
-      onClose() {
-        void reconnectOrFinish()
-      },
-    })
-  } catch (error) {
-    await reconnectOrFinish(error)
+    onReconnect(currentAttempt)
+    try {
+      await waitForReconnect(reconnectDelayMs(currentAttempt), signal)
+    } catch {
+      // aborted while waiting
+      return
+    }
   }
 }


### PR DESCRIPTION
## Summary

Hardens the chat run event-subscription retry logic. The events endpoint failing persistently used to be retried forever at a capped ~1s interval with the chat stuck in "receiving" and no feedback; reconnect attempts are now bounded and surface a visible failure, while long-running streams keep reconnecting as long as they make progress.

## Details

- `maintainChatRunSubscription` is rewritten as an iterative loop instead of recursing into itself for every reconnect; the loop is driven by the subscribe promise settling (with `@microsoft/fetch-event-source`, resolution means the stream closed).
- Consecutive reconnect attempts that make no progress are capped at 10 (delays unchanged, 250ms growing to 1s); hitting the cap reports the failure through `onFailed` instead of polling forever.
- The attempt counter resets whenever a connection receives an event, so a long stream that reconnects occasionally (e.g. proxy idle timeouts) is not eventually killed by the cap.
- An abort raised while waiting between reconnects now exits the loop cleanly; previously the `waitForReconnect` rejection escaped as an unhandled rejection.
- A subscribe promise that resolves without the stream ever opening is now treated as a close and retried/finished, instead of ending the maintenance silently and leaving the chat status stuck.

## Tests

- `__tests__/chatRunSubscription.test.ts` extended: reconnect-with-latest-sequence (updated to the promise-driven contract), attempt cap reached, attempt reset on progress, clean abort during the reconnect wait, plus the existing lookup-failure cases.
- `npx vitest run` — full suite, 1082 passed / 21 skipped
- `npm run check-types`, `biome check`, `prettier` on touched files — clean
- Manual check in the browser (Playwright, local dev server): normal send/stream flow works with the loop implementation (response streamed and run finalized with no stuck status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)