### PR TITLE
Make SSO login a real navigation so it reaches the backend

### DIFF
--- a/apps/frontend/app/auth/login/LoginPanel.tsx
+++ b/apps/frontend/app/auth/login/LoginPanel.tsx
@@ -7,7 +7,7 @@ import { Link } from '@/components/ui/link'
 import { PasswordInput } from '@/components/ui/password-input'
 import * as dto from '@/types/dto'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { FC, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
@@ -29,7 +29,6 @@ const Login: FC<Props> = ({ connections, enableSignup }) => {
 
   const searchParams = useSearchParams()
   const [errorMessage, setErrorMessage] = useState<string | null>(searchParams.get('error'))
-  const router = useRouter()
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     mode: 'onChange',
@@ -79,7 +78,11 @@ const Login: FC<Props> = ({ connections, enableSignup }) => {
     }
   }
   const onSubmitSso = async (client_id: string) => {
-    router.push(`/api/auth/saml/login?connection=${encodeURIComponent(client_id)}`)
+    // SSO initiation is a backend route that answers with a redirect to the
+    // IdP — it must be a real browser navigation, not a client-side router
+    // push (which the SPA router would try to match against its own routes
+    // and 404 without ever hitting the server).
+    window.location.href = `/api/auth/saml/login?connection=${encodeURIComponent(client_id)}`
   }
   return (
     <div className="flex flex-col">


### PR DESCRIPTION
## Summary

The SSO provider buttons on the login page were unusable after the move to Vite + React Router (#1038): clicking one showed the 404 page instantly and never contacted the server. They now trigger a real browser navigation to the backend SSO initiation route, which redirects on to the IdP as before.

## Details

- `onSubmitSso` in `apps/frontend/app/auth/login/LoginPanel.tsx` called `useRouter().push('/api/auth/saml/login?connection=...')`. Under the `next/navigation` shim that is `react-router`'s `navigate()`, which resolves the path against the SPA route tree, misses, and renders the catch-all 404 — the `/api` request is never sent.
- Replaced it with `window.location.href = '/api/auth/saml/login?connection=...'`, the same real-navigation pattern already used for the password-login success redirect a few lines above.
- Removed the now-unused `useRouter` import and local.

## Risks

- Low. Single call site; the backend route and the IdP redirect flow are unchanged.

## Tests

- `npm run check-types` — passes.