### PR TITLE
feat(chat): add focused mobile experience

### DIFF
--- a/apps/frontend-vite/src/layoutAdapters.tsx
+++ b/apps/frontend-vite/src/layoutAdapters.tsx
@@ -1,10 +1,11 @@
-import { Outlet } from 'react-router-dom'
+import { Navigate, Outlet } from 'react-router-dom'
 import AdminLayout from '@/app/admin/layout'
 import MeLayout from '@/app/me/layout'
 import ChatLayout from '@/app/chat/layout'
 import ImagesLayout from '@/app/images/layout'
 import SatellitesLayout from '@/app/satellites/layout'
 import AuthPageLayout from '@/app/auth/layout'
+import { useLayoutConfig } from '@/components/providers/layoutconfigContext'
 
 // Real Next layout.tsx files all take a `children: ReactNode` prop (Next's
 // App Router convention) rather than rendering an <Outlet/> themselves —
@@ -48,3 +49,15 @@ export const AuthRouteLayout = () => (
     <Outlet />
   </AuthPageLayout>
 )
+
+// On phones Logicle deliberately exposes a focused chat experience, including
+// when somebody opens an old admin or management bookmark directly.
+export const MobileChatOnlyRoute = () => {
+  const { isMobile } = useLayoutConfig()
+  return isMobile ? <Navigate to="/chat" replace /> : <Outlet />
+}
+
+export const MobileAssistantManagementRoute = () => {
+  const { isMobile } = useLayoutConfig()
+  return isMobile ? <Navigate to="/chat/assistants/select" replace /> : <Outlet />
+}

--- a/apps/frontend-vite/src/router.tsx
+++ b/apps/frontend-vite/src/router.tsx
@@ -9,6 +9,8 @@ import {
   ImagesRouteLayout,
   SatellitesRouteLayout,
   AuthRouteLayout,
+  MobileChatOnlyRoute,
+  MobileAssistantManagementRoute,
 } from './layoutAdapters'
 
 // Full route tree, mechanically ported from apps/frontend/app/**/page.tsx +
