### PR TITLE
feat(chart): support structured provisioning files

### DIFF
--- a/charts/logicle/README.md
+++ b/charts/logicle/README.md
@@ -8,10 +8,13 @@ release name convention as the former EE chart (`nameOverride: logicle-ee`
 by default) so existing `logicle-ee-$TENANT` releases can be upgraded onto
 this chart in place.
 
-The chart itself carries no product-specific provisioning content
-(backends, users, standard tools). Those are raw YAML blobs passed via
-`provisioning.backends` / `provisioning.users` / `provisioning.standardTools`
-and owned by the deployer (see `logicle-infra-deploy`).
+The chart itself carries no product-specific provisioning content. The
+preferred interface is `provisioning.files`, a map whose keys are filenames
+mounted under `/provisioning` (for example, `30-assistants.yaml`). This keeps
+each provisioning document separate and lets Logicle process them in filename
+order. The legacy `provisioning.backends`, `provisioning.users`, and
+`provisioning.standardTools` fields remain supported for older deployers (see
+`logicle-infra-deploy`).
 
 ## Prerequisites
 

--- a/charts/logicle/templates/deployment.yaml
+++ b/charts/logicle/templates/deployment.yaml
@@ -28,6 +28,11 @@ spec:
         - secretRef:
             name: {{ include "logicle.fullname" . }}
         volumeMounts:
+        {{- if .Values.provisioning.files }}
+        - name: provisioning-files
+          mountPath: /provisioning
+          readOnly: true
+        {{- else }}
         {{- if .Values.provisioning.backends }}
         - name: backends-config
           mountPath: /provisioning/00-backends.yaml
@@ -46,6 +51,7 @@ spec:
           subPath: 20-standard-tools.yaml
           readOnly: true
         {{- end }}
+        {{- end }}
         {{- if eq .Values.storage.type "pvc" }}
         - name: uploaded-files-data
           mountPath: /data/files
@@ -56,6 +62,11 @@ spec:
           readOnly: true
         {{- end }}
       volumes:
+      {{- if .Values.provisioning.files }}
+      - name: provisioning-files
+        configMap:
+          name: {{ include "logicle.fullname" . }}-provisioning
+      {{- else }}
       {{- if .Values.provisioning.standardTools }}
       - name: standard-tools-config
         configMap:
@@ -70,6 +81,7 @@ spec:
       - name: users-config
         configMap:
           name: {{ include "logicle.fullname" . }}-users
+      {{- end }}
       {{- end }}
       {{- if eq .Values.storage.type "pvc" }}
       - name: uploaded-files-data

--- a/charts/logicle/templates/provisioning-configmap.yaml
+++ b/charts/logicle/templates/provisioning-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.provisioning.files }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "logicle.fullname" . }}-provisioning
+  labels:
+    {{- include "logicle.labels" . | nindent 4 }}
+data:
+  {{- range $filename, $content := .Values.provisioning.files }}
+  {{ $filename | quote }}: |
+{{ $content | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/logicle/values.yaml
+++ b/charts/logicle/values.yaml
@@ -40,10 +40,12 @@ tools:
 opentelemetry:
   endpoint: "http://10.0.0.7:4318"
 
-# Raw YAML blobs, mounted verbatim into /provisioning/*.yaml. Left empty
-# by default (no provisioning configmaps rendered); the actual content is
-# owned by the deployer, not the chart.
+# Raw YAML blobs, mounted verbatim into /provisioning/*.yaml. The structured
+# `files` map is preferred: each key becomes a file, preserving the
+# provisioning directory layout and filename ordering. The fixed fields are
+# retained for compatibility with older deployers.
 provisioning:
+  files: {}
   backends: ""
   users: ""
   standardTools: ""


### PR DESCRIPTION
## Summary

- add a structured `provisioning.files` map to the Logicle Helm chart
- mount each entry as a separate file under `/provisioning`
- keep legacy fixed provisioning values for older deployers
- document the new interface

## Validation

- `helm lint charts/logicle`
- `helm template` with multiple provisioning files
