### PR TITLE
fix(files): serve browser-viewable images inline

### DIFF
--- a/apps/backend/api/files/[fileId]/content/route.ts
+++ b/apps/backend/api/files/[fileId]/content/route.ts
@@ -185,6 +185,16 @@ export const PUT = operation({
   },
 })
 
+// Image types every browser can render safely inline. SVG is intentionally excluded
+// (it can carry scripts). For these, serve the file inline so links open it in a new
+// tab instead of downloading it; anything else stays an attachment.
+const INLINE_VIEWABLE_TYPES = ['image/jpeg', 'image/png', 'image/webp']
+
+function contentDispositionFor(type: string, name: string): string {
+  const disposition = INLINE_VIEWABLE_TYPES.includes(type) ? 'inline' : 'attachment'
+  return `${disposition}; filename="${name.replace(/[\\"\r\n]/g, '_')}"`
+}
+
 function parseRangeHeader(header: string, totalSize: number): { start: number; end: number } | null {
   const match = /^bytes=(\d*)-(\d*)$/.exec(header)
   if (!match) return null
@@ -244,7 +254,7 @@ export const GET = operation({
         status: 206,
         headers: {
           'content-type': file.type,
-          'content-disposition': `attachment; filename="${file.name.replace(/[\\"\r\n]/g, '_')}"`,
+          'content-disposition': contentDispositionFor(file.type, file.name),
           'x-content-type-options': 'nosniff',
           'content-range': `bytes ${start}-${end}/${file.size}`,
           'content-length': `${end - start + 1}`,
@@ -260,7 +270,7 @@ export const GET = operation({
     return new Response(fileContent, {
       headers: {
         'content-type': file.type,
-        'content-disposition': `attachment; filename="${file.name.replace(/[\\"\r\n]/g, '_')}"`,
+        'content-disposition': contentDispositionFor(file.type, file.name),
         'x-content-type-options': 'nosniff',
         ...(typeof file.size === 'number' ? { 'content-length': `${file.size}` } : {}),
         'accept-ranges': supportsRanges ? 'bytes' : 'none',


### PR DESCRIPTION
## Summary

The `/api/files/{id}/content` endpoint always returned `Content-Disposition: attachment`, forcing browsers to download the file even when the user opened an image link in a new tab. Images that browsers can render safely (`image/jpeg`, `image/png`, `image/webp`) are now served with `Content-Disposition: inline`, so links open them directly in a new tab. All other file types are unchanged and still download as attachments.

## Details

- Added `contentDispositionFor(type, name)` helper in the content route; applied to both the full-body and HTTP range (`206`) responses.
- SVG is deliberately excluded from the inline list (it can carry scripts); `X-Content-Type-Options: nosniff` is retained.
- Mirrors the existing inline/attachment logic in `apps/backend/api/images/{imageId}/route.ts`.

## Tests

- `npm run check-types` — passed.
- `npm run generate:openapi` — no changes (headers are not part of the spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)