### PR TITLE
fix(search): case-insensitive conversation search on the SQL fallback

### DIFF
--- a/apps/backend/api/conversations/search/route.ts
+++ b/apps/backend/api/conversations/search/route.ts
@@ -32,12 +32,15 @@ async function search(query: string, userId: string): Promise<dto.ConversationWi
       )
       .selectAll('Conversation')
       .select('ConversationFolderMembership.folderId')
-      .where((eb) =>
-        eb.or([
-          eb('Conversation.name', 'like', `%${query}%`),
-          eb('Message.content', 'like', `%${query}%`),
+      .where((eb) => {
+        // Case-insensitive match. SQLite's LIKE already ignores ASCII case, but
+        // Postgres' does not, so lower() both sides for consistent behavior.
+        const needle = `%${query.toLowerCase()}%`
+        return eb.or([
+          eb(eb.fn('lower', ['Conversation.name']), 'like', needle),
+          eb(eb.fn('lower', ['Message.content']), 'like', needle),
         ])
-      )
+      })
       .where('Conversation.ownerId', '=', userId)
       .distinct()
       .limit(20)


### PR DESCRIPTION
## Summary

Completes issue #296's third acceptance criterion (consistent case handling). The Meilisearch search path is already case-insensitive, but the SQL fallback (used wherever Meilisearch is not configured, including all Postgres tenants) used a bare `LIKE`. SQLite's `LIKE` ignores ASCII case, so local dev appeared correct, but Postgres' `LIKE` is case-sensitive — searching `MAXWELL` would not match a chat titled `Maxwell's Equations`. The fallback now lowercases both the column and the search term for the title and message-content clauses.

## Details

- `apps/backend/api/conversations/search/route.ts`: wrap `Conversation.name` and `Message.content` in `lower(...)` and compare against `query.toLowerCase()`.
- Both columns are `text` in both dialects, so `lower()` is safe (no `jsonb` involved).
- No index implications: leading-wildcard `LIKE` was already unindexed.

## Tests

- `npm run check-types` — passed.
- Local (SQLite): `ZEBRA`, `zebra`, `Quokka` all match a chat titled `Zebra Quokka Marmalade` via `POST /api/conversations/search`.
- Postgres verification to follow on `dev.logicle.dev` after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)