### PR TITLE
Align ApiError.code type with the value actually stored in it

### DIFF
--- a/packages/core/src/types/base.ts
+++ b/packages/core/src/types/base.ts
@@ -1,5 +1,7 @@
+// `code`, when present, is the HTTP status the client-side fetch layer
+// derived the error from; backend error bodies don't include it.
 export type ApiError = {
-  code?: string
+  code?: number
   message: string
   values: { [key: string]: string }
 }


### PR DESCRIPTION
## Summary

`ApiError.code` was declared `string` but the only producer (`fetchApiResponse` in the client fetch layer) has always stored the numeric HTTP status there, hidden by `as` casts; no code produces or reads a string value. The type now says `number`, with a comment documenting that backend error bodies don't include the field.

## Tests

- `npm run check-types` — clean
- `npx vitest run __tests__/fetch.test.ts` — 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)