### PR TITLE
feat(search): find chats by their title

### DIFF
--- a/__tests__/search-indexer.test.ts
+++ b/__tests__/search-indexer.test.ts
@@ -2,8 +2,13 @@ import { describe, it, expect } from 'vitest'
 import { diffRanges } from '@/lib/search/indexer'
 import type { ConversationIndexDoc } from '@/lib/search/Index'
 
-const doc = (id: string, lastMsgSentAt: string | null = null): ConversationIndexDoc => ({
+const doc = (
+  id: string,
+  lastMsgSentAt: string | null = null,
+  title = 'title'
+): ConversationIndexDoc => ({
   id,
+  title,
   lastMsgSentAt,
 })
 
@@ -40,6 +45,14 @@ describe('diffRanges', () => {
   it('upserts entries whose lastMsgSentAt changed', () => {
     const db = [doc('a', 't2'), doc('b', 't1')]
     const idx = [doc('a', 't1'), doc('b', 't1')]
+    const result = diffRanges(db, idx, BATCH)
+    expect(result!.toUpsert).toEqual(['a'])
+    expect(result!.toDelete).toEqual([])
+  })
+
+  it('upserts entries whose title changed even when lastMsgSentAt is unchanged', () => {
+    const db = [doc('a', 't1', 'Renamed'), doc('b', 't1', 'title')]
+    const idx = [doc('a', 't1', 'Original'), doc('b', 't1', 'title')]
     const result = diffRanges(db, idx, BATCH)
     expect(result!.toUpsert).toEqual(['a'])
     expect(result!.toDelete).toEqual([])

--- a/apps/backend/lib/search/Index.ts
+++ b/apps/backend/lib/search/Index.ts
@@ -1,5 +1,6 @@
 export interface ConversationIndexDoc {
   id: string
+  title: string
   lastMsgSentAt: string | null
 }
 
@@ -24,6 +25,7 @@ export interface ConversationSearchResult {
 
 export interface ConversationRow {
   id: string
+  title: string
   lastMsgSentAt: string | null
 }
 

--- a/apps/backend/lib/search/MeiliIndex.ts
+++ b/apps/backend/lib/search/MeiliIndex.ts
@@ -29,11 +29,12 @@ export class MeiliSearchIndex implements ConversationIndex {
     const res = await this.index.search(null, {
       filter: `id > "${toHex(fromId)}"`,
       sort: ['id:asc'],
-      attributesToRetrieve: ['id', 'lastMsgSentAt'],
+      attributesToRetrieve: ['id', 'title', 'lastMsgSentAt'],
       limit: maxResults,
     })
     return res.hits.map((h) => ({
       id: fromHex(h.id),
+      title: h.title,
       lastMsgSentAt: h.lastMsgSentAt,
     })) satisfies ConversationRow[]
   }

--- a/apps/backend/lib/search/__tests__/MeiliIndex.test.ts
+++ b/apps/backend/lib/search/__tests__/MeiliIndex.test.ts
@@ -37,7 +37,7 @@ describe('MeiliSearchIndex', () => {
 
   it('fetchEntriesAfterId filters by the hex-encoded cursor and decodes ids back from hex', async () => {
     const search = vi.fn().mockResolvedValue({
-      hits: [{ id: toHex('conv-2'), lastMsgSentAt: '2024-01-02' }],
+      hits: [{ id: toHex('conv-2'), title: 'Renamed', lastMsgSentAt: '2024-01-02' }],
     })
     const index = new MeiliSearchIndex({ search } as any)
 
@@ -49,9 +49,10 @@ describe('MeiliSearchIndex', () => {
         filter: `id > "${toHex('conv-1')}"`,
         sort: ['id:asc'],
         limit: 50,
+        attributesToRetrieve: ['id', 'title', 'lastMsgSentAt'],
       })
     )
-    expect(result).toEqual([{ id: 'conv-2', lastMsgSentAt: '2024-01-02' }])
+    expect(result).toEqual([{ id: 'conv-2', title: 'Renamed', lastMsgSentAt: '2024-01-02' }])
   })
 
   it('searchConversations combines ownerId/assistantId into an AND filter only when provided', async () => {

--- a/apps/backend/lib/search/indexer.ts
+++ b/apps/backend/lib/search/indexer.ts
@@ -62,7 +62,7 @@ async function fetchUpdatedAfter(
 ): Promise<ConversationRow[]> {
   return db
     .selectFrom('Conversation')
-    .select(['id', 'lastMsgSentAt'])
+    .select(['id', 'name as title', 'lastMsgSentAt'])
     .where('lastMsgSentAt', '>', since)
     .orderBy('lastMsgSentAt', 'asc')
     .limit(limit)
@@ -76,7 +76,7 @@ async function fetchAfterId(
 ): Promise<ConversationRow[]> {
   return db
     .selectFrom('Conversation')
-    .select(['id', 'lastMsgSentAt'])
+    .select(['id', 'name as title', 'lastMsgSentAt'])
     .where('id', '>', fromId)
     .orderBy('id', 'asc')
     .limit(maxResults)
@@ -139,7 +139,13 @@ export function diffRanges(
   const toUpsert = db
     .filter((row) => {
       const existing = indexById.get(row.id)
-      return !existing || row.lastMsgSentAt !== existing.lastMsgSentAt
+      // Re-index when a new message arrived (lastMsgSentAt moved) or when the
+      // conversation was renamed (title changed without a new message).
+      return (
+        !existing ||
+        row.lastMsgSentAt !== existing.lastMsgSentAt ||
+        row.title !== existing.title
+      )
     })
     .map((row) => row.id)
 


### PR DESCRIPTION
## Summary

Chat search is expected to match on a conversation's title as well as its messages. Both search backends already query the title, but the Meilisearch background sync worker only re-indexed a conversation when a new message advanced `lastMsgSentAt`. A conversation renamed without a new message kept its old title in the index, so it could not be found by its new name. The heal reconciler now also compares the indexed title with the database and re-indexes on a mismatch, so renames are picked up on the next heal pass. The DB-fallback search path (no Meilisearch configured) already matched on `Conversation.name` and is unchanged.

## Details

- `ConversationIndexDoc` / `ConversationRow` carry `title`; the heal queries (`fetchAfterId`, `fetchUpdatedAfter`) and `MeiliSearchIndex.fetchEntriesAfterId` now select/return it.
- `diffRanges` marks a conversation for re-index when either `lastMsgSentAt` or `title` differs from the indexed copy.
- Case sensitivity is unchanged: Meilisearch and the SQL `LIKE` fallback both match case-insensitively.

## Tests

- `npm run check-types` — passed.
- `npx vitest run __tests__/search-indexer.test.ts apps/backend/lib/search` — 20 passed, including a new case covering a title-only change and an updated `fetchEntriesAfterId` expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)