### PR TITLE
Surface truncated responses and allow continuation (#292)

### DIFF
--- a/__tests__/streamApply.test.ts
+++ b/__tests__/streamApply.test.ts
@@ -148,6 +148,26 @@ describe('applyStreamPartToMessage – citations', () => {
   })
 })
 
+describe('applyStreamPartToMessage – finish reason', () => {
+  test('persists the model finish reason on an assistant message', () => {
+    const result = applyStreamPartToMessage(assistantMsg(), {
+      type: 'finish',
+      finishReason: 'length',
+    }) as dto.AssistantMessage
+
+    expect(result.finishReason).toBe('length')
+  })
+
+  test('throws for a finish event on a non-assistant message', () => {
+    expect(() =>
+      applyStreamPartToMessage(userMsg(), {
+        type: 'finish',
+        finishReason: 'stop',
+      })
+    ).toThrow('non-assistant message')
+  })
+})
+
 describe('applyStreamPartToMessage – attachment', () => {
   test('appends attachment to user message', () => {
     const attachment: dto.Attachment = { id: 'f1', mimetype: 'image/png', name: 'img.png', size: 100 }

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -1031,6 +1031,8 @@ export class ChatAssistant {
               message: chunk.rawFinishReason ?? 'LLM sent an error finish chunk',
             })
           }
+          chatState.applyStreamPart({ type: 'finish', finishReason: chunk.finishReason })
+          clientSink.enqueue({ type: 'finish', finishReason: chunk.finishReason })
         } else if (chunk.type === 'error') {
           if (ai.AISDKError.isInstance(chunk.error)) {
             throw chunk.error

--- a/apps/frontend/app/chat/components/AssistantMessageGroup.tsx
+++ b/apps/frontend/app/chat/components/AssistantMessageGroup.tsx
@@ -396,6 +396,31 @@ export const AssistantMessageGroup: FC<Props> = ({ assistant, group, isLast, sha
                   assistantSubAssistants={assistant.subAssistants}
                   assistantId={assistant.id}
                 ></AssistantGroupMessage>
+                {message.role === 'assistant' &&
+                  message.finishReason === 'length' &&
+                  isLast &&
+                  index + 1 === group.messages.length && (
+                    <div className="mt-2 flex items-center gap-2 text-sm text-muted-foreground">
+                      <span>{t('response-truncated')}</span>
+                      {chatStatus.state === 'idle' && sendMessage && (
+                        <Button
+                          variant="secondary"
+                          size="small"
+                          onClick={() =>
+                            sendMessage({
+                              msg: {
+                                role: 'user',
+                                content: t('continue-response-prompt'),
+                                attachments: [],
+                              },
+                            })
+                          }
+                        >
+                          {t('continue')}
+                        </Button>
+                      )}
+                    </div>
+                  )}
                 {message.error && (
                   <MessageError error={message.error} msgId={message.id}></MessageError>
                 )}

--- a/apps/frontend/locales/en/logicle.json
+++ b/apps/frontend/locales/en/logicle.json
@@ -33,6 +33,7 @@
   "allow-workspace": "Allow workspace members to login using an Identity Provider.",
   "connect": "Connect",
   "continue": "Continue",
+  "continue-response-prompt": "Continue the previous response from where you stopped.",
   "continue-after-connect": "Continue after connect",
   "already-have-an-account": "Already have an account?",
   "analytics": "Analytics",

--- a/apps/frontend/locales/it/logicle.json
+++ b/apps/frontend/locales/it/logicle.json
@@ -33,6 +33,7 @@
   "allow-workspace": "Consenti ai membri del workspace di accedere utilizzando un Identity Provider.",
   "connect": "Connetti",
   "continue": "Continua",
+  "continue-response-prompt": "Continua la risposta precedente da dove si è interrotta.",
   "continue-after-connect": "Continua dopo la connessione",
   "already-have-an-account": "Hai già un account?",
   "analytics": "Statistiche uso",

--- a/packages/core/src/chat/streamApply.ts
+++ b/packages/core/src/chat/streamApply.ts
@@ -76,6 +76,16 @@ export function applyStreamPartToMessage(
     }
   }
 
+  if (streamPart.type === 'finish') {
+    if (message.role !== 'assistant') {
+      throw new Error('Received finish event for non-assistant message')
+    }
+    return {
+      ...message,
+      finishReason: streamPart.finishReason,
+    }
+  }
+
   if (streamPart.type === 'citations') {
     return {
       ...message,

--- a/packages/core/src/types/dto/chat.ts
+++ b/packages/core/src/types/dto/chat.ts
@@ -200,6 +200,14 @@ export type MessageRole =
   | 'user-request'
   | 'user-response'
 
+export type FinishReason =
+  | 'stop'
+  | 'length'
+  | 'content-filter'
+  | 'tool-calls'
+  | 'error'
+  | 'other'
+
 export interface BaseMessage {
   id: string
   conversationId: string
@@ -262,6 +270,8 @@ export type AssistantMessagePart =
 export type AssistantMessage = BaseMessage & {
   role: 'assistant'
   parts: AssistantMessagePart[]
+  /** Why the model stopped generating this assistant response. */
+  finishReason?: FinishReason
 }
 
 export type UserRequestMessage = BaseMessage & {
@@ -351,6 +361,11 @@ interface TextStreamPartSummary extends TextStreamPartGeneric {
   summary: string
 }
 
+interface TextStreamPartFinish extends TextStreamPartGeneric {
+  type: 'finish'
+  finishReason: FinishReason
+}
+
 /** Emitted once per assistant turn, right after the LLM call finishes — carries the same token
  * counts already computed for DB persistence (see apps/backend/lib/chat/usage.ts's `Usage`), just
  * surfaced to the stream consumer too. Never mutates message history (see streamApply.ts). */
@@ -370,6 +385,7 @@ export type TextStreamPart =
   | TextStreamPartCitations
   | TextStreamPartUserRequest
   | TextStreamPartSummary
+  | TextStreamPartFinish
   | TextStreamPartUsage
 
 export const messageSchema = z.record(z.string(), z.unknown()) as unknown as z.ZodType<Message>


### PR DESCRIPTION
## Summary
Fixes #292 by carrying the model finish reason through chat streams and persisted assistant messages. Responses stopped by the output-token limit are now clearly marked and can be continued from the interrupted turn.

## Details
- Add a typed `finish` stream event and persist `finishReason` on assistant messages.
- Show a localized truncation notice for `finishReason: length`.
- Add a localized Continue action that starts the next turn from the truncated response.

## Tests
- `pnpm exec vitest run __tests__/streamApply.test.ts`
- `pnpm run check-types`
