### PR TITLE
Fix conversation history reconstruction (#294)

### DIFF
--- a/__tests__/conversationUtils.test.ts
+++ b/__tests__/conversationUtils.test.ts
@@ -47,6 +47,18 @@ describe('extractLinearConversation', () => {
     const m3 = userMsg('m3', 'm2') as dto.Message
     expect(extractLinearConversation([m1, m2, m3], m3)).toEqual([m1, m2, m3])
   })
+
+  test('resolves the persisted parent chain instead of dropping history', () => {
+    const root = userMsg('root', null) as dto.Message
+    const assistant = assistantMsg('assistant', 'root') as dto.Message
+    const current = userMsg('current', 'assistant') as dto.Message
+
+    expect(extractLinearConversation([root, assistant, current], current)).toEqual([
+      root,
+      assistant,
+      current,
+    ])
+  })
 })
 
 // ---- flatten ----

--- a/packages/core/src/chat/conversationUtils.ts
+++ b/packages/core/src/chat/conversationUtils.ts
@@ -24,7 +24,9 @@ export function extractLinearConversation(
   const list: dto.Message[] = []
   do {
     list.push(from)
-    from = msgMap.get(from.parent ?? 'none')
+    const parent = msgMap.get(from.parent ?? 'none')
+    if (!parent) break
+    from = parent
   } while (from)
   return list.slice().reverse()
 }

--- a/packages/core/src/chat/conversationUtils.ts
+++ b/packages/core/src/chat/conversationUtils.ts
@@ -18,13 +18,13 @@ export function extractLinearConversation(
 ): dto.Message[] {
   const msgMap = new Map<string, dto.Message>()
   messages.forEach((msg) => {
-    msgMap[msg.id] = msg
+    msgMap.set(msg.id, msg)
   })
 
   const list: dto.Message[] = []
   do {
     list.push(from)
-    from = msgMap[from.parent ?? 'none']
+    from = msgMap.get(from.parent ?? 'none')
   } while (from)
   return list.slice().reverse()
 }


### PR DESCRIPTION
## Summary
Fixes #294 by correctly resolving parent messages when reconstructing the linear conversation sent to the model. Multi-turn conversations now retain their persisted history instead of silently collapsing to the current message.

## Details
- Populate and read the parent lookup with `Map.set`/`Map.get`.
- Add a regression test covering a user → assistant → user chain.

## Tests
- `pnpm exec vitest run __tests__/conversationUtils.test.ts`
