### PR TITLE
fix(imagegen): normalize source images before editing

### DIFF
--- a/__tests__/imagegenFiles.test.ts
+++ b/__tests__/imagegenFiles.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import {
   generatedImageExtensionForMimeType,
   normalizeGeneratedImageMimeType,
+  prepareImageForEditing,
 } from '@/backend/lib/imagegen/files'
 
 describe('generated image file metadata', () => {
@@ -16,5 +17,55 @@ describe('generated image file metadata', () => {
     expect(normalizeGeneratedImageMimeType(undefined)).toBe('image/png')
     expect(normalizeGeneratedImageMimeType('application/octet-stream')).toBe('image/png')
     expect(generatedImageExtensionForMimeType('application/octet-stream')).toBe('png')
+  })
+
+  test('normalizes provider-supported source MIME parameters without changing the bytes', async () => {
+    const source = Buffer.from('jpeg-bytes')
+
+    await expect(
+      prepareImageForEditing({
+        data: source,
+        fileName: 'photo.original',
+        mimeType: 'image/jpg; charset=binary',
+      })
+    ).resolves.toEqual({
+      data: source,
+      fileName: 'photo.original',
+      mimeType: 'image/jpeg',
+    })
+  })
+
+  test('converts image formats unsupported by providers to PNG', async () => {
+    const source = await (await import('sharp'))
+      .default({
+        create: {
+          width: 1,
+          height: 1,
+          channels: 3,
+          background: { r: 255, g: 0, b: 0 },
+        },
+      })
+      .gif()
+      .toBuffer()
+
+    const prepared = await prepareImageForEditing({
+      data: source,
+      fileName: 'animation.gif',
+      mimeType: 'image/gif',
+    })
+
+    expect(prepared.mimeType).toBe('image/png')
+    expect(prepared.fileName).toBe('animation.png')
+    expect(prepared.data.equals(source)).toBe(false)
+  })
+
+  test('rejects non-image source files before calling a provider', async () => {
+    await expect(
+      prepareImageForEditing({
+        data: Buffer.from('not-an-image'),
+        fileName: 'document.pdf',
+        mimeType: 'application/pdf',
+      })
+    ).rejects.toThrow('Image editing requires an image file')
   })
 })

--- a/apps/backend/lib/imagegen/files.ts
+++ b/apps/backend/lib/imagegen/files.ts
@@ -1,9 +1,15 @@
+import sharp from 'sharp'
+
+import type { ImageEditInput } from './types'
+
 const IMAGE_EXTENSION_BY_MIME_TYPE: Record<string, string> = {
   'image/jpeg': 'jpg',
   'image/png': 'png',
   'image/webp': 'webp',
   'image/gif': 'gif',
 }
