### PR TITLE
Populate SSO user display name from IdP claims

### DIFF
--- a/apps/backend/api/oauth/oidc/route.ts
+++ b/apps/backend/api/oauth/oidc/route.ts
@@ -1,6 +1,6 @@
 import env from '@/lib/env'
 import { getClientConfig, getSsoFlowSession } from '@/lib/auth/oidc'
-import { resolveOidcEmailClaim } from '@/lib/auth/ssoIdentity'
+import { resolveOidcEmailClaim, resolveOidcNameClaim } from '@/lib/auth/ssoIdentity'
 import * as client from 'openid-client'
 import { getOrCreateUserByEmail } from '@/models/user'
 import { addSessionCookie } from '@/lib/auth/session'
@@ -52,7 +52,10 @@ export const GET = operation({
       }
 
       try {
-        const user = await getOrCreateUserByEmail(normalizedEmailOrSub)
+        const user = await getOrCreateUserByEmail(
+          normalizedEmailOrSub,
+          resolveOidcNameClaim(claims as Record<string, unknown>)
+        )
         if (!user.enabled) {
           return error(403, 'user-disabled')
         }

--- a/apps/backend/api/oauth/saml/route.ts
+++ b/apps/backend/api/oauth/saml/route.ts
@@ -1,5 +1,5 @@
 // app/api/oauth/saml/route.ts (ACS URL)
-import { createSaml, findEmailInSamlProfile } from '@/lib/auth/saml'
+import { createSaml, findEmailInSamlProfile, findNameInSamlProfile } from '@/lib/auth/saml'
 import { addSessionCookie } from '@/lib/auth/session'
 import env from '@/lib/env'
 import { findIdpConnection } from '@/models/sso'
@@ -76,7 +76,7 @@ export const POST = operation({
       if (!email) {
         return error(400, 'SAML claims missing usable email')
       }
-      const user = await getOrCreateUserByEmail(email)
+      const user = await getOrCreateUserByEmail(email, findNameInSamlProfile(profile))
       if (!user.enabled) {
         return error(403, 'user-disabled')
       }

--- a/apps/backend/lib/auth/__tests__/ssoIdentity.test.ts
+++ b/apps/backend/lib/auth/__tests__/ssoIdentity.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { Profile } from '@node-saml/node-saml'
+import { findNameInSamlProfile, resolveOidcNameClaim } from '@/backend/lib/auth/ssoIdentity'
+
+const samlProfile = (attrs: Record<string, unknown>) => attrs as unknown as Profile
+
+describe('findNameInSamlProfile', () => {
+  it('prefers the friendly displayName attribute', () => {
+    expect(findNameInSamlProfile(samlProfile({ displayName: 'Barbara Schivo' }))).toBe(
+      'Barbara Schivo'
+    )
+  })
+
+  it('reads the Microsoft displayname claim URI', () => {
+    expect(
+      findNameInSamlProfile(
+        samlProfile({
+          'http://schemas.microsoft.com/identity/claims/displayname': 'Emma Pellegrini',
+        })
+      )
+    ).toBe('Emma Pellegrini')
+  })
+
+  it('falls back to givenName + surname claim URIs', () => {
+    expect(
+      findNameInSamlProfile(
+        samlProfile({
+          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname': 'Sandra',
+          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname': 'Lavalle',
+        })
+      )
+    ).toBe('Sandra Lavalle')
+  })
+
+  it('returns null when no usable name claim is present', () => {
+    expect(findNameInSamlProfile(samlProfile({ nameID: 'sandra.lavalle@example.com' }))).toBeNull()
+  })
+})
+
+describe('resolveOidcNameClaim', () => {
+  it('prefers the name claim', () => {
+    expect(resolveOidcNameClaim({ name: 'Sonia Caderbe', given_name: 'Sonia' })).toBe('Sonia Caderbe')
+  })
+
+  it('joins given_name and family_name', () => {
+    expect(resolveOidcNameClaim({ given_name: 'Valentina', family_name: 'Cecconi' })).toBe(
+      'Valentina Cecconi'
+    )
+  })
+
+  it('returns null when nothing usable is present', () => {
+    expect(resolveOidcNameClaim({})).toBeNull()
+  })
+})

--- a/apps/backend/lib/auth/saml.ts
+++ b/apps/backend/lib/auth/saml.ts
@@ -3,7 +3,7 @@ export const runtime = 'nodejs'
 import { SAML } from '@node-saml/node-saml'
 import * as dto from '@/types/dto'
 import env from '@/lib/env'
-export { findEmailInSamlProfile } from './ssoIdentity'
+export { findEmailInSamlProfile, findNameInSamlProfile } from './ssoIdentity'
 
 export function createSaml(config: dto.SAMLConfig) {
   return new SAML({

--- a/apps/backend/lib/auth/ssoIdentity.ts
+++ b/apps/backend/lib/auth/ssoIdentity.ts
@@ -27,6 +27,38 @@ function normalizeClaim(value: unknown): string | null {
   return normalized || null
 }
 
+function cleanName(value: unknown): string | null {
+  const normalized = String(value ?? '')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  return normalized || null
+}
+
+export function resolveOidcNameClaim(claims: Record<string, unknown>): string | null {
+  return (
+    cleanName(claims.name) ||
+    cleanName([claims.given_name, claims.family_name].filter(Boolean).join(' '))
+  )
+}
+
+export function findNameInSamlProfile(profile: Profile): string | null {
+  const p = profile as Record<string, unknown>
+  return (
+    cleanName(p.displayName) ||
+    cleanName(p['http://schemas.microsoft.com/identity/claims/displayname']) ||
+    cleanName(
+      [
+        p.givenName ??
+          p['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname'],
+        p.surname ?? p['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname'],
+      ]
+        .filter(Boolean)
+        .join(' ')
+    )
+  )
+}
+
 export function findEmailInSamlProfile(profile: Profile): string | null {
   return (
     // Match the old BoxyHQ/Jackson outcome as closely as possible:

--- a/apps/backend/models/user.ts
+++ b/apps/backend/models/user.ts
@@ -79,12 +79,37 @@ export const getUserByEmail = async (email: string): Promise<schema.User | undef
     .executeTakeFirst()
 }
 
-export const getOrCreateUserByEmail = async (email: string): Promise<schema.User> => {
+export const getOrCreateUserByEmail = async (
+  email: string,
+  displayName?: string | null
+): Promise<schema.User> => {
   const normalizedEmail = email.trim().toLowerCase()
-  const user = await getUserByEmail(normalizedEmail)
-  if (user) return user
+  const emailLocalPart = normalizedEmail.split('@')[0] || 'user'
+  const resolvedDisplayName = displayName?.trim() || null
 
-  const userName = normalizedEmail.split('@')[0] || 'user'
+  const user = await getUserByEmail(normalizedEmail)
+  if (user) {
+    // Older SSO logins provisioned users with their email local part as the
+    // display name because no name claim was read from the IdP. Backfill the
+    // real name once it becomes available, but never touch a SCIM-provisioned
+    // user or one an admin has since renamed.
+    if (
+      resolvedDisplayName &&
+      !user.provisioned &&
+      user.name === emailLocalPart &&
+      user.name !== resolvedDisplayName
+    ) {
+      await db
+        .updateTable('User')
+        .set({ name: resolvedDisplayName, updatedAt: new Date().toISOString() })
+        .where('id', '=', user.id)
+        .execute()
+      return { ...user, name: resolvedDisplayName }
+    }
+    return user
+  }
+
+  const userName = resolvedDisplayName || emailLocalPart
 
   try {
     return await createUser({


### PR DESCRIPTION
## Summary

Auto-provisioned SSO users are now created with the display name reported by the identity provider instead of the email local part. Users who log in via SAML or OIDC and don't yet exist in Logicle get a proper `First Last` name; users previously provisioned with the wrong name have it corrected automatically on their next login.

## Details

- `findNameInSamlProfile` reads `displayName`, the Microsoft `.../identity/claims/displayname` claim, or `givenName` + `surname` (friendly and claim-URI forms).
- `resolveOidcNameClaim` reads the OIDC `name` claim, falling back to `given_name` + `family_name`.
- `getOrCreateUserByEmail` takes an optional display name: it is used for the created row, and for an existing row it backfills `name` only when the user is not SCIM-provisioned and their current name still equals the email local part (never overrides an admin rename).
- SAML and OIDC callbacks pass the resolved name through.

## Risks

- Backfill is conservative (guarded by `provisioned` flag and exact match against the email local part), so it won't clobber manually set names.

## Tests

- `npm run check-types` — passes.
- `npx vitest run apps/backend/lib/auth/__tests__/ssoIdentity.test.ts` — 7 tests pass (new coverage for both claim resolvers).
- `npx biome check` on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)