@@ -83,8 +85,19 @@ export const router = createBrowserRouter([
             path: 'chat/:chatId?',
             ...named('ChatSection')(() => import('@/app/chat/components/ChatSection')),
           },
-          { path: 'chat/assistants/select', ...page(() => import('@/app/chat/assistants/select/page')) },
-          { path: 'chat/assistants/mine', ...page(() => import('@/app/chat/assistants/mine/page')) },
+          {
+            path: 'chat/assistants/select',
+            ...page(() => import('@/app/chat/assistants/select/page')),
+          },
+          {
+            element: <MobileAssistantManagementRoute />,
+            children: [
+              {
+                path: 'chat/assistants/mine',
+                ...page(() => import('@/app/chat/assistants/mine/page')),
+              },
+            ],
+          },
           {
             path: 'chat/folders/:folderId',
             ...page(() => import('@/app/chat/folders/[folderId]/PageClient')),
@@ -93,101 +106,131 @@ export const router = createBrowserRouter([
       },
 
       {
-        element: <ImagesRouteLayout />,
-        children: [{ path: 'images', ...page(() => import('@/app/images/page')) }],
-      },
-
-      {
-        element: <SatellitesRouteLayout />,
+        element: <MobileChatOnlyRoute />,
         children: [
-          { path: 'satellites', ...page(() => import('@/app/satellites/page')) },
-          { path: 'satellites/create', element: <Navigate to="/satellites" replace /> },
-          { path: 'satellites/:id', ...page(() => import('@/app/satellites/[id]/PageClient')) },
-        ],
-      },
-
-      { path: 'assistants/:id', ...page(() => import('@/app/assistants/[id]/PageClient')) },
-      {
-        path: 'assistants/:id/history',
-        ...page(() => import('@/app/assistants/[id]/history/PageClient')),
-      },
-
-      { path: 'share/:shareId', ...page(() => import('@/app/share/[shareId]/PageClient')) },
-
-      { path: 'internals/palette', ...page(() => import('@/app/internals/palette/page')) },
-      { path: 'internals/styleguide', ...page(() => import('@/app/internals/styleguide/page')) },
-
-      {
-        element: <AdminRouteLayout />,
-        children: [
-          { path: 'admin', element: <Navigate to="/admin/analytics" replace /> },
-          { path: 'admin/analytics', ...page(() => import('@/app/admin/analytics/AnalyticsPage')) },
           {
-            path: 'admin/assistants',
-            ...named('AssistantsAdminPage')(
-              () => import('@/app/admin/assistants/components/AssistantsAdminPage')
-            ),
+            element: <ImagesRouteLayout />,
+            children: [{ path: 'images', ...page(() => import('@/app/images/page')) }],
           },
           {
-            path: 'admin/backends',
-            ...named('BackendsPage')(() => import('@/app/admin/backends/BackendsPage')),
+            element: <SatellitesRouteLayout />,
+            children: [
+              { path: 'satellites', ...page(() => import('@/app/satellites/page')) },
+              { path: 'satellites/create', element: <Navigate to="/satellites" replace /> },
+              { path: 'satellites/:id', ...page(() => import('@/app/satellites/[id]/PageClient')) },
+            ],
+          },
+          { path: 'assistants/:id', ...page(() => import('@/app/assistants/[id]/PageClient')) },
+          {
+            path: 'assistants/:id/history',
+            ...page(() => import('@/app/assistants/[id]/history/PageClient')),
+          },
+          { path: 'share/:shareId', ...page(() => import('@/app/share/[shareId]/PageClient')) },
+          { path: 'internals/palette', ...page(() => import('@/app/internals/palette/page')) },
+          {
+            path: 'internals/styleguide',
+            ...page(() => import('@/app/internals/styleguide/page')),
           },
           {
-            path: 'admin/backends/create',
-            ...page(() => import('@/app/admin/backends/create/page')),
+            element: <AdminRouteLayout />,
+            children: [
+              { path: 'admin', element: <Navigate to="/admin/analytics" replace /> },
+              {
+                path: 'admin/analytics',
+                ...page(() => import('@/app/admin/analytics/AnalyticsPage')),
+              },
+              {
+                path: 'admin/assistants',
+                ...named('AssistantsAdminPage')(
+                  () => import('@/app/admin/assistants/components/AssistantsAdminPage')
+                ),
+              },
+              {
+                path: 'admin/backends',
+                ...named('BackendsPage')(() => import('@/app/admin/backends/BackendsPage')),
+              },
+              {
+                path: 'admin/backends/create',
+                ...page(() => import('@/app/admin/backends/create/page')),
+              },
+              {
+                path: 'admin/backends/:id',
+                ...page(() => import('@/app/admin/backends/[id]/PageClient')),
+              },
+              {
+                path: 'admin/organization',
+                ...page(() => import('@/app/admin/organization/page')),
+              },
+              { path: 'admin/satellites', ...page(() => import('@/app/admin/satellites/page')) },
+              {
+                path: 'admin/satellites/create',
+                ...page(() => import('@/app/admin/satellites/create/page')),
+              },
+              {
+                path: 'admin/satellites/:id',
+                ...page(() => import('@/app/admin/satellites/[id]/PageClient')),
+              },
+              {
+                path: 'admin/settings',
+                ...page(() => import('@/app/admin/settings/AppSettingsPage')),
+              },
+              { path: 'admin/sso', ...page(() => import('@/app/admin/sso/SSOPage')) },
+              {
+                path: 'admin/sso/:clientId',
+                ...page(() => import('@/app/admin/sso/[clientId]/PageClient')),
+              },
+              { path: 'admin/tools', ...page(() => import('@/app/admin/tools/page')) },
+              {
+                path: 'admin/tools/create',
+                ...page(() => import('@/app/admin/tools/create/page')),
+              },
+              {
+                path: 'admin/tools/:id',
+                ...page(() => import('@/app/admin/tools/[id]/PageClient')),
+              },
+              { path: 'admin/users', ...page(() => import('@/app/admin/users/UsersPage')) },
+              {
+                path: 'admin/users/:userId',
+                ...page(() => import('@/app/admin/users/[userId]/PageClient')),
+              },
+              {
+                path: 'admin/workspaces',
+                ...page(() => import('@/app/admin/workspaces/components/WorkspacesPage')),
+              },
+              {
+                path: 'admin/workspaces/:workspaceId',
+                ...page(() => import('@/app/admin/workspaces/[workspaceId]/PageClient')),
+              },
+            ],
           },
           {
-            path: 'admin/backends/:id',
-            ...page(() => import('@/app/admin/backends/[id]/PageClient')),
+            element: <MeRouteLayout />,
+            children: [
+              { path: 'me/apikeys', ...page(() => import('@/app/me/apikeys/page')) },
+              {
+                path: 'me/parameters',
+                ...named('ParametersPage')(() => import('@/app/me/components/ParametersPage')),
+              },
+              {
+                path: 'me/password',
+                ...named('UpdatePasswordPage')(
+                  () => import('@/app/me/components/UpdatePasswordPage')
+                ),
+              },
+              {
+                path: 'me/preferences',
+                ...named('UserPreferencesPage')(
+                  () => import('@/app/me/components/UserPreferencesPage')
+                ),
+              },
+              {
+                path: 'me/profile',
+                ...named('ProfilePage')(() => import('@/app/me/components/ProfilePage')),
+              },
+              { path: 'me/secrets', ...page(() => import('@/app/me/secrets/page')) },
+              { path: 'me/sessions', ...page(() => import('@/app/me/sessions/page')) },
+            ],
           },
-          { path: 'admin/organization', ...page(() => import('@/app/admin/organization/page')) },
-          { path: 'admin/satellites', ...page(() => import('@/app/admin/satellites/page')) },
-          {
-            path: 'admin/satellites/create',
-            ...page(() => import('@/app/admin/satellites/create/page')),
-          },
-          {
-            path: 'admin/satellites/:id',
-            ...page(() => import('@/app/admin/satellites/[id]/PageClient')),
-          },
-          { path: 'admin/settings', ...page(() => import('@/app/admin/settings/AppSettingsPage')) },
-          { path: 'admin/sso', ...page(() => import('@/app/admin/sso/SSOPage')) },
-          { path: 'admin/sso/:clientId', ...page(() => import('@/app/admin/sso/[clientId]/PageClient')) },
-          { path: 'admin/tools', ...page(() => import('@/app/admin/tools/page')) },
-          { path: 'admin/tools/create', ...page(() => import('@/app/admin/tools/create/page')) },
-          { path: 'admin/tools/:id', ...page(() => import('@/app/admin/tools/[id]/PageClient')) },
-          { path: 'admin/users', ...page(() => import('@/app/admin/users/UsersPage')) },
-          { path: 'admin/users/:userId', ...page(() => import('@/app/admin/users/[userId]/PageClient')) },
-          {
-            path: 'admin/workspaces',
-            ...page(() => import('@/app/admin/workspaces/components/WorkspacesPage')),
-          },
-          {
-            path: 'admin/workspaces/:workspaceId',
-            ...page(() => import('@/app/admin/workspaces/[workspaceId]/PageClient')),
-          },
-        ],
-      },
-
-      {
-        element: <MeRouteLayout />,
-        children: [
-          { path: 'me/apikeys', ...page(() => import('@/app/me/apikeys/page')) },
-          {
-            path: 'me/parameters',
-            ...named('ParametersPage')(() => import('@/app/me/components/ParametersPage')),
-          },
-          {
-            path: 'me/password',
-            ...named('UpdatePasswordPage')(() => import('@/app/me/components/UpdatePasswordPage')),
-          },
-          {
-            path: 'me/preferences',
-            ...named('UserPreferencesPage')(() => import('@/app/me/components/UserPreferencesPage')),
-          },
-          { path: 'me/profile', ...named('ProfilePage')(() => import('@/app/me/components/ProfilePage')) },
-          { path: 'me/secrets', ...page(() => import('@/app/me/secrets/page')) },
-          { path: 'me/sessions', ...page(() => import('@/app/me/sessions/page')) },
         ],
       },
 

--- a/apps/frontend/app/chat/assistants/select/page.tsx
+++ b/apps/frontend/app/chat/assistants/select/page.tsx
@@ -22,6 +22,7 @@ import {
 import { IconArrowNarrowDown, IconCalendar, IconClock, IconSortAZ } from '@tabler/icons-react'
 import { useUiState } from '@/components/providers/uistate'
 import * as RovingFocus from '@radix-ui/react-roving-focus'
+import { useLayoutConfig } from '@/components/providers/layoutconfigContext'
 
 const EMPTY_ASSISTANT_NAME = ''
 
@@ -33,6 +34,7 @@ const SelectAssistantPage = () => {
   const { t } = useTranslation()
   const router = useRouter()
   const profile = useUserProfile()
+  const { isMobile } = useLayoutConfig()
   const [searchTerm, setSearchTerm] = useState<string>('')
   const [tagsFilter, setTagsFilter] = useState<string | null>(null)
   const [ordering, setOrdering] = useUiState<Ordering>('assistants_select_ordering', 'lastused')
@@ -100,36 +102,31 @@ const SelectAssistantPage = () => {
 
   return (
     <WithLoadingAndError isLoading={isLoading} error={error}>
-      <div className="flex flex-1 h-full w-full justify-center">
-        <div className="flex flex-1 flex-col gap-2 max-w-[1440px] w-5/6 px-4 py-6">
-          <div className="relative">
+      <div className="flex h-full w-full flex-1 justify-center">
+        <div className="flex w-full max-w-[1440px] flex-1 flex-col gap-3 px-3 py-4 sm:w-5/6 sm:px-4 sm:py-6">
+          <div className="flex items-center justify-between gap-3">
             <h1 className="text-center">{t('select-assistant')}</h1>
-            <Button
-              className="absolute right-0 top-1/2 -translate-y-1/2"
-              onClick={gotoMyAssistants}
-            >
-              {t('my-assistants')}
-            </Button>
+            {!isMobile && <Button onClick={gotoMyAssistants}>{t('my-assistants')}</Button>}
           </div>
-          <div className="flex-1 flex min-h-0 flex-row gap-2">
-            <div className="h-full w-[220px] flex flex-col">
-              <h2 className="p-2">{t('tags')}</h2>
-              <ScrollArea className="scroll-workaround h-full p-2">
-                <RovingFocus.Root orientation="vertical" loop>
-                  <ul>
+          <div className="flex min-h-0 flex-1 flex-col gap-3 md:flex-row">
+            <div className="flex w-full shrink-0 flex-col md:h-full md:w-[220px]">
+              <h2 className="hidden p-2 md:block">{t('tags')}</h2>
+              <ScrollArea className="scroll-workaround w-full md:h-full md:p-2">
+                <RovingFocus.Root orientation={isMobile ? 'horizontal' : 'vertical'} loop>
+                  <ul className="flex gap-1 pb-1 md:block md:space-y-1">
                     {tags.map((tag) => (
-                    <li
-                      key={tag?.key ?? ''}
-                      className={`flex items-center py-1 px-1 gap-2 rounded hover:bg-gray-100 ${
-                        tagsFilter === tag?.key ? 'bg-secondary-hover' : ''
-                      }`}
-                    >
+                      <li
+                        key={tag?.key ?? ''}
+                        className={`flex shrink-0 items-center gap-2 rounded px-1 py-1 hover:bg-gray-100 ${
+                          tagsFilter === tag?.key ? 'bg-secondary-hover' : ''
+                        }`}
+                      >
                         <RovingFocus.Item asChild>
                           <button
                             type="button"
                             role="option"
                             aria-selected={tagsFilter === tag?.key}
-                            className="w-full text-left px-2 py-1 text-small rounded ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                            className="w-full whitespace-nowrap rounded px-2 py-1 text-left text-small ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                             onClick={() => setTagsFilter(tag?.key ?? null)}
                           >
                             <span className="flex-1 first-letter:capitalize truncate block overflow-hidden">
@@ -143,7 +140,7 @@ const SelectAssistantPage = () => {
                 </RovingFocus.Root>
               </ScrollArea>
             </div>
-            <div className="h-full flex-1 flex flex-col gap-3">
+            <div className="flex min-h-0 flex-1 flex-col gap-3">
               <SearchBarWithButtonsOnRight
                 searchTerm={searchTerm}
                 onSearchTermChange={setSearchTerm}
@@ -176,7 +173,7 @@ const SelectAssistantPage = () => {
                 {
                   //     grid-template-columns: repeat(auto-fill, minmax(max(var(--max-item-width), calc((100% - var(--gap) * (var(--rows) - 1)) / var(--rows))), 1fr));
                 }
-                <div className="grid grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(max(300px,calc((100%-1rem*2)/3)),1fr))] m-auto">
+                <div className="m-auto grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
                   {availableAssistants
                     .filter(filterWithSearch)
                     .filter(filterWithTags)

--- a/apps/frontend/app/chat/components/AssistantDropdown.tsx
+++ b/apps/frontend/app/chat/components/AssistantDropdown.tsx
@@ -25,6 +25,7 @@ import { AssistantDetailsDialog } from '@/components/app/AssistantDetailsDialog'
 import toast from 'react-hot-toast'
 import { canEditAssistant } from '@/lib/rbac'
 import { useEnvironment } from '@/app/context/environmentProvider'
+import { useLayoutConfig } from '@/components/providers/layoutconfigContext'
 
 interface Props {
   assistant: dto.UserAssistant
@@ -35,6 +36,7 @@ export const AssistantDropdown: FC<Props> = ({ assistant }) => {
   const userProfile = useUserProfile()
   const router = useRouter()
   const environment = useEnvironment()
+  const { isMobile } = useLayoutConfig()
   const [showDetailsDialog, setShowDetailsDialog] = useState<boolean>(false)
   const isAssistantMine = () => {
     return userProfile && canEditAssistant(assistant, userProfile?.id, userProfile.workspaces || [])
@@ -72,11 +74,11 @@ export const AssistantDropdown: FC<Props> = ({ assistant }) => {
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon" className="px-1 py-1">
-            <div className="flex flex-row items-center gap-2">
+          <Button variant="ghost" size="small" className="max-w-[45vw] px-1 py-1">
+            <div className="flex min-w-0 flex-row items-center gap-2">
               <AssistantAvatar assistant={assistant} />
-              <h3 className=" flex justify-center py-2">{assistant?.name ?? ''}</h3>
-              <IconChevronDown size="16" color="gray"></IconChevronDown>
+              <h3 className="truncate py-2">{assistant?.name ?? ''}</h3>
+              <IconChevronDown className="shrink-0" size="16" color="gray"></IconChevronDown>
             </div>
           </Button>
         </DropdownMenuTrigger>
@@ -87,12 +89,12 @@ export const AssistantDropdown: FC<Props> = ({ assistant }) => {
           >
             {t(assistant.pinned ? 'hide-in-sidebar' : 'show-in-sidebar')}
           </DropdownMenuButton>
-          {isAssistantMine() && (
+          {!isMobile && isAssistantMine() && (
             <DropdownMenuButton onClick={onEditAssistant} icon={IconSettings}>
               {t('edit')}
             </DropdownMenuButton>
           )}
-          {(isAssistantMine() || isAssistantCloneable()) && (
+          {!isMobile && (isAssistantMine() || isAssistantCloneable()) && (
             <DropdownMenuButton onClick={onCloneAssistant} icon={IconCopy}>
               {t('duplicate')}
             </DropdownMenuButton>

--- a/apps/frontend/app/chat/components/Chat.tsx
+++ b/apps/frontend/app/chat/components/Chat.tsx
@@ -15,6 +15,7 @@ import { useTokenRateLimit } from '@/components/providers/tokenRateLimitContext'
 import { TokenRateLimitBanner } from './TokenRateLimitBanner'
 import { MessageLimitBanner } from './MessageLimitBanner'
 import { useEnvironment } from '@/app/context/environmentProvider'
+import { useLayoutConfig } from '@/components/providers/layoutconfigContext'
 
 export interface ChatProps {
   assistant: dto.AssistantIdentification & {
@@ -46,6 +47,7 @@ export const Chat = ({
   } = useContext(ChatPageContext)
   const tokenRateLimit = useTokenRateLimit()
   const environment = useEnvironment()
+  const { isMobile } = useLayoutConfig()
   const { t } = useTranslation()
 
   const [chatInput, setChatInput] = useChatInput(selectedConversation?.id ?? '')
@@ -136,8 +138,8 @@ export const Chat = ({
     userMessageCount >= environment.softMessageLimit
 
   return (
-    <div className={`flex overflow-hidden gap-4 ${className ?? ''}`}>
-      <div className={`flex flex-1 flex-col overflow-hidden`}>
+    <div className={`relative flex min-w-0 overflow-hidden gap-4 ${className ?? ''}`}>
+      <div className={`flex min-w-0 flex-1 flex-col overflow-hidden`}>
         <ScrollArea
           className="max-h-full flex-1 overflow-x-hidden relative"
           ref={chatContainerRef}
@@ -202,7 +204,12 @@ export const Chat = ({
         )}
         {tokenRateLimit?.enabled && tokenRateLimit.exceeded && <TokenRateLimitBanner />}
       </div>
-      {sideBarContent && <ConversationSidebar content={sideBarContent} />}
+      {sideBarContent && (
+        <ConversationSidebar
+          content={sideBarContent}
+          className={isMobile ? 'absolute inset-0 z-20 bg-background p-3 shadow-xl' : undefined}
+        />
+      )}
     </div>
   )
 }

--- a/apps/frontend/app/chat/components/ChatHeader.tsx
+++ b/apps/frontend/app/chat/components/ChatHeader.tsx
@@ -8,6 +8,7 @@ import { useEnvironment } from '@/app/context/environmentProvider'
 import { AssistantDropdown } from './AssistantDropdown'
 import { saveConversation } from '@/services/conversation'
 import { mutate } from 'swr'
+import { useLayoutConfig } from '@/components/providers/layoutconfigContext'
 
 interface Props {
   assistant: dto.UserAssistant
@@ -16,6 +17,7 @@ interface Props {
 export const ChatHeader: FC<Props> = ({ assistant }) => {
   const { t } = useTranslation()
   const environment = useEnvironment()
+  const { isMobile } = useLayoutConfig()
   const {
     state: { selectedConversation },
     setSelectedConversation,
@@ -53,44 +55,52 @@ export const ChatHeader: FC<Props> = ({ assistant }) => {
     setIsRenaming(false)
   }
   return (
-    <div className="group flex flex-row justify-center px-2 gap-3 h-16 items-center">
+    <div className="group flex h-14 flex-row items-center justify-center gap-2 px-3 sm:h-16 sm:gap-3">
       <AssistantDropdown assistant={assistant} />
-      <h3 className="flex-1 text-center">
-        {!isRenaming && (
-          <button
-            type="button"
-            className="cursor-text truncate"
-            onClick={() => {
-              if (!selectedConversation) return
-              setRenameValue(selectedConversation.name ?? '')
-              setIsRenaming(true)
-            }}
-          >
-            {selectedConversation?.name || t('untitled-conversation')}
-          </button>
-        )}
-        {isRenaming && (
-          <input
-            className="max-w-[360px] w-full bg-transparent text-center text-h3 outline-none"
-            type="text"
-            value={renameValue}
-            onChange={(e) => setRenameValue(e.target.value)}
-            onBlur={() => void handleSaveRename()}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault()
-                void handleSaveRename()
-              } else if (e.key === 'Escape') {
-                e.preventDefault()
-                handleCancelRename()
-              }
-            }}
-            autoFocus
-          />
-        )}
-      </h3>
+      {!isMobile && (
+        <h3 className="min-w-0 flex-1 text-center">
+          {!isRenaming && (
+            <button
+              type="button"
+              className="cursor-text truncate"
+              onClick={() => {
+                if (!selectedConversation) return
+                setRenameValue(selectedConversation.name ?? '')
+                setIsRenaming(true)
+              }}
+            >
+              {selectedConversation?.name || t('untitled-conversation')}
+            </button>
+          )}
+          {isRenaming && (
+            <input
+              className="max-w-[360px] w-full bg-transparent text-center text-h3 outline-none"
+              type="text"
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+              onBlur={() => void handleSaveRename()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  void handleSaveRename()
+                } else if (e.key === 'Escape') {
+                  e.preventDefault()
+                  handleCancelRename()
+                }
+              }}
+              autoFocus
+            />
+          )}
+        </h3>
+      )}
       {environment.enableChatSharing && (
-        <Button onClick={() => setShowSharingDialog(true)}>{t('share')}</Button>
+        <Button
+          className={isMobile ? 'ml-auto shrink-0 px-2 text-base' : undefined}
+          size={isMobile ? 'small' : undefined}
+          onClick={() => setShowSharingDialog(true)}
+        >
+          {t('share')}
+        </Button>
       )}
       {showSharingDialog && (
         <ChatSharingDialog

--- a/apps/frontend/app/chat/components/ChatInput.tsx
+++ b/apps/frontend/app/chat/components/ChatInput.tsx
@@ -97,7 +97,8 @@ export const ChatInput = ({
   const environment = useEnvironment()
   const model = environment.models.find((candidate) => candidate.id === modelId)
   const hardLimitReached =
-    (environment.hardMessageLimit !== undefined && (userMessageCount ?? 0) >= environment.hardMessageLimit) ||
+    (environment.hardMessageLimit !== undefined &&
+      (userMessageCount ?? 0) >= environment.hardMessageLimit) ||
     !!locked
   const [isTyping, setIsTyping] = useState<boolean>(false)
   // using useState to keep the state of the uploads does not work, as xhr callbacks will not "pick up"
@@ -475,7 +476,11 @@ export const ChatInput = ({
     setRefresh(Math.random())
   }
   return (
-    <div onDrop={handleDrop} onDragOver={(event) => event.preventDefault()} className="pt-.5 px-4">
+    <div
+      onDrop={handleDrop}
+      onDragOver={(event) => event.preventDefault()}
+      className="px-3 pt-0.5 pb-[max(0.5rem,env(safe-area-inset-bottom))] sm:px-4"
+    >
       <div className="max-w-[48em] mx-auto w-full">
         <div className="relative flex flex-col rounded-md border">
           <UploadList files={uploadedFiles.current} onDelete={handleDelete} modelId={modelId} />
@@ -504,7 +509,11 @@ export const ChatInput = ({
               className="absolute right-2 bottom-2 opacity-60"
               size="icon"
               variant="secondary"
-              disabled={disabled || hardLimitReached || (chatStatus.state === 'receiving' && !!chatStatus.stopRequested)}
+              disabled={
+                disabled ||
+                hardLimitReached ||
+                (chatStatus.state === 'receiving' && !!chatStatus.stopRequested)
+              }
               onClick={() => handleStopConversation()}
             >
               <IconPlayerStopFilled size={18} />

--- a/apps/frontend/app/chat/components/ConversationSidebar.tsx
+++ b/apps/frontend/app/chat/components/ConversationSidebar.tsx
@@ -57,7 +57,7 @@ export const ConversationSidebar = ({
           <IconX></IconX>
         </Button>
       </div>
-      <ScrollArea className="w-[400px] flex-1 overflow-hidden scroll-workaround p-2">
+      <ScrollArea className="w-full md:w-[400px] flex-1 overflow-hidden scroll-workaround p-2">
         <div className="flex flex-col gap-4">
           {content.type === 'tool-call-result' && (
             <div className="whitespace-pre-wrap break-all">

--- a/apps/frontend/app/layouts/MainLayout.tsx
+++ b/apps/frontend/app/layouts/MainLayout.tsx
@@ -7,7 +7,7 @@ import {
   IconSatellite,
 } from '@tabler/icons-react'
 import Link from 'next/link'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import * as Dialog from '@radix-ui/react-dialog'
 import { MessageSquare, Compass, Images } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -40,43 +40,44 @@ export interface Props {
 const MobileLayout: React.FC<Props> = ({ leftBar, leftBarCollapsible, children }) => {
   const LeftBar = leftBar
   const [showDrawer, setShowDrawer] = useState<boolean>(false)
-  const environment = useEnvironment()
+  const pathname = usePathname()
+
+  // Selecting a conversation changes the route, but the chat shell remains
+  // mounted. Close the drawer explicitly so it never obscures the new chat.
+  useEffect(() => setShowDrawer(false), [pathname])
+
   return (
-    <main
-      className={`"grid lg:grid-cols-5 flex h-screen w-screen flex-row text-sm overflow-hidden divide-x`}
-    >
-      <div className="flex flex-col justify-between align-center justify-center gap-3 p-2">
-        <div className="flex flex-col flex-1 items-center gap-3">
-          {leftBarCollapsible && (
-            <Button size="icon" variant="ghost" onClick={() => setShowDrawer(true)}>
-              <IconMenu2 size={32}></IconMenu2>
+    <main className="flex h-[100dvh] min-h-0 w-full flex-col overflow-hidden text-sm">
+      <header className="flex h-[calc(3.5rem+env(safe-area-inset-top))] shrink-0 items-center justify-between border-b px-2 pt-[env(safe-area-inset-top)]">
+        <div className="flex items-center gap-1">
+          {leftBarCollapsible && LeftBar && (
+            <Button
+              size="icon"
+              variant="ghost"
+              title={t('show-sidebar')}
+              onClick={() => setShowDrawer(true)}
+            >
+              <IconMenu2 size={24} />
             </Button>
           )}
-          <Link href="/chat">
-            <MessageSquare size={28}></MessageSquare>
+          <Link
+            href="/chat"
+            title={t('goto-chats')}
+            className="p-2"
+            onClick={() => setShowDrawer(false)}
+          >
+            <MessageSquare size={22} />
           </Link>
-          <Link href="/chat/assistants/select">
-            <Compass size={28}></Compass>
-          </Link>
-          <Link href="/images">
-            <Images size={28}></Images>
-          </Link>
-          {environment.enableSatellitesUi && <SatelliteNavIcon />}
         </div>
-        <div>
-          <AppMenu />
-        </div>
-      </div>
-      {children}
+        <AppMenu chatOnly />
+      </header>
+      <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">{children}</div>
       {LeftBar && (
-        <Dialog.Root open={showDrawer}>
+        <Dialog.Root open={showDrawer} onOpenChange={setShowDrawer}>
           <Dialog.Portal>
-            <Dialog.Overlay />
-            <Dialog.Content
-              className="border absolute left-0 top-0 bottom-0 md:w-[260px] w-[260px] max-w-[80%] md:max-w-[80%] overflow-hidden p-0 translate-x-[0%] translate-y-[0%] slide-in-from-left"
-              onInteractOutside={() => setShowDrawer(false)}
-              onPointerDownOutside={() => setShowDrawer(false)}
-            >
+            <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40" />
+            <Dialog.Content className="fixed inset-y-0 left-0 z-50 flex w-[min(22rem,85vw)] flex-col overflow-hidden border-r bg-background p-0 pt-[env(safe-area-inset-top)] shadow-xl">
+              <Dialog.Title className="sr-only">{t('show-sidebar')}</Dialog.Title>
               {leftBar}
             </Dialog.Content>
           </Dialog.Portal>
@@ -92,9 +93,7 @@ const StandardLayout: React.FC<Props> = ({ leftBar, children }) => {
   const environment = useEnvironment()
   const hideLeftBar = pathname === '/chat/assistants/select'
   return (
-    <main
-      className={`"grid lg:grid-cols-5 flex h-screen w-screen flex-row text-sm overflow-hidden divide-x`}
-    >
+    <main className="flex h-[100dvh] w-screen flex-row overflow-hidden divide-x text-sm">
       <div className="flex flex-col justify-between align-center justify-center gap-3 p-2">
         <div className="flex flex-col flex-1 items-center gap-3">
           <button

--- a/apps/frontend/components/app/app-menu.tsx
+++ b/apps/frontend/components/app/app-menu.tsx
@@ -21,7 +21,10 @@ import * as dto from '@/types/dto'
 import { UserDialog } from './UserDialog'
 import { redirect } from 'next/navigation'
 
-type Params = Record<string, never>
+type Params = {
+  /** Keep the mobile shell focused on conversations; logout remains available. */
+  chatOnly?: boolean
+}
 
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
@@ -41,7 +44,7 @@ DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 
 DropdownMenuContent.displayName = 'DropdownMenuContent'
 
-export const AppMenu: FC<Params> = () => {
+export const AppMenu: FC<Params> = ({ chatOnly = false }) => {
   const { t } = useTranslation()
   const dropdownContainer = createRef<HTMLDivElement>()
   const userProfile = useUserProfile()
@@ -62,18 +65,22 @@ export const AppMenu: FC<Params> = () => {
           </div>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
-          <DropdownMenuButton icon={IconUser} onClick={async () => setShowUserDialog(true)}>
-            {t('my-profile')}
-          </DropdownMenuButton>
-          <DropdownMenuLink href="/chat/assistants/mine" icon={IconUserCode}>
-            {t('my-assistants')}
-          </DropdownMenuLink>
-          {userProfile?.role === dto.UserRole.ADMIN && (
-            <DropdownMenuLink href="/admin/analytics" icon={IconSettings}>
-              {t('administrator-settings')}
-            </DropdownMenuLink>
+          {!chatOnly && (
+            <>
+              <DropdownMenuButton icon={IconUser} onClick={async () => setShowUserDialog(true)}>
+                {t('my-profile')}
+              </DropdownMenuButton>
+              <DropdownMenuLink href="/chat/assistants/mine" icon={IconUserCode}>
+                {t('my-assistants')}
+              </DropdownMenuLink>
+              {userProfile?.role === dto.UserRole.ADMIN && (
+                <DropdownMenuLink href="/admin/analytics" icon={IconSettings}>
+                  {t('administrator-settings')}
+                </DropdownMenuLink>
+              )}
+              <DropdownMenuSeparator />
+            </>
           )}
-          <DropdownMenuSeparator />
           <DropdownMenuButton
             variant="destructive"
             onClick={async () => await signOut()}
@@ -84,7 +91,9 @@ export const AppMenu: FC<Params> = () => {
         </DropdownMenuContent>
         <DropdownMenuPortal container={dropdownContainer.current}></DropdownMenuPortal>
       </DropdownMenu>
-      {showUserDialog && <UserDialog onClose={() => setShowUserDialog(false)}></UserDialog>}
+      {!chatOnly && showUserDialog && (
+        <UserDialog onClose={() => setShowUserDialog(false)}></UserDialog>
+      )}
     </div>
   )
 }

--- a/apps/frontend/components/providers/layoutconfigContext.tsx
+++ b/apps/frontend/components/providers/layoutconfigContext.tsx
@@ -19,7 +19,12 @@ type Props = {
  * @returns {boolean}
  */
 function useBetterMediaQuery(mediaQueryString): boolean {
-  const [matches, setMatches] = useState<boolean>(undefined!)
+  // The frontend is client-rendered, so read the initial value synchronously.
+  // Apart from avoiding a desktop-layout flash on a phone, this prevents
+  // mobile-only route guards from briefly mounting their expensive page.
+  const [matches, setMatches] = useState<boolean>(
+    () => typeof window !== 'undefined' && window.matchMedia(mediaQueryString).matches
+  )
 
   useEffect(() => {
     const mediaQueryList = window.matchMedia(mediaQueryString)

--- a/apps/frontend/styles/globals.css
+++ b/apps/frontend/styles/globals.css
@@ -80,6 +80,9 @@
   html {
     height: 100%;
   }
+  #root {
+    min-height: 100%;
+  }
   body {
     @apply bg-background text-foreground min-h-screen;
   }
@@ -202,6 +205,10 @@ h5 {
     linear-gradient(45deg, transparent 75%, #ccc 75%),
     linear-gradient(-45deg, transparent 75%, #ccc 75%);
   background-size: 16px 16px;
-  background-position: 0 0, 0 8px, 8px -8px, -8px 0px;
+  background-position:
+    0 0,
+    0 8px,
+    8px -8px,
+    -8px 0px;
   background-color: #fff;
 }


### PR DESCRIPTION
## Summary

Adds a phone-focused chat experience with responsive conversation navigation and keeps management surfaces out of the mobile flow. Desktop behavior, including the admin area, remains available.

## Details

- Replace the mobile navigation rail with a safe-area-aware chat header and conversation drawer.
- Adapt chat headers, input spacing, tool-result panels, and assistant selection for narrow viewports.
- Redirect non-chat and assistant-management routes to chat on phones, while preserving desktop routes.

## Tests

- `npm run check-types` — passed.
- `npm run build` — passed.
- Playwright with Chrome in iPhone 13 emulation — authenticated chat, conversation drawer, no horizontal overflow, and mobile admin redirect passed; desktop admin availability passed.