+
+const EDITABLE_IMAGE_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp'])
 
 export const normalizeGeneratedImageMimeType = (mimeType?: string) => {
   const normalized = mimeType?.split(';', 1)[0]?.trim().toLowerCase()
@@ -15,3 +21,47 @@ export const normalizeGeneratedImageMimeType = (mimeType?: string) => {
 
 export const generatedImageExtensionForMimeType = (mimeType?: string) =>
   IMAGE_EXTENSION_BY_MIME_TYPE[normalizeGeneratedImageMimeType(mimeType)] ?? 'png'
+
+const normalizeSourceImageMimeType = (mimeType: string) => {
+  const normalized = mimeType.split(';', 1)[0]?.trim().toLowerCase()
+  return normalized === 'image/jpg' ? 'image/jpeg' : normalized
+}
+
+const pngFileName = (fileName: string) => {
+  const withoutExtension = fileName.replace(/\.[^./]+$/, '') || 'upload'
+  return `${withoutExtension}.png`
+}
+
+/**
+ * Normalize an image before sending it to an image-edit provider.
+ *
+ * The providers accept PNG/JPEG/WebP, while the upload UI intentionally accepts
+ * any image/* MIME type. Converting the other image formats here keeps provider
+ * requests identical for filesystem- and S3-backed tenants and prevents a
+ * provider from receiving a misleading MIME type (for example image/gif data
+ * labelled as image/png).
+ */
+export const prepareImageForEditing = async (image: ImageEditInput): Promise<ImageEditInput> => {
+  const mimeType = normalizeSourceImageMimeType(image.mimeType)
+  if (EDITABLE_IMAGE_MIME_TYPES.has(mimeType)) {
+    return { ...image, mimeType }
+  }
+
+  if (!mimeType.startsWith('image/')) {
+    throw new Error(`Image editing requires an image file, received ${image.mimeType}`)
+  }
+
+  try {
+    const data = await sharp(image.data).png().toBuffer()
+    return {
+      ...image,
+      data,
+      fileName: pngFileName(image.fileName),
+      mimeType: 'image/png',
+    }
+  } catch (error) {
+    throw new Error(`Unable to convert ${image.fileName} to a supported image format`, {
+      cause: error,
+    })
+  }
+}

--- a/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/direct-implementation.ts
@@ -23,6 +23,7 @@ import { recordImageGenerationEvent } from '@/backend/lib/imagegen/metering'
 import {
   generatedImageExtensionForMimeType,
   normalizeGeneratedImageMimeType,
+  prepareImageForEditing,
 } from '@/backend/lib/imagegen/files'
 import {
   isGeminiImageModel,
@@ -246,11 +247,11 @@ abstract class DirectImageGeneratorPlugin implements ToolImplementation {
       throw new Error(`Tool invocation required non existing file: ${fileId}`)
     }
     const fileContent = await storage.readBuffer(fileEntry.path, fileEntry.encryption)
-    return {
+    return await prepareImageForEditing({
       data: Buffer.from(ensureABView(fileContent)),
       fileName: fileEntry.name || 'upload.png',
       mimeType: fileEntry.type,
-    }
+    })
   }
 
   private async invokeEdit({

--- a/apps/backend/lib/tools/imagegenerator/implementation.ts
+++ b/apps/backend/lib/tools/imagegenerator/implementation.ts
@@ -22,6 +22,7 @@ import { ImagesResponse } from 'openai/resources/images'
 import { ensureABView } from '@/backend/lib/utils'
 import { LlmModel } from '@/lib/chat/models'
 import { shouldExposeImageEditingTool } from '@/backend/lib/imagegen/models'
+import { prepareImageForEditing } from '@/backend/lib/imagegen/files'
 import { materializeFile } from '@/backend/lib/files/materialize'
 import { resolveFileOwner } from '@/backend/lib/tools/ownership'
 
@@ -135,8 +136,13 @@ export class ImageGeneratorPlugin
     }
     // FIXME: doing an unsafe cast. There should be no problems with node
     const fileContent = await storage.readBuffer(fileEntry.path, fileEntry.encryption)
-    const blob = new Blob([ensureABView(fileContent)], { type: fileEntry.type })
-    return new File([blob], 'upload.png', { type: fileEntry.type })
+    const image = await prepareImageForEditing({
+      data: Buffer.from(ensureABView(fileContent)),
+      fileName: fileEntry.name || 'upload.png',
+      mimeType: fileEntry.type,
+    })
+    const blob = new Blob([ensureABView(image.data)], { type: image.mimeType })
+    return new File([blob], image.fileName, { type: image.mimeType })
   }
 
   private async invokeEdit({


### PR DESCRIPTION
## Summary
Addresses [logicleai/logicle-issues#293](https://github.com/logicleai/logicle-issues/issues/293) by normalizing every source image before it reaches an image-edit provider. VM/docker-compose and Kubernetes tenants now send the same provider-compatible PNG/JPEG/WebP payload, including when uploads carry GIF, `image/jpg`, or MIME parameters.

## Details
- Normalize supported source MIME types and strip MIME parameters.
- Convert other image/* formats to PNG before OpenAI, Together, or Gemini editing.
- Reject non-image references with an actionable error before the provider call.
- Preserve the converted filename and MIME type in the legacy and direct image tools.

## Tests
- `pnpm exec vitest run __tests__/imagegenFiles.test.ts apps/backend/lib/imagegen/providers/__tests__/openai.test.ts apps/backend/lib/imagegen/providers/__tests__/together.test.ts apps/backend/lib/imagegen/providers/__tests__/gemini.test.ts`
- `pnpm run check-types`
- `git diff --check`