### PR TITLE
Gate image editing by assistant capability (#291)

### DIFF
--- a/apps/frontend/app/chat/components/Attachment.tsx
+++ b/apps/frontend/app/chat/components/Attachment.tsx
@@ -21,7 +21,7 @@ export const isImage = (mimeType: string) => {
 
 export const Attachment = ({ file, uiHidden, className, conversationId }: AttachmentProps) => {
   const { t } = useTranslation()
-  const { openImageEditor } = useContext(ChatPageContext)
+  const { openImageEditor, canEditImages } = useContext(ChatPageContext)
 
   if (uiHidden) return null
 
@@ -47,7 +47,7 @@ export const Attachment = ({ file, uiHidden, className, conversationId }: Attach
           </div>
         )}
         <div className="flex flex-horz m-2 gap-1 absolute top-0 right-0 invisible group-hover/attachment:visible">
-          {isImage(file.fileType) && openImageEditor && file.fileId && (
+          {isImage(file.fileType) && canEditImages && openImageEditor && file.fileId && (
             <button
               type="button"
               title={t('edit-image')}

--- a/apps/frontend/app/chat/components/ChatPageContextProvider.tsx
+++ b/apps/frontend/app/chat/components/ChatPageContextProvider.tsx
@@ -76,21 +76,29 @@ export const ChatPageContextProvider: FC<Props> = ({ children }) => {
 
   const [imageEditorState, setImageEditorState] = useState<ImageEditorState | null>(null)
 
+  const {
+    state: { selectedConversation },
+    dispatch,
+  } = contextValue
+
+  const canEditImages = Boolean(
+    selectedConversation &&
+      userProfile?.assistants
+        .find((assistant) => assistant.id === selectedConversation.assistantId)
+        ?.tools.some((tool) => imageGenToolNames.has(tool.type))
+  )
+
   const openImageEditor = useCallback(
     (attachment: dto.Attachment, options?: { conversationId?: string; startNewChat?: boolean }) => {
+      if (!options?.startNewChat && !canEditImages) return
       setImageEditorState({
         attachment,
         conversationId: options?.conversationId,
         startNewChat: options?.startNewChat,
       })
     },
-    []
+    [canEditImages]
   )
-
-  const {
-    state: { selectedConversation },
-    dispatch,
-  } = contextValue
 
   const selectedConversationRef = useRef<ConversationWithMessages | undefined>(undefined)
   const chatRunMachineRef = useRef<ChatRunMachineState>(idleChatRunMachineState)
@@ -555,6 +563,7 @@ export const ChatPageContextProvider: FC<Props> = ({ children }) => {
         requestStopActiveRun,
         setSideBarContent,
         openImageEditor,
+        canEditImages,
       }}
     >
       {children}

--- a/apps/frontend/app/chat/components/UserMessageGroup.tsx
+++ b/apps/frontend/app/chat/components/UserMessageGroup.tsx
@@ -42,7 +42,14 @@ export const UserMessageGroup: FC<Props> = ({ group }) => {
         {uploads.length !== 0 && (
           <div className="flex flex-col gap-2">
             {uploads.map((file) => {
-              return <Attachment key={file.fileId} file={file} className="w-[250px]"></Attachment>
+              return (
+                <Attachment
+                  key={file.fileId}
+                  file={file}
+                  className="w-[250px]"
+                  conversationId={group.message.conversationId}
+                />
+              )
             })}
           </div>
         )}

--- a/apps/frontend/app/chat/components/context.tsx
+++ b/apps/frontend/app/chat/components/context.tsx
@@ -64,6 +64,7 @@ export interface ChatPageContextProps {
     attachment: dto.Attachment,
     options?: { conversationId?: string; startNewChat?: boolean }
   ) => void
+  canEditImages?: boolean
 }
 
 const ChatPageContext = createContext<ChatPageContextProps>(undefined!)


### PR DESCRIPTION
## Summary
Fixes #291 by hiding and rejecting the image-edit action when the assistant assigned to the current conversation does not expose an image-generation tool.

## Details
- Derive the image-edit capability from the active conversation assistant.
- Guard the editor opener as a second line of defense against stale UI state.
- Preserve the conversation id for user-message attachments, matching tool-result attachments.

## Tests
- `pnpm run check-types`
