### PR TITLE
fix(chat): restore code fence controls and syntax highlighting

### DIFF
--- a/__tests__/markdownSanitization.test.ts
+++ b/__tests__/markdownSanitization.test.ts
@@ -64,6 +64,18 @@ describe('Markdown HTML sanitization', () => {
     expect(html).toContain('<span style="color:red">x</span>')
   })
 
+  test('keeps the fenced-code flag so blocks render as CodeBlock, not inline <code>', async () => {
+    const { markdownSanitizeSchema } = await import('@/frontend/app/chat/components/Markdown')
+    // `rehypeSanitize` must not strip the `isBlockCode` hProperty set by
+    // `remarkAddBlockCodeFlag`; otherwise every fence falls back to inline
+    // <code> (no copy/word-wrap buttons, no syntax highlighting).
+    expect(markdownSanitizeSchema.attributes.code).toContain('isBlockCode')
+
+    // And a fenced block must not come out as an inline language-tagged <code>.
+    const html = renderMarkdown('```js\nconst a = 1\n```\n')
+    expect(html).not.toContain('<code class="language-js"')
+  })
+
   test('removes executable markup and unsafe URLs', () => {
     const html = renderMarkdown(`
 <script>alert('xss')</script>

--- a/apps/frontend/app/chat/components/Markdown.tsx
+++ b/apps/frontend/app/chat/components/Markdown.tsx
@@ -95,6 +95,11 @@ export const markdownSanitizeSchema = {
     // `style` is allowed on every element; its declarations are already
     // filtered by `rehypeFilterInlineStyles` (runs before `rehypeSanitize`).
     '*': [...(defaultSchema.attributes?.['*'] ?? []), 'style'],
+    // `remarkAddBlockCodeFlag` tags fenced-code nodes with this so the `code`
+    // renderer can tell a block fence from inline code; without it in the
+    // allowlist `rehypeSanitize` strips it and every fence falls back to plain
+    // inline `<code>` (no copy/word-wrap controls, no syntax highlighting).
+    code: [...(defaultSchema.attributes?.code ?? []), 'isBlockCode'],
   },
 }
 


### PR DESCRIPTION
## Summary

Fenced code blocks in chat rendered as plain inline `<code>`: the copy button, the word-wrap toggle, and syntax highlighting were all missing (logicleai/logicle-issues#297). `rehypeSanitize` (added in #1041) was stripping the `isBlockCode` hProperty that `remarkAddBlockCodeFlag` attaches to fenced-code nodes, so the `code` renderer could no longer tell a block fence from inline code and always took the inline fallback path. The flag is now allowlisted on `code` in the sanitize schema, so blocks render through `CodeBlock` again.

## Tests

- `npx vitest run __tests__/markdownSanitization.test.ts` — 5 passed, including a new regression test asserting the fence flag survives sanitization and blocks don't fall back to inline `<code>`.
- `npm run check-types` — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)