### PR TITLE
perf(chat): reduce context compression cost with prefetch

### DIFF
--- a/apps/backend/db/dialect.ts
+++ b/apps/backend/db/dialect.ts
@@ -17,7 +17,9 @@ async function createDialect() {
     dbUrlString = 'memory:'
   }
   const url = new URL(dbUrlString)
-  logger.info(`Connecting to db @${url}`)
+  const safeUrl = new URL(url)
+  if (safeUrl.password) safeUrl.password = '[REDACTED]'
+  logger.info(`Connecting to db @${safeUrl}`)
   if (url.protocol === 'file:' || url.protocol === 'memory:') {
     const dirName = path.dirname(url.pathname)
     if (!fs.existsSync(dirName)) {

--- a/apps/backend/lib/chat/__tests__/compression-planner.test.ts
+++ b/apps/backend/lib/chat/__tests__/compression-planner.test.ts
@@ -8,6 +8,7 @@ import {
   applyCompressionPlan,
   warmCompressionCache,
   resolveCompressionRetrievalMode,
+  resolveCompressionUserQuery,
   resolveCompressionTriggerTokens,
 } from '@/backend/lib/chat/compression-planner'
 import env from '@/lib/env'
@@ -382,6 +383,56 @@ describe('resolveCompressionRetrievalMode', () => {
   })
 })
 
+describe('resolveCompressionUserQuery', () => {
+  test('uses the current user text when it is non-empty', () => {
+    const messages: dto.Message[] = [
+      { ...base, id: 'u1', role: 'user', content: 'old question', attachments: [] },
+      { ...base, id: 'u2', role: 'user', content: ' current question ', attachments: [] },
+    ]
+
+    expect(resolveCompressionUserQuery(messages)).toBe('current question')
+  })
+
+  test('falls back to the nearest non-empty user request for an attachment-only turn', () => {
+    const messages: dto.Message[] = [
+      { ...base, id: 'u1', role: 'user', content: 'Is the premium indexed?', attachments: [] },
+      {
+        ...base,
+        id: 'a1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Please upload the general conditions.' }],
+      },
+      {
+        ...base,
+        id: 'u2',
+        role: 'user',
+        content: '   ',
+        attachments: [
+          { id: 'file-follow-up', name: 'conditions.pdf', mimetype: 'application/pdf', size: 10 },
+        ],
+      },
+    ]
+
+    expect(resolveCompressionUserQuery(messages)).toBe('Is the premium indexed?')
+  })
+
+  test('returns undefined when the lineage contains no user-authored text', () => {
+    const messages: dto.Message[] = [
+      {
+        ...base,
+        id: 'u1',
+        role: 'user',
+        content: '',
+        attachments: [
+          { id: 'file-follow-up', name: 'conditions.pdf', mimetype: 'application/pdf', size: 10 },
+        ],
+      },
+    ]
+
+    expect(resolveCompressionUserQuery(messages)).toBeUndefined()
+  })
+})
+
 describe('applyCompressionPlan', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -595,6 +646,117 @@ describe('applyCompressionPlan', () => {
     expect(rendered).toContain('[AUTOMATICALLY RETRIEVED FOR THE CURRENT REQUEST')
     expect(rendered).toContain('Final migration program codename: Kestrel Blue.')
     expect(rendered.match(/Routine background note/g)?.length).toBeLessThan(30)
+  })
+
+  test('attachment-only continuation prefetch recovers the previous task from a compressed answer', async () => {
+    const previousQuestion = 'Is the insurance premium indexed?'
+    const messages: dto.Message[] = [
+      { ...base, id: 'u1', role: 'user', content: previousQuestion, attachments: [] },
+      {
+        ...base,
+        id: 'a1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: `${'Unrelated policy background. '.repeat(
+              100
+            )}The insurance premium is indexed under section 17. Please upload the general conditions to verify the formula.`,
+          },
+        ],
+      },
+      {
+        ...base,
+        id: 'u2',
+        role: 'user',
+        content: '',
+        attachments: [
+          { id: 'file-follow-up', name: 'conditions.pdf', mimetype: 'application/pdf', size: 10 },
+        ],
+      },
+    ]
+    const decisions = planMessageCompression(messages, 'conservative')
+    expect(decisions.find((decision) => decision.messageId === 'a1')?.policy).toBe('summary')
+
+    const compressed = await applyCompressionPlan(messages, decisions, {
+      prefetchQuery: resolveCompressionUserQuery(messages),
+      attachmentContinuationQuery: resolveCompressionUserQuery(messages),
+    })
+    const previousAnswer = compressed[1] as dto.AssistantMessage
+    const rendered = previousAnswer.parts
+      .filter((part): part is dto.TextPart => part.type === 'text')
+      .map((part) => part.text)
+      .join('\n')
+
+    expect(rendered).toContain('[AUTOMATICALLY RETRIEVED FOR THE CURRENT REQUEST')
+    expect(rendered).toContain('The insurance premium is indexed under section 17.')
+    const currentTurn = compressed[2] as dto.UserMessage
+    expect(currentTurn.attachments).toHaveLength(1)
+    expect(currentTurn.content).toContain('[CONVERSATION CONTINUATION]')
+    expect(currentTurn.content).toContain(previousQuestion)
+  })
+
+  test('does not add continuation context to a non-empty current turn', async () => {
+    const messages: dto.Message[] = [
+      { ...base, id: 'u1', role: 'user', content: 'Old request', attachments: [] },
+      {
+        ...base,
+        id: 'u2',
+        role: 'user',
+        content: 'Analyze this attachment',
+        attachments: [
+          { id: 'file-current', name: 'current.pdf', mimetype: 'application/pdf', size: 10 },
+        ],
+      },
+    ]
+
+    const compressed = await applyCompressionPlan(
+      messages,
+      planMessageCompression(messages, 'conservative'),
+      {
+        prefetchQuery: resolveCompressionUserQuery(messages),
+        attachmentContinuationQuery: resolveCompressionUserQuery(messages),
+      }
+    )
+
+    expect((compressed[1] as dto.UserMessage).content).toBe('Analyze this attachment')
+  })
+
+  test('tool-only retrieval still adds attachment-only continuation context without prefetching', async () => {
+    const previousQuestion = 'Is the insurance premium indexed?'
+    const messages: dto.Message[] = [
+      { ...base, id: 'u1', role: 'user', content: previousQuestion, attachments: [] },
+      {
+        ...base,
+        id: 'a1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Background. '.repeat(300) }],
+      },
+      {
+        ...base,
+        id: 'u2',
+        role: 'user',
+        content: '',
+        attachments: [
+          { id: 'file-current', name: 'current.pdf', mimetype: 'application/pdf', size: 10 },
+        ],
+      },
+    ]
+
+    const compressed = await applyCompressionPlan(
+      messages,
+      planMessageCompression(messages, 'conservative'),
+      { attachmentContinuationQuery: resolveCompressionUserQuery(messages) }
+    )
+    const historicalAnswer = (compressed[1] as dto.AssistantMessage).parts
+      .filter((part): part is dto.TextPart => part.type === 'text')
+      .map((part) => part.text)
+      .join('\n')
+    const currentTurn = compressed[2] as dto.UserMessage
+
+    expect(historicalAnswer).not.toContain('[AUTOMATICALLY RETRIEVED FOR THE CURRENT REQUEST')
+    expect(currentTurn.content).toContain('[CONVERSATION CONTINUATION]')
+    expect(currentTurn.content).toContain(previousQuestion)
   })
 })
 

--- a/apps/backend/lib/chat/__tests__/compression-planner.test.ts
+++ b/apps/backend/lib/chat/__tests__/compression-planner.test.ts
@@ -7,6 +7,7 @@ import {
   planMessageCompression,
   applyCompressionPlan,
   warmCompressionCache,
+  resolveCompressionRetrievalMode,
   resolveCompressionTriggerTokens,
 } from '@/backend/lib/chat/compression-planner'
 import env from '@/lib/env'
@@ -26,7 +27,9 @@ vi.mock('@/models/file', () => ({
       fileBlobId: `blob-${id}`,
       name: isImage ? 'horse.png' : 'documento_semplice.docx',
       origin: 'generated',
-      type: isImage ? 'image/png' : 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      type: isImage
+        ? 'image/png'
+        : 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       path: isImage ? '/tmp/horse.png' : '/tmp/documento_semplice.docx',
       encryption: null,
       size: isImage ? 1594448 : 3173,
@@ -77,7 +80,13 @@ const modelWithoutDocxNativeSupport: LlmModel = {
 const languageModel = { provider: 'openai.responses' } as LanguageModelV3
 
 const makeGeneratedDocxHistory = (): dto.Message[] => [
-  { ...base, id: 'u-create-docx', role: 'user', content: 'Puoi generare un file word', attachments: [] },
+  {
+    ...base,
+    id: 'u-create-docx',
+    role: 'user',
+    content: 'Puoi generare un file word',
+    attachments: [],
+  },
   {
     ...base,
     id: 'a-tool-call',
@@ -116,18 +125,35 @@ const makeGeneratedDocxHistory = (): dto.Message[] => [
           type: 'content',
           value: [
             { type: 'text', text: 'Published 1 resource(s): documento_semplice.docx' },
-            { type: 'file', id: 'file-docx', mimetype: docxMime, name: 'documento_semplice.docx', size: 3173 },
+            {
+              type: 'file',
+              id: 'file-docx',
+              mimetype: docxMime,
+              name: 'documento_semplice.docx',
+              size: 3173,
+            },
           ],
         },
       },
     ],
   },
-  { ...base, id: 'a-final', role: 'assistant', parts: [{ type: 'text', text: 'Hei, ho generato un documento word' }] },
+  {
+    ...base,
+    id: 'a-final',
+    role: 'assistant',
+    parts: [{ type: 'text', text: 'Hei, ho generato un documento word' }],
+  },
   { ...base, id: 'u-ask-content', role: 'user', content: "E cosa c'e dentro?", attachments: [] },
 ]
 
 const makeGeneratedHorseImageHistory = (): dto.Message[] => [
-  { ...base, id: 'u-create-image', role: 'user', content: 'Genera immagine di un cavallo', attachments: [] },
+  {
+    ...base,
+    id: 'u-create-image',
+    role: 'user',
+    content: 'Genera immagine di un cavallo',
+    attachments: [],
+  },
   {
     ...base,
     id: 'a-image-tool-call',
@@ -153,18 +179,41 @@ const makeGeneratedHorseImageHistory = (): dto.Message[] => [
         result: {
           type: 'content',
           value: [
-            { type: 'text', text: 'The tool displayed 1 images. The images are already plainly visible.' },
-            { type: 'file', id: 'file-horse', mimetype: 'image/png', name: 'horse.png', size: 1594448 },
+            {
+              type: 'text',
+              text: 'The tool displayed 1 images. The images are already plainly visible.',
+            },
+            {
+              type: 'file',
+              id: 'file-horse',
+              mimetype: 'image/png',
+              name: 'horse.png',
+              size: 1594448,
+            },
           ],
         },
       },
     ],
   },
-  { ...base, id: 'a-image-final', role: 'assistant', parts: [{ type: 'text', text: 'Hei, ho generato una immagine di un cavallo' }] },
-  { ...base, id: 'u-ask-hooves', role: 'user', content: 'Di che colore erano gli zoccoli?', attachments: [] },
+  {
+    ...base,
+    id: 'a-image-final',
+    role: 'assistant',
+    parts: [{ type: 'text', text: 'Hei, ho generato una immagine di un cavallo' }],
+  },
+  {
+    ...base,
+    id: 'u-ask-hooves',
+    role: 'user',
+    content: 'Di che colore erano gli zoccoli?',
+    attachments: [],
+  },
 ]
 
-async function compress(messages: dto.Message[], preset: dto.ContextCompressionPreset = 'conservative') {
+async function compress(
+  messages: dto.Message[],
+  preset: dto.ContextCompressionPreset = 'conservative'
+) {
   const decisions = planMessageCompression(messages, preset)
   return { decisions, compressed: await applyCompressionPlan(messages, decisions) }
 }
@@ -209,6 +258,41 @@ describe('planMessageCompression', () => {
     const decisions = planMessageCompression(messages, 'conservative')
     expect(decisions[0]!.policy).toBe('summary')
     expect(decisions[1]!.policy).toBe('full')
+  })
+
+  test('keeps the configured number of completed recent turns verbatim', () => {
+    const messages: dto.Message[] = [
+      {
+        ...base,
+        id: 'u1',
+        role: 'user',
+        content: 'old attachment',
+        attachments: [{ id: 'f1', name: 'old.pdf', mimetype: 'application/pdf', size: 10 }],
+      },
+      { ...base, id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'x'.repeat(3000) }] },
+      {
+        ...base,
+        id: 'u2',
+        role: 'user',
+        content: 'recent attachment',
+        attachments: [{ id: 'f2', name: 'recent.pdf', mimetype: 'application/pdf', size: 10 }],
+      },
+      { ...base, id: 'a2', role: 'assistant', parts: [{ type: 'text', text: 'x'.repeat(3000) }] },
+      { ...base, id: 'u3', role: 'user', content: 'current question', attachments: [] },
+    ]
+
+    const decisions = new Map(
+      planMessageCompression(messages, 'conservative', { keepRecentTurns: 1 }).map((decision) => [
+        decision.messageId,
+        decision,
+      ])
+    )
+
+    expect(decisions.get('u1')?.policy).toBe('summary')
+    expect(decisions.get('a1')?.policy).toBe('summary')
+    expect(decisions.get('u2')).toMatchObject({ policy: 'full', reason: 'recent turn kept full' })
+    expect(decisions.get('a2')).toMatchObject({ policy: 'full', reason: 'recent turn kept full' })
+    expect(decisions.get('u3')?.reason).toBe('current turn is never compressed')
   })
 
   test('a historical decision does not depend on what the current user message says (stable for prompt caching)', () => {
@@ -275,7 +359,9 @@ describe('planMessageCompression', () => {
 
 describe('resolveCompressionTriggerTokens', () => {
   test('a low or unset assistant threshold never drops below the default floor', () => {
-    expect(resolveCompressionTriggerTokens(undefined)).toBe(env.chat.contextCompressionTriggerTokens)
+    expect(resolveCompressionTriggerTokens(undefined)).toBe(
+      env.chat.contextCompressionTriggerTokens
+    )
     expect(resolveCompressionTriggerTokens(100)).toBe(env.chat.contextCompressionTriggerTokens)
   })
 
@@ -286,6 +372,16 @@ describe('resolveCompressionTriggerTokens', () => {
   })
 })
 
+describe('resolveCompressionRetrievalMode', () => {
+  test('defaults existing assistant configurations to measured query-aware prefetch', () => {
+    expect(resolveCompressionRetrievalMode(undefined)).toBe('prefetch')
+  })
+
+  test('keeps explicit tool-only evaluation arms available', () => {
+    expect(resolveCompressionRetrievalMode('tool')).toBe('tool')
+  })
+})
+
 describe('applyCompressionPlan', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -293,30 +389,47 @@ describe('applyCompressionPlan', () => {
   })
 
   test('compressed previous turn redacts duplicated document text, extracts a plain-text preview, and adds a file + message recovery reference', async () => {
-    mockExtractFromFile.mockResolvedValueOnce('Documento semplice: contains a title and one paragraph.')
+    mockExtractFromFile.mockResolvedValueOnce(
+      'Documento semplice: contains a title and one paragraph.'
+    )
 
     const { compressed } = await compress(makeGeneratedDocxHistory())
 
-    const segments = await buildHistorySegments(compressed, modelWithoutDocxNativeSupport, languageModel, { userId: 'test-user' })
+    const segments = await buildHistorySegments(
+      compressed,
+      modelWithoutDocxNativeSupport,
+      languageModel,
+      { userId: 'test-user' }
+    )
     const promptText = JSON.stringify(segments.map((segment) => segment.message))
 
     expect(promptText).toContain('File available on demand: documento_semplice.docx')
     expect(promptText).toContain('id: file-docx')
     expect(promptText).toContain(docxMime)
-    expect(promptText).toContain('context-retrieve.get_file')
+    expect(promptText).toContain('search function of the context-retrieve tool')
+    expect(promptText).toContain('Use get_file only if the targeted excerpts are insufficient')
     expect(promptText).toContain('summary: Documento semplice: contains a title and one paragraph.')
-    expect(promptText).toContain('[Tool output summarized for context efficiency.]')
-    expect(promptText).toContain('context-retrieve.get_message with id: t-docx')
+    expect(promptText).toContain('[Tool output summarized for context efficiency.')
+    expect(promptText).toContain('Full original message id: t-docx')
     expect(promptText).not.toContain('Published 1 resource(s): documento_semplice.docx')
-    expect(promptText).not.toContain('Questo e un semplice documento Word generato automaticamente.')
-    expect(promptText).toContain('[redacted: content available via context-retrieve, see summarized result]')
+    expect(promptText).not.toContain(
+      'Questo e un semplice documento Word generato automaticamente.'
+    )
+    expect(promptText).toContain(
+      '[redacted: content available via context-retrieve, see summarized result]'
+    )
     expect(mockExtractFromFile).toHaveBeenCalledTimes(1)
   })
 
   test('uncompressed generated DOCX tool result is still converted through text extraction when not natively supported', async () => {
     mockExtractFromFile.mockResolvedValueOnce('EXTRACTED DOCX CONTENT')
 
-    const segments = await buildHistorySegments(makeGeneratedDocxHistory(), modelWithoutDocxNativeSupport, languageModel, { userId: 'test-user' })
+    const segments = await buildHistorySegments(
+      makeGeneratedDocxHistory(),
+      modelWithoutDocxNativeSupport,
+      languageModel,
+      { userId: 'test-user' }
+    )
     const promptText = JSON.stringify(segments.map((segment) => segment.message))
 
     expect(promptText).toContain('Attachment 1: documento_semplice.docx')
@@ -327,14 +440,19 @@ describe('applyCompressionPlan', () => {
   test('compressed generated image tool result never upgrades to image-data / native bytes, and never calls a model to describe it', async () => {
     const { compressed } = await compress(makeGeneratedHorseImageHistory())
 
-    const segments = await buildHistorySegments(compressed, modelWithoutDocxNativeSupport, languageModel, { userId: 'test-user' })
+    const segments = await buildHistorySegments(
+      compressed,
+      modelWithoutDocxNativeSupport,
+      languageModel,
+      { userId: 'test-user' }
+    )
     const promptText = JSON.stringify(segments.map((segment) => segment.message))
 
     expect(promptText).toContain('File available on demand: horse.png')
     expect(promptText).toContain('id: file-horse')
     expect(promptText).toContain('summary: Image file; no text preview available.')
-    expect(promptText).toContain('[Tool output summarized for context efficiency.]')
-    expect(promptText).toContain('context-retrieve.get_message with id: t-image')
+    expect(promptText).toContain('[Tool output summarized for context efficiency.')
+    expect(promptText).toContain('Full original message id: t-image')
     expect(promptText).not.toContain('Attachment 1: horse.png')
     expect(promptText).not.toContain('The tool displayed 1 images')
     expect(promptText).not.toContain('image-data')
@@ -345,7 +463,12 @@ describe('applyCompressionPlan', () => {
   test('uncompressed generated image tool result still sends image bytes (provider adapters do not change full-policy semantics)', async () => {
     mockReadBuffer.mockResolvedValueOnce(Buffer.from('horse-image-bytes'))
 
-    const segments = await buildHistorySegments(makeGeneratedHorseImageHistory(), modelWithoutDocxNativeSupport, languageModel, { userId: 'test-user' })
+    const segments = await buildHistorySegments(
+      makeGeneratedHorseImageHistory(),
+      modelWithoutDocxNativeSupport,
+      languageModel,
+      { userId: 'test-user' }
+    )
     const promptText = JSON.stringify(segments.map((segment) => segment.message))
 
     expect(promptText).toContain('Attachment 1: horse.png')
@@ -369,7 +492,15 @@ describe('applyCompressionPlan', () => {
             toolName: 'gen',
             result: {
               type: 'content',
-              value: [{ type: 'file', id: 'file-docx', mimetype: docxMime, name: 'unknown.docx', size: 10 }],
+              value: [
+                {
+                  type: 'file',
+                  id: 'file-docx',
+                  mimetype: docxMime,
+                  name: 'unknown.docx',
+                  size: 10,
+                },
+              ],
             },
           },
         ],
@@ -381,10 +512,14 @@ describe('applyCompressionPlan', () => {
     const toolMessage = result.find((m) => m.id === 't1') as dto.ToolMessage
     const text = (toolMessage.parts[0] as dto.ToolCallResultPart).result
     expect(text.type).toBe('text')
-    expect((text as { value: string }).value).toContain('No extractable text preview available for this file type.')
+    expect((text as { value: string }).value).toContain(
+      'No extractable text preview available for this file type.'
+    )
     expect((text as { value: string }).value).toContain('File available on demand: unknown.docx')
-    expect((text as { value: string }).value).toContain('[Tool output summarized for context efficiency.]')
-    expect((text as { value: string }).value).toContain('context-retrieve.get_message with id: t1')
+    expect((text as { value: string }).value).toContain(
+      '[Tool output summarized for context efficiency.'
+    )
+    expect((text as { value: string }).value).toContain('Full original message id: t1')
   })
 
   test('user attachments summarized on a historical turn strip raw attachments, extract a plain-text preview, and add file + message recovery references', async () => {
@@ -395,7 +530,9 @@ describe('applyCompressionPlan', () => {
         id: 'u1',
         role: 'user',
         content: 'Please inspect this file.',
-        attachments: [{ id: 'file-123', mimetype: 'application/pdf', name: 'report.pdf', size: 1024 }],
+        attachments: [
+          { id: 'file-123', mimetype: 'application/pdf', name: 'report.pdf', size: 1024 },
+        ],
       },
       { ...base, id: 'u2', role: 'user', content: 'What is in the file?', attachments: [] },
     ]
@@ -406,9 +543,10 @@ describe('applyCompressionPlan', () => {
     expect(first.attachments).toEqual([])
     expect(first.content).toContain('File available on demand: report.pdf')
     expect(first.content).toContain('id: file-123')
-    expect(first.content).toContain('context-retrieve.get_file')
+    expect(first.content).toContain('search function of the context-retrieve tool')
+    expect(first.content).toContain('Use get_file only if the targeted excerpts are insufficient')
     expect(first.content).toContain('summary: The report covers Q1 revenue.')
-    expect(first.content).toContain('context-retrieve.get_message with id: u1')
+    expect(first.content).toContain('Full original message id: u1')
   })
 
   test('a long historical user message with no attachment is still recoverable by id under the aggressive preset', async () => {
@@ -421,7 +559,42 @@ describe('applyCompressionPlan', () => {
 
     const first = compressed[0] as dto.UserMessage
     expect(first.content).toContain('…[truncated;')
-    expect(first.content).toContain('context-retrieve.get_message with id: u1')
+    expect(first.content).toContain('Full original message id: u1')
+  })
+
+  test('query-aware prefetch adds only the relevant excerpt to a compressed message in its original role', async () => {
+    const question = 'What is the exact migration program codename?'
+    const messages: dto.Message[] = [
+      { ...base, id: 'u1', role: 'user', content: 'Record the decision.', attachments: [] },
+      {
+        ...base,
+        id: 'a1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: `${'Routine background note.\n\n'.repeat(
+              150
+            )}Final migration program codename: Kestrel Blue.`,
+          },
+        ],
+      },
+      { ...base, id: 'u2', role: 'user', content: question, attachments: [] },
+    ]
+    const decisions = planMessageCompression(messages, 'conservative')
+
+    const compressed = await applyCompressionPlan(messages, decisions, {
+      prefetchQuery: question,
+    })
+    const assistant = compressed[1] as dto.AssistantMessage
+    const rendered = assistant.parts
+      .filter((part): part is dto.TextPart => part.type === 'text')
+      .map((part) => part.text)
+      .join('\n')
+
+    expect(rendered).toContain('[AUTOMATICALLY RETRIEVED FOR THE CURRENT REQUEST')
+    expect(rendered).toContain('Final migration program codename: Kestrel Blue.')
+    expect(rendered.match(/Routine background note/g)?.length).toBeLessThan(30)
   })
 })
 
@@ -438,7 +611,9 @@ describe('warmCompressionCache', () => {
       id: 'u1',
       role: 'user',
       content: 'here is the file',
-      attachments: [{ id: 'file-123', mimetype: 'application/pdf', name: 'report.pdf', size: 1024 }],
+      attachments: [
+        { id: 'file-123', mimetype: 'application/pdf', name: 'report.pdf', size: 1024 },
+      ],
     }
 
     await warmCompressionCache(message)
@@ -450,7 +625,13 @@ describe('warmCompressionCache', () => {
   })
 
   test('does nothing for messages with no compressible content', async () => {
-    const message: dto.UserMessage = { ...base, id: 'u1', role: 'user', content: 'hi', attachments: [] }
+    const message: dto.UserMessage = {
+      ...base,
+      id: 'u1',
+      role: 'user',
+      content: 'hi',
+      attachments: [],
+    }
 
     await warmCompressionCache(message)
 
@@ -465,7 +646,9 @@ describe('warmCompressionCache', () => {
       id: 'u1',
       role: 'user',
       content: 'here',
-      attachments: [{ id: 'file-123', mimetype: 'application/pdf', name: 'report.pdf', size: 1024 }],
+      attachments: [
+        { id: 'file-123', mimetype: 'application/pdf', name: 'report.pdf', size: 1024 },
+      ],
     }
 
     await expect(warmCompressionCache(message)).resolves.toBeUndefined()
@@ -479,9 +662,14 @@ describe('warmCompressionCache', () => {
       id: 'u-concurrent',
       role: 'user',
       content: 'here is the file',
-      attachments: [{ id: 'file-123', mimetype: 'application/pdf', name: 'report.pdf', size: 1024 }],
+      attachments: [
+        { id: 'file-123', mimetype: 'application/pdf', name: 'report.pdf', size: 1024 },
+      ],
     }
-    const messages: dto.Message[] = [message, { ...base, id: 'u-next', role: 'user', content: 'next', attachments: [] }]
+    const messages: dto.Message[] = [
+      message,
+      { ...base, id: 'u-next', role: 'user', content: 'next', attachments: [] },
+    ]
 
     // Fired the way models/message.ts fires it: right away, unawaited.
     const warmPromise = warmCompressionCache(message)

--- a/apps/backend/lib/chat/compression-planner.ts
+++ b/apps/backend/lib/chat/compression-planner.ts
@@ -31,18 +31,60 @@ export function resolveCompressionRetrievalMode(
   return retrievalMode ?? 'prefetch'
 }
 
+/**
+ * Recovers the user-authored query that drives both prefetch and attachment-only continuation
+ * context.
+ *
+ * Attachment-only follow-ups commonly have an empty current text body: the attachment is the
+ * answer to, or continuation of, the preceding user request. Falling back to that nearest
+ * non-empty request preserves the ongoing task without changing any turn-stable compression
+ * decision. `user-response` messages carry structured tool input rather than user-authored text,
+ * so they are intentionally skipped.
+ */
+export function resolveCompressionUserQuery(messages: dto.Message[]): string | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]!
+    if (message.role !== 'user') continue
+    const query = message.content.trim()
+    if (query) return query
+  }
+  return undefined
+}
+
 type ToolMessagePart = dto.ToolMessage['parts'][number]
 
 const LARGE_TEXT_THRESHOLD_CHARS = 2000
 const AGGRESSIVE_LARGE_TEXT_THRESHOLD_CHARS = 800
 const LARGE_ARGS_VALUE_THRESHOLD_CHARS = 200
 const INLINE_SUMMARY_MAX_CHARS = 500
+const ATTACHMENT_CONTINUATION_QUERY_MAX_CHARS = 1000
 const REDACTED_ARGS_MARKER =
   '[redacted: content available via context-retrieve, see summarized result]'
 const INLINE_SUMMARY_CONCURRENCY = 2
 
 const isImageMimeType = (mimetype: string) => mimetype.startsWith('image/')
 const charsToTokens = (chars: number) => Math.ceil(chars / 4)
+
+function addAttachmentContinuationContext(messages: dto.Message[], query: string): void {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]!
+    if (message.role !== 'user') continue
+    if (message.content.trim() || message.attachments.length === 0) return
+
+    const boundedQuery =
+      query.length > ATTACHMENT_CONTINUATION_QUERY_MAX_CHARS
+        ? `${query.slice(0, ATTACHMENT_CONTINUATION_QUERY_MAX_CHARS)}…`
+        : query
+    messages[index] = {
+      ...message,
+      content:
+        "[CONVERSATION CONTINUATION] This attachment-only turn continues the user's nearest " +
+        'preceding request. Interpret the attached file in that context. If the file does not ' +
+        `answer it, explain that specifically.\n\nPrevious request:\n${boundedQuery}`,
+    }
+    return
+  }
+}
 
 async function mapWithConcurrency<T, R>(
   items: T[],
@@ -260,12 +302,14 @@ export function planMessageCompression(
  * messages are replaced with a compact, cached representation (see `CompressedMessage`). Also
  * redacts duplicated generated-artifact content from assistant `tool-call.args` when the
  * corresponding tool-result was summarized, per docs/context-compression.md's "Generated
- * Artifacts" section.
+ * Artifacts" section. `prefetchQuery` selects historical excerpts;
+ * `attachmentContinuationQuery` annotates an otherwise-empty current attachment turn without
+ * enabling prefetch in tool-only mode.
  */
 export async function applyCompressionPlan(
   messages: dto.Message[],
   decisions: dto.MessageCompressionDecision[],
-  options: { prefetchQuery?: string } = {}
+  options: { prefetchQuery?: string; attachmentContinuationQuery?: string } = {}
 ): Promise<dto.Message[]> {
   const decisionByMessageId = new Map(decisions.map((d) => [d.messageId, d]))
   const output: dto.Message[] = []
@@ -307,7 +351,10 @@ export async function applyCompressionPlan(
   }
 
   if (options.prefetchQuery?.trim()) {
-    await addPrefetchedExcerpts(messages, output, decisions, options.prefetchQuery)
+    await addPrefetchedExcerpts(messages, output, decisions, options.prefetchQuery.trim())
+  }
+  if (options.attachmentContinuationQuery?.trim()) {
+    addAttachmentContinuationContext(output, options.attachmentContinuationQuery.trim())
   }
   return output
 }

--- a/apps/backend/lib/chat/compression-planner.ts
+++ b/apps/backend/lib/chat/compression-planner.ts
@@ -2,7 +2,8 @@ import * as dto from '@/types/dto'
 import type { FileDbRow } from '@/backend/models/file'
 import env from '@/lib/env'
 import { logger } from '@/lib/logging'
-import { projectMessageForEstimationCached } from './message-projection'
+import { projectMessageForEstimationCached, renderMessagePlainText } from './message-projection'
+import { findRelevantExcerpts } from './context-search'
 
 // Model/DB-backed helpers are imported dynamically (below, at point of use) rather than statically
 // at module scope. This file is on the hot import path of `apps/backend/lib/chat/index.ts`, and a
@@ -13,7 +14,7 @@ import { projectMessageForEstimationCached } from './message-projection'
  * Bump when the summary-building rules below change so stale `CompressedMessage` rows are
  * regenerated instead of reused.
  */
-export const COMPRESSION_VERSION = 4
+export const COMPRESSION_VERSION = 8
 
 /**
  * The assistant-configured `triggerAtTokens` can only raise the floor below which compression
@@ -21,6 +22,13 @@ export const COMPRESSION_VERSION = 4
  */
 export function resolveCompressionTriggerTokens(triggerAtTokens: number | undefined): number {
   return Math.max(triggerAtTokens ?? 0, env.chat.contextCompressionTriggerTokens)
+}
+
+/** Query-aware prefetch is the measured default; `tool` remains available for controlled arms. */
+export function resolveCompressionRetrievalMode(
+  retrievalMode: 'tool' | 'prefetch' | undefined
+): 'tool' | 'prefetch' {
+  return retrievalMode ?? 'prefetch'
 }
 
 type ToolMessagePart = dto.ToolMessage['parts'][number]
@@ -79,7 +87,7 @@ export function buildFileRecoveryReference(
     `id: ${fileRef.id}`,
     `type: ${fileRef.mimetype}`,
     `summary: ${summary}`,
-    'Use context-retrieve.get_file with this id if exact contents are needed.',
+    `[EXACT CONTENT OMITTED] If the exact answer is already present in other visible context, or an [AUTOMATICALLY RETRIEVED] excerpt below answers the request, no tool call is needed. Otherwise, if the request could depend on omitted content, you MUST call the search function of the context-retrieve tool with { "id": "${fileRef.id}", "query": "<terms from the request>" } before answering. Use get_file only if the targeted excerpts are insufficient. Never guess or merely report that an omitted value is unavailable.`,
   ].join('\n')
 }
 
@@ -90,7 +98,7 @@ export function buildFileRecoveryReference(
  * Its Own Message Id" in docs/context-compression.md.
  */
 export function buildMessageRecoveryNote(messageId: string): string {
-  return `Full original message available on demand via context-retrieve.get_message with id: ${messageId}.`
+  return `[EXACT CONTENT OMITTED] Full original message id: ${messageId}. If the exact answer is already present in other visible context, or an [AUTOMATICALLY RETRIEVED] excerpt below answers the request, no tool call is needed. Otherwise, if the request could depend on omitted content, you MUST call the search function of the context-retrieve tool with { "id": "${messageId}", "query": "<terms from the request>" } before answering. Use get_message only if the targeted excerpts are insufficient. Never guess or merely report that an omitted value is unavailable.`
 }
 
 /**
@@ -114,7 +122,9 @@ async function buildInlineTextSummary(fileEntry: FileDbRow | undefined): Promise
 
 const truncateInline = (text: string): string =>
   text.length > INLINE_SUMMARY_MAX_CHARS
-    ? `${text.slice(0, INLINE_SUMMARY_MAX_CHARS)}…[truncated; ${text.length} chars omitted]`
+    ? `${text.slice(0, INLINE_SUMMARY_MAX_CHARS)}…[truncated; ${
+        text.length
+      } chars omitted — retrieve the original before using omitted details]`
     : text
 
 /**
@@ -164,9 +174,21 @@ function findCurrentTurnUserMessageId(messages: dto.Message[]): string | undefin
  */
 export function planMessageCompression(
   messages: dto.Message[],
-  preset: dto.ContextCompressionPreset
+  preset: dto.ContextCompressionPreset,
+  options: { keepRecentTurns?: number } = {}
 ): dto.MessageCompressionDecision[] {
   const currentTurnUserMessageId = findCurrentTurnUserMessageId(messages)
+  const keepRecentTurns = Math.max(0, Math.floor(options.keepRecentTurns ?? 0))
+  const historicalTurnIds = messages
+    .filter(
+      (message): message is dto.UserMessage | dto.UserResponseMessage =>
+        message.role === 'user' || message.role === 'user-response'
+    )
+    .map((message) => message.id)
+    .filter((id) => id !== currentTurnUserMessageId)
+  const recentTurnIds = new Set(
+    keepRecentTurns === 0 ? [] : historicalTurnIds.slice(-keepRecentTurns)
+  )
   const largeTextThreshold =
     preset === 'aggressive' ? AGGRESSIVE_LARGE_TEXT_THRESHOLD_CHARS : LARGE_TEXT_THRESHOLD_CHARS
 
@@ -178,6 +200,8 @@ export function planMessageCompression(
       activeTurnUserMessageId = message.id
     }
     const isCurrentTurn = activeTurnUserMessageId === currentTurnUserMessageId
+    const isRecentTurn =
+      activeTurnUserMessageId !== undefined && recentTurnIds.has(activeTurnUserMessageId)
 
     const chars = estimateMessageChars(message)
     const tokensBefore = charsToTokens(chars)
@@ -186,6 +210,8 @@ export function planMessageCompression(
 
     if (isCurrentTurn) {
       reason = 'current turn is never compressed'
+    } else if (isRecentTurn) {
+      reason = 'recent turn kept full'
     } else if (message.role === 'user') {
       const hasAttachments = message.attachments.length > 0
       const hasLargeText = preset === 'aggressive' && message.content.length > largeTextThreshold
@@ -238,7 +264,8 @@ export function planMessageCompression(
  */
 export async function applyCompressionPlan(
   messages: dto.Message[],
-  decisions: dto.MessageCompressionDecision[]
+  decisions: dto.MessageCompressionDecision[],
+  options: { prefetchQuery?: string } = {}
 ): Promise<dto.Message[]> {
   const decisionByMessageId = new Map(decisions.map((d) => [d.messageId, d]))
   const output: dto.Message[] = []
@@ -279,7 +306,82 @@ export async function applyCompressionPlan(
     recordAssistantToolCallIndices(message, outputIndex, assistantToolCallIndices)
   }
 
+  if (options.prefetchQuery?.trim()) {
+    await addPrefetchedExcerpts(messages, output, decisions, options.prefetchQuery)
+  }
   return output
+}
+
+const PREFETCH_MAX_TOTAL_CHARS = 6000
+
+async function relevantExcerptsForMessage(message: dto.Message, query: string): Promise<string[]> {
+  const excerpts = findRelevantExcerpts(renderMessagePlainText(message), query)
+  if (message.role !== 'user' || message.attachments.length === 0) return excerpts
+
+  const { getFileWithId } = await import('@/models/file')
+  const { cachingExtractor } = await import('@/lib/textextraction/cache')
+  const attachmentExcerpts = await mapWithConcurrency(
+    message.attachments,
+    async (attachment) => {
+      const file = await getFileWithId(attachment.id)
+      const text = file ? await cachingExtractor.extractFromFile(file) : undefined
+      if (!text) return []
+      return findRelevantExcerpts(text, query).map(
+        (excerpt) => `File ${attachment.name} (${attachment.id}):\n${excerpt}`
+      )
+    },
+    INLINE_SUMMARY_CONCURRENCY
+  )
+  return [...excerpts, ...attachmentExcerpts.flat()]
+}
+
+/**
+ * Query-aware default: inserts small lexical excerpts into each compressed message in its original
+ * role. This removes the model's first retrieval round-trip while preserving full on-demand
+ * retrieval as a fallback. It intentionally changes the compressed prefix per request; the eval
+ * accounts for whether the token saving outweighs the resulting cache loss.
+ */
+async function addPrefetchedExcerpts(
+  original: dto.Message[],
+  compacted: dto.Message[],
+  decisions: dto.MessageCompressionDecision[],
+  query: string
+): Promise<void> {
+  const summarized = new Set(
+    decisions
+      .filter((decision) => decision.policy === 'summary')
+      .map((decision) => decision.messageId)
+  )
+  let remainingChars = PREFETCH_MAX_TOTAL_CHARS
+  for (let index = 0; index < original.length && remainingChars > 0; index++) {
+    const source = original[index]!
+    if (!summarized.has(source.id)) continue
+    const excerpts = await relevantExcerptsForMessage(source, query)
+    if (excerpts.length === 0) continue
+    const recovered = excerpts.join('\n\n---\n\n').slice(0, remainingChars)
+    remainingChars -= recovered.length
+    const marker = `\n\n[AUTOMATICALLY RETRIEVED FOR THE CURRENT REQUEST — this satisfies the retrieval requirement when sufficient; do not call the tool again]\n${recovered}`
+    const target = compacted[index]!
+    if (target.role === 'user') {
+      compacted[index] = { ...target, content: `${target.content}${marker}` }
+    } else if (target.role === 'assistant') {
+      compacted[index] = {
+        ...target,
+        parts: [...target.parts, { type: 'text', text: marker.trim() }],
+      }
+    } else if (target.role === 'tool') {
+      const partIndex = target.parts.findIndex((part) => part.type === 'tool-result')
+      if (partIndex === -1) continue
+      const parts = [...target.parts]
+      const part = parts[partIndex] as dto.ToolCallResultPart
+      const current =
+        part.result.type === 'text' || part.result.type === 'error-text'
+          ? part.result.value
+          : JSON.stringify(part.result.value)
+      parts[partIndex] = { ...part, result: { type: 'text', value: `${current}${marker}` } }
+      compacted[index] = { ...target, parts }
+    }
+  }
 }
 
 /**
@@ -449,7 +551,8 @@ async function compressToolMessage(
   return { compacted: { ...message, parts }, compactedToolCallIds }
 }
 
-const TOOL_RESULT_OVERVIEW = '[Tool output summarized for context efficiency.]'
+const TOOL_RESULT_OVERVIEW =
+  '[Tool output summarized for context efficiency. Use an automatically retrieved excerpt when supplied; otherwise retrieval is mandatory whenever the request could depend on exact omitted values.]'
 
 async function compressToolResultPart(
   part: dto.ToolCallResultPart,
@@ -542,7 +645,7 @@ function redactSiblingToolCallArgs(
     if (!indices) continue
     for (const i of indices) {
       const candidate = output[i]
-      if (!candidate || candidate.role !== 'assistant') continue
+      if (candidate?.role !== 'assistant') continue
       let mutated = false
       const parts = candidate.parts.map((part) => {
         if (part.type !== 'tool-call' || part.toolCallId !== toolCallId) return part

--- a/apps/backend/lib/chat/context-search.ts
+++ b/apps/backend/lib/chat/context-search.ts
@@ -1,0 +1,92 @@
+const MAX_TARGET_EXCERPTS = 4
+const MAX_EXCERPT_CHARS = 800
+const SEARCH_STOP_WORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'by',
+  'for',
+  'from',
+  'give',
+  'in',
+  'include',
+  'is',
+  'it',
+  'me',
+  'of',
+  'on',
+  'only',
+  'reply',
+  'the',
+  'to',
+  'was',
+  'what',
+  'with',
+])
+
+const searchTokens = (value: string): string[] =>
+  [...value.toLowerCase().matchAll(/[\p{L}\p{N}][\p{L}\p{N}._-]*/gu)]
+    .map(([token]) => token)
+    .filter((token) => token.length > 1 && !SEARCH_STOP_WORDS.has(token))
+
+const splitSearchChunks = (text: string): string[] =>
+  text.split(/\n\s*\n+/).flatMap((paragraph) => {
+    const trimmed = paragraph.trim()
+    if (trimmed.length <= MAX_EXCERPT_CHARS) return trimmed ? [trimmed] : []
+    const chunks: string[] = []
+    for (let start = 0; start < trimmed.length; start += MAX_EXCERPT_CHARS) {
+      chunks.push(trimmed.slice(start, start + MAX_EXCERPT_CHARS))
+    }
+    return chunks
+  })
+
+interface RankedExcerpt {
+  excerpt: string
+  index: number
+  score: number
+}
+
+const rankRelevantExcerpts = (text: string, query: string): RankedExcerpt[] => {
+  const queryTokens = [...new Set(searchTokens(query))]
+  if (queryTokens.length === 0) return []
+  const normalizedQuery = query.trim().toLowerCase()
+  return splitSearchChunks(text)
+    .map((excerpt, index) => {
+      const lower = excerpt.toLowerCase()
+      const chunkTokens = new Set(searchTokens(excerpt))
+      const matched = queryTokens.filter((token) => chunkTokens.has(token)).length
+      const phraseBonus = normalizedQuery.length > 2 && lower.includes(normalizedQuery) ? 2 : 0
+      return { excerpt, index, score: matched + phraseBonus }
+    })
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+}
+
+/** Deterministic lexical excerpts used to keep retrieval cheaper than replaying a full payload. */
+export const findRelevantExcerpts = (text: string, query: string): string[] => {
+  const ranked = rankRelevantExcerpts(text, query)
+  const bestScore = ranked[0]?.score
+  return ranked
+    .filter(({ score }) => score === bestScore)
+    .slice(0, MAX_TARGET_EXCERPTS)
+    .map(({ excerpt }) => excerpt)
+}
+
+/** Ranks the best excerpt from each message, preferring stronger matches then newer messages. */
+export const findRelevantMessageExcerpts = (
+  messages: Array<{ id: string; role: string; text: string }>,
+  query: string,
+  limit: number
+): Array<{ id: string; role: string; excerpt: string }> =>
+  messages
+    .flatMap((message, messageIndex) => {
+      const best = rankRelevantExcerpts(message.text, query)[0]
+      return best ? [{ ...message, messageIndex, excerpt: best.excerpt, score: best.score }] : []
+    })
+    .sort((a, b) => b.score - a.score || b.messageIndex - a.messageIndex)
+    .slice(0, limit)
+    .map(({ id, role, excerpt }) => ({ id, role, excerpt }))

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -62,6 +62,7 @@ import { prefixToolFunctionNames } from './toolFunctionNames'
 import {
   planMessageCompression,
   applyCompressionPlan,
+  resolveCompressionRetrievalMode,
   resolveCompressionTriggerTokens,
 } from './compression-planner'
 
@@ -98,7 +99,11 @@ export interface AssistantParams {
 export type AssistantParamsSource = Pick<
   AssistantParams,
   'model' | 'systemPrompt' | 'temperature' | 'tokenLimit' | 'reasoning_effort'
-> & { assistantId?: string; id?: string; contextCompression?: dto.ContextCompressionConfig | string | null }
+> & {
+  assistantId?: string
+  id?: string
+  contextCompression?: dto.ContextCompressionConfig | string | null
+}
 
 interface Options {
   saveMessage?: (message: dto.Message, usage?: Usage) => Promise<void>
@@ -313,6 +318,9 @@ export class ChatAssistant {
     }
     if (assistantParams.contextCompression) {
       const { ContextRetrievePlugin } = await import('../tools/context-retrieve/implementation')
+      const retrievalMode = resolveCompressionRetrievalMode(
+        assistantParams.contextCompression.retrievalMode
+      )
       tools = [
         ...tools,
         new ContextRetrievePlugin(
@@ -321,7 +329,9 @@ export class ChatAssistant {
             provisioned: false,
             name: 'context-retrieve',
             promptFragment:
-              '\nContext compression may replace older attachments, tool outputs, or long messages with a short summary that includes an id. Use the context-retrieve tool to recover the original: get_file(id) for a file, get_message(id) for a whole message, or search(query) to find a message when you don\'t already have its id.\n',
+              retrievalMode === 'prefetch'
+                ? "\nContext compression may replace older content with summaries. Excerpts marked [AUTOMATICALLY RETRIEVED FOR THE CURRENT REQUEST] have already been recovered from the original context: use them directly and do not call a retrieval tool again when they answer the request. If the answer is not already present in visible context and those excerpts are absent or insufficient, call this context-retrieve tool's search(query, id) with focused terms, then use get_file(id) or get_message(id) only if necessary. Never guess an omitted value.\n"
+                : "\nContext compression may replace older attachments, tool outputs, or long messages with a short summary that includes an id. If a user's request could depend on exact omitted content that is not already present in visible context, you MUST retrieve it before answering. First call this context-retrieve tool's search(query, id) with focused terms from the request; it returns small relevant excerpts from that message or file. Use get_file(id) or get_message(id) only if those excerpts are insufficient. Never guess, and never merely say that an omitted value is unavailable without making the retrieval call. When no id is known, search(query) searches the conversation.\n",
           },
           {}
         ),
@@ -584,8 +594,18 @@ export class ChatAssistant {
       const estimatedTokens = historyCosts.reduce((sum, cost) => sum + cost.tokens, 0)
       const shouldCompress = estimatedTokens >= triggerAtTokens
       if (shouldCompress) {
-        const decisions = planMessageCompression(messages, compression.preset)
-        promptMessages = await applyCompressionPlan(messages, decisions)
+        const decisions = planMessageCompression(messages, compression.preset, {
+          keepRecentTurns: compression.keepRecentTurns,
+        })
+        const currentUserMessage = [...messages]
+          .reverse()
+          .find((message) => message.role === 'user')
+        promptMessages = await applyCompressionPlan(messages, decisions, {
+          prefetchQuery:
+            resolveCompressionRetrievalMode(compression.retrievalMode) === 'prefetch'
+              ? currentUserMessage?.content
+              : undefined,
+        })
       } else {
         historyCosts = undefined
       }
@@ -1107,6 +1127,13 @@ export class ChatAssistant {
             inputTokens: usage.inputTokens,
             outputTokens: usage.outputTokens,
             totalTokens: usage.totalTokens,
+            inputTokenDetails: usage.inputTokenDetails as
+              | {
+                  noCacheTokens?: number
+                  cacheReadTokens?: number
+                  cacheWriteTokens?: number
+                }
+              | undefined,
           })
         }
       }

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -63,6 +63,7 @@ import {
   planMessageCompression,
   applyCompressionPlan,
   resolveCompressionRetrievalMode,
+  resolveCompressionUserQuery,
   resolveCompressionTriggerTokens,
 } from './compression-planner'
 
@@ -597,14 +598,13 @@ export class ChatAssistant {
         const decisions = planMessageCompression(messages, compression.preset, {
           keepRecentTurns: compression.keepRecentTurns,
         })
-        const currentUserMessage = [...messages]
-          .reverse()
-          .find((message) => message.role === 'user')
+        const userQuery = resolveCompressionUserQuery(messages)
         promptMessages = await applyCompressionPlan(messages, decisions, {
           prefetchQuery:
             resolveCompressionRetrievalMode(compression.retrievalMode) === 'prefetch'
-              ? currentUserMessage?.content
+              ? userQuery
               : undefined,
+          attachmentContinuationQuery: userQuery,
         })
       } else {
         historyCosts = undefined

--- a/apps/backend/lib/eval/__tests__/metrics.test.ts
+++ b/apps/backend/lib/eval/__tests__/metrics.test.ts
@@ -8,20 +8,23 @@ const transcript = (...entries: [string, string][]): TranscriptEntry[] =>
 
 describe('resolveModelPrice', () => {
   it('matches a known model exactly', () => {
-    expect(resolveModelPrice('gpt-4o-mini')).toEqual({ input: 0.15, output: 0.6 })
+    expect(resolveModelPrice('gpt-4o-mini')).toMatchObject({ input: 0.15, output: 0.6 })
   })
 
   it('is case-insensitive', () => {
-    expect(resolveModelPrice('GPT-4o-Mini')).toEqual({ input: 0.15, output: 0.6 })
+    expect(resolveModelPrice('GPT-4o-Mini')).toMatchObject({ input: 0.15, output: 0.6 })
   })
 
   it('falls back to the longest matching prefix for a dated snapshot', () => {
     // Must resolve to gpt-4o-mini, not to the shorter gpt-4o.
-    expect(resolveModelPrice('gpt-4o-mini-2024-07-18')).toEqual({ input: 0.15, output: 0.6 })
+    expect(resolveModelPrice('gpt-4o-mini-2024-07-18')).toMatchObject({
+      input: 0.15,
+      output: 0.6,
+    })
   })
 
   it('strips a vendor prefix', () => {
-    expect(resolveModelPrice('openai/gpt-4o')).toEqual({ input: 2.5, output: 10.0 })
+    expect(resolveModelPrice('openai/gpt-4o')).toMatchObject({ input: 2.5, output: 10.0 })
   })
 
   it('returns undefined for an unknown model rather than guessing', () => {
@@ -37,6 +40,21 @@ describe('computeCostUsd', () => {
 
   it('degrades to undefined for an unpriced model instead of reporting zero', () => {
     expect(computeCostUsd('mystery-model', 1000, 1000)).toBeUndefined()
+  })
+
+  it('prices provider-reported cache reads and writes separately', () => {
+    expect(
+      computeCostUsd('gpt-4.1-mini', 1000, 100, {
+        noCacheTokens: 400,
+        cacheReadTokens: 500,
+        cacheWriteTokens: 100,
+      })
+    ).toBeCloseTo((400 * 0.4 + 500 * 0.1 + 100 * 0.4 + 100 * 1.6) / 1_000_000, 10)
+  })
+
+  it('prices the production latest aliases used by the model registry', () => {
+    expect(computeCostUsd('gpt-5-latest', 1000, 100)).toBeCloseTo(0.0032, 10)
+    expect(computeCostUsd('claude-sonnet-latest', 1000, 100)).toBeCloseTo(0.003, 10)
   })
 })
 
@@ -136,6 +154,24 @@ describe('computeTotals', () => {
       (3000 * 0.15 + 300 * 0.6) / 1_000_000,
       10
     )
+  })
+
+  it('aggregates prompt-cache token details and uses them for cost', () => {
+    const cachedTurns: TurnMetrics[] = turns.map((turn, index) => ({
+      ...turn,
+      inputTokenDetails: {
+        noCacheTokens: index === 0 ? 1000 : 500,
+        cacheReadTokens: index === 0 ? 0 : 1500,
+        cacheWriteTokens: 0,
+      },
+    }))
+    const totals = computeTotals(cachedTurns, 'gpt-4.1-mini', 0)
+    expect(totals.inputTokenDetails).toEqual({
+      noCacheTokens: 1500,
+      cacheReadTokens: 1500,
+      cacheWriteTokens: 0,
+    })
+    expect(totals.costUsd).toBeCloseTo((1500 * 0.4 + 1500 * 0.1 + 300 * 1.6) / 1_000_000, 10)
   })
 
   it('leaves cost undefined for an unpriced model', () => {

--- a/apps/backend/lib/eval/__tests__/referenceChat.test.ts
+++ b/apps/backend/lib/eval/__tests__/referenceChat.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { materializeReferenceChat } from '@/backend/lib/eval/referenceChat'
+
+describe('materializeReferenceChat', () => {
+  it('builds a parent-linked DTO history with attachments and tool traffic', () => {
+    const history = materializeReferenceChat(
+      {
+        history: [
+          { role: 'user', text: 'read this', attachments: ['record.txt'] },
+          {
+            role: 'assistant',
+            text: 'checking',
+            toolCall: { id: 'call-1', name: 'lookup', args: { key: 'x' } },
+          },
+          { role: 'tool', toolCallId: 'call-1', toolName: 'lookup', result: 'result' },
+        ],
+        finalUserMessage: 'what was it?',
+      },
+      {
+        conversationId: 'conversation',
+        runId: 'run',
+        corpus: [{ name: 'record.txt', mimeType: 'text/plain', text: 'body' }],
+        files: [{ id: 'file-1', name: 'record.txt', type: 'text/plain', size: 4 }],
+      }
+    )
+
+    expect(history.map((message) => message.role)).toEqual(['user', 'assistant', 'tool'])
+    expect(history[0]).toMatchObject({
+      attachments: [{ id: 'file-1', name: 'record.txt', mimetype: 'text/plain', size: 4 }],
+    })
+    expect(history[1]!.parent).toBe(history[0]!.id)
+    expect(history[2]!.parent).toBe(history[1]!.id)
+  })
+
+  it('fails loudly when a saved attachment is not in the corpus', () => {
+    expect(() =>
+      materializeReferenceChat(
+        {
+          history: [{ role: 'user', text: 'read', attachments: ['missing.txt'] }],
+          finalUserMessage: 'what?',
+        },
+        { conversationId: 'c', runId: 'r', corpus: [], files: [] }
+      )
+    ).toThrow('missing from the scenario corpus')
+  })
+})

--- a/apps/backend/lib/eval/__tests__/report.test.ts
+++ b/apps/backend/lib/eval/__tests__/report.test.ts
@@ -74,6 +74,11 @@ describe('computeBreakEven', () => {
       score: { n: 3, mean: 1, median: 1, min: 1, max: 1, stdev: 0 },
       inputTokens: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
       outputTokens: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
+      cacheReadTokens: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
+      cacheWriteTokens: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
+      estimatedHistoryTokensBefore: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
+      estimatedHistoryTokensAfter: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
+      summarizedMessages: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
       costUsd: { n: 3, mean: costMean, median: costMean, min: costMean, max: costMean, stdev: 0 },
       costKnown: true,
       turns: { n: 3, mean: 1, median: 1, min: 1, max: 1, stdev: 0 },
@@ -149,6 +154,18 @@ describe('compare', () => {
 })
 
 describe('renderMarkdown', () => {
+  it('starts with an overall arm summary across scenarios', () => {
+    const markdown = renderMarkdown(
+      [
+        makeRun({ armName: 'a' }),
+        makeRun({ armName: 'a', scenarioId: 'scenario-2', repetition: 1 }),
+      ],
+      'a'
+    )
+    expect(markdown).toContain('## Overall')
+    expect(markdown).toContain('| a | 2 | 100% |')
+  })
+
   it('warns when there are too few repetitions to separate anything', () => {
     const markdown = renderMarkdown([makeRun({ armName: 'a' })], 'a')
     expect(markdown).toContain('distinguishable from noise')

--- a/apps/backend/lib/eval/arms.ts
+++ b/apps/backend/lib/eval/arms.ts
@@ -30,6 +30,41 @@ export const allInContextArm: Arm = {
   }),
 }
 
+/** Historical messages are sent verbatim and no context-retrieval tool is registered. */
+export const compressionOffArm: Arm = {
+  name: 'compression-off',
+  description: 'Context compression disabled; the saved conversation is sent verbatim.',
+  setup: async (): Promise<ArmSetup> => ({ tools: [], knowledge: [] }),
+}
+
+export interface ContextCompressionArmOptions {
+  keepRecentTurns: number
+  preset?: 'conservative' | 'aggressive'
+  retrievalMode?: 'tool' | 'prefetch'
+  name?: string
+}
+
+/** A context-compression policy arm with an explicit recent-turn window. */
+export const createContextCompressionArm = (options: ContextCompressionArmOptions): Arm => {
+  const preset = options.preset ?? 'conservative'
+  const retrievalMode = options.retrievalMode ?? 'tool'
+  return {
+    name: options.name ?? `compression-keep-${options.keepRecentTurns}`,
+    description: `${preset} context compression with ${retrievalMode} retrieval, keeping ${options.keepRecentTurns} completed recent turn(s) verbatim.`,
+    setup: async (): Promise<ArmSetup> => ({
+      tools: [],
+      knowledge: [],
+      assistant: {
+        contextCompression: {
+          preset,
+          keepRecentTurns: options.keepRecentTurns,
+          retrievalMode,
+        },
+      },
+    }),
+  }
+}
+
 export interface KnowledgeBoxArmOptions {
   /** Questions asked of every document at ingestion. Empty means chunks-only retrieval. */
   questions?: KnowledgeBoxQuestion[]

--- a/apps/backend/lib/eval/cost.ts
+++ b/apps/backend/lib/eval/cost.ts
@@ -12,17 +12,23 @@ export interface ModelPrice {
   input: number
   /** USD per million output tokens. */
   output: number
+  /** Provider prompt-cache read price. Omitted when it is the same as ordinary input. */
+  cacheReadInput?: number
+  /** Provider prompt-cache write price. Omitted when it is the same as ordinary input. */
+  cacheWriteInput?: number
 }
 
 export const modelPrices: Record<string, ModelPrice> = {
   // OpenAI
-  'gpt-4o-mini': { input: 0.15, output: 0.6 },
-  'gpt-4o': { input: 2.5, output: 10.0 },
-  'gpt-4.1-mini': { input: 0.4, output: 1.6 },
-  'gpt-4.1': { input: 2.0, output: 8.0 },
+  'gpt-4o-mini': { input: 0.15, output: 0.6, cacheReadInput: 0.075 },
+  'gpt-4o': { input: 2.5, output: 10.0, cacheReadInput: 1.25 },
+  'gpt-4.1-mini': { input: 0.4, output: 1.6, cacheReadInput: 0.1 },
+  'gpt-4.1': { input: 2.0, output: 8.0, cacheReadInput: 0.5 },
+  'gpt-5.6-terra': { input: 2.0, output: 12.0, cacheReadInput: 0.2 },
+  'gpt-5-latest': { input: 2.0, output: 12.0, cacheReadInput: 0.2 },
   // Replay-eval-only cheap tier (REPLAY_EXTRA_MODELS in eval-replay-production-chats.ts).
   // TODO(luca): confirm the real gpt-5.6-luna list price — this is an estimate.
-  'gpt-5.6-luna': { input: 0.25, output: 2.0 },
+  'gpt-5.6-luna': { input: 0.25, output: 2.0, cacheReadInput: 0.025 },
   'gpt-4-turbo': { input: 10.0, output: 30.0 },
   'gpt-4': { input: 30.0, output: 60.0 },
   'gpt-3.5-turbo': { input: 0.5, output: 1.5 },
@@ -32,15 +38,22 @@ export const modelPrices: Record<string, ModelPrice> = {
   o3: { input: 10.0, output: 40.0 },
 
   // Anthropic
-  'claude-3-haiku': { input: 0.25, output: 1.25 },
-  'claude-3-5-haiku': { input: 0.8, output: 4.0 },
-  'claude-3-5-sonnet': { input: 3.0, output: 15.0 },
-  'claude-3-7-sonnet': { input: 3.0, output: 15.0 },
-  'claude-3-opus': { input: 15.0, output: 75.0 },
-  'claude-haiku-4': { input: 0.8, output: 4.0 },
-  'claude-sonnet-4': { input: 3.0, output: 15.0 },
-  'claude-opus-4': { input: 15.0, output: 75.0 },
-  'claude-opus-4-5': { input: 5.0, output: 25.0 },
+  'claude-3-haiku': { input: 0.25, output: 1.25, cacheReadInput: 0.025, cacheWriteInput: 0.3125 },
+  'claude-3-5-haiku': { input: 0.8, output: 4.0, cacheReadInput: 0.08, cacheWriteInput: 1.0 },
+  'claude-3-5-sonnet': { input: 3.0, output: 15.0, cacheReadInput: 0.3, cacheWriteInput: 3.75 },
+  'claude-3-7-sonnet': { input: 3.0, output: 15.0, cacheReadInput: 0.3, cacheWriteInput: 3.75 },
+  'claude-3-opus': { input: 15.0, output: 75.0, cacheReadInput: 1.5, cacheWriteInput: 18.75 },
+  'claude-haiku-4': { input: 0.8, output: 4.0, cacheReadInput: 0.08, cacheWriteInput: 1.0 },
+  'claude-sonnet-4': { input: 3.0, output: 15.0, cacheReadInput: 0.3, cacheWriteInput: 3.75 },
+  'claude-opus-4': { input: 15.0, output: 75.0, cacheReadInput: 1.5, cacheWriteInput: 18.75 },
+  'claude-opus-4-5': { input: 5.0, output: 25.0, cacheReadInput: 0.5, cacheWriteInput: 6.25 },
+  'claude-sonnet-5': { input: 2.0, output: 10.0, cacheReadInput: 0.2, cacheWriteInput: 2.5 },
+  'claude-sonnet-latest': {
+    input: 2.0,
+    output: 10.0,
+    cacheReadInput: 0.2,
+    cacheWriteInput: 2.5,
+  },
 
   // Google
   'gemini-1.5-flash': { input: 0.075, output: 0.3 },
@@ -76,11 +89,33 @@ export const resolveModelPrice = (modelId: string): ModelPrice | undefined => {
 export const computeCostUsd = (
   modelId: string,
   inputTokens: number,
-  outputTokens: number
+  outputTokens: number,
+  inputTokenDetails?: {
+    noCacheTokens?: number
+    cacheReadTokens?: number
+    cacheWriteTokens?: number
+  }
 ): number | undefined => {
   const price = resolveModelPrice(modelId)
   if (!price) return undefined
-  return (inputTokens * price.input + outputTokens * price.output) / 1_000_000
+  const hasCacheDetails =
+    inputTokenDetails?.cacheReadTokens !== undefined ||
+    inputTokenDetails?.cacheWriteTokens !== undefined
+  if (!hasCacheDetails) {
+    return (inputTokens * price.input + outputTokens * price.output) / 1_000_000
+  }
+  const cacheReadTokens = inputTokenDetails?.cacheReadTokens ?? 0
+  const cacheWriteTokens = inputTokenDetails?.cacheWriteTokens ?? 0
+  const noCacheTokens =
+    inputTokenDetails?.noCacheTokens ??
+    Math.max(inputTokens - cacheReadTokens - cacheWriteTokens, 0)
+  return (
+    (noCacheTokens * price.input +
+      cacheReadTokens * (price.cacheReadInput ?? price.input) +
+      cacheWriteTokens * (price.cacheWriteInput ?? price.input) +
+      outputTokens * price.output) /
+    1_000_000
+  )
 }
 
 /** Formats a cost for the report, keeping small numbers readable rather than rounding them to 0. */

--- a/apps/backend/lib/eval/harness.ts
+++ b/apps/backend/lib/eval/harness.ts
@@ -3,10 +3,19 @@ import type { LanguageModelV3 } from '@ai-sdk/provider'
 import type * as dto from '@/types/dto'
 import { applyStreamPartToMessages } from '@/lib/chat/streamApply'
 import { ChatAssistant, type AssistantParams } from '@/backend/lib/chat'
+import {
+  applyCompressionPlan,
+  planMessageCompression,
+  resolveCompressionRetrievalMode,
+  resolveCompressionTriggerTokens,
+} from '@/backend/lib/chat/compression-planner'
+import { estimateHistoryMessageCosts } from '@/backend/lib/chat/token-estimator'
+import type { LlmModel } from '@/lib/chat/models'
 import type { ProviderConfig } from '@/types/provider'
 import { computeCostUsd } from './cost'
 import { materializeCorpus } from './corpus'
 import { checkAnswerKey, computeTotals, scoreRun } from './metrics'
+import { materializeReferenceChat } from './referenceChat'
 import { EvalSink } from './sink'
 import { createSimulatedUser } from './simulatedUser'
 import type { Judge } from './judge'
@@ -29,6 +38,7 @@ export interface RunOptions {
   assistant: {
     providerConfig: ProviderConfig
     model: string
+    llmModel: LlmModel
     systemPrompt: string
     tokenLimit: number
   }
@@ -74,17 +84,21 @@ export const runOne = async (options: RunOptions): Promise<RunResult> => {
   const corpus = await materializeCorpus(scenario.corpus, runId)
   let teardown: (() => Promise<void>) | undefined
   let setupCost: RunResult['setupCost']
+  let compressionDiagnostics: RunResult['compression']
 
   try {
     const setup = await arm.setup({ scenario, files: corpus.files, runId })
     teardown = setup.teardown
     setupCost = setup.setupCost
 
+    const promptSuffix = [scenario.systemPromptSuffix, setup.systemPromptSuffix]
+      .filter(Boolean)
+      .join('\n\n')
     const assistantParams: AssistantParams = {
       assistantId: `eval-assistant-${runId}`,
       model: assistant.model,
-      systemPrompt: setup.systemPromptSuffix
-        ? `${assistant.systemPrompt}\n\n${setup.systemPromptSuffix}`
+      systemPrompt: promptSuffix
+        ? `${assistant.systemPrompt}\n\n${promptSuffix}`
         : assistant.systemPrompt,
       temperature: 0,
       tokenLimit: assistant.tokenLimit,
@@ -93,7 +107,14 @@ export const runOne = async (options: RunOptions): Promise<RunResult> => {
     }
 
     const conversationId = `eval-conv-${runId}`
-    let messages: dto.Message[] = []
+    let messages: dto.Message[] = scenario.referenceChat
+      ? materializeReferenceChat(scenario.referenceChat, {
+          conversationId,
+          runId,
+          files: corpus.files,
+          corpus: scenario.corpus,
+        })
+      : []
 
     const chatAssistant = await ChatAssistant.build(
       assistant.providerConfig,
@@ -104,10 +125,15 @@ export const runOne = async (options: RunOptions): Promise<RunResult> => {
       { user: 'eval-user', conversationId }
     )
 
-    const simulatedUser = createSimulatedUser(userModel, scenario)
+    const simulatedUser = scenario.referenceChat
+      ? undefined
+      : createSimulatedUser(userModel, scenario)
 
-    for (let turn = 0; turn < scenario.maxTurns; turn++) {
-      const decision = await simulatedUser.next(transcript)
+    const turnLimit = scenario.referenceChat ? 1 : scenario.maxTurns
+    for (let turn = 0; turn < turnLimit; turn++) {
+      const decision = scenario.referenceChat
+        ? { action: 'message' as const, message: scenario.referenceChat.finalUserMessage }
+        : await simulatedUser!.next(transcript)
       if (decision.action === 'done') {
         outcome = 'goal-reached'
         break
@@ -125,6 +151,56 @@ export const runOne = async (options: RunOptions): Promise<RunResult> => {
       const parent = messages.at(-1)?.id ?? null
       const message = userMessage(conversationId, parent, content)
       messages = [...messages, message]
+
+      if (scenario.referenceChat) {
+        const costsBefore = await estimateHistoryMessageCosts(assistant.llmModel, messages)
+        const estimatedHistoryTokensBefore = costsBefore.reduce(
+          (total, cost) => total + cost.tokens,
+          0
+        )
+        const compression = assistantParams.contextCompression
+        if (!compression) {
+          compressionDiagnostics = {
+            enabled: false,
+            estimatedHistoryTokensBefore,
+            estimatedHistoryTokensAfter: estimatedHistoryTokensBefore,
+            triggered: false,
+            summarizedMessages: 0,
+          }
+        } else {
+          const triggerAtTokens = resolveCompressionTriggerTokens(compression.triggerAtTokens)
+          const triggered = estimatedHistoryTokensBefore >= triggerAtTokens
+          const decisions = triggered
+            ? planMessageCompression(messages, compression.preset, {
+                keepRecentTurns: compression.keepRecentTurns,
+              })
+            : []
+          const plannedMessages = triggered
+            ? await applyCompressionPlan(messages, decisions, {
+                prefetchQuery:
+                  resolveCompressionRetrievalMode(compression.retrievalMode) === 'prefetch'
+                    ? message.content
+                    : undefined,
+              })
+            : messages
+          const costsAfter = await estimateHistoryMessageCosts(assistant.llmModel, plannedMessages)
+          compressionDiagnostics = {
+            enabled: true,
+            estimatedHistoryTokensBefore,
+            estimatedHistoryTokensAfter: costsAfter.reduce((total, cost) => total + cost.tokens, 0),
+            triggerAtTokens,
+            triggered,
+            summarizedMessages: decisions.filter((decision) => decision.policy === 'summary')
+              .length,
+            keepRecentTurns: compression.keepRecentTurns,
+          }
+          if (!triggered) {
+            throw new Error(
+              `Reference chat estimated at ${estimatedHistoryTokensBefore} tokens, below compression trigger ${triggerAtTokens}`
+            )
+          }
+        }
+      }
 
       const sink = new EvalSink()
       const turnStartedAt = Date.now()
@@ -146,6 +222,11 @@ export const runOne = async (options: RunOptions): Promise<RunResult> => {
           toolCalls.length > 0 ? ` [${toolCalls.join(', ')}]` : ''
         }`
       )
+
+      if (scenario.referenceChat) {
+        outcome = 'goal-reached'
+        break
+      }
     }
   } catch (caught) {
     outcome = 'error'
@@ -181,6 +262,7 @@ export const runOne = async (options: RunOptions): Promise<RunResult> => {
         ? computeCostUsd(setupCost.modelId, setupCost.inputTokens, setupCost.outputTokens)
         : undefined
       : undefined,
+    compression: compressionDiagnostics,
     score: 0,
   }
   result.score = scoreRun(result)

--- a/apps/backend/lib/eval/metrics.ts
+++ b/apps/backend/lib/eval/metrics.ts
@@ -63,6 +63,16 @@ export const checkAnswerKey = (
 export const computeTotals = (turns: TurnMetrics[], modelId: string, wallMs: number): RunTotals => {
   const inputTokens = turns.reduce((total, turn) => total + turn.inputTokens, 0)
   const outputTokens = turns.reduce((total, turn) => total + turn.outputTokens, 0)
+  const detailKeys = ['noCacheTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const
+  const hasInputTokenDetails = turns.some((turn) => turn.inputTokenDetails !== undefined)
+  const inputTokenDetails = hasInputTokenDetails
+    ? Object.fromEntries(
+        detailKeys.map((key) => [
+          key,
+          turns.reduce((total, turn) => total + (turn.inputTokenDetails?.[key] ?? 0), 0),
+        ])
+      )
+    : undefined
   return {
     inputTokens,
     outputTokens,
@@ -70,7 +80,8 @@ export const computeTotals = (turns: TurnMetrics[], modelId: string, wallMs: num
     turns: turns.length,
     toolCalls: turns.reduce((total, turn) => total + turn.toolCalls.length, 0),
     wallMs,
-    costUsd: computeCostUsd(modelId, inputTokens, outputTokens),
+    inputTokenDetails,
+    costUsd: computeCostUsd(modelId, inputTokens, outputTokens, inputTokenDetails),
   }
 }
 

--- a/apps/backend/lib/eval/productionChatReplay.ts
+++ b/apps/backend/lib/eval/productionChatReplay.ts
@@ -7,10 +7,9 @@ import type { ProviderType } from '@/types/provider'
 /**
  * One production turn selected for offline replay.
  *
- * The bundle builder (`eval-build-replay-bundle.ts`) writes the full lineage, the published
- * assistant configuration, and the saved production reply into a self-contained SQLite bundle;
- * attachment bytes travel in the bundle's `ReplayFileBlob` table, already decrypted. The runner
- * reconstructs this shape from the bundle and never touches the source deployment.
+ * The runner reconstructs this shape from a complete conversation, loaded either from the live
+ * database or from a bundle produced by `eval-build-replay-bundle.ts`. Bundle attachment bytes
+ * live in `ReplayFileBlob`, already decrypted.
  */
 export interface ProductionReplayCase {
   id: string

--- a/apps/backend/lib/eval/referenceChat.ts
+++ b/apps/backend/lib/eval/referenceChat.ts
@@ -1,0 +1,78 @@
+import type * as dto from '@/types/dto'
+import type { CorpusDocument, ReferenceChat } from './types'
+
+interface MaterializeReferenceChatOptions {
+  conversationId: string
+  runId: string
+  files: dto.AssistantFile[]
+  corpus: CorpusDocument[]
+}
+
+/** Converts a saved, portable reference chat into the exact DTO history ChatAssistant consumes. */
+export const materializeReferenceChat = (
+  referenceChat: ReferenceChat,
+  options: MaterializeReferenceChatOptions
+): dto.Message[] => {
+  const { conversationId, runId, files, corpus } = options
+  const filesByName = new Map(files.map((file) => [file.name, file]))
+  const corpusNames = new Set(corpus.map((document) => document.name))
+  const messages: dto.Message[] = []
+  const sentAt = (index: number) => new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString()
+
+  for (const [index, reference] of referenceChat.history.entries()) {
+    const base = {
+      id: `eval-history-${runId}-${index}`,
+      conversationId,
+      parent: messages.at(-1)?.id ?? null,
+      sentAt: sentAt(index),
+    }
+
+    if (reference.role === 'user') {
+      const attachments = (reference.attachments ?? []).map((name) => {
+        if (!corpusNames.has(name)) {
+          throw new Error(`Reference chat attachment "${name}" is missing from the scenario corpus`)
+        }
+        const file = filesByName.get(name)
+        if (!file) throw new Error(`Reference chat attachment "${name}" was not materialized`)
+        return { id: file.id, name: file.name, mimetype: file.type, size: file.size }
+      })
+      messages.push({ ...base, role: 'user', content: reference.text, attachments })
+      continue
+    }
+
+    if (reference.role === 'assistant') {
+      const parts: dto.AssistantMessagePart[] = []
+      if (reference.text) parts.push({ type: 'text', text: reference.text })
+      if (reference.toolCall) {
+        parts.push({
+          type: 'tool-call',
+          toolCallId: reference.toolCall.id,
+          toolName: reference.toolCall.name,
+          args: reference.toolCall.args,
+        })
+      }
+      messages.push({
+        ...base,
+        role: 'assistant',
+        parts,
+        finishReason: reference.toolCall ? 'tool-calls' : 'stop',
+      })
+      continue
+    }
+
+    messages.push({
+      ...base,
+      role: 'tool',
+      parts: [
+        {
+          type: 'tool-result',
+          toolCallId: reference.toolCallId,
+          toolName: reference.toolName,
+          result: { type: 'text', value: reference.result },
+        },
+      ],
+    })
+  }
+
+  return messages
+}

--- a/apps/backend/lib/eval/report.ts
+++ b/apps/backend/lib/eval/report.ts
@@ -19,6 +19,11 @@ export interface ArmAggregate {
   score: Summary
   inputTokens: Summary
   outputTokens: Summary
+  cacheReadTokens: Summary
+  cacheWriteTokens: Summary
+  estimatedHistoryTokensBefore: Summary
+  estimatedHistoryTokensAfter: Summary
+  summarizedMessages: Summary
   costUsd: Summary
   /** Undefined when no run had a known price. */
   costKnown: boolean
@@ -54,6 +59,19 @@ export const aggregate = (runs: RunResult[]): ArmAggregate[] => {
       score: summarize(group.map((run) => run.score)),
       inputTokens: summarize(group.map((run) => run.totals.inputTokens)),
       outputTokens: summarize(group.map((run) => run.totals.outputTokens)),
+      cacheReadTokens: summarize(
+        group.map((run) => run.totals.inputTokenDetails?.cacheReadTokens ?? 0)
+      ),
+      cacheWriteTokens: summarize(
+        group.map((run) => run.totals.inputTokenDetails?.cacheWriteTokens ?? 0)
+      ),
+      estimatedHistoryTokensBefore: summarize(
+        group.map((run) => run.compression?.estimatedHistoryTokensBefore ?? 0)
+      ),
+      estimatedHistoryTokensAfter: summarize(
+        group.map((run) => run.compression?.estimatedHistoryTokensAfter ?? 0)
+      ),
+      summarizedMessages: summarize(group.map((run) => run.compression?.summarizedMessages ?? 0)),
       costUsd: summarize(withCost.map((run) => run.totals.costUsd!)),
       costKnown: withCost.length > 0,
       turns: summarize(group.map((run) => run.totals.turns)),
@@ -185,19 +203,59 @@ export const renderMarkdown = (runs: RunResult[], baselineArmName: string): stri
   const aggregates = aggregate(runs)
   const lines: string[] = ['# Evaluation report', '']
 
-  for (const scenarioId of [...new Set(runs.map((run) => run.scenarioId))]) {
-    const scenarioAggregates = aggregates.filter((entry) => entry.scenarioId === scenarioId)
-    lines.push(`## ${scenarioId}`, '')
+  const overall = aggregate(runs.map((run) => ({ ...run, scenarioId: 'overall' })))
+  if (overall.length > 0) {
     lines.push(
-      '| arm | runs | success | score | in tok | out tok | cost | tools | turns | setup |',
-      '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
+      '## Overall',
+      '',
+      '| arm | runs | success | score | in tok | cache read | out tok | cost | tools |',
+      '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
     )
-    for (const entry of scenarioAggregates) {
+    for (const entry of overall) {
       lines.push(
         `| ${entry.armName} | ${entry.runs} | ${percent(entry.successRate)} | ${round(
           entry.score.mean,
           2
-        )} | ${round(entry.inputTokens.mean, 0)} | ${round(entry.outputTokens.mean, 0)} | ${
+        )} | ${round(entry.inputTokens.mean, 0)} | ${round(
+          entry.cacheReadTokens.mean,
+          0
+        )} | ${round(entry.outputTokens.mean, 0)} | ${
+          entry.costKnown ? formatCostUsd(entry.costUsd.mean) : 'n/a'
+        } | ${round(entry.toolCalls.mean)} |`
+      )
+    }
+    lines.push('')
+  }
+
+  for (const scenarioId of [...new Set(runs.map((run) => run.scenarioId))]) {
+    const scenarioAggregates = aggregates.filter((entry) => entry.scenarioId === scenarioId)
+    const showCompression = runs.some(
+      (run) => run.scenarioId === scenarioId && run.compression !== undefined
+    )
+    lines.push(`## ${scenarioId}`, '')
+    lines.push(
+      showCompression
+        ? '| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |'
+        : '| arm | runs | success | score | in tok | cache read | out tok | cost | tools | turns | setup |',
+      showCompression
+        ? '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
+        : '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
+    )
+    for (const entry of scenarioAggregates) {
+      const compressionColumns = showCompression
+        ? ` ${round(entry.estimatedHistoryTokensBefore.mean, 0)}→${round(
+            entry.estimatedHistoryTokensAfter.mean,
+            0
+          )} | ${round(entry.summarizedMessages.mean)} |`
+        : ''
+      lines.push(
+        `| ${entry.armName} | ${entry.runs} | ${percent(entry.successRate)} | ${round(
+          entry.score.mean,
+          2
+        )} |${compressionColumns} ${round(entry.inputTokens.mean, 0)} | ${round(
+          entry.cacheReadTokens.mean,
+          0
+        )} | ${round(entry.outputTokens.mean, 0)} | ${
           entry.costKnown ? formatCostUsd(entry.costUsd.mean) : 'n/a'
         } | ${round(entry.toolCalls.mean)} | ${round(entry.turns.mean)} | ${
           entry.setupCostUsd !== undefined ? formatCostUsd(entry.setupCostUsd) : '—'

--- a/apps/backend/lib/eval/scenarios/contextCompression.ts
+++ b/apps/backend/lib/eval/scenarios/contextCompression.ts
@@ -1,0 +1,257 @@
+import type { CorpusDocument, ReferenceChatMessage, Scenario } from '../types'
+
+/**
+ * Saved, anonymized reference chats for context-compression policy evaluation.
+ *
+ * No production text, title, user id, tenant id, assistant id, or conversation id is retained.
+ * Their turn counts are anchored to aggregate shapes from the 100 most expensive conversations
+ * observed over a 30-day window (p25=6, p50=13, p75=33 messages). Facts and prose are synthetic.
+ */
+
+const padding = (label: string, paragraphs: number): string =>
+  Array.from(
+    { length: paragraphs },
+    (_, index) =>
+      `${label} background note ${
+        index + 1
+      }: routine operational commentary covering ownership, scheduling, review status, dependencies, and non-binding implementation observations. This paragraph is intentionally ordinary and contains no decision or answer required by the evaluation.`
+  ).join('\n\n')
+
+const attachment = (name: string, fact: string, paragraphs = 150): CorpusDocument => ({
+  name,
+  mimeType: 'text/plain',
+  text: [
+    `${name}\n`,
+    padding(name, paragraphs),
+    '\nAuthoritative final record\n',
+    fact,
+    '\nEnd of record.',
+  ].join('\n'),
+})
+
+const user = (text: string, attachments?: string[]): ReferenceChatMessage => ({
+  role: 'user',
+  text,
+  attachments,
+})
+const assistant = (text: string): ReferenceChatMessage => ({ role: 'assistant', text })
+
+const routineTurn = (index: number): ReferenceChatMessage[] => [
+  user(`Give me a brief status update for routine workstream ${index}.`),
+  assistant(
+    `Workstream ${index} remains on schedule. ${padding(
+      `Workstream ${index}`,
+      4
+    )} No exception in this update supersedes a separately approved final record.`
+  ),
+]
+
+const scenario = (
+  id: string,
+  description: string,
+  corpus: CorpusDocument[],
+  history: ReferenceChatMessage[],
+  finalUserMessage: string,
+  rubric: string,
+  answerKey: NonNullable<Scenario['answerKey']>,
+  sourceShape: NonNullable<NonNullable<Scenario['referenceChat']>['sourceShape']>
+): Scenario => ({
+  id,
+  description,
+  corpus,
+  goal: finalUserMessage,
+  maxTurns: 1,
+  rubric,
+  answerKey,
+  systemPromptSuffix: [
+    'You are continuing a saved company conversation.',
+    'Answer the final user message from the exact historical record.',
+    'When a historical message says its original content is available through a context retrieval function, call the function before answering if the visible summary does not contain the exact fact.',
+    'Do not guess or substitute a similar value from another turn.',
+  ].join(' '),
+  referenceChat: { history, finalUserMessage, sourceShape },
+})
+
+const recentAttachmentName = 'release-approval-record.txt'
+const recentAttachment = attachment(
+  recentAttachmentName,
+  'The final release authorization code is ORCHID-7419. The transposed code ORCHID-1749 is invalid.'
+)
+
+export const recentAttachmentScenario = scenario(
+  'compression-recent-attachment',
+  'Single-turn recall from an attachment in the immediately preceding turn (n-1).',
+  [recentAttachment],
+  [
+    ...routineTurn(1),
+    ...routineTurn(2),
+    user('Archive this release approval record for the launch review.', [recentAttachmentName]),
+    assistant('Archived. I will use the final record if you ask for the authorization later.'),
+  ],
+  'What is the exact final release authorization code? Reply with the code only.',
+  'The assistant returns the exact authorization code from the attachment in the immediately preceding turn.',
+  { mustMention: ['ORCHID-7419'], mustNotMention: ['ORCHID-1749'] },
+  { cohort: 'expensive-conversations-30d-p25', messageCount: 6 }
+)
+
+const middleAttachmentName = 'transition-calendar.txt'
+const middleAttachment = attachment(
+  middleAttachmentName,
+  'The approved production transition date is 17 November 2027. Earlier planning dates are superseded.'
+)
+
+export const middleAttachmentScenario = scenario(
+  'compression-middle-attachment',
+  'Single-turn recall from an attachment three completed turns behind the final question (n-3).',
+  [middleAttachment],
+  [
+    ...routineTurn(1),
+    ...routineTurn(2),
+    ...routineTurn(3),
+    user('Store the approved transition calendar for later.', [middleAttachmentName]),
+    assistant('Stored. I will treat the final record as authoritative.'),
+    ...routineTurn(5),
+    ...routineTurn(6),
+  ],
+  'According to the approved record, what is the exact production transition date?',
+  'The assistant returns the authoritative date from the attachment at n-3, not a guessed planning date.',
+  { mustMention: ['17 November 2027'] },
+  { cohort: 'expensive-conversations-30d-p50', messageCount: 12 }
+)
+
+const recentDecisionText = [
+  padding('Architecture decision discussion', 150),
+  'Final decision: the migration program codename is Kestrel Blue. This supersedes every working name above.',
+].join('\n\n')
+
+export const recentAssistantDecisionScenario = scenario(
+  'compression-recent-assistant',
+  'Single-turn recall from a long assistant response in the immediately preceding turn (n-1).',
+  [],
+  [
+    ...routineTurn(1),
+    ...routineTurn(2),
+    user('Record the final architecture decision and its program codename.'),
+    assistant(recentDecisionText),
+  ],
+  'What exact program codename did you record in the final decision? Reply with the codename only.',
+  'The assistant recalls the final codename from its own immediately preceding long response.',
+  { mustMention: ['Kestrel Blue'] },
+  { cohort: 'expensive-conversations-30d-p25', messageCount: 6 }
+)
+
+const farToolResult = [
+  'Ledger reconciliation export',
+  padding('Ledger row', 150),
+  'Authoritative reconciled balance: EUR 418,275.60.',
+  'A provisional balance of EUR 481,257.60 was rejected and must not be used.',
+].join('\n\n')
+
+const farHistory: ReferenceChatMessage[] = [
+  user('Run the ledger reconciliation and keep the authoritative balance available.'),
+  {
+    role: 'assistant',
+    text: 'I will query the ledger now.',
+    toolCall: { id: 'ledger-call-1', name: 'ledger_lookup', args: { period: 'FY27-Q2' } },
+  },
+  {
+    role: 'tool',
+    toolCallId: 'ledger-call-1',
+    toolName: 'ledger_lookup',
+    result: farToolResult,
+  },
+  assistant(
+    'The reconciliation completed; the authoritative output is recorded in the tool result.'
+  ),
+  ...Array.from({ length: 14 }, (_, index) => routineTurn(index + 2)).flat(),
+]
+
+export const farToolScenario = scenario(
+  'compression-far-tool-output',
+  'Single-turn recall from a large historical tool result near the start of a 32-message history.',
+  [],
+  farHistory,
+  'What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents.',
+  'The assistant retrieves the original historical tool result and returns the authoritative balance.',
+  { mustMention: ['EUR 418,275.60'], mustNotMention: ['EUR 481,257.60'] },
+  { cohort: 'expensive-conversations-30d-p75', messageCount: 32 }
+)
+
+const irrelevantToolResult = [
+  'Historical observability export',
+  padding('Archived telemetry row', 150),
+  'End of archived export. This payload is unrelated to current escalation routing.',
+].join('\n\n')
+
+export const irrelevantOldBulkScenario = scenario(
+  'compression-irrelevant-old-bulk',
+  'A large far tool result is irrelevant; the answer is in a short recent assistant message.',
+  [],
+  [
+    user('Archive the old observability export.'),
+    {
+      role: 'assistant',
+      toolCall: { id: 'telemetry-call-1', name: 'telemetry_export', args: { period: 'archive' } },
+    },
+    {
+      role: 'tool',
+      toolCallId: 'telemetry-call-1',
+      toolName: 'telemetry_export',
+      result: irrelevantToolResult,
+    },
+    assistant('The historical export is archived.'),
+    ...Array.from({ length: 12 }, (_, index) => routineTurn(index + 2)).flat(),
+    user('Record the current escalation channel.'),
+    assistant('The current escalation channel is Falcon Desk.'),
+  ],
+  'What is the current escalation channel? Reply with its name only.',
+  'The assistant answers from the recent short message without retrieving the irrelevant old payload.',
+  { mustMention: ['Falcon Desk'] },
+  { cohort: 'expensive-conversations-30d-p75', messageCount: 30 }
+)
+
+const mixedAttachmentName = 'service-acceptance.txt'
+const mixedAttachment = attachment(
+  mixedAttachmentName,
+  'The accepted service restoration window is 14 business days from verified incident closure.'
+)
+const mixedToolResult = [
+  padding('Registry response', 100),
+  'The authoritative service registry identifier is LUMEN-83. LUMEN-38 is a retired identifier.',
+].join('\n\n')
+
+export const mixedDepthScenario = scenario(
+  'compression-mixed-depth',
+  'Two-fact recall combining a far tool result with an immediately preceding attachment.',
+  [mixedAttachment],
+  [
+    user('Look up the active service registry identifier.'),
+    {
+      role: 'assistant',
+      toolCall: { id: 'registry-call-1', name: 'service_registry', args: { status: 'active' } },
+    },
+    {
+      role: 'tool',
+      toolCallId: 'registry-call-1',
+      toolName: 'service_registry',
+      result: mixedToolResult,
+    },
+    assistant('The active identifier is recorded in the registry result.'),
+    ...Array.from({ length: 5 }, (_, index) => routineTurn(index + 2)).flat(),
+    user('Also store the accepted restoration window.', [mixedAttachmentName]),
+    assistant('Stored. The attached acceptance record is authoritative.'),
+  ],
+  'Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only.',
+  'The assistant combines the far tool result with the recent attached record, without using the retired identifier.',
+  { mustMention: ['LUMEN-83', '14 business days'], mustNotMention: ['LUMEN-38'] },
+  { cohort: 'expensive-conversations-30d-p50', messageCount: 16 }
+)
+
+export const contextCompressionScenarios: Scenario[] = [
+  recentAttachmentScenario,
+  middleAttachmentScenario,
+  recentAssistantDecisionScenario,
+  farToolScenario,
+  irrelevantOldBulkScenario,
+  mixedDepthScenario,
+]

--- a/apps/backend/lib/eval/sink.ts
+++ b/apps/backend/lib/eval/sink.ts
@@ -41,25 +41,39 @@ export class EvalSink implements ClientSink {
   }
 
   getUsage(): TurnUsage {
-    return this.events
-      .filter(
-        (
-          event
-        ): event is dto.TextStreamPart & {
-          type: 'usage'
-          inputTokens: number
-          outputTokens: number
-          totalTokens: number
-        } => event.type === 'usage'
-      )
-      .reduce(
-        (total, event) => ({
-          inputTokens: total.inputTokens + event.inputTokens,
-          outputTokens: total.outputTokens + event.outputTokens,
-          totalTokens: total.totalTokens + event.totalTokens,
-        }),
-        { inputTokens: 0, outputTokens: 0, totalTokens: 0 }
-      )
+    const usageEvents = this.events.filter(
+      (
+        event
+      ): event is dto.TextStreamPart & {
+        type: 'usage'
+        inputTokens: number
+        outputTokens: number
+        totalTokens: number
+        inputTokenDetails?: TurnUsage['inputTokenDetails']
+      } => event.type === 'usage'
+    )
+    const totals = usageEvents.reduce(
+      (total, event) => ({
+        inputTokens: total.inputTokens + event.inputTokens,
+        outputTokens: total.outputTokens + event.outputTokens,
+        totalTokens: total.totalTokens + event.totalTokens,
+      }),
+      { inputTokens: 0, outputTokens: 0, totalTokens: 0 }
+    )
+    const detailKeys = ['noCacheTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const
+    const hasDetails = usageEvents.some((event) =>
+      detailKeys.some((key) => event.inputTokenDetails?.[key] !== undefined)
+    )
+    if (!hasDetails) return totals
+    return {
+      ...totals,
+      inputTokenDetails: Object.fromEntries(
+        detailKeys.map((key) => [
+          key,
+          usageEvents.reduce((sum, event) => sum + (event.inputTokenDetails?.[key] ?? 0), 0),
+        ])
+      ),
+    }
   }
 
   getErrors(): string[] {

--- a/apps/backend/lib/eval/types.ts
+++ b/apps/backend/lib/eval/types.ts
@@ -32,6 +32,49 @@ export interface AnswerKey {
   mustNotMention?: string[]
 }
 
+/** A saved message in a single-turn reference conversation. */
+export type ReferenceChatMessage =
+  | {
+      role: 'user'
+      text: string
+      /** Corpus document names attached to this historical user message. */
+      attachments?: string[]
+    }
+  | {
+      role: 'assistant'
+      text?: string
+      /** Optional historical tool call. Its result is stored in the following tool message. */
+      toolCall?: {
+        id: string
+        name: string
+        args: Record<string, unknown>
+      }
+    }
+  | {
+      role: 'tool'
+      toolCallId: string
+      toolName: string
+      result: string
+    }
+
+/**
+ * A fixed conversation prefix followed by one fixed user question.
+ *
+ * This mode removes the simulated user's stochastic trajectory from policy comparisons. The
+ * saved history is input context only: it is deliberately excluded from the scored transcript,
+ * otherwise an answer planted in history could satisfy the deterministic gate by itself.
+ */
+export interface ReferenceChat {
+  history: ReferenceChatMessage[]
+  finalUserMessage: string
+  /** Provenance of the shape, never production content or identifiers. */
+  sourceShape?: {
+    cohort: string
+    messageCount: number
+    approximateInputTokens?: number
+  }
+}
+
 export interface Scenario {
   id: string
   description: string
@@ -43,6 +86,10 @@ export interface Scenario {
   persona?: string
   /** Hard stop, so a failing arm cannot burn the budget. */
   maxTurns: number
+  /** Fixed-history, single-message mode for context-policy evaluations. */
+  referenceChat?: ReferenceChat
+  /** Added to the assistant prompt for every arm in this scenario. */
+  systemPromptSuffix?: string
   /** What a good outcome looks like, handed to the judge together with the transcript. */
   rubric: string
   answerKey?: AnswerKey
@@ -119,11 +166,27 @@ export interface TurnUsage {
   inputTokens: number
   outputTokens: number
   totalTokens: number
+  /** Provider-reported prompt-cache accounting, when available. */
+  inputTokenDetails?: {
+    noCacheTokens?: number
+    cacheReadTokens?: number
+    cacheWriteTokens?: number
+  }
 }
 
 export interface TurnMetrics extends TurnUsage {
   toolCalls: string[]
   latencyMs: number
+}
+
+export interface CompressionDiagnostics {
+  enabled: boolean
+  estimatedHistoryTokensBefore: number
+  estimatedHistoryTokensAfter: number
+  triggerAtTokens?: number
+  triggered: boolean
+  summarizedMessages: number
+  keepRecentTurns?: number
 }
 
 export type RunOutcome = 'goal-reached' | 'max-turns' | 'gave-up' | 'error'
@@ -170,6 +233,8 @@ export interface RunResult {
   setupCost?: SetupCost
   /** USD equivalent of `setupCost`, when the ingestion model's price is known. */
   setupCostUsd?: number
+  /** Exact tokenizer-based planner precondition and estimated history reduction. */
+  compression?: CompressionDiagnostics
   /**
    * The single number arms are ranked on: deterministic pass and judge score combined. See
    * `scoreRun` in metrics.ts for how the two are reconciled.
@@ -183,6 +248,7 @@ export interface EvaluationArtifact {
   createdAt: string
   metadata: {
     gitRevision?: string
+    gitDirty?: boolean
     provider: string
     assistantModel: string
     userModel: string
@@ -191,6 +257,7 @@ export interface EvaluationArtifact {
     arms: string[]
     scenarios: string[]
     repeat: number
+    suite?: string
     sweep?: {
       documents: number[]
       wordsPerDocument: number

--- a/apps/backend/lib/storage/HttpReadOnlyStorage.ts
+++ b/apps/backend/lib/storage/HttpReadOnlyStorage.ts
@@ -41,7 +41,7 @@ export class HttpReadOnlyStorage extends BaseStorage {
   }
 
   supportsRangeReads(_encryption: StorageEncryption): boolean {
-    return false
+    return true
   }
 
   async readStream(
@@ -51,6 +51,14 @@ export class HttpReadOnlyStorage extends BaseStorage {
   ): Promise<ReadableStream<Uint8Array>> {
     const headers = new Headers()
     if (this.authorization) headers.set('authorization', this.authorization)
+    let expectedRange: { start: number; end: number } | undefined
+    if (options?.rangeStart !== undefined || options?.rangeEnd !== undefined) {
+      if (options.rangeStart === undefined || options.rangeEnd === undefined) {
+        throw new Error('File storage proxy reads require both rangeStart and rangeEnd')
+      }
+      headers.set('range', `bytes=${options.rangeStart}-${options.rangeEnd}`)
+      expectedRange = { start: options.rangeStart, end: options.rangeEnd }
+    }
     const response = await fetch(this.urlFor(path), {
       headers,
       signal: options?.signal,
@@ -59,6 +67,30 @@ export class HttpReadOnlyStorage extends BaseStorage {
     })
     if (!response.ok || !response.body) {
       throw new Error(`File storage proxy read failed for ${path}: HTTP ${response.status}`)
+    }
+    if (expectedRange && response.status !== 206) {
+      throw new Error(
+        `File storage proxy ignored the byte range for ${path}: expected HTTP 206, got ${response.status}`
+      )
+    }
+    if (expectedRange) {
+      const contentRange = response.headers.get('content-range')
+      const match = contentRange?.match(/^bytes (\d+)-(\d+)\/(\d+|\*)$/)
+      const returnedEnd = Number(match?.[2])
+      const totalSize = match?.[3] === '*' ? undefined : Number(match?.[3])
+      const endedAtEof = totalSize !== undefined && returnedEnd === totalSize - 1
+      if (
+        !match ||
+        Number(match[1]) !== expectedRange.start ||
+        returnedEnd > expectedRange.end ||
+        (returnedEnd !== expectedRange.end && !endedAtEof)
+      ) {
+        throw new Error(
+          `File storage proxy returned an invalid Content-Range for ${path}: ${
+            contentRange ?? 'missing'
+          }`
+        )
+      }
     }
     return response.body
   }

--- a/apps/backend/lib/storage/__tests__/HttpReadOnlyStorage.test.ts
+++ b/apps/backend/lib/storage/__tests__/HttpReadOnlyStorage.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { HttpReadOnlyStorage } from '../HttpReadOnlyStorage'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('HttpReadOnlyStorage', () => {
+  test('forwards closed byte ranges to the read-only proxy', async () => {
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response(new Uint8Array(64), {
+          status: 206,
+          headers: { 'content-range': 'bytes 0-63/100' },
+        })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const storage = new HttpReadOnlyStorage('https://proxy.example/prefix/', 'Bearer test')
+
+    expect(storage.supportsRangeReads('aead')).toBe(true)
+    await storage.readStream('folder/a file.bin', 'aead', { rangeStart: 0, rangeEnd: 63 })
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(String(url)).toBe('https://proxy.example/prefix/folder/a%20file.bin')
+    const headers = new Headers(init?.headers)
+    expect(headers.get('range')).toBe('bytes=0-63')
+    expect(headers.get('authorization')).toBe('Bearer test')
+    expect(init?.redirect).toBe('error')
+  })
+
+  test('rejects a partial range instead of accidentally downloading the whole blob', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const storage = new HttpReadOnlyStorage('https://proxy.example/')
+
+    await expect(storage.readStream('blob.bin', 'aead', { rangeStart: 0 })).rejects.toThrow(
+      'require both rangeStart and rangeEnd'
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test('rejects a proxy that ignores a requested byte range', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(new Uint8Array([1, 2, 3])))
+    )
+    const storage = new HttpReadOnlyStorage('https://proxy.example/')
+
+    await expect(
+      storage.readStream('blob.bin', 'aead', { rangeStart: 0, rangeEnd: 1 })
+    ).rejects.toThrow('expected HTTP 206, got 200')
+  })
+
+  test('rejects a mismatched Content-Range', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(new Uint8Array([1, 2]), {
+            status: 206,
+            headers: { 'content-range': 'bytes 4-5/100' },
+          })
+      )
+    )
+    const storage = new HttpReadOnlyStorage('https://proxy.example/')
+
+    await expect(
+      storage.readStream('blob.bin', 'aead', { rangeStart: 0, rangeEnd: 1 })
+    ).rejects.toThrow('invalid Content-Range')
+  })
+})

--- a/apps/backend/lib/tools/context-retrieve/__tests__/implementation.test.ts
+++ b/apps/backend/lib/tools/context-retrieve/__tests__/implementation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { ContextRetrievePlugin } from '@/backend/lib/tools/context-retrieve/implementation'
+import { findRelevantExcerpts } from '@/backend/lib/chat/context-search'
 import type { ToolFunction, ToolInvokeParams, ToolParams } from '@/lib/chat/tools'
 import { ChatState } from '@/backend/lib/chat/ChatState'
 import { dtoMessageToDbMessage } from '@/backend/models/message'
@@ -16,7 +17,10 @@ vi.mock('@/db/database', () => ({
       if (table === 'File') {
         return {
           selectAll: () => ({
-            where: () => ({ where: () => ({ executeTakeFirst: mockFileExecuteTakeFirst }), executeTakeFirst: mockFileExecuteTakeFirst }),
+            where: () => ({
+              where: () => ({ executeTakeFirst: mockFileExecuteTakeFirst }),
+              executeTakeFirst: mockFileExecuteTakeFirst,
+            }),
           }),
         }
       }
@@ -44,7 +48,9 @@ beforeEach(() => {
 
 const toolParams: ToolParams = { id: 't1', name: 'fm', provisioned: false, promptFragment: '' }
 const textOnlyModel = { capabilities: { vision: false, supportedMedia: [] } } as any
-const nativePdfModel = { capabilities: { vision: false, supportedMedia: ['application/pdf'] } } as any
+const nativePdfModel = {
+  capabilities: { vision: false, supportedMedia: ['application/pdf'] },
+} as any
 
 function makeInvokeParams(
   params: Record<string, unknown>,
@@ -297,7 +303,13 @@ describe('ContextRetrievePlugin get_message', () => {
 describe('ContextRetrievePlugin search', () => {
   it('finds a matching historical message and returns its id and a snippet', async () => {
     const messages: dto.Message[] = [
-      { ...base, id: 'u1', role: 'user', content: 'the quarterly revenue figures are attached', attachments: [] },
+      {
+        ...base,
+        id: 'u1',
+        role: 'user',
+        content: 'the quarterly revenue figures are attached',
+        attachments: [],
+      },
       { ...base, id: 'u2', role: 'user', content: 'thanks', attachments: [] },
     ]
     const fns = await getFunctions()
@@ -309,8 +321,52 @@ describe('ContextRetrievePlugin search', () => {
     expect((result as { value: string }).value).toContain('quarterly revenue figures')
   })
 
+  it('ranks lexical matches and excludes the live request and retrieval call', async () => {
+    const messages: dto.Message[] = [
+      {
+        ...base,
+        id: 'historical-answer',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'The current escalation channel is Falcon Desk.' }],
+      },
+      {
+        ...base,
+        id: 'current-request',
+        role: 'user',
+        content: 'What is the current escalation channel?',
+        attachments: [],
+      },
+      {
+        ...base,
+        id: 'current-tool-call',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'context-retrieve__search',
+            args: { query: 'escalation channel Falcon Desk' },
+          },
+        ],
+      },
+    ]
+    const fns = await getFunctions()
+
+    const result = await fns.search.invoke(
+      makeInvokeParams({ query: 'escalation channel Falcon Desk' }, messages)
+    )
+
+    expect(result.type).toBe('text')
+    expect((result as { value: string }).value).toContain('id: historical-answer')
+    expect((result as { value: string }).value).toContain('Falcon Desk')
+    expect((result as { value: string }).value).not.toContain('current-request')
+    expect((result as { value: string }).value).not.toContain('current-tool-call')
+  })
+
   it('returns a friendly message when nothing matches', async () => {
-    const messages: dto.Message[] = [{ ...base, id: 'u1', role: 'user', content: 'hello', attachments: [] }]
+    const messages: dto.Message[] = [
+      { ...base, id: 'u1', role: 'user', content: 'hello', attachments: [] },
+    ]
     const fns = await getFunctions()
 
     const result = await fns.search.invoke(makeInvokeParams({ query: 'nonexistent' }, messages))
@@ -324,5 +380,73 @@ describe('ContextRetrievePlugin search', () => {
     const result = await fns.search.invoke(makeInvokeParams({ query: '   ' }, []))
 
     expect(result).toEqual({ type: 'error-text', value: 'Empty search query' })
+  })
+
+  it('searches only the requested message and returns lexical matches rather than the full payload', async () => {
+    const messages: dto.Message[] = [
+      {
+        ...base,
+        id: 't1',
+        role: 'tool',
+        parts: [
+          {
+            type: 'tool-result',
+            toolCallId: 'c1',
+            toolName: 'ledger',
+            result: {
+              type: 'text',
+              value: `${'irrelevant archive material\n\n'.repeat(
+                100
+              )}Authoritative reconciled balance: EUR 418,275.60.`,
+            },
+          },
+        ],
+      },
+    ]
+    const fns = await getFunctions()
+
+    const result = await fns.search.invoke(
+      makeInvokeParams({ id: 't1', query: 'exact ledger reconciled balance' }, messages)
+    )
+
+    expect(result.type).toBe('text')
+    expect((result as { value: string }).value).toContain('EUR 418,275.60')
+    expect((result as { value: string }).value).not.toContain('irrelevant archive material')
+    expect(mockFileExecuteTakeFirst).not.toHaveBeenCalled()
+  })
+
+  it('searches an accessible file by id without returning its irrelevant bulk', async () => {
+    mockFileExecuteTakeFirst.mockResolvedValue({
+      id: 'f1',
+      name: 'transition.txt',
+      type: 'text/plain',
+      fileBlobId: null,
+      path: 'files/transition.txt',
+    })
+    mockExtractFromFile.mockResolvedValue(
+      `${'routine planning notes\n\n'.repeat(
+        100
+      )}Approved production transition date: 17 November 2027.`
+    )
+    const fns = await getFunctions()
+
+    const result = await fns.search.invoke(
+      makeInvokeParams({ id: 'f1', query: 'exact approved transition date' })
+    )
+
+    expect(result.type).toBe('text')
+    expect((result as { value: string }).value).toContain('17 November 2027')
+    expect((result as { value: string }).value).not.toContain('routine planning notes')
+  })
+})
+
+describe('findRelevantExcerpts', () => {
+  it('matches related terms when the complete query is not a literal substring', () => {
+    const excerpts = findRelevantExcerpts(
+      'Ordinary note.\n\nThe authoritative service registry identifier is LUMEN-83.',
+      'exact active registry identifier'
+    )
+
+    expect(excerpts).toEqual(['The authoritative service registry identifier is LUMEN-83.'])
   })
 })

--- a/apps/backend/lib/tools/context-retrieve/implementation.ts
+++ b/apps/backend/lib/tools/context-retrieve/implementation.ts
@@ -10,15 +10,21 @@ import { LlmModel } from '@/lib/chat/models'
 import { cachingExtractor } from '@/lib/textextraction/cache'
 import type { FileDbRow } from '@/backend/models/file'
 import { canAccessFile } from '@/backend/lib/files/authorization'
-import { canSendAsNativeFile, canSendAsNativeImage } from '@/backend/lib/chat/file-attachment-policy'
+import {
+  canSendAsNativeFile,
+  canSendAsNativeImage,
+} from '@/backend/lib/chat/file-attachment-policy'
 import { renderMessagePlainText } from '@/backend/lib/chat/message-projection'
+import {
+  findRelevantExcerpts,
+  findRelevantMessageExcerpts,
+} from '@/backend/lib/chat/context-search'
 import type * as dto from '@/types/dto'
 
 const isTextLikeMimeType = (mimeType: string) =>
   mimeType.startsWith('text/') || mimeType === 'application/json'
 
 const MAX_SEARCH_RESULTS = 20
-const SNIPPET_RADIUS_CHARS = 80
 
 /**
  * Exposes the chat's own uncompressed context back to the model: read a file by id, read a
@@ -33,8 +39,7 @@ export class ContextRetrievePlugin implements ToolImplementation {
   constructor(
     public toolParams: ToolParams,
     public params: Record<string, never>
-  ) {
-  }
+  ) {}
 
   functions = async (_model: LlmModel, _context: ToolFunctionContext) => this.functions_
 
@@ -162,7 +167,7 @@ export class ContextRetrievePlugin implements ToolImplementation {
     },
     search: {
       description:
-        "Search this conversation's original, uncompressed message history for a text query (case-insensitive). Returns matching message ids with a short snippet — use the id with get_message to read the full original content.",
+        "Search original, uncompressed context using focused terms from the user's request. When id is supplied, returns small relevant excerpts from that exact message or file; prefer this targeted form for a compression marker. Without id, searches the conversation and returns matching message ids. Use get_message or get_file only when the excerpts are insufficient.",
       parameters: {
         type: 'object',
         properties: {
@@ -170,27 +175,70 @@ export class ContextRetrievePlugin implements ToolImplementation {
             type: 'string',
             description: 'text to search for',
           },
+          id: {
+            type: 'string',
+            description: 'optional compressed message or file id to search within',
+          },
         },
         additionalProperties: false,
         required: ['query'],
       },
-      invoke: async ({ messages, params }: ToolInvokeParams) => {
+      invoke: async ({ messages, params, userId }: ToolInvokeParams) => {
         const query = `${params.query}`.trim()
         if (!query) {
           return { type: 'error-text', value: 'Empty search query' }
         }
-        const needle = query.toLowerCase()
-        const matches: string[] = []
-        for (const message of messages) {
-          const text = renderMessagePlainText(message)
-          const index = text.toLowerCase().indexOf(needle)
-          if (index === -1) continue
-          const start = Math.max(0, index - SNIPPET_RADIUS_CHARS)
-          const end = Math.min(text.length, index + needle.length + SNIPPET_RADIUS_CHARS)
-          const snippet = `${start > 0 ? '…' : ''}${text.slice(start, end)}${end < text.length ? '…' : ''}`
-          matches.push(`id: ${message.id} (role: ${message.role})\n${snippet}`)
-          if (matches.length >= MAX_SEARCH_RESULTS) break
+        const id = typeof params.id === 'string' ? params.id.trim() : ''
+        if (id) {
+          const message = this.findMessage(messages, id)
+          let targetText: string | undefined
+          let targetKind = 'message'
+          if (message) {
+            targetText = renderMessagePlainText(message)
+          } else {
+            const file = await this.getFileDbRowBy({ id })
+            if (!file || !(await canAccessFile({ userId }, file.id))) {
+              return { type: 'error-text', value: 'Message or file not found' }
+            }
+            targetKind = 'file'
+            const extracted = await cachingExtractor.extractFromFile(file)
+            if (typeof extracted === 'string' && extracted.length > 0) targetText = extracted
+          }
+          if (!targetText) {
+            return { type: 'error-text', value: `No searchable text found for ${targetKind} ${id}` }
+          }
+          const excerpts = findRelevantExcerpts(targetText, query)
+          if (excerpts.length === 0) {
+            return { type: 'text', value: `No relevant excerpts found in ${targetKind} ${id}.` }
+          }
+          return {
+            type: 'text',
+            value: `Relevant excerpts from ${targetKind} ${id}:\n\n${excerpts.join('\n\n---\n\n')}`,
+          }
         }
+        // The invocation receives the live turn too. Search only the context that existed before
+        // the latest user request, otherwise a context-retrieve call can rank its own arguments
+        // and result above the historical message it is trying to recover.
+        let currentTurnStart = -1
+        for (let index = messages.length - 1; index >= 0; index -= 1) {
+          if (messages[index]?.role === 'user') {
+            currentTurnStart = index
+            break
+          }
+        }
+        const historicalMessages =
+          currentTurnStart === -1 ? messages : messages.slice(0, currentTurnStart)
+        const matches = findRelevantMessageExcerpts(
+          historicalMessages.map((message) => ({
+            id: message.id,
+            role: message.role,
+            text: renderMessagePlainText(message),
+          })),
+          query,
+          MAX_SEARCH_RESULTS
+        ).map(({ id: messageId, role, excerpt }) =>
+          `id: ${messageId} (role: ${role})\n${excerpt}`
+        )
         if (matches.length === 0) {
           return { type: 'text', value: `No messages matched "${query}".` }
         }

--- a/apps/backend/scripts/eval-build-replay-bundle.ts
+++ b/apps/backend/scripts/eval-build-replay-bundle.ts
@@ -1,7 +1,7 @@
 /**
  * Builds a self-contained offline replay bundle from a source Logicle database.
  *
- * The bundle is a single SQLite file: the app schema, plus only the selected conversations'
+ * The bundle is a single SQLite file for one conversation: the app schema, plus the selected
  * `Conversation` / `Message` / `MessageAudit` / `Assistant*` / `Backend` / `File` / `FileBlob` /
  * `FileAnalysis` rows, plus a `ReplayFileBlob(path, size, bytes)` table holding every referenced
  * attachment's bytes and its extracted-text sidecar, **decrypted**.
@@ -9,7 +9,7 @@
  *
  * This script is infra-agnostic. It reads the source database via `--source-db` (or `DATABASE_URL`)
  * and attachment bytes via the normal storage stack (`FILE_STORAGE_LOCATION` plus the
- * `FILE_STORAGE_ENCRYPTION_*` vars, only needed when a selected turn has attachments).
+ * `FILE_STORAGE_ENCRYPTION_*` vars, only needed when the conversation has attachments).
  * `FILE_STORAGE_LOCATION` may be an `s3://` bucket, a directory, or an `http(s)://` read-only
  * proxy (`HttpReadOnlyStorage`) — wiring any of those to a specific tenant is the job of the ops
  * repo's `download_replay_bundle`, not this script.
@@ -18,20 +18,15 @@
  *   FILE_STORAGE_LOCATION=s3://tenant-bucket FILE_STORAGE_ENCRYPTION_ENABLE=1 \
  *   FILE_STORAGE_ENCRYPTION_KEY=... \
  *   npx tsx apps/backend/scripts/eval-build-replay-bundle.ts \
- *     --source-db postgres://... --out bundle.sqlite --min-input-tokens 12000 --limit 25
+ *     --source-db postgres://... --out bundle.sqlite <conversation-id>
  *
  * Flags:
  *   --source-db <path|url>     source SQLite path or DATABASE_URL (default: $DATABASE_URL)
  *   --out <path>               bundle SQLite file to write (required); <out>.skipped.json is also written
- *   --min-input-tokens <n>     MessageAudit input-token floor (default: 12000)
- *   --limit <n>                admitted turns (default: 20)
- *   --assistant <id>           restrict to one assistant
- *   --distinct-conversations   admit at most one turn per conversation
- *   --since <ISO date>         only turns sent on/after this date (default: 90 days ago)
+ *   <conversation-id>          conversation to replay (required positional argument)
  *
- * Only turns that can be replayed faithfully are considered: the assistant still exists, is not
- * tool/knowledge/sub-assistant configured, still runs the model the turn actually used, and the
- * turn did not error in production.
+ * The builder does not choose a replay target. It saves the complete conversation; the replay
+ * runner chooses one audited user message, defaulting to the latest one with a saved response.
  */
 
 export {}
@@ -39,40 +34,38 @@ export {}
 import { rmSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { Kysely, Migrator, SqliteDialect, sql } from 'kysely'
-import type { DB, Message as DbMessage } from '@/db/schema'
+import type { DB } from '@/db/schema'
 
 const errText = (error: unknown): string => (error instanceof Error ? error.message : String(error))
 
+const usage =
+  'Usage: --source-db <path|url> (or $DATABASE_URL) --out <bundle.sqlite> <conversation-id>'
 const args = process.argv.slice(2).filter((arg) => arg !== '--')
-const flag = (name: string): string | undefined => {
-  const index = args.indexOf(`--${name}`)
-  return index === -1 ? undefined : args[index + 1]
+let sourceDb = process.env.DATABASE_URL
+let out: string | undefined
+const positionals: string[] = []
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index]
+  if (arg === '--source-db' || arg === '--out') {
+    const value = args[index + 1]
+    if (!value || value.startsWith('--')) {
+      console.error(`${arg} requires a value\n${usage}`)
+      process.exit(1)
+    }
+    if (arg === '--source-db') sourceDb = value
+    else out = value
+    index += 1
+  } else if (arg.startsWith('--')) {
+    console.error(`Unknown option: ${arg}\n${usage}`)
+    process.exit(1)
+  } else {
+    positionals.push(arg)
+  }
 }
 
-const sourceDb = flag('source-db') ?? process.env.DATABASE_URL
-const out = flag('out')
-if (!sourceDb || !out) {
-  console.error('Usage: --source-db <path|url> (or $DATABASE_URL) --out <bundle.sqlite>')
-  process.exit(1)
-}
-
-const minimumAuditedInputTokens = Number(flag('min-input-tokens') ?? 12000)
-const limit = Number(flag('limit') ?? 20)
-const assistantFilter = flag('assistant')
-const distinctConversations = args.includes('--distinct-conversations')
-if (!Number.isFinite(minimumAuditedInputTokens) || minimumAuditedInputTokens < 1) {
-  console.error('--min-input-tokens must be a positive number')
-  process.exit(1)
-}
-if (!Number.isInteger(limit) || limit < 1) {
-  console.error('--limit must be a positive integer')
-  process.exit(1)
-}
-// Replay is only faithful for turns whose assistant is still configured the way it was then.
-// Default to the last 90 days; pass `--since 1970-01-01` to disable.
-const sinceIso = flag('since') ?? new Date(Date.now() - 90 * 86_400_000).toISOString()
-if (Number.isNaN(Date.parse(sinceIso))) {
-  console.error('--since must be an ISO date')
+const conversationId = positionals[0]
+if (!sourceDb || !out || !conversationId || positionals.length !== 1) {
+  console.error(usage)
   process.exit(1)
 }
 
@@ -81,10 +74,7 @@ process.env.DATABASE_URL = sourceDb.includes('://') ? sourceDb : `file://${sourc
 
 const { db: source } = await import('@/db/database')
 const { dtoMessageFromDbMessage } = await import('@/models/utils')
-const { renderMessagePlainText } = await import('@/backend/lib/chat/message-projection')
-const { isReplayableLineage, collectAttachmentFileIds } = await import(
-  '@/backend/lib/eval/productionChatReplay'
-)
+const { collectAttachmentFileIds } = await import('@/backend/lib/eval/productionChatReplay')
 const { migrationModules } = await import('@/db/migrations.generated')
 
 // Remove any stale bundle so the schema is rebuilt cleanly, then open it as a second connection.
@@ -112,9 +102,9 @@ if (migration.error) {
   console.error(`Failed to build bundle schema: ${errText(migration.error)}`)
   process.exit(1)
 }
-// The bundle is a deliberately partial copy (one lineage per conversation, files re-owned), so
-// foreign-key enforcement would reject valid rows. A migration leaves this connection with keys
-// on; turn it back off for the copy phase.
+// The bundle is a deliberately partial database copy (one conversation, files re-owned), so
+// foreign-key enforcement would reject references outside that conversation. A migration leaves
+// this connection with keys on; turn it back off for the copy phase.
 await sql`PRAGMA foreign_keys = OFF`.execute(bundle)
 await sql`
   CREATE TABLE IF NOT EXISTS "ReplayFileBlob" (
@@ -125,89 +115,8 @@ await sql`
 `.execute(bundle)
 
 const REPLAY_OWNER = 'production-replay-user'
-
-const skipped: Array<{
-  messageId: string
-  conversationId: string
-  auditedInputTokens: number
-  reason: string
-}> = []
-const seenBackends = new Set<string>()
-const seenAssistants = new Set<string>()
-const seenAssistantVersions = new Set<string>()
-const seenConversations = new Set<string>()
-const seenMessages = new Set<string>()
-const seenFileIds = new Set<string>()
-const seenBlobIds = new Set<string>()
 const seenBlobPaths = new Set<string>()
-let admitted = 0
-
-let candidates = source
-  .selectFrom('MessageAudit')
-  .innerJoin('Conversation', 'Conversation.id', 'MessageAudit.conversationId')
-  .innerJoin('Assistant', 'Assistant.id', 'Conversation.assistantId')
-  .innerJoin('AssistantVersion', 'AssistantVersion.id', 'Assistant.publishedVersionId')
-  .select([
-    'MessageAudit.messageId',
-    'MessageAudit.conversationId',
-    'MessageAudit.tokens as auditedInputTokens',
-    'MessageAudit.sentAt',
-    'Conversation.assistantId',
-  ])
-  .where('MessageAudit.type', '=', 'user')
-  .where('MessageAudit.tokens', '>=', minimumAuditedInputTokens)
-  .where('MessageAudit.sentAt', '>=', sinceIso)
-  // The turn errored in production — not a clean baseline to compare a replay against.
-  .where('MessageAudit.errors', 'is', null)
-  // The assistant must still exist and still run the model this turn actually used, or the replay
-  // measures a different assistant than the one that incurred the cost.
-  .where('Assistant.deleted', '=', 0)
-  .whereRef('MessageAudit.model', '=', 'AssistantVersion.model')
-  // Assistants with tools or knowledge files can't be replayed faithfully; exclude them in SQL so
-  // `--limit` counts admissible turns rather than being eaten by the (often most expensive)
-  // tool/knowledge cohort. Sub-assistants are checked per row below — `subAssistants` is jsonb on
-  // postgres, so it can't be string-compared here.
-  .where((eb) =>
-    eb.not(
-      eb.exists(
-        eb
-          .selectFrom('AssistantVersionToolAssociation')
-          .select('toolId')
-          .whereRef(
-            'AssistantVersionToolAssociation.assistantVersionId',
-            '=',
-            'AssistantVersion.id'
-          )
-      )
-    )
-  )
-  .where((eb) =>
-    eb.not(
-      eb.exists(
-        eb
-          .selectFrom('AssistantVersionFile')
-          .select('fileId')
-          .whereRef('AssistantVersionFile.assistantVersionId', '=', 'AssistantVersion.id')
-      )
-    )
-  )
-  .orderBy('MessageAudit.tokens', 'desc')
-  .orderBy('MessageAudit.sentAt', 'desc')
-  // Lineage shape / attachment resolution can still skip a row, so scan a little past the target.
-  .limit(limit * 10)
-if (assistantFilter) candidates = candidates.where('Conversation.assistantId', '=', assistantFilter)
-
-const skip = (
-  candidate: { messageId: string; conversationId: string; auditedInputTokens: number },
-  reason: string
-) => {
-  skipped.push({
-    messageId: candidate.messageId,
-    conversationId: candidate.conversationId,
-    auditedInputTokens: candidate.auditedInputTokens,
-    reason,
-  })
-}
+const seenBlobIds = new Set<string>()
 
 const copyBlobBytes = async (blobPath: string, encryption: 'pgp' | 'aead' | null, size: number) => {
   if (seenBlobPaths.has(blobPath)) return
@@ -220,305 +129,296 @@ const copyBlobBytes = async (blobPath: string, encryption: 'pgp' | 'aead' | null
   seenBlobPaths.add(blobPath)
 }
 
+let copied:
+  | { messages: number; audits: number; attachments: number; replayableTargets: number }
+  | undefined
+let failure: string | undefined
 try {
-  for (const candidate of await candidates.execute()) {
-    if (admitted >= limit) break
-    if (distinctConversations && seenConversations.has(candidate.conversationId)) {
-      skip(candidate, 'another turn from this conversation is already admitted')
-      continue
-    }
+  const conversation = await source
+    .selectFrom('Conversation')
+    .selectAll()
+    .where('id', '=', conversationId)
+    .executeTakeFirst()
+  if (!conversation) throw new Error(`Conversation ${conversationId} does not exist`)
 
-    const messages = await source
-      .selectFrom('Message')
-      .selectAll()
-      .where('conversationId', '=', candidate.conversationId)
-      .execute()
-    const byId = new Map(messages.map((message) => [message.id, message]))
+  const messages = await source
+    .selectFrom('Message')
+    .selectAll()
+    .where('conversationId', '=', conversationId)
+    .execute()
+  if (messages.length === 0) throw new Error(`Conversation ${conversationId} has no messages`)
 
-    const lineageRows: DbMessage[] = []
-    let cursor = byId.get(candidate.messageId)
-    while (cursor) {
-      lineageRows.push(cursor)
-      cursor = cursor.parent ? byId.get(cursor.parent) : undefined
-    }
-    lineageRows.reverse()
+  const audits = await source
+    .selectFrom('MessageAudit')
+    .selectAll()
+    .where('conversationId', '=', conversationId)
+    .execute()
 
-    let lineage: ReturnType<typeof dtoMessageFromDbMessage>[]
-    try {
-      lineage = lineageRows.map(dtoMessageFromDbMessage)
-    } catch (error) {
-      skip(candidate, `saved message cannot be converted: ${errText(error)}`)
-      continue
-    }
-    const lineageReason = isReplayableLineage(lineage)
-    if (lineageReason) {
-      skip(candidate, lineageReason)
-      continue
-    }
+  const assistant = await source
+    .selectFrom('Assistant')
+    .innerJoin('AssistantVersion', 'AssistantVersion.id', 'Assistant.publishedVersionId')
+    .select([
+      'Assistant.id as assistantId',
+      'Assistant.owner as assistantOwner',
+      'Assistant.provisioned as assistantProvisioned',
+      'Assistant.deleted as assistantDeleted',
+      'Assistant.hidden as assistantHidden',
+      'AssistantVersion.id as versionId',
+      'AssistantVersion.backendId as backendId',
+      'AssistantVersion.subAssistants as subAssistants',
+    ])
+    .where('Assistant.id', '=', conversation.assistantId)
+    .executeTakeFirst()
+  if (!assistant) throw new Error('Assistant or its published version is unavailable')
+  if (assistant.assistantDeleted !== 0) throw new Error('Assistant is deleted')
 
-    // The candidate query already excluded tool and knowledge-file assistants.
-    const assistant = await source
-      .selectFrom('Assistant')
-      .innerJoin('AssistantVersion', 'AssistantVersion.id', 'Assistant.publishedVersionId')
-      .select([
-        'Assistant.id as assistantId',
-        'Assistant.owner as assistantOwner',
-        'Assistant.provisioned as assistantProvisioned',
-        'Assistant.deleted as assistantDeleted',
-        'Assistant.hidden as assistantHidden',
-        'AssistantVersion.id as versionId',
-        'AssistantVersion.backendId as backendId',
-        'AssistantVersion.subAssistants as subAssistants',
-      ])
-      .where('Assistant.id', '=', candidate.assistantId)
-      .executeTakeFirst()
-    if (!assistant) {
-      skip(candidate, 'assistant or its published version is unavailable')
-      continue
-    }
-    const subAssistants = assistant.subAssistants
-      ? (JSON.parse(String(assistant.subAssistants)) as unknown[])
-      : []
-    if (Array.isArray(subAssistants) && subAssistants.length > 0) {
-      skip(candidate, 'assistant has sub-assistants')
-      continue
-    }
-
-    const productionResponse = messages
-      .filter((message) => message.parent === candidate.messageId && message.role === 'assistant')
-      .sort((a, b) => a.sentAt.localeCompare(b.sentAt))[0]
-    if (!productionResponse) {
-      skip(candidate, 'no saved assistant response follows the audited user message')
-      continue
-    }
-    try {
-      const productionMessage = dtoMessageFromDbMessage(productionResponse)
-      if (
-        productionMessage.role !== 'assistant' ||
-        productionMessage.parts.some((part) => part.type.includes('tool-call'))
-      ) {
-        skip(candidate, 'production response begins tool activity; a tool fixture is required')
-        continue
-      }
-      renderMessagePlainText(productionMessage)
-    } catch (error) {
-      skip(candidate, `saved production response cannot be converted: ${errText(error)}`)
-      continue
-    }
-
-    // Resolve every attachment's File + FileBlob rows and bytes before writing anything.
-    const attachmentFileIds = collectAttachmentFileIds(lineage)
-    const attachmentRows: Array<{
-      file: {
-        id: string
-        name: string
-        path: string
-        type: string
-        origin: 'uploaded' | 'generated' | null
-        createdAt: string
-        fileBlobId: string | null
-      }
-      blob: {
-        id: string
-        contentHash: string
-        path: string
-        type: string
-        size: number
-        encryption: 'pgp' | 'aead' | null
-        createdAt: string
-      } | null
-      analysis: {
-        fileId: string
-        kind: string
-        status: string
-        payload: string | null
-        error: string | null
-        createdAt: string
-        updatedAt: string
-      } | null
-    }> = []
-    let attachmentFailure: string | undefined
-    for (const fileId of attachmentFileIds) {
-      const fileRow = await source
-        .selectFrom('File')
-        .select(['id', 'name', 'path', 'type', 'origin', 'createdAt', 'fileBlobId'])
-        .where('id', '=', fileId)
-        .executeTakeFirst()
-      if (!fileRow) {
-        attachmentFailure = `attachment ${fileId} has no File row`
-        break
-      }
-      const blobRow = fileRow.fileBlobId
-        ? await source
-            .selectFrom('FileBlob')
-            .select(['id', 'contentHash', 'path', 'type', 'size', 'encryption', 'createdAt'])
-            .where('id', '=', fileRow.fileBlobId)
-            .executeTakeFirst()
-        : undefined
-      if (fileRow.fileBlobId && !blobRow) {
-        attachmentFailure = `attachment ${fileId} FileBlob ${fileRow.fileBlobId} is missing`
-        break
-      }
-      // Production's cached file analysis (extracted PDF/office text) — carry it so the replay
-      // reuses it instead of re-analyzing (which would fail on the read-only replay storage and,
-      // worse, change the prompt: without extracted text a PDF is sent natively, inflating tokens
-      // past what production actually paid).
-      const analysisRow = await source
-        .selectFrom('FileAnalysis')
-        .select(['fileId', 'kind', 'status', 'payload', 'error', 'createdAt', 'updatedAt'])
-        .where('fileId', '=', fileId)
-        .executeTakeFirst()
-      let extractedTextPath: string | undefined
-      if (analysisRow?.status === 'ready' && analysisRow.payload) {
-        try {
-          const parsed = JSON.parse(analysisRow.payload) as { extractedTextPath?: string | null }
-          extractedTextPath = parsed.extractedTextPath ?? undefined
-        } catch {
-          /* leave analysis without a sidecar; it will just re-analyze */
-        }
-      }
-      try {
-        if (blobRow) await copyBlobBytes(blobRow.path, blobRow.encryption, blobRow.size)
-        if (extractedTextPath)
-          await copyBlobBytes(extractedTextPath, blobRow?.encryption ?? null, 0)
-      } catch (error) {
-        attachmentFailure = `attachment ${fileId} bytes could not be read: ${errText(error)}`
-        break
-      }
-      attachmentRows.push({ file: fileRow, blob: blobRow ?? null, analysis: analysisRow ?? null })
-    }
-    if (attachmentFailure) {
-      skip(candidate, attachmentFailure)
-      continue
-    }
-
-    // --- write the turn into the bundle ---
-    if (!seenBackends.has(assistant.backendId)) {
-      const backend = await source
-        .selectFrom('Backend')
-        .selectAll()
-        .where('id', '=', assistant.backendId)
-        .executeTakeFirstOrThrow()
-      await bundle.insertInto('Backend').values(backend).execute()
-      seenBackends.add(assistant.backendId)
-    }
-    if (!seenAssistantVersions.has(assistant.versionId)) {
-      const version = await source
-        .selectFrom('AssistantVersion')
-        .selectAll()
-        .where('id', '=', assistant.versionId)
-        .executeTakeFirstOrThrow()
-      await bundle
-        .insertInto('AssistantVersion')
-        .values({ ...version, imageId: null })
-        .execute()
-      seenAssistantVersions.add(assistant.versionId)
-    }
-    if (!seenAssistants.has(assistant.assistantId)) {
-      await bundle
-        .insertInto('Assistant')
-        .values({
-          id: assistant.assistantId,
-          owner: assistant.assistantOwner,
-          provisioned: assistant.assistantProvisioned,
-          deleted: assistant.assistantDeleted,
-          hidden: assistant.assistantHidden,
-          publishedVersionId: assistant.versionId,
-          draftVersionId: null,
-        })
-        .execute()
-      seenAssistants.add(assistant.assistantId)
-    }
-    if (!seenConversations.has(candidate.conversationId)) {
-      const conversation = await source
-        .selectFrom('Conversation')
-        .selectAll()
-        .where('id', '=', candidate.conversationId)
-        .executeTakeFirstOrThrow()
-      await bundle.insertInto('Conversation').values(conversation).execute()
-      seenConversations.add(candidate.conversationId)
-    }
-
-    for (const row of [...lineageRows, productionResponse]) {
-      if (seenMessages.has(row.id)) continue
-      await bundle.insertInto('Message').values(row).execute()
-      seenMessages.add(row.id)
-    }
-
-    const audit = await source
-      .selectFrom('MessageAudit')
-      .selectAll()
-      .where('messageId', '=', candidate.messageId)
-      .where('type', '=', 'user')
-      .executeTakeFirstOrThrow()
-    await bundle.insertInto('MessageAudit').values(audit).execute()
-
-    for (const { file, blob, analysis } of attachmentRows) {
-      if (blob && !seenBlobIds.has(blob.id)) {
-        await bundle
-          .insertInto('FileBlob')
-          .values({
-            id: blob.id,
-            contentHash: blob.contentHash,
-            path: blob.path,
-            type: blob.type,
-            size: blob.size,
-            encryption: null,
-            createdAt: blob.createdAt,
-          })
-          .execute()
-        seenBlobIds.add(blob.id)
-      }
-      if (seenFileIds.has(file.id)) continue
-      await bundle
-        .insertInto('File')
-        .values({
-          id: file.id,
-          name: file.name,
-          path: file.path,
-          type: file.type,
-          origin: file.origin ?? 'uploaded',
-          size: blob?.size ?? 0,
-          uploaded: blob ? 1 : 0,
-          createdAt: file.createdAt,
-          encrypted: 0,
-          fileBlobId: blob?.id ?? null,
-          ownerType: 'USER',
-          ownerId: REPLAY_OWNER,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any)
-        .execute()
-      seenFileIds.add(file.id)
-      if (analysis) {
-        await bundle
-          .insertInto('FileAnalysis')
-          .values({
-            fileId: analysis.fileId,
-            kind: analysis.kind,
-            status: analysis.status,
-            // Bump past any analyzer version the replay checkout might expect, so it is reused
-            // verbatim and never re-run.
-            analyzerVersion: 2_000_000_000,
-            payload: analysis.payload,
-            error: analysis.error,
-            createdAt: analysis.createdAt,
-            updatedAt: analysis.updatedAt,
-          })
-          .execute()
-      }
-    }
-
-    admitted += 1
-    process.stderr.write(
-      `admitted ${candidate.messageId} (${candidate.auditedInputTokens} input tokens)\n`
+  const subAssistants = assistant.subAssistants
+    ? (JSON.parse(String(assistant.subAssistants)) as unknown[])
+    : []
+  if (Array.isArray(subAssistants) && subAssistants.length > 0) {
+    throw new Error('Assistant has sub-assistants, which the offline replay cannot reconstruct')
+  }
+  const configuredTool = await source
+    .selectFrom('AssistantVersionToolAssociation')
+    .select('toolId')
+    .where('assistantVersionId', '=', assistant.versionId)
+    .executeTakeFirst()
+  if (configuredTool) {
+    throw new Error('Assistant has configured tools, which the offline replay cannot reconstruct')
+  }
+  const configuredKnowledgeFile = await source
+    .selectFrom('AssistantVersionFile')
+    .select('fileId')
+    .where('assistantVersionId', '=', assistant.versionId)
+    .executeTakeFirst()
+  if (configuredKnowledgeFile) {
+    throw new Error(
+      'Assistant has configured knowledge files, which the offline replay cannot reconstruct'
     )
   }
+
+  let replayMessages: ReturnType<typeof dtoMessageFromDbMessage>[]
+  try {
+    replayMessages = messages.map(dtoMessageFromDbMessage)
+  } catch (error) {
+    throw new Error(`A saved message cannot be converted: ${errText(error)}`)
+  }
+
+  // Resolve every attachment in the complete conversation before writing the relational rows.
+  const attachmentFileIds = collectAttachmentFileIds(replayMessages)
+  const attachmentRows: Array<{
+    file: {
+      id: string
+      name: string
+      path: string
+      type: string
+      origin: 'uploaded' | 'generated' | null
+      createdAt: string
+      fileBlobId: string | null
+    }
+    blob: {
+      id: string
+      contentHash: string
+      path: string
+      type: string
+      size: number
+      encryption: 'pgp' | 'aead' | null
+      createdAt: string
+    } | null
+    analysis: {
+      fileId: string
+      kind: string
+      status: string
+      payload: string | null
+      error: string | null
+      createdAt: string
+      updatedAt: string
+    } | null
+  }> = []
+  for (const fileId of attachmentFileIds) {
+    const fileRow = await source
+      .selectFrom('File')
+      .select(['id', 'name', 'path', 'type', 'origin', 'createdAt', 'fileBlobId'])
+      .where('id', '=', fileId)
+      .executeTakeFirst()
+    if (!fileRow) {
+      throw new Error(`Attachment ${fileId} has no File row`)
+    }
+    const blobRow = fileRow.fileBlobId
+      ? await source
+          .selectFrom('FileBlob')
+          .select(['id', 'contentHash', 'path', 'type', 'size', 'encryption', 'createdAt'])
+          .where('id', '=', fileRow.fileBlobId)
+          .executeTakeFirst()
+      : undefined
+    if (fileRow.fileBlobId && !blobRow) {
+      throw new Error(`Attachment ${fileId} FileBlob ${fileRow.fileBlobId} is missing`)
+    }
+    // Production's cached file analysis (extracted PDF/office text) — carry it so the replay
+    // reuses it instead of re-analyzing (which would fail on the read-only replay storage and,
+    // worse, change the prompt: without extracted text a PDF is sent natively, inflating tokens
+    // past what production actually paid).
+    const analysisRow = await source
+      .selectFrom('FileAnalysis')
+      .select(['fileId', 'kind', 'status', 'payload', 'error', 'createdAt', 'updatedAt'])
+      .where('fileId', '=', fileId)
+      .executeTakeFirst()
+    let extractedTextPath: string | undefined
+    if (analysisRow?.status === 'ready' && analysisRow.payload) {
+      try {
+        const parsed = JSON.parse(analysisRow.payload) as { extractedTextPath?: string | null }
+        extractedTextPath = parsed.extractedTextPath ?? undefined
+      } catch {
+        /* leave analysis without a sidecar; it will just re-analyze */
+      }
+    }
+    if (blobRow) {
+      try {
+        await copyBlobBytes(blobRow.path, blobRow.encryption, blobRow.size)
+      } catch (error) {
+        throw new Error(
+          `Attachment ${fileId} blob ${blobRow.path} could not be read: ${errText(error)}`
+        )
+      }
+    }
+    if (extractedTextPath) {
+      try {
+        await copyBlobBytes(extractedTextPath, blobRow?.encryption ?? null, 0)
+      } catch (error) {
+        throw new Error(
+          `Attachment ${fileId} extracted-text sidecar ${extractedTextPath} could not be read: ${errText(
+            error
+          )}`
+        )
+      }
+    }
+    attachmentRows.push({ file: fileRow, blob: blobRow ?? null, analysis: analysisRow ?? null })
+  }
+
+  const backend = await source
+    .selectFrom('Backend')
+    .selectAll()
+    .where('id', '=', assistant.backendId)
+    .executeTakeFirstOrThrow()
+  const version = await source
+    .selectFrom('AssistantVersion')
+    .selectAll()
+    .where('id', '=', assistant.versionId)
+    .executeTakeFirstOrThrow()
+  await bundle.insertInto('Backend').values(backend).execute()
+  await bundle
+    .insertInto('AssistantVersion')
+    .values({ ...version, imageId: null })
+    .execute()
+  await bundle
+    .insertInto('Assistant')
+    .values({
+      id: assistant.assistantId,
+      owner: assistant.assistantOwner,
+      provisioned: assistant.assistantProvisioned,
+      deleted: assistant.assistantDeleted,
+      hidden: assistant.assistantHidden,
+      publishedVersionId: assistant.versionId,
+      draftVersionId: null,
+    })
+    .execute()
+  await bundle.insertInto('Conversation').values(conversation).execute()
+
+  for (const row of messages) await bundle.insertInto('Message').values(row).execute()
+  for (const audit of audits) await bundle.insertInto('MessageAudit').values(audit).execute()
+
+  for (const { file, blob, analysis } of attachmentRows) {
+    if (blob && !seenBlobIds.has(blob.id)) {
+      await bundle
+        .insertInto('FileBlob')
+        .values({
+          id: blob.id,
+          contentHash: blob.contentHash,
+          path: blob.path,
+          type: blob.type,
+          size: blob.size,
+          encryption: null,
+          createdAt: blob.createdAt,
+        })
+        .execute()
+      seenBlobIds.add(blob.id)
+    }
+    await bundle
+      .insertInto('File')
+      .values({
+        id: file.id,
+        name: file.name,
+        path: file.path,
+        type: file.type,
+        origin: file.origin ?? 'uploaded',
+        size: blob?.size ?? 0,
+        uploaded: blob ? 1 : 0,
+        createdAt: file.createdAt,
+        encrypted: 0,
+        fileBlobId: blob?.id ?? null,
+        ownerType: 'USER',
+        ownerId: REPLAY_OWNER,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+      .execute()
+    if (analysis) {
+      await bundle
+        .insertInto('FileAnalysis')
+        .values({
+          fileId: analysis.fileId,
+          kind: analysis.kind,
+          status: analysis.status,
+          // Bump past any analyzer version the replay checkout might expect, so it is reused
+          // verbatim and never re-run.
+          analyzerVersion: 2_000_000_000,
+          payload: analysis.payload,
+          error: analysis.error,
+          createdAt: analysis.createdAt,
+          updatedAt: analysis.updatedAt,
+        })
+        .execute()
+    }
+  }
+
+  const messageIds = new Set(messages.map((message) => message.id))
+  const replayableTargets = audits.filter(
+    (audit) =>
+      audit.type === 'user' &&
+      audit.errors === null &&
+      messages.some(
+        (message) =>
+          messageIds.has(audit.messageId) &&
+          message.parent === audit.messageId &&
+          message.role === 'assistant'
+      )
+  ).length
+  copied = {
+    messages: messages.length,
+    audits: audits.length,
+    attachments: attachmentFileIds.length,
+    replayableTargets,
+  }
+} catch (error) {
+  failure = errText(error)
 } finally {
   await source.destroy()
   await bundle.destroy()
 }
 
-await writeFile(`${out}.skipped.json`, JSON.stringify(skipped, null, 2), 'utf-8')
-console.error(
-  `Wrote ${admitted} replayable turn(s) to ${out} and ${skipped.length} skipped candidate(s) to ${out}.skipped.json.`
+await writeFile(
+  `${out}.skipped.json`,
+  JSON.stringify(failure ? [{ conversationId, reason: failure }] : [], null, 2),
+  'utf-8'
 )
+if (failure || !copied) {
+  console.error(
+    `Could not build ${out}: ${failure ?? 'unknown error'}. Details: ${out}.skipped.json.`
+  )
+  process.exitCode = 1
+} else {
+  console.error(
+    `Wrote conversation ${conversationId} to ${out}: ${copied.messages} messages, ` +
+      `${copied.audits} audits, ${copied.attachments} attachments, ` +
+      `${copied.replayableTargets} candidate replay messages.`
+  )
+}

--- a/apps/backend/scripts/eval-build-replay-bundle.ts
+++ b/apps/backend/scripts/eval-build-replay-bundle.ts
@@ -29,8 +29,6 @@
  * runner chooses one audited user message, defaulting to the latest one with a saved response.
  */
 
-export {}
-
 import { rmSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { Kysely, Migrator, SqliteDialect, sql } from 'kysely'

--- a/apps/backend/scripts/eval-replay-production-chats.ts
+++ b/apps/backend/scripts/eval-replay-production-chats.ts
@@ -1,9 +1,10 @@
 /**
- * Replays production turns from an offline bundle through the current code.
+ * Replays one production turn through the current code, loading the conversation either from an
+ * offline bundle or directly from the configured live database/storage.
  *
- * By default it replays exactly one turn — the most expensive in the bundle — so a single
- * invocation is a single LLM call and the spend is predictable. Pass `--case <messageId>` (repeat
- * for a handful) or `--limit <n>` to widen it deliberately.
+ * `--message <messageId>` selects the audited user message. Without it, the runner selects the
+ * latest audited user message with a saved assistant response. It reconstructs that message's
+ * parent lineage from the complete saved conversation.
  *
  * For each turn the runner rebuilds the saved assistant, applies `--override` on top of its
  * configuration, runs the turn once, and records the response plus the real provider token usage
@@ -12,18 +13,26 @@
  * preset, a different model, a new build) run it with the corresponding `--override` — or from a
  * checkout / deployment that has the change — and read the delta against production.
  *
- * Input is a bundle from `eval-build-replay-bundle.ts`. The runner copies it to a scratch dir,
- * points the app at that copy and at `FILE_STORAGE_LOCATION=replaydb:` (attachment bytes served
- * straight from the bundle), and never touches any source deployment, S3, or the network beyond
- * the LLM provider.
+ * In bundle mode, the runner copies the SQLite bundle to a scratch dir and serves attachment bytes
+ * from `ReplayFileBlob`. In live mode it reads the already-configured database and storage. The
+ * ChatAssistant receives no persistence callbacks, so live replay does not write messages; normal
+ * compression/file-analysis cache writes can still occur, so use bundle mode when zero source-DB
+ * mutation is required.
  *
  * Usage:
  *   OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
  *     --bundle bundle.sqlite --out replay-results.json --report replay-report.md \
  *     --override '{"contextCompression":{"preset":"conservative"}}'
  *
+ *   DATABASE_URL=... FILE_STORAGE_LOCATION=... OPENAI_API_KEY=... \
+ *   npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
+ *     --conversation <conversation-id> --message <message-id> \
+ *     --out replay-results.json --report replay-report.md
+ *
  * Flags:
- *   --bundle <path>        offline bundle from eval-build-replay-bundle.ts (required)
+ *   --bundle <path>        offline bundle from eval-build-replay-bundle.ts
+ *   --conversation <id>    live conversation (mutually exclusive with --bundle)
+ *   --message <id>         audited user message (default: latest with saved assistant response)
  *   --out <path>           JSON results, including response text (required)
  *   --report <path>        human-readable Markdown report (required)
  *   --override <json>      JSON object merged over each turn's saved assistant config
@@ -33,8 +42,7 @@
  *   --model <id>           shorthand for --override '{"model":"<id>"}' (Mode B: a cheap model for
  *                          an off/on pair — see docs/evaluation-harness.md; ids in
  *                          REPLAY_EXTRA_MODELS below are dev-only and not user-visible)
- *   --case <messageId>     replay only this turn; repeat the flag to select several
- *   --limit <n>            replay the n most expensive turns (default: 1; ignored when --case is used)
+ *   --inspect-only         calculate compression decisions/token estimates without an LLM call
  *   --judge                also classify each response against the saved production reply
  *   --judge-model <id>     judge model (default: the replay model)
  */
@@ -57,19 +65,20 @@ const flag = (name: string): string | undefined => {
   return index === -1 ? undefined : args[index + 1]
 }
 const bool = (name: string) => args.includes(`--${name}`)
-const flagAll = (name: string): string[] => {
-  const values: string[] = []
-  for (let index = 0; index < args.length; index += 1) {
-    if (args[index] === `--${name}` && args[index + 1]) values.push(args[index + 1]!)
-  }
-  return values
-}
-
 const bundlePath = flag('bundle')
+const liveConversationId = flag('conversation')
 const out = flag('out')
 const reportPath = flag('report')
-if (!bundlePath || !out || !reportPath) {
-  console.error('Usage: --bundle <bundle.sqlite> --out <results.json> --report <report.md>')
+if (
+  (!bundlePath && !liveConversationId) ||
+  (bundlePath && liveConversationId) ||
+  !out ||
+  !reportPath
+) {
+  console.error(
+    'Usage: (--bundle <bundle.sqlite> | --conversation <id>) [--message <id>] ' +
+      '--out <results.json> --report <report.md>'
+  )
   process.exit(1)
 }
 
@@ -89,11 +98,15 @@ const modelShorthand = flag('model')
 if (modelShorthand) override.model = modelShorthand
 
 // Work on a copy so a failed run never corrupts the bundle. Configure the app before imports.
-const workdir = mkdtempSync(path.join(tmpdir(), 'logicle-production-replay-'))
-const replayDbPath = path.join(workdir, 'replay.sqlite')
-copyFileSync(bundlePath, replayDbPath)
-process.env.DATABASE_URL = `file://${replayDbPath}`
-process.env.FILE_STORAGE_LOCATION = 'replaydb:'
+const workdir = bundlePath
+  ? mkdtempSync(path.join(tmpdir(), 'logicle-production-replay-'))
+  : undefined
+if (bundlePath && workdir) {
+  const replayDbPath = path.join(workdir, 'replay.sqlite')
+  copyFileSync(bundlePath, replayDbPath)
+  process.env.DATABASE_URL = `file://${replayDbPath}`
+  process.env.FILE_STORAGE_LOCATION = 'replaydb:'
+}
 
 const { db } = await import('@/db/database')
 const { dtoMessageFromDbMessage } = await import('@/models/utils')
@@ -104,7 +117,16 @@ const { setTokenizerCounter } = await import('@/backend/lib/chat/prompt-token-co
 const { countTextWithTokenizer } = await import('@/lib/chat/tokenizer')
 const { llmModels } = await import('@/lib/models')
 const { modelSupportsReasoning } = await import('@/lib/chat/models')
-const { createReplayJudge } = await import('@/backend/lib/eval/productionChatReplay')
+const { estimateHistoryMessageCosts } = await import('@/backend/lib/chat/token-estimator')
+const {
+  applyCompressionPlan,
+  planMessageCompression,
+  resolveCompressionRetrievalMode,
+  resolveCompressionTriggerTokens,
+} = await import('@/backend/lib/chat/compression-planner')
+const { createReplayJudge, isReplayableLineage } = await import(
+  '@/backend/lib/eval/productionChatReplay'
+)
 type LlmModel = (typeof llmModels)[number]
 
 setTokenizerCounter({
@@ -130,138 +152,202 @@ const REPLAY_EXTRA_MODELS: LlmModel[] = [
 ]
 const modelCatalog: LlmModel[] = [...llmModels, ...REPLAY_EXTRA_MODELS]
 
-// --- reconstruct the replay cases from the bundle ---
-// One turn per invocation by default: the most expensive in the bundle. `--case` picks specific
-// turns; `--limit` widens the window. Both are opt-in so an accidental run costs one LLM call.
-const caseIds = flagAll('case')
-const limit = caseIds.length > 0 ? Infinity : Math.max(1, Number(flag('limit') ?? 1))
-const cases: ProductionReplayCase[] = []
-let audits = await db
+const abortReplay = async (message: string): Promise<never> => {
+  console.error(message)
+  await db.destroy()
+  if (workdir) rmSync(workdir, { recursive: true, force: true })
+  process.exit(1)
+}
+
+// --- choose one conversation, then one audited user message ---
+let conversationId = liveConversationId
+if (bundlePath) {
+  const bundledConversations = await db.selectFrom('Conversation').selectAll().limit(2).execute()
+  if (bundledConversations.length !== 1) {
+    await abortReplay(
+      `Bundle must contain exactly one conversation; found ${bundledConversations.length}.`
+    )
+  }
+  conversationId = bundledConversations[0]!.id
+}
+if (!conversationId) await abortReplay('No conversation was selected.')
+const replayConversationId = conversationId as string
+
+const conversationRecord = await db
+  .selectFrom('Conversation')
+  .selectAll()
+  .where('id', '=', replayConversationId)
+  .executeTakeFirst()
+if (!conversationRecord) await abortReplay(`Conversation ${replayConversationId} does not exist.`)
+const conversation = conversationRecord!
+
+const conversationMessages = await db
+  .selectFrom('Message')
+  .selectAll()
+  .where('conversationId', '=', replayConversationId)
+  .execute()
+const byId = new Map(conversationMessages.map((message) => [message.id, message]))
+const userAudits = await db
   .selectFrom('MessageAudit')
   .selectAll()
   .where('type', '=', 'user')
-  .orderBy('tokens', 'desc')
+  .where('conversationId', '=', replayConversationId)
+  .orderBy('sentAt', 'desc')
   .execute()
-if (caseIds.length > 0) {
-  const wanted = new Set(caseIds)
-  audits = audits.filter((audit) => wanted.has(audit.messageId))
-  const missing = caseIds.filter((id) => !audits.some((audit) => audit.messageId === id))
-  if (missing.length > 0) {
-    console.error(`Bundle has no turn for --case ${missing.join(', ')}.`)
-    await db.destroy()
-    rmSync(workdir, { recursive: true, force: true })
-    process.exit(1)
-  }
-} else {
-  audits = audits.slice(0, limit)
+const requestedMessageId = flag('message')
+const hasSavedAssistantResponse = (messageId: string) =>
+  conversationMessages.some(
+    (message) => message.parent === messageId && message.role === 'assistant'
+  )
+const audit = requestedMessageId
+  ? userAudits.find((entry) => entry.messageId === requestedMessageId)
+  : userAudits.find((entry) => hasSavedAssistantResponse(entry.messageId))
+if (!audit) {
+  await abortReplay(
+    requestedMessageId
+      ? `Message ${requestedMessageId} has no user MessageAudit in conversation ${replayConversationId}.`
+      : `Conversation ${replayConversationId} has no audited user message with a saved assistant response.`
+  )
+}
+const selectedAudit = audit!
+const targetMessage = byId.get(selectedAudit.messageId)
+if (!targetMessage || (targetMessage.role !== 'user' && targetMessage.role !== 'user-response')) {
+  await abortReplay(`Audited message ${selectedAudit.messageId} is not a saved user message.`)
+}
+if (!hasSavedAssistantResponse(selectedAudit.messageId)) {
+  await abortReplay(`Message ${selectedAudit.messageId} has no saved assistant response.`)
+}
+if (selectedAudit.errors !== null) {
+  await abortReplay(
+    `Message ${selectedAudit.messageId} errored in production: ${selectedAudit.errors}`
+  )
 }
 
-for (const audit of audits) {
-  const conversationMessages = await db
-    .selectFrom('Message')
-    .selectAll()
-    .where('conversationId', '=', audit.conversationId)
-    .execute()
-  const byId = new Map(conversationMessages.map((message) => [message.id, message]))
+// Parent-lineage reconstruction belongs here, not in the bundle builder. The same code therefore
+// runs against a complete offline conversation and a live one.
+const lineageRows: DbMessage[] = []
+let cursor: DbMessage | undefined = targetMessage
+while (cursor) {
+  lineageRows.push(cursor)
+  if (!cursor.parent) break
+  const parentId: string = cursor.parent
+  cursor = byId.get(parentId)
+  if (!cursor)
+    await abortReplay(`Message ${lineageRows.at(-1)!.id} has missing parent ${parentId}.`)
+}
+lineageRows.reverse()
+let messages: dto.Message[]
+try {
+  messages = lineageRows.map(dtoMessageFromDbMessage)
+} catch (error) {
+  await abortReplay(
+    `Lineage for message ${selectedAudit.messageId} cannot be converted: ${
+      error instanceof Error ? error.message : error
+    }`
+  )
+}
+const replayMessages = messages!
+const lineageReason = isReplayableLineage(replayMessages)
+if (lineageReason)
+  await abortReplay(`Message ${selectedAudit.messageId} is not replayable: ${lineageReason}.`)
 
-  const lineageRows: DbMessage[] = []
-  let cursor = byId.get(audit.messageId)
-  while (cursor) {
-    lineageRows.push(cursor)
-    cursor = cursor.parent ? byId.get(cursor.parent) : undefined
-  }
-  lineageRows.reverse()
-  if (lineageRows.length === 0) continue
-  const messages = lineageRows.map(dtoMessageFromDbMessage)
+const assistant = await db
+  .selectFrom('Assistant')
+  .innerJoin('AssistantVersion', 'AssistantVersion.id', 'Assistant.publishedVersionId')
+  .innerJoin('Backend', 'Backend.id', 'AssistantVersion.backendId')
+  .select([
+    'Assistant.deleted as deleted',
+    'AssistantVersion.id as versionId',
+    'AssistantVersion.model as model',
+    'AssistantVersion.systemPrompt as systemPrompt',
+    'AssistantVersion.temperature as temperature',
+    'AssistantVersion.tokenLimit as tokenLimit',
+    'AssistantVersion.reasoning_effort as reasoningEffort',
+    'AssistantVersion.contextCompression as contextCompression',
+    'AssistantVersion.subAssistants as subAssistants',
+    'Backend.providerType as providerType',
+    'Backend.configuration as backendConfiguration',
+  ])
+  .where('Assistant.id', '=', selectedAudit.assistantId)
+  .executeTakeFirst()
+if (!assistant)
+  await abortReplay(`Assistant ${selectedAudit.assistantId} or its version is unavailable.`)
+const selectedAssistant = assistant!
+if (selectedAssistant.deleted !== 0)
+  await abortReplay(`Assistant ${selectedAudit.assistantId} is deleted.`)
+if (selectedAssistant.model !== selectedAudit.model) {
+  await abortReplay(
+    `Model drift for message ${selectedAudit.messageId}: production used ${selectedAudit.model}, ` +
+      `current saved assistant uses ${selectedAssistant.model}.`
+  )
+}
+const subAssistants = selectedAssistant.subAssistants
+  ? (JSON.parse(String(selectedAssistant.subAssistants)) as unknown[])
+  : []
+if (Array.isArray(subAssistants) && subAssistants.length > 0) {
+  await abortReplay(
+    `Assistant ${selectedAudit.assistantId} has sub-assistants; replay has no fixture.`
+  )
+}
+const configuredTool = await db
+  .selectFrom('AssistantVersionToolAssociation')
+  .select('toolId')
+  .where('assistantVersionId', '=', selectedAssistant.versionId)
+  .executeTakeFirst()
+if (configuredTool) {
+  await abortReplay(
+    `Assistant ${selectedAudit.assistantId} has configured tools; replay has no fixture.`
+  )
+}
+const configuredKnowledgeFile = await db
+  .selectFrom('AssistantVersionFile')
+  .select('fileId')
+  .where('assistantVersionId', '=', selectedAssistant.versionId)
+  .executeTakeFirst()
+if (configuredKnowledgeFile) {
+  await abortReplay(
+    `Assistant ${selectedAudit.assistantId} has configured knowledge files; replay has no index fixture.`
+  )
+}
 
-  const assistant = await db
-    .selectFrom('Assistant')
-    .innerJoin('AssistantVersion', 'AssistantVersion.id', 'Assistant.publishedVersionId')
-    .innerJoin('Backend', 'Backend.id', 'AssistantVersion.backendId')
-    .select([
-      'AssistantVersion.id as versionId',
-      'AssistantVersion.model as model',
-      'AssistantVersion.systemPrompt as systemPrompt',
-      'AssistantVersion.temperature as temperature',
-      'AssistantVersion.tokenLimit as tokenLimit',
-      'AssistantVersion.reasoning_effort as reasoningEffort',
-      'AssistantVersion.contextCompression as contextCompression',
-      'Backend.providerType as providerType',
-      'Backend.configuration as backendConfiguration',
-    ])
-    .where('Assistant.id', '=', audit.assistantId)
-    .executeTakeFirstOrThrow()
-
-  const productionResponseRow = conversationMessages
-    .filter((message) => message.parent === audit.messageId && message.role === 'assistant')
-    .sort((a, b) => a.sentAt.localeCompare(b.sentAt))[0]
-  const productionReply = productionResponseRow
-    ? renderMessagePlainText(dtoMessageFromDbMessage(productionResponseRow))
-    : ''
-
-  cases.push({
-    id: audit.messageId,
+const productionResponseRow = conversationMessages
+  .filter((message) => message.parent === selectedAudit.messageId && message.role === 'assistant')
+  .sort((a, b) => a.sentAt.localeCompare(b.sentAt))[0]!
+const productionReply = renderMessagePlainText(dtoMessageFromDbMessage(productionResponseRow))
+const cases: ProductionReplayCase[] = [
+  {
+    id: selectedAudit.messageId,
     source: {
-      conversationId: audit.conversationId,
-      messageId: audit.messageId,
-      auditedInputTokens: audit.tokens,
-      auditedModel: audit.model,
-      sentAt: audit.sentAt,
+      conversationId: selectedAudit.conversationId,
+      messageId: selectedAudit.messageId,
+      auditedInputTokens: selectedAudit.tokens,
+      auditedModel: selectedAudit.model,
+      sentAt: selectedAudit.sentAt,
     },
     assistant: {
-      id: audit.assistantId,
-      versionId: assistant.versionId,
-      providerType: assistant.providerType as ProviderType,
-      model: assistant.model,
-      systemPrompt: assistant.systemPrompt,
-      temperature: assistant.temperature,
-      tokenLimit: assistant.tokenLimit,
-      reasoningEffort: assistant.reasoningEffort,
-      contextCompression: assistant.contextCompression
-        ? (JSON.parse(assistant.contextCompression) as Record<string, unknown>)
+      id: selectedAudit.assistantId,
+      versionId: selectedAssistant.versionId,
+      providerType: selectedAssistant.providerType as ProviderType,
+      model: selectedAssistant.model,
+      systemPrompt: selectedAssistant.systemPrompt,
+      temperature: selectedAssistant.temperature,
+      tokenLimit: selectedAssistant.tokenLimit,
+      reasoningEffort: selectedAssistant.reasoningEffort,
+      contextCompression: selectedAssistant.contextCompression
+        ? (JSON.parse(selectedAssistant.contextCompression) as Record<string, unknown>)
         : null,
-      backendEndpoint: assistant.backendConfiguration
-        ? (JSON.parse(assistant.backendConfiguration) as { endPoint?: string }).endPoint ??
+      backendEndpoint: selectedAssistant.backendConfiguration
+        ? (JSON.parse(selectedAssistant.backendConfiguration) as { endPoint?: string }).endPoint ??
           undefined
         : undefined,
     },
-    messages,
+    messages: replayMessages,
     productionReply,
-  })
-}
-
-if (cases.length === 0) {
-  console.error('Bundle contains no replayable turns. Inspect its .skipped.json before retrying.')
-  await db.destroy()
-  rmSync(workdir, { recursive: true, force: true })
-  process.exit(1)
-}
+  },
+]
+const replayUser = bundlePath ? 'production-replay-user' : conversation.ownerId
 
 const providerType = flag('provider') ?? cases[0]!.assistant.providerType
-const apiKeyByProvider: Record<string, string | undefined> = {
-  openai: process.env.OPENAI_API_KEY,
-  anthropic: process.env.ANTHROPIC_API_KEY,
-  'google-ai-studio': process.env.GEMINI_API_KEY,
-  logiclecloud: process.env.LOGICLECLOUD_API_KEY,
-}
-// The mock provider (ALLOW_MOCK_PROVIDER) is keyless and only used to smoke-test this pipeline.
-const apiKey = providerType === 'mock' ? 'mock' : apiKeyByProvider[providerType]
-if (!apiKey) {
-  console.error(`Missing API key for provider "${providerType}".`)
-  await db.destroy()
-  rmSync(workdir, { recursive: true, force: true })
-  process.exit(1)
-}
-
-const backendEndpoint = flag('endpoint') ?? cases[0]!.assistant.backendEndpoint
-const providerConfig = {
-  providerType,
-  name: 'production-replay',
-  apiKey,
-  provisioned: false,
-  ...(backendEndpoint ? { endPoint: backendEndpoint } : {}),
-} as Parameters<typeof ChatAssistant.build>[0]
-
 const resolveModel = (id: string) => {
   // Prefer the definition the replay provider actually lists; otherwise fall back to the model of
   // that id from any provider. The replay deliberately points the provider config at one backend
@@ -274,6 +360,164 @@ const resolveModel = (id: string) => {
   return model
 }
 
+const inspectedAssistantConfig: Record<string, unknown> = {
+  assistantId: `production-replay-${selectedAudit.messageId}`,
+  model: cases[0]!.assistant.model,
+  systemPrompt: cases[0]!.assistant.systemPrompt,
+  temperature: cases[0]!.assistant.temperature,
+  tokenLimit: cases[0]!.assistant.tokenLimit,
+  reasoning_effort: cases[0]!.assistant.reasoningEffort,
+  contextCompression: cases[0]!.assistant.contextCompression,
+  ...override,
+}
+const inspectedModel = resolveModel(String(inspectedAssistantConfig.model))
+const historyCostsBefore = await estimateHistoryMessageCosts(inspectedModel, replayMessages)
+const estimatedHistoryTokensBefore = historyCostsBefore.reduce(
+  (total, entry) => total + entry.tokens,
+  0
+)
+const compression = inspectedAssistantConfig.contextCompression as dto.ContextCompressionConfig
+const triggerAtTokens = compression
+  ? resolveCompressionTriggerTokens(compression.triggerAtTokens)
+  : undefined
+const triggered = !!compression && estimatedHistoryTokensBefore >= triggerAtTokens!
+const decisions = triggered
+  ? planMessageCompression(replayMessages, compression.preset, {
+      keepRecentTurns: compression.keepRecentTurns,
+    })
+  : []
+const finalUserMessage = [...replayMessages]
+  .reverse()
+  .find((message): message is dto.UserMessage => message.role === 'user')
+const plannedMessages = triggered
+  ? await applyCompressionPlan(replayMessages, decisions, {
+      prefetchQuery:
+        resolveCompressionRetrievalMode(compression.retrievalMode) === 'prefetch'
+          ? finalUserMessage?.content
+          : undefined,
+    })
+  : replayMessages
+const historyCostsAfter = await estimateHistoryMessageCosts(inspectedModel, plannedMessages)
+const estimatedHistoryTokensAfter = historyCostsAfter.reduce(
+  (total, entry) => total + entry.tokens,
+  0
+)
+const tokenLimit = Number(inspectedAssistantConfig.tokenLimit)
+const inspection = {
+  model: inspectedModel.id,
+  tokenLimit,
+  productionInputTokens: selectedAudit.tokens,
+  productionInputExceedsTokenLimit: selectedAudit.tokens > tokenLimit,
+  compressionEnabled: !!compression,
+  triggerAtTokens,
+  triggered,
+  preset: compression?.preset,
+  retrievalMode: compression
+    ? resolveCompressionRetrievalMode(compression.retrievalMode)
+    : undefined,
+  estimatedHistoryTokensBefore,
+  estimatedHistoryTokensAfter,
+  estimatedHistoryTokenReduction: estimatedHistoryTokensBefore - estimatedHistoryTokensAfter,
+  estimatedHistoryReductionRatio:
+    estimatedHistoryTokensBefore > 0
+      ? (estimatedHistoryTokensBefore - estimatedHistoryTokensAfter) / estimatedHistoryTokensBefore
+      : 0,
+  historyAloneExceedsTokenLimitBefore: estimatedHistoryTokensBefore > tokenLimit,
+  historyAloneExceedsTokenLimitAfter: estimatedHistoryTokensAfter > tokenLimit,
+  summarizedMessages: decisions
+    .filter((decision) => decision.policy === 'summary')
+    .map((decision) => ({
+      messageId: decision.messageId,
+      reason: decision.reason,
+      estimatedTokensBefore: decision.estimatedTokensBefore,
+      estimatedTokensAfter: decision.estimatedTokensAfter,
+    })),
+  selectedMessageDecision:
+    decisions.find((decision) => decision.messageId === selectedAudit.messageId) ?? null,
+}
+
+if (bool('inspect-only')) {
+  const inspectionMarkdown = [
+    '# Production chat replay inspection',
+    '',
+    `Conversation: \`${replayConversationId}\``,
+    `Selected message: \`${selectedAudit.messageId}\``,
+    `Model: \`${inspection.model}\``,
+    `Saved token limit: **${tokenLimit}**`,
+    `Production input tokens: **${selectedAudit.tokens}**`,
+    '',
+    `Compression: **${inspection.compressionEnabled ? 'enabled' : 'disabled'}**` +
+      (compression
+        ? `; preset \`${compression.preset}\`; retrieval \`${inspection.retrievalMode}\`; ` +
+          `trigger ${triggerAtTokens}; triggered: **${triggered}**`
+        : ''),
+    `Estimated history tokens: **${estimatedHistoryTokensBefore} → ${estimatedHistoryTokensAfter}** ` +
+      `(${(inspection.estimatedHistoryReductionRatio * 100).toFixed(1)}% reduction).`,
+    `Summarized messages: **${inspection.summarizedMessages.length}**.`,
+    `Selected/current message policy: **${
+      inspection.selectedMessageDecision?.policy ?? 'not planned'
+    }**` +
+      (inspection.selectedMessageDecision
+        ? ` (${inspection.selectedMessageDecision.reason}).`
+        : '.'),
+    '',
+    ...(inspection.summarizedMessages.length > 0
+      ? [
+          '| message | reason | rough policy tokens before | after |',
+          '| --- | --- | ---: | ---: |',
+          ...inspection.summarizedMessages.map(
+            (entry) =>
+              `| ${entry.messageId} | ${entry.reason} | ${entry.estimatedTokensBefore} | ${entry.estimatedTokensAfter} |`
+          ),
+          '',
+        ]
+      : []),
+    '_Inspection only: no LLM call was made._',
+  ].join('\n')
+  await writeFile(
+    out,
+    JSON.stringify(
+      {
+        version: 3,
+        createdAt: new Date().toISOString(),
+        source: bundlePath
+          ? { mode: 'bundle', bundle: bundlePath }
+          : { mode: 'live', conversationId: replayConversationId },
+        selectedMessageId: selectedAudit.messageId,
+        override,
+        inspection,
+      },
+      null,
+      2
+    ),
+    'utf-8'
+  )
+  await writeFile(reportPath, inspectionMarkdown, 'utf-8')
+  await db.destroy()
+  if (workdir) rmSync(workdir, { recursive: true, force: true })
+  console.error(`Wrote ${out} and ${reportPath}. No LLM call was made.`)
+  process.exit(0)
+}
+
+const apiKeyByProvider: Record<string, string | undefined> = {
+  openai: process.env.OPENAI_API_KEY,
+  anthropic: process.env.ANTHROPIC_API_KEY,
+  'google-ai-studio': process.env.GEMINI_API_KEY,
+  logiclecloud: process.env.LOGICLECLOUD_API_KEY,
+}
+// The mock provider (ALLOW_MOCK_PROVIDER) is keyless and only used to smoke-test this pipeline.
+const apiKey = providerType === 'mock' ? 'mock' : apiKeyByProvider[providerType]
+if (!apiKey) await abortReplay(`Missing API key for provider "${providerType}".`)
+
+const backendEndpoint = flag('endpoint') ?? cases[0]!.assistant.backendEndpoint
+const providerConfig = {
+  providerType,
+  name: 'production-replay',
+  apiKey,
+  provisioned: false,
+  ...(backendEndpoint ? { endPoint: backendEndpoint } : {}),
+} as Parameters<typeof ChatAssistant.build>[0]
+
 interface ReplayResult {
   caseId: string
   source: ProductionReplayCase['source']
@@ -281,6 +525,8 @@ interface ReplayResult {
   assistantConfig: Record<string, unknown>
   response: string
   usage: { inputTokens: number; outputTokens: number }
+  providerCalls: number
+  toolCalls: string[]
   costUsd?: number
   productionInputCostUsd?: number
   inputTokensVsProduction: number
@@ -317,6 +563,8 @@ try {
     const sink = new EvalSink()
     let response = ''
     let usage = { inputTokens: 0, outputTokens: 0 }
+    let providerCalls = 0
+    let toolCalls: string[] = []
     let error: string | undefined
     try {
       const assistant = await ChatAssistant.build(
@@ -325,11 +573,13 @@ try {
         {},
         [],
         [],
-        { user: 'production-replay-user', conversationId: `production-replay-${entry.id}` }
+        { user: replayUser, conversationId: replayConversationId }
       )
       await assistant.processUserMessageWithSink(cloneMessages(entry.messages), sink)
       const raw = sink.getUsage()
       usage = { inputTokens: raw.inputTokens, outputTokens: raw.outputTokens }
+      providerCalls = sink.events.filter((event) => event.type === 'usage').length
+      toolCalls = sink.getToolCallNames()
       response = sink.getText().trim() || `[no reply] ${sink.getErrors().join('; ')}`.trim()
     } catch (caught) {
       error = caught instanceof Error ? caught.message : String(caught)
@@ -354,6 +604,10 @@ try {
       assistantConfig: { contextCompression: assistantConfig.contextCompression },
       response,
       usage,
+      providerCalls,
+      toolCalls,
+      // Deliberately omit provider cache details: replay comparisons price every input token at
+      // the ordinary rate, so a warm/cold prompt cache cannot manufacture a compression saving.
       costUsd: computeCostUsd(model.id, usage.inputTokens, usage.outputTokens),
       productionInputCostUsd: computeCostUsd(model.id, entry.source.auditedInputTokens, 0),
       inputTokensVsProduction: entry.source.auditedInputTokens - usage.inputTokens,
@@ -363,7 +617,7 @@ try {
   }
 } finally {
   await db.destroy()
-  rmSync(workdir, { recursive: true, force: true })
+  if (workdir) rmSync(workdir, { recursive: true, force: true })
 }
 
 const totalInputDelta = results.reduce((total, r) => total + r.inputTokensVsProduction, 0)
@@ -377,25 +631,31 @@ for (const result of results) {
 const markdown = [
   '# Production chat replay',
   '',
-  `Replayed ${results.length} production turn(s) from \`${path.basename(
-    bundlePath
-  )}\` through the ` +
-    'current code. No source deployment was contacted. Production input tokens are from the saved ' +
-    '`MessageAudit` (input only).',
+  `Replayed message \`${selectedAudit.messageId}\` from conversation \`${replayConversationId}\` ` +
+    (bundlePath
+      ? `using offline bundle \`${path.basename(bundlePath)}\`.`
+      : 'using the configured live database and storage.') +
+    ' Production input tokens are from `MessageAudit` (input only).',
   '',
   override && Object.keys(override).length > 0
     ? `Config override: \`${JSON.stringify(override)}\``
     : 'No config override — replayed with each turn’s saved assistant configuration.',
   '',
-  '| message | production input | replay input | replay output | replay cost | input Δ vs prod | verdict |',
-  '| --- | ---: | ---: | ---: | ---: | ---: | --- |',
+  `Deterministic history estimate: **${inspection.estimatedHistoryTokensBefore} → ` +
+    `${inspection.estimatedHistoryTokensAfter}**; summarized messages: ` +
+    `**${inspection.summarizedMessages.length}**.`,
+  '',
+  '| message | production input | replay input | replay output | provider calls | tool calls | replay cost | input Δ vs prod | verdict |',
+  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
   ...results.map(
     (r) =>
       `| ${r.caseId} | ${r.source.auditedInputTokens} | ${
         r.error ? 'error' : r.usage.inputTokens
-      } | ${r.error ? '—' : r.usage.outputTokens} | ${formatCostUsd(r.costUsd)} | ${
-        r.error ? '—' : r.inputTokensVsProduction
-      } | ${r.error ? r.error : r.judgment?.verdict ?? 'not judged'} |`
+      } | ${r.error ? '—' : r.usage.outputTokens} | ${r.error ? '—' : r.providerCalls} | ${
+        r.error ? '—' : r.toolCalls.length
+      } | ${formatCostUsd(r.costUsd)} | ${r.error ? '—' : r.inputTokensVsProduction} | ${
+        r.error ? r.error : r.judgment?.verdict ?? 'not judged'
+      } |`
   ),
   '',
   `Total input-token delta vs production: **${totalInputDelta}** ` +
@@ -422,7 +682,17 @@ const markdown = [
 await writeFile(
   out,
   JSON.stringify(
-    { version: 2, createdAt: new Date().toISOString(), bundle: bundlePath, override, results },
+    {
+      version: 3,
+      createdAt: new Date().toISOString(),
+      source: bundlePath
+        ? { mode: 'bundle', bundle: bundlePath }
+        : { mode: 'live', conversationId: replayConversationId },
+      selectedMessageId: selectedAudit.messageId,
+      override,
+      inspection,
+      results,
+    },
     null,
     2
   ),

--- a/apps/backend/scripts/eval-replay-production-chats.ts
+++ b/apps/backend/scripts/eval-replay-production-chats.ts
@@ -121,6 +121,7 @@ const { estimateHistoryMessageCosts } = await import('@/backend/lib/chat/token-e
 const {
   applyCompressionPlan,
   planMessageCompression,
+  resolveCompressionUserQuery,
   resolveCompressionRetrievalMode,
   resolveCompressionTriggerTokens,
 } = await import('@/backend/lib/chat/compression-planner')
@@ -389,12 +390,14 @@ const decisions = triggered
 const finalUserMessage = [...replayMessages]
   .reverse()
   .find((message): message is dto.UserMessage => message.role === 'user')
+const userQuery = compression ? resolveCompressionUserQuery(replayMessages) : undefined
 const plannedMessages = triggered
   ? await applyCompressionPlan(replayMessages, decisions, {
       prefetchQuery:
         resolveCompressionRetrievalMode(compression.retrievalMode) === 'prefetch'
-          ? finalUserMessage?.content
+          ? userQuery
           : undefined,
+      attachmentContinuationQuery: userQuery,
     })
   : replayMessages
 const historyCostsAfter = await estimateHistoryMessageCosts(inspectedModel, plannedMessages)
@@ -415,6 +418,14 @@ const inspection = {
   retrievalMode: compression
     ? resolveCompressionRetrievalMode(compression.retrievalMode)
     : undefined,
+  prefetchQuerySource:
+    compression && resolveCompressionRetrievalMode(compression.retrievalMode) === 'prefetch'
+      ? finalUserMessage?.content.trim()
+        ? 'current-user'
+        : userQuery
+        ? 'previous-user-fallback'
+        : 'none'
+      : undefined,
   estimatedHistoryTokensBefore,
   estimatedHistoryTokensAfter,
   estimatedHistoryTokenReduction: estimatedHistoryTokensBefore - estimatedHistoryTokensAfter,

--- a/apps/backend/scripts/eval-replay-production-chats.ts
+++ b/apps/backend/scripts/eval-replay-production-chats.ts
@@ -47,8 +47,6 @@
  *   --judge-model <id>     judge model (default: the replay model)
  */
 
-export {}
-
 import { copyFileSync, mkdtempSync, rmSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'

--- a/apps/backend/scripts/eval.ts
+++ b/apps/backend/scripts/eval.ts
@@ -12,7 +12,8 @@
  *     --scenario supplier-penalty --arms all-in-context,knowledge-box --repeat 8 --out report.md
  *
  * Flags:
- *   --scenario <id,...>   scenarios to run (default: all built-in)
+ *   --scenario <id,...>   scenarios to run (default: all in the selected suite)
+ *   --suite <name>        knowledge | context-compression (default: knowledge)
  *   --sweep <n,...>       replace the built-in scenarios with generated ones holding N documents
  *                         each, to trace cost and accuracy against corpus size
  *   --doc-words <n>       words per generated document (default: 700)
@@ -31,8 +32,6 @@
  *   --runs-in <path>      re-render a previous --runs-out artifact (or legacy raw run array); no API key needed
  *   --verbose             stream the conversation as it happens
  */
-
-export {}
 
 import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync } from 'node:fs'
@@ -55,12 +54,14 @@ const list = (name: string): string[] | undefined =>
     .filter(Boolean)
 
 const providerType = flag('provider') ?? 'openai'
+const suite = flag('suite') ?? 'knowledge'
 const assistantModel = flag('model') ?? 'gpt-4o-mini'
 const userModelId = flag('user-model') ?? assistantModel
 const judgeModelId = flag('judge-model') ?? assistantModel
 const repeat = Number(flag('repeat') ?? 3)
 const requestedBaselineArm = flag('baseline')
-const baselineArm = requestedBaselineArm ?? 'all-in-context'
+const baselineArm =
+  requestedBaselineArm ?? (suite === 'context-compression' ? 'compression-off' : 'all-in-context')
 const verbose = bool('verbose')
 const useJudge = !bool('no-judge')
 const runsIn = flag('runs-in')
@@ -105,8 +106,12 @@ const { migrateToLatest } = await import('@/db/migrations')
 await migrateToLatest()
 
 const { db } = await import('@/db/database')
-const { createKnowledgeBoxArm, allInContextArm } = await import('@/backend/lib/eval/arms')
+const { createContextCompressionArm, createKnowledgeBoxArm, compressionOffArm, allInContextArm } =
+  await import('@/backend/lib/eval/arms')
 const { builtInScenarios } = await import('@/backend/lib/eval/scenarios/supplierContracts')
+const { contextCompressionScenarios } = await import(
+  '@/backend/lib/eval/scenarios/contextCompression'
+)
 const { generateNeedleScenario } = await import('@/backend/lib/eval/scenarios/generator')
 const { runOne } = await import('@/backend/lib/eval/harness')
 const { createJudge } = await import('@/backend/lib/eval/judge')
@@ -178,9 +183,38 @@ const armRegistry: Record<string, Arm> = {
   'all-in-context': allInContextArm,
   'knowledge-box': createKnowledgeBoxArm({ questions }),
   'knowledge-box-no-projections': createKnowledgeBoxArm({ questions: [] }),
+  'compression-off': compressionOffArm,
+  'compression-keep-0': createContextCompressionArm({ keepRecentTurns: 0 }),
+  'compression-keep-1': createContextCompressionArm({ keepRecentTurns: 1 }),
+  'compression-keep-2': createContextCompressionArm({ keepRecentTurns: 2 }),
+  'compression-keep-4': createContextCompressionArm({ keepRecentTurns: 4 }),
+  'compression-prefetch-keep-0': createContextCompressionArm({
+    name: 'compression-prefetch-keep-0',
+    keepRecentTurns: 0,
+    retrievalMode: 'prefetch',
+  }),
+  'compression-prefetch-keep-1': createContextCompressionArm({
+    name: 'compression-prefetch-keep-1',
+    keepRecentTurns: 1,
+    retrievalMode: 'prefetch',
+  }),
 }
 
-const armNames = list('arms') ?? ['all-in-context', 'knowledge-box', 'knowledge-box-no-projections']
+if (suite !== 'knowledge' && suite !== 'context-compression') {
+  console.error(`Unknown suite "${suite}". Known: knowledge, context-compression`)
+  process.exit(1)
+}
+
+const armNames =
+  list('arms') ??
+  (suite === 'context-compression'
+    ? [
+        'compression-off',
+        'compression-keep-0',
+        'compression-prefetch-keep-0',
+        'compression-prefetch-keep-1',
+      ]
+    : ['all-in-context', 'knowledge-box', 'knowledge-box-no-projections'])
 const arms = armNames.map((name) => {
   const arm = armRegistry[name]
   if (!arm) {
@@ -194,6 +228,8 @@ const sweepSizes = list('sweep')
   ?.map(Number)
   .filter((size) => Number.isFinite(size) && size > 0)
 const scenarioIds = list('scenario')
+const suiteScenarios =
+  suite === 'context-compression' ? contextCompressionScenarios : builtInScenarios
 
 // A sweep replaces the built-in scenarios with generated ones, one per corpus size. Each keeps its
 // size in its id, so the existing per-scenario report sections read as the points of a curve.
@@ -209,16 +245,16 @@ const scenarios = sweepSizes
     )
   : scenarioIds
   ? scenarioIds.map((id) => {
-      const scenario = builtInScenarios.find((entry) => entry.id === id)
+      const scenario = suiteScenarios.find((entry) => entry.id === id)
       if (!scenario) {
         console.error(
-          `Unknown scenario "${id}". Known: ${builtInScenarios.map((entry) => entry.id).join(', ')}`
+          `Unknown scenario "${id}". Known: ${suiteScenarios.map((entry) => entry.id).join(', ')}`
         )
         process.exit(1)
       }
       return scenario
     })
-  : builtInScenarios
+  : suiteScenarios
 
 if (sweepSizes) {
   for (const scenario of scenarios) {
@@ -254,6 +290,7 @@ for (const scenario of scenarios) {
         assistant: {
           providerConfig,
           model: assistantLlmModel.id,
+          llmModel: assistantLlmModel,
           systemPrompt:
             'You are a company assistant answering questions about internal documents. Answer from the documents only. Always name the document a figure came from. If you cannot find something, say so instead of guessing.',
           tokenLimit: assistantLlmModel.context_length,
@@ -291,12 +328,19 @@ if (out) {
 const runsOut = flag('runs-out')
 if (runsOut) {
   let gitRevision: string | undefined
+  let gitDirty: boolean | undefined
   try {
     gitRevision = execFileSync('git', ['rev-parse', 'HEAD'], {
       cwd: process.cwd(),
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim()
+    gitDirty =
+      execFileSync('git', ['status', '--porcelain'], {
+        cwd: process.cwd(),
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim().length > 0
   } catch {
     // The runner also works from a source archive; revision metadata is useful, not required.
   }
@@ -305,6 +349,7 @@ if (runsOut) {
     createdAt: new Date().toISOString(),
     metadata: {
       gitRevision,
+      gitDirty,
       provider: providerType,
       assistantModel: assistantLlmModel.id,
       userModel: userLlmModel.id,
@@ -313,6 +358,7 @@ if (runsOut) {
       arms: arms.map((arm) => arm.name),
       scenarios: scenarios.map((scenario) => scenario.id),
       repeat,
+      suite,
       sweep: sweepSizes
         ? {
             documents: sweepSizes,

--- a/apps/frontend/app/assistants/components/AdvancedTabPanel.tsx
+++ b/apps/frontend/app/assistants/components/AdvancedTabPanel.tsx
@@ -83,6 +83,8 @@ export const AdvancedTabPanel = ({
                       field.onChange({
                         preset: v,
                         triggerAtTokens: field.value?.triggerAtTokens,
+                        keepRecentTurns: field.value?.keepRecentTurns,
+                        retrievalMode: field.value?.retrievalMode,
                       })
                     }
                   }}
@@ -95,7 +97,9 @@ export const AdvancedTabPanel = ({
                     <SelectItem value="conservative">
                       {t('context-compression-conservative')}
                     </SelectItem>
-                    <SelectItem value="aggressive">{t('context-compression-aggressive')}</SelectItem>
+                    <SelectItem value="aggressive">
+                      {t('context-compression-aggressive')}
+                    </SelectItem>
                   </SelectContent>
                 </Select>
                 <p className="text-sm text-muted-foreground">
@@ -110,7 +114,10 @@ export const AdvancedTabPanel = ({
             control={form.control}
             name="contextCompression"
             render={({ field }) => (
-              <FormItem label={t('context-compression-trigger')} title={t('context-compression-trigger-help')}>
+              <FormItem
+                label={t('context-compression-trigger')}
+                title={t('context-compression-trigger-help')}
+              >
                 <NumberInput
                   mode="integer"
                   placeholder={t('context-compression-trigger-placeholder')}
@@ -119,6 +126,8 @@ export const AdvancedTabPanel = ({
                     field.onChange({
                       preset: field.value?.preset ?? 'conservative',
                       triggerAtTokens: v === '' ? undefined : Number(v),
+                      keepRecentTurns: field.value?.keepRecentTurns,
+                      retrievalMode: field.value?.retrievalMode,
                     })
                   }}
                 />

--- a/apps/frontend/app/assistants/components/AssistantFormField.ts
+++ b/apps/frontend/app/assistants/components/AssistantFormField.ts
@@ -18,6 +18,8 @@ export const contextCompressionConfigSchema = z
   .object({
     preset: contextCompressionPresetSchema,
     triggerAtTokens: z.number().int().positive().optional(),
+    keepRecentTurns: z.number().int().min(0).optional(),
+    retrievalMode: z.enum(['tool', 'prefetch']).optional(),
   })
   .nullable()
 

--- a/apps/frontend/public/openapi.yaml
+++ b/apps/frontend/public/openapi.yaml
@@ -3690,6 +3690,15 @@ components:
                   type: integer
                   exclusiveMinimum: 0
                   maximum: 9007199254740991
+                keepRecentTurns:
+                  type: integer
+                  minimum: 0
+                  maximum: 9007199254740991
+                retrievalMode:
+                  type: string
+                  enum:
+                    - tool
+                    - prefetch
               required:
                 - preset
               additionalProperties: false
@@ -3833,6 +3842,15 @@ components:
                   type: integer
                   exclusiveMinimum: 0
                   maximum: 9007199254740991
+                keepRecentTurns:
+                  type: integer
+                  minimum: 0
+                  maximum: 9007199254740991
+                retrievalMode:
+                  type: string
+                  enum:
+                    - tool
+                    - prefetch
               required:
                 - preset
               additionalProperties: false
@@ -3953,6 +3971,15 @@ components:
                   type: integer
                   exclusiveMinimum: 0
                   maximum: 9007199254740991
+                keepRecentTurns:
+                  type: integer
+                  minimum: 0
+                  maximum: 9007199254740991
+                retrievalMode:
+                  type: string
+                  enum:
+                    - tool
+                    - prefetch
               required:
                 - preset
               additionalProperties: false
@@ -4063,6 +4090,15 @@ components:
                   type: integer
                   exclusiveMinimum: 0
                   maximum: 9007199254740991
+                keepRecentTurns:
+                  type: integer
+                  minimum: 0
+                  maximum: 9007199254740991
+                retrievalMode:
+                  type: string
+                  enum:
+                    - tool
+                    - prefetch
               required:
                 - preset
               additionalProperties: false

--- a/docs/context-compression.md
+++ b/docs/context-compression.md
@@ -240,7 +240,14 @@ Given the decisions above, `applyCompressionPlan` rewrites the message list: `fu
 through unchanged; `summary` messages are replaced by a compact, cached representation. In
 `prefetch` mode, deterministic lexical ranking then appends up to 6,000 characters of matching
 excerpts from compressed messages. Excerpts stay in the original message role; no
-historical tool output is promoted to a system or user instruction.
+historical tool output is promoted to a system or user instruction. The current user's non-empty
+text is the query. For an attachment-only turn with an empty text body, prefetch falls back to the
+nearest preceding non-empty user request so the uploaded file remains connected to the task it
+continues. The prompt builder also adds a bounded continuation note to that otherwise-empty current
+user message, making the relationship explicit instead of expecting the model to infer a task from
+retrieved historical excerpts alone. The continuation note is also present in `tool` mode, while
+the historical excerpts remain exclusive to `prefetch` mode. This changes only query-dependent
+prompt content, never the planner's stable decisions or cached base summaries.
 
 ### Summaries Are Always Plain Text
 
@@ -504,6 +511,8 @@ Covered in `apps/backend/lib/chat/__tests__/compression-planner.test.ts`:
 - Every `summary`-policy message carries a mandatory-retrieval line naming `context-retrieve`'s
   targeted `search` function, with full-message/file retrieval as fallback.
 - Query-aware prefetch inserts a relevant excerpt into the compressed message's original role.
+- Attachment-only continuation prefetch falls back to the nearest non-empty user request and
+  recovers the preceding task from a compressed answer.
 - `warmCompressionCache` builds/caches eligible messages and no-ops on ineligible ones, without
   throwing on failure.
 - A concurrent build for the same message joins the in-flight one instead of duplicating work.

--- a/docs/context-compression.md
+++ b/docs/context-compression.md
@@ -16,12 +16,14 @@ Quando il contesto supera la soglia configurata, il planner guarda i messaggi de
   testuale;
 - i risultati dei tool che contengono file vengono sostituiti da riferimenti recuperabili;
 - i risultati testuali dei tool troppo grandi vengono ridotti a un'anteprima;
+- le risposte lunghe dell'assistente nei turni storici vengono ridotte a un'anteprima;
 - con il preset `aggressive`, anche i messaggi testuali lunghi dell'utente vengono abbreviati.
 
-Il turno corrente non viene mai compresso. Ogni messaggio abbreviato contiene comunque il proprio
-id e un'istruzione per usare `context-retrieve.get_message`; per il contenuto di un file è presente
-anche `context-retrieve.get_file`. Se il modello non conosce l'id, può usare `search` nella
-cronologia originale della conversazione.
+Il turno corrente non viene mai compresso. Per impostazione predefinita, una ricerca lessicale usa
+il messaggio corrente per reinserire piccoli estratti rilevanti nei messaggi abbreviati, mantenendo
+il ruolo originale. Ogni messaggio abbreviato conserva comunque il proprio id: il modello può
+usare `search(query, id)` per altri estratti mirati e `get_message`/`get_file` per l'originale
+completo. Se non conosce l'id, `search(query)` cerca nella cronologia della conversazione.
 
 Quindi la compressione non è un riassunto generato da un LLM e non è una cancellazione: è una
 proiezione deterministica, con recupero esplicito del dettaglio quando serve.
@@ -45,6 +47,8 @@ Per-assistant, stored as `Assistant.contextCompression` (`contextCompressionConf
 type ContextCompressionConfig = {
   preset: 'conservative' | 'aggressive'
   triggerAtTokens?: number
+  keepRecentTurns?: number
+  retrievalMode?: 'tool' | 'prefetch'
 } | null
 ```
 
@@ -57,8 +61,17 @@ separate mechanism). This is the default for new assistants
   the size thresholds used by `planMessageCompression` (see the preset table below). There is no
   third "off" value at this level — set the whole config to `null` to disable instead.
 - **`triggerAtTokens`** (optional, positive integer) — assistant-specific override that can only
-  *raise* the server-wide token floor described below, never lower it. Leave unset to just use the
+  _raise_ the server-wide token floor described below, never lower it. Leave unset to just use the
   floor as-is.
+- **`keepRecentTurns`** (optional, non-negative integer) — number of completed turns immediately
+  before the current turn to leave verbatim. The measured default is `0`: in the fixed-reference
+  suite, retaining one turn preserved accuracy but raised mean input from 2,434 to 5,606 tokens.
+  This is an algorithm/evaluation knob; the assistant editor currently preserves it but does not
+  expose a dedicated control.
+- **`retrievalMode`** (optional) — `prefetch` (default) adds small query-relevant excerpts to
+  compressed messages before the model call; `tool` leaves retrieval entirely to the model. Full
+  originals remain available through `context-retrieve` in both modes. This field is preserved by
+  the editor but currently has no dedicated control.
 
 ### Server-Wide Floor: `CHAT_CONTEXT_COMPRESSION_TRIGGER_TOKENS`
 
@@ -70,7 +83,7 @@ assistant, without relying on each assistant's config being set sensibly.
 - **Default:** `6000` if unset or unparsable (`packages/core/src/env.ts`, `env.chat.contextCompressionTriggerTokens`).
 - **Resolution:** `resolveCompressionTriggerTokens(triggerAtTokens)` in `compression-planner.ts`
   returns `Math.max(triggerAtTokens ?? 0, env.chat.contextCompressionTriggerTokens)` — the env var
-  is a hard floor, and an assistant's `triggerAtTokens` is only ever honored when it's *higher* than
+  is a hard floor, and an assistant's `triggerAtTokens` is only ever honored when it's _higher_ than
   that floor:
 
 ```ts
@@ -96,24 +109,28 @@ compression kicks in at all.
 ## Presets: `conservative` vs `aggressive`
 
 There are exactly two presets, both implemented entirely inside `planMessageCompression`
-(`compression-planner.ts`). A preset only changes *size thresholds* for historical messages — it
+(`compression-planner.ts`). A preset only changes _size thresholds_ for historical messages — it
 never changes what counts as "current turn" (see below) and never triggers a model call. There is
 no per-field customization beyond `triggerAtTokens`: everything else about a preset's behavior is
 fixed by these two constants:
 
 ```ts
-const LARGE_TEXT_THRESHOLD_CHARS = 2000            // conservative
-const AGGRESSIVE_LARGE_TEXT_THRESHOLD_CHARS = 800  // aggressive
+const LARGE_TEXT_THRESHOLD_CHARS = 2000 // conservative
+const AGGRESSIVE_LARGE_TEXT_THRESHOLD_CHARS = 800 // aggressive
 ```
 
-| Rule (applied to historical messages only)                       | `conservative`                          | `aggressive`                            |
-| ------------------------------------------------------------------ | ---------------------------------------- | ----------------------------------------- |
-| Current turn (last user/user-response message + everything after) | always `full`, no exceptions             | always `full`, no exceptions — **identical to conservative; this preset never touches the current turn** |
-| Historical `user` message **with attachments**                     | `summary`                                | `summary`                                |
-| Historical `user` message, **long plain text, no attachments**     | `full` (left alone)                      | `summary` if `content.length > 800`      |
-| Historical `tool` result **with a recoverable file**                | `summary`                                | `summary`                                |
-| Historical `tool` result, **large text-only output**                | `summary` if estimated chars `> 2000`    | `summary` if estimated chars `> 800`     |
-| Everything else (short historical text, no attachments/files)      | `full`                                   | `full`                                   |
+| Rule (applied to historical messages only)                        | `conservative`                        | `aggressive`                                                                                             |
+| ----------------------------------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Current turn (last user/user-response message + everything after) | always `full`, no exceptions          | always `full`, no exceptions — **identical to conservative; this preset never touches the current turn** |
+| Historical `user` message **with attachments**                    | `summary`                             | `summary`                                                                                                |
+| Historical `user` message, **long plain text, no attachments**    | `full` (left alone)                   | `summary` if `content.length > 800`                                                                      |
+| Historical `tool` result **with a recoverable file**              | `summary`                             | `summary`                                                                                                |
+| Historical `tool` result, **large text-only output**              | `summary` if estimated chars `> 2000` | `summary` if estimated chars `> 800`                                                                     |
+| Historical `assistant` response, **large text**                   | `summary` if estimated chars `> 2000` | `summary` if estimated chars `> 800`                                                                     |
+| Everything else (short historical text, no attachments/files)     | `full`                                | `full`                                                                                                   |
+
+Before these shape rules run, every message belonging to one of the configured
+`keepRecentTurns` completed turns is assigned `full`.
 
 In short: **`aggressive` is a strict superset of `conservative`** — every message `conservative`
 would summarize, `aggressive` also summarizes, plus two extra cases (long historical plain-text
@@ -123,11 +140,11 @@ identically. The one place `aggressive` differs qualitatively rather than just n
 2 (`hasLargeText` in `planMessageCompression`) — that check is gated on
 `preset === 'aggressive'` entirely, so `conservative` never fires it no matter how long the text is.
 
-**A common misconception worth stating explicitly: `aggressive` does *not* summarize attachments or
+**A common misconception worth stating explicitly: `aggressive` does _not_ summarize attachments or
 tool results in the current turn.** The "current turn is never compressed" rule in
 `planMessageCompression` is checked first and unconditionally, before any preset-specific logic —
 there is no code path, under any preset, that assigns `policy: 'summary'` to a current-turn message.
-If you need to keep the model from re-reading a huge attachment *just uploaded in this turn*, that
+If you need to keep the model from re-reading a huge attachment _just uploaded in this turn_, that
 is not something either preset controls; it would require a different mechanism (e.g. the ordinary
 token-budget truncation in `truncateChat`, or advising the user to start a fresh conversation).
 
@@ -138,7 +155,7 @@ token-budget truncation in `truncateChat`, or advising the user to start a fresh
   large tool/file payloads). Preserves more of the model's own past reasoning text untouched.
 - **`aggressive`** — pick this when conversations run very long and include large blocks of pasted
   text from the user (long historical messages, not just files), or when a stricter savings target
-  is worth the model needing `context-retrieve.get_message`/`get_file` more often to recover detail.
+  is worth targeted prefetch or `context-retrieve` recovering detail more often.
 
 ## Current Turn Is Never Compressed
 
@@ -181,42 +198,49 @@ It reads no DB state and makes no I/O calls — it only looks at each message's 
 recency relative to the current turn. Decision rules, in order:
 
 1. **Current turn → always `full`.** (see above)
-2. **Historical `user` message with attachments → `summary`.**
-3. **Historical `user` message with a long text body (aggressive preset only) → `summary`.**
+2. **Configured recent completed turns → `full`.**
+3. **Historical `user` message with attachments → `summary`.**
+4. **Historical `user` message with a long text body (aggressive preset only) → `summary`.**
    Conservative preset leaves long historical text messages alone unless they carry attachments.
-4. **Historical `tool` message whose result carries a recoverable file → `summary`.**
-5. **Historical `tool` message with a large text-only result → `summary`.** The size threshold is
+5. **Historical `tool` message whose result carries a recoverable file → `summary`.**
+6. **Historical `tool` message with a large text-only result → `summary`.** The size threshold is
    2000 characters under `conservative`, 800 under `aggressive` — `aggressive` summarizes smaller
    historical tool output than `conservative` does. Neither preset changes what happens to the
    current turn.
-6. Everything else → `full`.
+7. **Historical `assistant` message with large text → `summary`.** It uses the same preset-specific
+   threshold as tool text.
+8. Everything else → `full`.
 
-### Decisions Are Turn-Stable
+### Policy Decisions Are Turn-Stable
 
 Crucially, the decision for a historical message never looks at what the _current_ message says.
 A message that mentions a historical file by name (`"what's on page 2 of report.pdf?"`) does
-**not** flip that historical message back to `full` — the compaction decision only depends on the
-historical message's own position and shape, so it is computed once (as soon as the message stops
-being "current turn") and never changes again for the rest of the conversation.
+**not** flip that historical message back to `full` — the compaction decision never depends on the
+current message's content. With `keepRecentTurns > 0`, an eligible turn changes once from `full` to
+`summary` when it ages out of the recent window. The cached base summary remains stable after that.
 
 This is deliberate, for two reasons:
 
-- **Prompt caching.** Providers cache the serialized prompt by shared prefix (e.g. Anthropic
-  breakpoints). If message M's representation depended on the current turn's content, the prefix
-  containing M would differ from one turn to the next, invalidating the cache on every single turn.
+- **Prompt caching.** The policy and cached base summary remain stable. In default `prefetch` mode,
+  only the small excerpts appended to that base depend on the current request, so the provider may
+  lose part of the shared prefix. This trade-off is included in reported cache-read tokens and was
+  still cheaper in the measured suite. `retrievalMode: 'tool'` keeps the base prefix stable.
 - **Simplicity.** A per-turn, content-dependent override is one more thing to reason about, test,
   and get wrong (fuzzy name matching, false positives on common words, etc.) for a case the model
   can already handle itself.
 
-If the model actually needs the original content of a summarized historical message, it calls
-`context-retrieve.get_message` (or `get_file`, for a specific recoverable file) with the id from
-the summary's reference block — that is precisely what the tool is for. There is no other path
-back to `full` for a historical message.
+If prefetch is insufficient, the model first calls `search(query, id)` for focused excerpts, then
+`get_message(id)` or `get_file(id)` only when the full original is necessary. With function-name
+prefixing enabled (the default), the provider-facing names are
+`context-retrieve__get_message`, `context-retrieve__get_file` and `context-retrieve__search`.
 
 ## Building the Summary: `applyCompressionPlan`
 
 Given the decisions above, `applyCompressionPlan` rewrites the message list: `full` messages pass
-through unchanged; `summary` messages are replaced by a compact, cached representation.
+through unchanged; `summary` messages are replaced by a compact, cached representation. In
+`prefetch` mode, deterministic lexical ranking then appends up to 6,000 characters of matching
+excerpts from compressed messages. Excerpts stay in the original message role; no
+historical tool output is promoted to a system or user instruction.
 
 ### Summaries Are Always Plain Text
 
@@ -224,7 +248,8 @@ There is no model call anywhere in this path. A summary is one of:
 
 - **Deterministic text extraction** of a file (via the existing `cachingExtractor`, the same
   extractor used for native-attachment fallback elsewhere), truncated to 500 characters.
-- **Truncation** of an overly long text block, with a `…[truncated; N chars omitted]` marker.
+- **Truncation** of an overly long text block, with a marker stating how many characters were
+  omitted and requiring retrieval before omitted details are used.
 - **A fixed fallback string** when neither applies — e.g. `Image file; no text preview available.`
   for images (there is no text to extract from an image), or `No extractable text preview available for this file type.` when extraction fails or returns nothing.
 
@@ -238,15 +263,14 @@ is the model's one recovery surface for anything compression touched:
 
 - **`get_file(id)`** — read a file's content by id (DB-authorized via `canAccessFile`, same as
   before this tool was renamed from `retrieve-file`).
-- **`get_message(id)`** — return a message's *original, uncompressed* content by message id.
+- **`get_message(id)`** — return a message's _original, uncompressed_ content by message id.
   Operates directly on the live `messages` array already passed to every tool call
   (`ChatState.chatHistory`, which compression never touches) — no DB access, no extra
   authorization needed beyond already being inside this conversation.
-- **`search(query)`** — case-insensitive substring search over this conversation's own message
-  history (via the same `messages` array), returning matching message ids with a short snippet.
-  For when the model doesn't already have an id to call `get_message` with. Deliberately scoped to
-  *this conversation's uncompressed context only* — it is not a knowledge-base or cross-conversation
-  search.
+- **`search(query, id?)`** — with an id, lexically ranks chunks from that exact original message or
+  file and returns only the best excerpts; without an id, searches this conversation's messages
+  and returns ids with short snippets. It is deliberately scoped to this conversation, not a
+  knowledge-base or cross-conversation search.
 
 ### File Recovery Reference
 
@@ -258,7 +282,7 @@ File available on demand: documento_semplice.docx
 id: xXj3tBxkt4CTy80XL1rFF
 type: application/vnd.openxmlformats-officedocument.wordprocessingml.document
 summary: Documento semplice: contains a title and one paragraph.
-Use context-retrieve.get_file with this id if exact contents are needed.
+[EXACT CONTENT OMITTED] If the user's request could depend on omitted content, you MUST call the search function of the context-retrieve tool with { "id": "xXj3tBxkt4CTy80XL1rFF", "query": "<terms from the request>" } before answering. Use get_file only if the targeted excerpts are insufficient.
 ```
 
 Built by `buildFileRecoveryReference(fileRef, summary)`. `fileRef` is a `CompressionFileRef`:
@@ -281,7 +305,7 @@ historical user message, a large plain-text tool result). Every `summary`-policy
 also gets its own recovery line, appended by `buildMessageRecoveryNote(messageId)`:
 
 ```
-Full original message available on demand via context-retrieve.get_message with id: u-old-1.
+[EXACT CONTENT OMITTED] Full original message id: u-old-1. If the user's request could depend on omitted content, call search with this id and focused terms before answering. Use get_message only if targeted excerpts are insufficient.
 ```
 
 This is unconditional: it's present whether or not the message also carries file references, so
@@ -331,14 +355,14 @@ After:
       "toolName": "office_script",
       "result": {
         "type": "text",
-        "value": "[Tool output summarized for context efficiency.]\n\nFile available on demand: documento_semplice.docx\nid: file-docx\ntype: application/vnd...wordprocessingml.document\nsummary: Documento semplice: contains a title and one paragraph.\nUse context-retrieve.get_file with this id if exact contents are needed.\n\nFull original message available on demand via context-retrieve.get_message with id: t-docx."
+        "value": "[Tool output summarized for context efficiency. A retrieval call is mandatory whenever the request could depend on exact omitted values.]\n\nFile available on demand: documento_semplice.docx\nid: file-docx\ntype: application/vnd...wordprocessingml.document\nsummary: Documento semplice: contains a title and one paragraph.\n[EXACT CONTENT OMITTED] Search this file id with focused terms before answering; use get_file only if targeted excerpts are insufficient.\n\n[EXACT CONTENT OMITTED] Full original message id: t-docx. Search this message id with focused terms before answering; use get_message only if targeted excerpts are insufficient."
       }
     }
   ]
 }
 ```
 
-The `[Tool output summarized for context efficiency.]` overview line is a fixed constant
+The `[Tool output summarized for context efficiency. ...]` overview line is a fixed constant
 (`TOOL_RESULT_OVERVIEW`) — it does not depend on any separately-generated narrative summary.
 
 ### Generated Artifacts: Redacting Duplicated Content
@@ -370,7 +394,7 @@ marker; short fields (like a `prompt` argument) are left alone.
 
 // after
 { "id": "u-old-1", "role": "user",
-  "content": "File available on demand: report.pdf\nid: file-123\ntype: application/pdf\nsummary: The report covers Q1 revenue.\nUse context-retrieve.get_file with this id if exact contents are needed.\n\nPlease inspect this file.\n\nFull original message available on demand via context-retrieve.get_message with id: u-old-1.",
+  "content": "File available on demand: report.pdf\nid: file-123\ntype: application/pdf\nsummary: The report covers Q1 revenue.\n[EXACT CONTENT OMITTED] Search this file id with focused terms before answering; use get_file only if targeted excerpts are insufficient.\n\nPlease inspect this file.\n\n[EXACT CONTENT OMITTED] Full original message id: u-old-1. Search this message id first; use get_message only if needed.",
   "attachments": [] }
 ```
 
@@ -400,7 +424,7 @@ thrown back at the save path.
 ### Building a Message's Summary Only Happens Once at a Time
 
 Because `warmCompressionCache` is fire-and-forget, it isn't awaited by anything — a prompt build
-for a *different*, concurrent request can decide it needs to compress the same message before the
+for a _different_, concurrent request can decide it needs to compress the same message before the
 warm-up has finished. `getCompressedMessage`/`saveCompressedMessage` alone make that safe (the
 table upserts on `(sourceMessageId, compressionVersion)`), but not free: without anything else,
 both callers would redundantly re-read the file and re-run the text extractor.
@@ -430,7 +454,7 @@ CompressedMessage
 unique(sourceMessageId, compressionVersion)
 ```
 
-`compressionVersion` (currently `COMPRESSION_VERSION = 2` in `compression-planner.ts`) is bumped
+`compressionVersion` (currently `COMPRESSION_VERSION = 8` in `compression-planner.ts`) is bumped
 whenever the summary-building rules change, so old cached rows are naturally ignored rather than
 served stale. Applying a cached row is a plain overlay:
 
@@ -450,9 +474,10 @@ prompt build (ChatAssistant.invokeLlm)
   │    no  → send messages as-is
   │    yes ↓
   ├─ planMessageCompression(messages, preset)       → MessageCompressionDecision[]
-  ├─ applyCompressionPlan(messages, decisions)
+  ├─ applyCompressionPlan(messages, decisions, current-query options)
   │    full    → message unchanged
   │    summary → cached CompressedMessage row, or built + cached now
+  │    prefetch→ matching excerpts appended in the original message role
   ├─ truncateChat(...)                              [separate token-budget window, unchanged]
   └─ buildHistorySegments(...) → dtoMessageToLlmMessage(...) → provider payload
 ```
@@ -467,6 +492,7 @@ they always were.
 Covered in `apps/backend/lib/chat/__tests__/compression-planner.test.ts`:
 
 - Current turn stays `full` under both presets.
+- The configured number of recent completed turns stays `full` as one unit.
 - A historical attachment is summarized once a later turn starts.
 - A historical message's decision does not change when a later user message names that file.
 - Large historical tool text is summarized; `aggressive` lowers the size threshold.
@@ -475,21 +501,23 @@ Covered in `apps/backend/lib/chat/__tests__/compression-planner.test.ts`:
 - A generated image summary never triggers a model call and never becomes `image-data`.
 - `full`-policy messages still convert exactly as before (native bytes/text-extraction fallback).
 - Failed text extraction falls back to deterministic minimal text, never blocks compaction.
-- Every `summary`-policy message carries a `context-retrieve.get_message` recovery line, with or
-  without an accompanying file reference.
+- Every `summary`-policy message carries a mandatory-retrieval line naming `context-retrieve`'s
+  targeted `search` function, with full-message/file retrieval as fallback.
+- Query-aware prefetch inserts a relevant excerpt into the compressed message's original role.
 - `warmCompressionCache` builds/caches eligible messages and no-ops on ineligible ones, without
   throwing on failure.
 - A concurrent build for the same message joins the in-flight one instead of duplicating work.
 
 `apps/backend/lib/tools/context-retrieve/__tests__/implementation.test.ts` covers the tool itself:
-`get_file` (unchanged behavior from the old `retrieve-file` tool), `get_message` (found/not-found,
-and that it needs no DB access), and `search` (match with snippet, no-match, empty query).
+`get_file`, `get_message`, and `search`, including targeted lexical search inside one message or
+authorized file without replaying its irrelevant bulk.
 
 ## Behavioral Regression Benchmark
 
 The unit tests above validate the planner and the transformed message shape. They do not prove that
 an LLM can solve a task after the relevant content has been removed from the prompt. That question
-is covered by `__tests__/contextCompressionBenchmark.test.ts`.
+has a release-smoke benchmark in `__tests__/contextCompressionBenchmark.test.ts` and a comparative,
+numeric suite in the goal-driven eval harness.
 
 The benchmark uses real provider calls and is skipped by default. Enable it with:
 
@@ -511,10 +539,25 @@ versions, tool-calling behavior and network conditions can affect it. Keep the d
 preconditions and retrieval assertions strict; use a small provider matrix for release smoke tests
 and run broader model comparisons separately.
 
+For the accuracy/cost decision, use the saved-reference, single-message suite:
+
+```bash
+OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval.ts \
+  --suite context-compression --repeat 5 \
+  --runs-out context-compression-runs.json --out context-compression-report.md
+```
+
+By default it compares compression off, tool-only retrieval with no recent window, and prefetch
+with recent windows of 0 and 1. Explicit `compression-keep-{1,2,4}` arms remain available for wider
+window sweeps. The report uses provider usage, including prompt-cache read/write token details when
+available, and stores raw runs so the same evidence can be re-reported without another model call.
+
 ## Relevant Files
 
 - `apps/backend/lib/chat/compression-planner.ts` — `planMessageCompression`, `applyCompressionPlan`,
   `warmCompressionCache`, `resolveCompressionTriggerTokens`.
+- `apps/backend/lib/chat/context-search.ts` — deterministic lexical ranking shared by prefetch and
+  targeted retrieval.
 - `apps/backend/lib/chat/index.ts` — wires compression into `ChatAssistant.invokeLlm`.
 - `apps/backend/models/message.ts` — calls `warmCompressionCache` after `saveMessage`.
 - `apps/backend/models/compressed-message.ts` — `CompressedMessage` cache reads/writes.

--- a/docs/context-strategy-research.md
+++ b/docs/context-strategy-research.md
@@ -169,29 +169,33 @@ Written down so we do not discover them in the results.
 
 ### Compression TODO from production replay
 
-Real same-model replay found that the token-saving mechanism works, but attachment-only follow-up
-turns are not quality-safe yet. In the reviewed sample, historical-attachment compression reduced
-input by 93–97% and preserved quality when the current user message contained a useful query. It
-produced a material continuity regression when the current message contained only an attachment:
-the attachment itself was read correctly, but the immediately preceding assistant answer had been
-compressed and prefetch received an empty query. A long text-only replay remained usable with a
-minor drafting regression.
+Real same-model replay found that historical-attachment compression reduced input by 93–97% and
+preserved quality when the current user message contained a useful query. It initially produced a
+material continuity regression when the current message contained only an attachment: the file was
+read correctly, but the immediately preceding assistant answer had been compressed and prefetch
+received an empty query. Falling back to the previous user request recovered relevant excerpts but
+was insufficient by itself: the model still treated the attachment-only turn as having no task. A
+bounded continuation note in the otherwise-empty current user message fixed the real replay while
+retaining a 96.51% input reduction. A long text-only replay remained usable with a minor drafting
+regression.
 
-- [ ] Add a prefetch-query fallback for an empty current user message. Start with the latest
-      non-empty user request in the parent lineage; consider the immediately preceding assistant
-      answer only if the user query alone is insufficient. Keep the planner's turn-stable
-      compression decisions unchanged.
-- [ ] Compare that fallback against `keepRecentTurns: 1` on the saved production bundles. Do not buy
-      an uncompressed high-token replay unless the cheaper compressed variants are inconclusive.
-- [ ] Add a synthetic attachment-only continuation case: the user asks a document question, the
+- [x] Recover the nearest non-empty user request for an empty current user message, use it for
+      prefetch, and add a bounded continuation note to attachment-only current turns. Keep the
+      planner's turn-stable decisions and cached base summaries unchanged; apply the note in both
+      `prefetch` and `tool` retrieval modes.
+- [x] Add a synthetic attachment-only continuation case: the user asks a document question, the
       assistant answers and requests a specific follow-up document, then the user uploads that
       document with empty text. Success requires connecting the new document to the prior answer,
       not asking what to do with it.
-- [ ] Use the two production cases that retained quality as regression controls. The attachment-only
-      case must recover continuity without materially erasing the measured token saving.
-- [ ] Record and review provider-call/tool-call counts. One successful prefetch replay invoked
+- [x] Verify the two production cases that retained quality as deterministic regression controls;
+      their compression decisions and estimated token counts remain unchanged.
+- [x] Record and review provider-call/tool-call counts. One successful prefetch replay invoked
       context retrieval three times, so the real turn cost was substantially above the one-pass
-      compressed-history estimate even though it remained far below production.
+      compressed-history estimate even though it remained far below production. The corrected
+      attachment-only replay used one provider call and no retrieval tools.
+- [ ] Compare against `keepRecentTurns: 1` only if a broader attachment-only sample exposes cases
+      where the continuation query and note are insufficient. Do not buy an uncompressed high-token
+      replay unless cheaper compressed variants are inconclusive.
 - [ ] Do not call context compression robust for attachment-heavy chats until the attachment-only
       case passes and the result is repeated across more than one conversation.
 

--- a/docs/context-strategy-research.md
+++ b/docs/context-strategy-research.md
@@ -167,6 +167,34 @@ Written down so we do not discover them in the results.
 
 ## Sequence
 
+### Compression TODO from production replay
+
+Real same-model replay found that the token-saving mechanism works, but attachment-only follow-up
+turns are not quality-safe yet. In the reviewed sample, historical-attachment compression reduced
+input by 93–97% and preserved quality when the current user message contained a useful query. It
+produced a material continuity regression when the current message contained only an attachment:
+the attachment itself was read correctly, but the immediately preceding assistant answer had been
+compressed and prefetch received an empty query. A long text-only replay remained usable with a
+minor drafting regression.
+
+- [ ] Add a prefetch-query fallback for an empty current user message. Start with the latest
+      non-empty user request in the parent lineage; consider the immediately preceding assistant
+      answer only if the user query alone is insufficient. Keep the planner's turn-stable
+      compression decisions unchanged.
+- [ ] Compare that fallback against `keepRecentTurns: 1` on the saved production bundles. Do not buy
+      an uncompressed high-token replay unless the cheaper compressed variants are inconclusive.
+- [ ] Add a synthetic attachment-only continuation case: the user asks a document question, the
+      assistant answers and requests a specific follow-up document, then the user uploads that
+      document with empty text. Success requires connecting the new document to the prior answer,
+      not asking what to do with it.
+- [ ] Use the two production cases that retained quality as regression controls. The attachment-only
+      case must recover continuity without materially erasing the measured token saving.
+- [ ] Record and review provider-call/tool-call counts. One successful prefetch replay invoked
+      context retrieval three times, so the real turn cost was substantially above the one-pass
+      compressed-history estimate even though it remained far below production.
+- [ ] Do not call context compression robust for attachment-heavy chats until the attachment-only
+      case passes and the result is repeated across more than one conversation.
+
 Done:
 
 - Harness: simulated user, judge, answer keys, bootstrap intervals, break-even

--- a/docs/eval-results/README.md
+++ b/docs/eval-results/README.md
@@ -1,0 +1,18 @@
+# Evaluation results
+
+Versioned evidence produced by `apps/backend/scripts/eval.ts` may be kept here when it contains
+only synthetic or explicitly approved data. Store both the markdown report and its `--runs-out`
+artifact so confidence intervals and reports can be regenerated without paying for another run.
+
+Never commit mined production transcripts, drafts, tenant identifiers, or filenames here. The
+context-compression reference chats are synthetic anonymized shape fixtures defined in
+`apps/backend/lib/eval/scenarios/contextCompression.ts`.
+
+The 2026-09-10 files retain the initial `gpt-4.1-mini` recent-window/tool-retrieval baseline, then
+the query-aware prefetch matrices for `gpt-4.1-mini`, `gpt-5-latest`, and
+`claude-sonnet-latest`. `context-compression-decision-2026-09-10.md` records the cross-model
+decision, production-shape aggregates, and limitations. The focused version-8 Claude regression
+captures the search-loop fix discovered while inspecting provider behavior.
+
+Keep each `.runs.json` file with its report; it is the auditable transcript and usage record behind
+the aggregate table.

--- a/docs/eval-results/context-compression-decision-2026-09-10.md
+++ b/docs/eval-results/context-compression-decision-2026-09-10.md
@@ -1,0 +1,78 @@
+# Context compression decision — 2026-09-10
+
+## Decision
+
+Use query-aware prefetch with `keepRecentTurns: 0` as the default context-compression strategy.
+Keep the exact originals retrievable through `context-retrieve.search(query, id)` and the full
+`get_message(id)` / `get_file(id)` fallbacks. Retain tool-only retrieval as an evaluation arm, not
+as the default.
+
+`keepRecentTurns: 0` means no completed turn is protected wholesale. It does not blindly replace
+tiny plain-text messages: the planner leaves those verbatim when an id plus recovery instructions
+would be larger than the original. Attachments, recoverable files, large tool results, large
+assistant responses, and aggressive-preset long user messages remain the compression targets.
+
+The evaluated task is intentionally one assistant response over a fixed reference chat. This
+removes simulated-user trajectory variance: every arm receives the same saved messages,
+attachments and tool results, followed by the same final user request. Success is the scenario's
+deterministic answer gate; these runs used `--no-judge`.
+
+## Result
+
+| model | arm | runs | success | mean input tokens | mean cache-read tokens | mean cost | mean tool calls |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `gpt-4.1-mini` | compression off | 30 | 100% | 8,977 | 4,868 | $0.00215 | 0.0 |
+| `gpt-4.1-mini` | prefetch, keep 0 | 30 | 100% | 2,434 | 538 | $0.00083 | 0.0 |
+| `gpt-4.1-mini` | prefetch, keep 1 | 30 | 100% | 5,606 | 1,399 | $0.00184 | 0.0 |
+| `gpt-5-latest` | compression off | 18 | 100% | 8,997 | 4,361 | $0.0105 | 0.0 |
+| `gpt-5-latest` | prefetch, keep 0 | 18 | 100% | 2,472 | 975 | $0.00357 | 0.0 |
+| `gpt-5-latest` | prefetch, keep 1 | 18 | 100% | 5,825 | 1,022 | $0.0104 | 0.1 |
+| `claude-sonnet-latest` | compression off | 18 | 100% | 16,552 | 5,360 | $0.0307 | 0.0 |
+| `claude-sonnet-latest` | prefetch, keep 0 | 18 | 100% | 5,825 | 2,269 | $0.0102 | 0.2 |
+| `claude-sonnet-latest` | prefetch, keep 1 | 18 | 100% | 15,697 | 7,727 | $0.0233 | 0.4 |
+
+Across the three model matrices, prefetch/keep-0 preserved 66/66 successes while reducing mean
+input tokens by 73% on `gpt-4.1-mini`, 73% on `gpt-5-latest`, and 65% on Claude Sonnet. The
+corresponding mean cost reductions were 61%, 66%, and 67%. Cache reads and writes are priced
+separately where the provider reports them.
+
+Keeping one recent turn uncompressed produced no accuracy improvement in this suite and increased
+cost versus keep-0 by 122% (`gpt-4.1-mini`), 191% (`gpt-5-latest`), and 128% (Claude Sonnet). The
+data therefore does not support a default uncompressed recent-turn window.
+
+Tool-only keep-0 also reached 100%, but cost more than prefetch/keep-0: 54% more on
+`gpt-4.1-mini`, 82% more on `gpt-5-latest`, and 18% more on Claude Sonnet. Targeted retrieval
+remains necessary as a fallback, but forcing a model round trip for every omitted fact is not the
+efficient default.
+
+## Reference-chat corpus
+
+The six synthetic chats cover exact facts in a recent attachment, a middle-depth attachment, a
+long assistant response, a far tool result with a rejected distractor, irrelevant old bulk, and a
+mixed far-tool/recent-attachment answer. Their message counts use the p25/p50/p75 shape of the 100
+most expensive conversations seen during a read-only 30-day production aggregate:
+
+- message count: p25 6, p50 13, p75 33, p90 52, maximum 128;
+- cumulative input tokens: p25 1,132,885, p50 1,877,757, p75 3,917,060, p90 5,977,545;
+- total conversation cost: p25 $3.586, p50 $4.931, p75 $9.256, p90 $12.396.
+
+No production message text, title, filename, user/tenant identifier, conversation identifier or raw
+row is stored. Only these aggregates informed the deterministic synthetic padding. The saved corpus
+lives in `apps/backend/lib/eval/scenarios/contextCompression.ts`; the JSON run artifacts preserve
+the evaluated transcripts and usage accounting.
+
+## Evidence and limits
+
+- Full reports: `context-compression-prefetch-gpt-4.1-mini-2026-09-10.md`,
+  `context-compression-prefetch-gpt-5-latest-2026-09-10.md`, and
+  `context-compression-prefetch-claude-sonnet-latest-2026-09-10.md`.
+- Each report has a matching `.runs.json` artifact with scenario, arm, transcript, token usage,
+  cache usage, cost and compression diagnostics.
+- A focused version-8 Claude regression covers the two cases that had redundant retrieval calls;
+  it remains 6/6 successful. Global search no longer sees the current request or its own tool call.
+- The corpus is synthetic and small. It validates the mechanism and the current default, not every
+  real conversational dependency. Expansion should add anonymized *derived fixtures*, never raw
+  production transcripts.
+- Cost comparisons use the published [OpenAI API pricing](https://developers.openai.com/api/docs/pricing)
+  and [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing), and exclude
+  any contractual discounts.

--- a/docs/eval-results/context-compression-gpt-4.1-mini-2026-09-10.md
+++ b/docs/eval-results/context-compression-gpt-4.1-mini-2026-09-10.md
@@ -1,0 +1,239 @@
+# Evaluation report
+
+## Overall
+
+| arm | runs | success | score | in tok | cache read | out tok | cost | tools |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 30 | 100% | 1.00 | 8974 | 4228 | 18 | $0.00235 | 0.0 |
+| compression-keep-0 | 30 | 83% | 0.83 | 8823 | 832 | 54 | $0.00337 | 0.9 |
+| compression-keep-1 | 30 | 77% | 0.77 | 7876 | 1148 | 31 | $0.00286 | 0.3 |
+| compression-keep-2 | 30 | 77% | 0.77 | 7876 | 1391 | 31 | $0.00278 | 0.3 |
+| compression-keep-4 | 30 | 73% | 0.73 | 7492 | 1587 | 29 | $0.00257 | 0.1 |
+
+## compression-recent-attachment
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 5 | 100% | 1.00 | 7326→7326 | 0.0 | 7509 | 0 | 7 | $0.00301 | 0.0 | 1.0 | — |
+| compression-keep-0 | 5 | 100% | 1.00 | 7321→678 | 1.0 | 9068 | 614 | 40 | $0.00351 | 1.0 | 1.0 | — |
+| compression-keep-1 | 5 | 100% | 1.00 | 7323→7323 | 0.0 | 7762 | 0 | 8 | $0.00312 | 0.0 | 1.0 | — |
+| compression-keep-2 | 5 | 100% | 1.00 | 7324→7324 | 0.0 | 7763 | 0 | 8 | $0.00312 | 0.0 | 1.0 | — |
+| compression-keep-4 | 5 | 100% | 1.00 | 7323→7323 | 0.0 | 7762 | 0 | 8 | $0.00312 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▲ $0.00049 (+16%) — 95% CI [$0.00037, $0.00061]
+- input tokens per conversation: ▲ 1559 (+21%) — 95% CI [1557, 1560]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00049 more per conversation, before its $0 of indexing
+
+### compression-keep-1 vs compression-off
+
+- cost per conversation: ▲ $0.00010 (+3%) — 95% CI [$0.00010, $0.00010]
+- input tokens per conversation: ▲ 252 (+3%) — 95% CI [250, 255]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00010 more per conversation, before its $0 of indexing
+
+### compression-keep-2 vs compression-off
+
+- cost per conversation: ▲ $0.00010 (+3%) — 95% CI [$0.00010, $0.00010]
+- input tokens per conversation: ▲ 254 (+3%) — 95% CI [251, 257]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00010 more per conversation, before its $0 of indexing
+
+### compression-keep-4 vs compression-off
+
+- cost per conversation: ▲ $0.00010 (+3%) — 95% CI [$0.00010, $0.00010]
+- input tokens per conversation: ▲ 253 (+3%) — 95% CI [250, 256]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00010 more per conversation, before its $0 of indexing
+
+## compression-middle-attachment
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 5 | 100% | 1.00 | 7638→7638 | 0.0 | 7843 | 0 | 28 | $0.00318 | 0.0 | 1.0 | — |
+| compression-keep-0 | 5 | 40% | 0.40 | 7636→1297 | 1.0 | 5072 | 333 | 43 | $0.00200 | 0.4 | 1.0 | — |
+| compression-keep-1 | 5 | 80% | 0.80 | 7633→1295 | 1.0 | 8382 | 333 | 53 | $0.00334 | 0.8 | 1.0 | — |
+| compression-keep-2 | 5 | 80% | 0.80 | 7637→1297 | 1.0 | 8384 | 333 | 56 | $0.00334 | 0.8 | 1.0 | — |
+| compression-keep-4 | 5 | 100% | 1.00 | 7634→7634 | 0.0 | 8094 | 0 | 27 | $0.00328 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00118 (-37%) — not separable at this sample size — 95% CI [$-0.00243, $0.00016] includes 0
+- input tokens per conversation: ▼ -2771 (-35%) — not separable at this sample size — 95% CI [-6083, 541] includes 0
+- score: ▼ -0.60 (-60%) — 95% CI [-1.00, -0.20]
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00118 saved per conversation
+
+### compression-keep-1 vs compression-off
+
+- cost per conversation: ▲ $0.00016 (+5%) — not separable at this sample size — 95% CI [$-0.00119, $0.00093] includes 0
+- input tokens per conversation: ▲ 539 (+7%) — not separable at this sample size — 95% CI [-2774, 2198] includes 0
+- score: ▼ -0.20 (-20%) — not separable at this sample size — 95% CI [-0.60, 0.00] includes 0
+- break-even: never — this arm costs $0.00016 more per conversation, before its $0 of indexing
+
+### compression-keep-2 vs compression-off
+
+- cost per conversation: ▲ $0.00016 (+5%) — not separable at this sample size — 95% CI [$-0.00118, $0.00093] includes 0
+- input tokens per conversation: ▲ 542 (+7%) — not separable at this sample size — 95% CI [-2772, 2202] includes 0
+- score: ▼ -0.20 (-20%) — not separable at this sample size — 95% CI [-0.60, 0.00] includes 0
+- break-even: never — this arm costs $0.00016 more per conversation, before its $0 of indexing
+
+### compression-keep-4 vs compression-off
+
+- cost per conversation: ▲ $0.00010 (+3%) — 95% CI [$0.00010, $0.00010]
+- input tokens per conversation: ▲ 252 (+3%) — 95% CI [249, 254]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00010 more per conversation, before its $0 of indexing
+
+## compression-recent-assistant
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 5 | 100% | 1.00 | 6926→6926 | 0.0 | 7113 | 5530 | 5 | $0.00119 | 0.0 | 1.0 | — |
+| compression-keep-0 | 5 | 100% | 1.00 | 6926→605 | 1.0 | 8619 | 0 | 42 | $0.00351 | 1.0 | 1.0 | — |
+| compression-keep-1 | 5 | 100% | 1.00 | 6926→6926 | 0.0 | 7367 | 5837 | 6 | $0.00121 | 0.0 | 1.0 | — |
+| compression-keep-2 | 5 | 100% | 1.00 | 6926→6926 | 0.0 | 7367 | 5837 | 6 | $0.00121 | 0.0 | 1.0 | — |
+| compression-keep-4 | 5 | 100% | 1.00 | 6926→6926 | 0.0 | 7367 | 7296 | 6 | $0.00077 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▲ $0.00232 (+194%) — 95% CI [$0.00149, $0.00274]
+- input tokens per conversation: ▲ 1506 (+21%) — 95% CI [1506, 1506]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00232 more per conversation, before its $0 of indexing
+
+### compression-keep-1 vs compression-off
+
+- cost per conversation: ▲ $0.00001 (+1%) — not separable at this sample size — 95% CI [$-0.00084, $0.00091] includes 0
+- input tokens per conversation: ▲ 254 (+4%) — 95% CI [254, 254]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00001 more per conversation, before its $0 of indexing
+
+### compression-keep-2 vs compression-off
+
+- cost per conversation: ▲ $0.00001 (+1%) — not separable at this sample size — 95% CI [$-0.00084, $0.00091] includes 0
+- input tokens per conversation: ▲ 254 (+4%) — 95% CI [254, 254]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00001 more per conversation, before its $0 of indexing
+
+### compression-keep-4 vs compression-off
+
+- cost per conversation: ▼ $-0.00043 (-36%) — 95% CI [$-0.00126, $-0.00001]
+- input tokens per conversation: ▲ 254 (+4%) — 95% CI [254, 254]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00043 saved per conversation
+
+## compression-far-tool-output
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 5 | 100% | 1.00 | 9533→9533 | 0.0 | 9642 | 9472 | 20 | $0.00105 | 0.0 | 1.0 | — |
+| compression-keep-0 | 5 | 60% | 0.60 | 9533→3221 | 1.0 | 11838 | 3277 | 65 | $0.00386 | 0.8 | 1.0 | — |
+| compression-keep-1 | 5 | 80% | 0.80 | 9533→3221 | 1.0 | 11840 | 717 | 63 | $0.00462 | 0.8 | 1.0 | — |
+| compression-keep-2 | 5 | 80% | 0.80 | 9533→3221 | 1.0 | 11837 | 2176 | 60 | $0.00418 | 0.8 | 1.0 | — |
+| compression-keep-4 | 5 | 40% | 0.40 | 9533→3221 | 1.0 | 9828 | 2227 | 77 | $0.00339 | 0.6 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▲ $0.00281 (+268%) — 95% CI [$0.00119, $0.00443]
+- input tokens per conversation: ▲ 2196 (+23%) — not separable at this sample size — 95% CI [-1862, 4237] includes 0
+- score: ▼ -0.40 (-40%) — not separable at this sample size — 95% CI [-0.80, 0.00] includes 0
+- break-even: never — this arm costs $0.00281 more per conversation, before its $0 of indexing
+
+### compression-keep-1 vs compression-off
+
+- cost per conversation: ▲ $0.00357 (+341%) — 95% CI [$0.00193, $0.00463]
+- input tokens per conversation: ▲ 2198 (+23%) — not separable at this sample size — 95% CI [-1856, 4234] includes 0
+- score: ▼ -0.20 (-20%) — not separable at this sample size — 95% CI [-0.60, 0.00] includes 0
+- break-even: never — this arm costs $0.00357 more per conversation, before its $0 of indexing
+
+### compression-keep-2 vs compression-off
+
+- cost per conversation: ▲ $0.00313 (+299%) — 95% CI [$0.00171, $0.00416]
+- input tokens per conversation: ▲ 2195 (+23%) — not separable at this sample size — 95% CI [-1862, 4236] includes 0
+- score: ▼ -0.20 (-20%) — not separable at this sample size — 95% CI [-0.60, 0.00] includes 0
+- break-even: never — this arm costs $0.00313 more per conversation, before its $0 of indexing
+
+### compression-keep-4 vs compression-off
+
+- cost per conversation: ▲ $0.00234 (+223%) — 95% CI [$0.00111, $0.00357]
+- input tokens per conversation: ▲ 186 (+2%) — not separable at this sample size — 95% CI [-3880, 4251] includes 0
+- score: ▼ -0.60 (-60%) — 95% CI [-1.00, -0.20]
+- break-even: never — this arm costs $0.00234 more per conversation, before its $0 of indexing
+
+## compression-irrelevant-old-bulk
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 5 | 100% | 1.00 | 9234→9234 | 0.0 | 9329 | 7373 | 4 | $0.00153 | 0.0 | 1.0 | — |
+| compression-keep-0 | 5 | 100% | 1.00 | 9234→2792 | 1.0 | 3289 | 0 | 5 | $0.00132 | 0.0 | 1.0 | — |
+| compression-keep-1 | 5 | 100% | 1.00 | 9234→2792 | 1.0 | 3289 | 0 | 5 | $0.00132 | 0.0 | 1.0 | — |
+| compression-keep-2 | 5 | 100% | 1.00 | 9234→2792 | 1.0 | 3289 | 0 | 5 | $0.00132 | 0.0 | 1.0 | — |
+| compression-keep-4 | 5 | 100% | 1.00 | 9234→2792 | 1.0 | 3289 | 0 | 5 | $0.00132 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00020 (-13%) — not separable at this sample size — 95% CI [$-0.00131, $0.00035] includes 0
+- input tokens per conversation: ▼ -6040 (-65%) — 95% CI [-6040, -6040]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00020 saved per conversation
+
+### compression-keep-1 vs compression-off
+
+- cost per conversation: ▼ $-0.00020 (-13%) — not separable at this sample size — 95% CI [$-0.00131, $0.00035] includes 0
+- input tokens per conversation: ▼ -6040 (-65%) — 95% CI [-6040, -6040]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00020 saved per conversation
+
+### compression-keep-2 vs compression-off
+
+- cost per conversation: ▼ $-0.00020 (-13%) — not separable at this sample size — 95% CI [$-0.00131, $0.00035] includes 0
+- input tokens per conversation: ▼ -6040 (-65%) — 95% CI [-6040, -6040]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00020 saved per conversation
+
+### compression-keep-4 vs compression-off
+
+- cost per conversation: ▼ $-0.00020 (-13%) — not separable at this sample size — 95% CI [$-0.00131, $0.00035] includes 0
+- input tokens per conversation: ▼ -6040 (-65%) — 95% CI [-6040, -6040]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00020 saved per conversation
+
+## compression-mixed-depth
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 5 | 100% | 1.00 | 12213→12213 | 0.0 | 12411 | 2995 | 45 | $0.00414 | 0.0 | 1.0 | — |
+| compression-keep-0 | 5 | 100% | 1.00 | 12212→1528 | 2.0 | 15054 | 768 | 128 | $0.00600 | 2.0 | 1.0 | — |
+| compression-keep-1 | 5 | 0% | 0.00 | 12213→8162 | 1.0 | 8614 | 0 | 52 | $0.00353 | 0.0 | 1.0 | — |
+| compression-keep-2 | 5 | 0% | 0.00 | 12211→8160 | 1.0 | 8613 | 0 | 49 | $0.00352 | 0.0 | 1.0 | — |
+| compression-keep-4 | 5 | 0% | 0.00 | 12214→8163 | 1.0 | 8614 | 0 | 49 | $0.00352 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▲ $0.00186 (+45%) — 95% CI [$0.00114, $0.00257]
+- input tokens per conversation: ▲ 2643 (+21%) — 95% CI [2639, 2647]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00186 more per conversation, before its $0 of indexing
+
+### compression-keep-1 vs compression-off
+
+- cost per conversation: ▼ $-0.00061 (-15%) — 95% CI [$-0.00121, $-0.00001]
+- input tokens per conversation: ▼ -3797 (-31%) — 95% CI [-3799, -3795]
+- score: ▼ -1.00 (-100%) — 95% CI [-1.00, -1.00]
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00061 saved per conversation
+
+### compression-keep-2 vs compression-off
+
+- cost per conversation: ▼ $-0.00061 (-15%) — 95% CI [$-0.00121, $-0.00001]
+- input tokens per conversation: ▼ -3798 (-31%) — 95% CI [-3801, -3796]
+- score: ▼ -1.00 (-100%) — 95% CI [-1.00, -1.00]
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00061 saved per conversation
+
+### compression-keep-4 vs compression-off
+
+- cost per conversation: ▼ $-0.00061 (-15%) — 95% CI [$-0.00121, $-0.00001]
+- input tokens per conversation: ▼ -3797 (-31%) — 95% CI [-3799, -3794]
+- score: ▼ -1.00 (-100%) — 95% CI [-1.00, -1.00]
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00061 saved per conversation

--- a/docs/eval-results/context-compression-gpt-4.1-mini-2026-09-10.runs.json
+++ b/docs/eval-results/context-compression-gpt-4.1-mini-2026-09-10.runs.json
@@ -1,0 +1,9785 @@
+{
+  "version": 1,
+  "createdAt": "2026-09-10T01:12:30.434Z",
+  "metadata": {
+    "gitRevision": "e8c21f8736312cb066790ca6d76020fd96639c58",
+    "gitDirty": true,
+    "provider": "openai",
+    "assistantModel": "gpt-4.1-mini",
+    "userModel": "gpt-4.1-mini",
+    "baselineArm": "compression-off",
+    "arms": [
+      "compression-off",
+      "compression-keep-0",
+      "compression-keep-1",
+      "compression-keep-2",
+      "compression-keep-4"
+    ],
+    "scenarios": [
+      "compression-recent-attachment",
+      "compression-middle-attachment",
+      "compression-recent-assistant",
+      "compression-far-tool-output",
+      "compression-irrelevant-old-bulk",
+      "compression-mixed-depth"
+    ],
+    "repeat": 5,
+    "suite": "context-compression"
+  },
+  "runs": [
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7510,
+          "outputTokens": 7,
+          "totalTokens": 7517,
+          "inputTokenDetails": {
+            "noCacheTokens": 7510,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1192
+        }
+      ],
+      "totals": {
+        "inputTokens": 7510,
+        "outputTokens": 7,
+        "totalTokens": 7517,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1466,
+        "inputTokenDetails": {
+          "noCacheTokens": 7510,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0030152
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7329,
+        "estimatedHistoryTokensAfter": 7329,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7508,
+          "outputTokens": 7,
+          "totalTokens": 7515,
+          "inputTokenDetails": {
+            "noCacheTokens": 7508,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1374
+        }
+      ],
+      "totals": {
+        "inputTokens": 7508,
+        "outputTokens": 7,
+        "totalTokens": 7515,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1463,
+        "inputTokenDetails": {
+          "noCacheTokens": 7508,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0030144
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7327,
+        "estimatedHistoryTokensAfter": 7327,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7512,
+          "outputTokens": 7,
+          "totalTokens": 7519,
+          "inputTokenDetails": {
+            "noCacheTokens": 7512,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 793
+        }
+      ],
+      "totals": {
+        "inputTokens": 7512,
+        "outputTokens": 7,
+        "totalTokens": 7519,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 855,
+        "inputTokenDetails": {
+          "noCacheTokens": 7512,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.003016
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 7325,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7508,
+          "outputTokens": 7,
+          "totalTokens": 7515,
+          "inputTokenDetails": {
+            "noCacheTokens": 7508,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1479
+        }
+      ],
+      "totals": {
+        "inputTokens": 7508,
+        "outputTokens": 7,
+        "totalTokens": 7515,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1534,
+        "inputTokenDetails": {
+          "noCacheTokens": 7508,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0030144
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7321,
+        "estimatedHistoryTokensAfter": 7321,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7508,
+          "outputTokens": 7,
+          "totalTokens": 7515,
+          "inputTokenDetails": {
+            "noCacheTokens": 7508,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1181
+        }
+      ],
+      "totals": {
+        "inputTokens": 7508,
+        "outputTokens": 7,
+        "totalTokens": 7515,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1237,
+        "inputTokenDetails": {
+          "noCacheTokens": 7508,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0030144
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7327,
+        "estimatedHistoryTokensAfter": 7327,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9068,
+          "outputTokens": 40,
+          "totalTokens": 9108,
+          "inputTokenDetails": {
+            "noCacheTokens": 8044,
+            "cacheReadTokens": 1024,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 2011
+        }
+      ],
+      "totals": {
+        "inputTokens": 9068,
+        "outputTokens": 40,
+        "totalTokens": 9108,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2088,
+        "inputTokenDetails": {
+          "noCacheTokens": 8044,
+          "cacheReadTokens": 1024,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0033840000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7321,
+        "estimatedHistoryTokensAfter": 678,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9068,
+          "outputTokens": 40,
+          "totalTokens": 9108,
+          "inputTokenDetails": {
+            "noCacheTokens": 8044,
+            "cacheReadTokens": 1024,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 3551
+        }
+      ],
+      "totals": {
+        "inputTokens": 9068,
+        "outputTokens": 40,
+        "totalTokens": 9108,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3632,
+        "inputTokenDetails": {
+          "noCacheTokens": 8044,
+          "cacheReadTokens": 1024,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0033840000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7323,
+        "estimatedHistoryTokensAfter": 679,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9068,
+          "outputTokens": 40,
+          "totalTokens": 9108,
+          "inputTokenDetails": {
+            "noCacheTokens": 9068,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 2050
+        }
+      ],
+      "totals": {
+        "inputTokens": 9068,
+        "outputTokens": 40,
+        "totalTokens": 9108,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2121,
+        "inputTokenDetails": {
+          "noCacheTokens": 9068,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0036912000000000004
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7321,
+        "estimatedHistoryTokensAfter": 678,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9068,
+          "outputTokens": 40,
+          "totalTokens": 9108,
+          "inputTokenDetails": {
+            "noCacheTokens": 8044,
+            "cacheReadTokens": 1024,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 2262
+        }
+      ],
+      "totals": {
+        "inputTokens": 9068,
+        "outputTokens": 40,
+        "totalTokens": 9108,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2345,
+        "inputTokenDetails": {
+          "noCacheTokens": 8044,
+          "cacheReadTokens": 1024,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0033840000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7321,
+        "estimatedHistoryTokensAfter": 678,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9067,
+          "outputTokens": 39,
+          "totalTokens": 9106,
+          "inputTokenDetails": {
+            "noCacheTokens": 9067,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 1942
+        }
+      ],
+      "totals": {
+        "inputTokens": 9067,
+        "outputTokens": 39,
+        "totalTokens": 9106,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2042,
+        "inputTokenDetails": {
+          "noCacheTokens": 9067,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0036892
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7321,
+        "estimatedHistoryTokensAfter": 678,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7764,
+          "outputTokens": 8,
+          "totalTokens": 7772,
+          "inputTokenDetails": {
+            "noCacheTokens": 7764,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1774
+        }
+      ],
+      "totals": {
+        "inputTokens": 7764,
+        "outputTokens": 8,
+        "totalTokens": 7772,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1846,
+        "inputTokenDetails": {
+          "noCacheTokens": 7764,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031184000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 7325,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7758,
+          "outputTokens": 8,
+          "totalTokens": 7766,
+          "inputTokenDetails": {
+            "noCacheTokens": 7758,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1326
+        }
+      ],
+      "totals": {
+        "inputTokens": 7758,
+        "outputTokens": 8,
+        "totalTokens": 7766,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1392,
+        "inputTokenDetails": {
+          "noCacheTokens": 7758,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031160000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7321,
+        "estimatedHistoryTokensAfter": 7321,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7760,
+          "outputTokens": 8,
+          "totalTokens": 7768,
+          "inputTokenDetails": {
+            "noCacheTokens": 7760,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 977
+        }
+      ],
+      "totals": {
+        "inputTokens": 7760,
+        "outputTokens": 8,
+        "totalTokens": 7768,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1041,
+        "inputTokenDetails": {
+          "noCacheTokens": 7760,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031168000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7321,
+        "estimatedHistoryTokensAfter": 7321,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-1",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7762,
+          "outputTokens": 8,
+          "totalTokens": 7770,
+          "inputTokenDetails": {
+            "noCacheTokens": 7762,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1102
+        }
+      ],
+      "totals": {
+        "inputTokens": 7762,
+        "outputTokens": 8,
+        "totalTokens": 7770,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1173,
+        "inputTokenDetails": {
+          "noCacheTokens": 7762,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031176000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 7325,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-1",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7764,
+          "outputTokens": 8,
+          "totalTokens": 7772,
+          "inputTokenDetails": {
+            "noCacheTokens": 7764,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 34144
+        }
+      ],
+      "totals": {
+        "inputTokens": 7764,
+        "outputTokens": 8,
+        "totalTokens": 7772,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 34241,
+        "inputTokenDetails": {
+          "noCacheTokens": 7764,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031184000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 7325,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-2",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7762,
+          "outputTokens": 8,
+          "totalTokens": 7770,
+          "inputTokenDetails": {
+            "noCacheTokens": 7762,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 31338
+        }
+      ],
+      "totals": {
+        "inputTokens": 7762,
+        "outputTokens": 8,
+        "totalTokens": 7770,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 31444,
+        "inputTokenDetails": {
+          "noCacheTokens": 7762,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031176000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7321,
+        "estimatedHistoryTokensAfter": 7321,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-2",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7760,
+          "outputTokens": 8,
+          "totalTokens": 7768,
+          "inputTokenDetails": {
+            "noCacheTokens": 7760,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1178
+        }
+      ],
+      "totals": {
+        "inputTokens": 7760,
+        "outputTokens": 8,
+        "totalTokens": 7768,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1338,
+        "inputTokenDetails": {
+          "noCacheTokens": 7760,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031168000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7323,
+        "estimatedHistoryTokensAfter": 7323,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-2",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7768,
+          "outputTokens": 8,
+          "totalTokens": 7776,
+          "inputTokenDetails": {
+            "noCacheTokens": 7768,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1034
+        }
+      ],
+      "totals": {
+        "inputTokens": 7768,
+        "outputTokens": 8,
+        "totalTokens": 7776,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1250,
+        "inputTokenDetails": {
+          "noCacheTokens": 7768,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031200000000000004
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7329,
+        "estimatedHistoryTokensAfter": 7329,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-2",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7766,
+          "outputTokens": 8,
+          "totalTokens": 7774,
+          "inputTokenDetails": {
+            "noCacheTokens": 7766,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 866
+        }
+      ],
+      "totals": {
+        "inputTokens": 7766,
+        "outputTokens": 8,
+        "totalTokens": 7774,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1158,
+        "inputTokenDetails": {
+          "noCacheTokens": 7766,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031192000000000004
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 7325,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-2",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7760,
+          "outputTokens": 8,
+          "totalTokens": 7768,
+          "inputTokenDetails": {
+            "noCacheTokens": 7760,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1195
+        }
+      ],
+      "totals": {
+        "inputTokens": 7760,
+        "outputTokens": 8,
+        "totalTokens": 7768,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1348,
+        "inputTokenDetails": {
+          "noCacheTokens": 7760,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031168000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7321,
+        "estimatedHistoryTokensAfter": 7321,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-4",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7760,
+          "outputTokens": 8,
+          "totalTokens": 7768,
+          "inputTokenDetails": {
+            "noCacheTokens": 7760,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 978
+        }
+      ],
+      "totals": {
+        "inputTokens": 7760,
+        "outputTokens": 8,
+        "totalTokens": 7768,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1225,
+        "inputTokenDetails": {
+          "noCacheTokens": 7760,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031168000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7323,
+        "estimatedHistoryTokensAfter": 7323,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-4",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7766,
+          "outputTokens": 8,
+          "totalTokens": 7774,
+          "inputTokenDetails": {
+            "noCacheTokens": 7766,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1124
+        }
+      ],
+      "totals": {
+        "inputTokens": 7766,
+        "outputTokens": 8,
+        "totalTokens": 7774,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1328,
+        "inputTokenDetails": {
+          "noCacheTokens": 7766,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031192000000000004
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7327,
+        "estimatedHistoryTokensAfter": 7327,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-4",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7764,
+          "outputTokens": 8,
+          "totalTokens": 7772,
+          "inputTokenDetails": {
+            "noCacheTokens": 7764,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 864
+        }
+      ],
+      "totals": {
+        "inputTokens": 7764,
+        "outputTokens": 8,
+        "totalTokens": 7772,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1043,
+        "inputTokenDetails": {
+          "noCacheTokens": 7764,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031184000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7323,
+        "estimatedHistoryTokensAfter": 7323,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-4",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7760,
+          "outputTokens": 8,
+          "totalTokens": 7768,
+          "inputTokenDetails": {
+            "noCacheTokens": 7760,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1010
+        }
+      ],
+      "totals": {
+        "inputTokens": 7760,
+        "outputTokens": 8,
+        "totalTokens": 7768,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1273,
+        "inputTokenDetails": {
+          "noCacheTokens": 7760,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031168000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7323,
+        "estimatedHistoryTokensAfter": 7323,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-4",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7760,
+          "outputTokens": 8,
+          "totalTokens": 7768,
+          "inputTokenDetails": {
+            "noCacheTokens": 7760,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 795
+        }
+      ],
+      "totals": {
+        "inputTokens": 7760,
+        "outputTokens": 8,
+        "totalTokens": 7768,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1045,
+        "inputTokenDetails": {
+          "noCacheTokens": 7760,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031168000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7321,
+        "estimatedHistoryTokensAfter": 7321,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt document, the exact production transition date is 17 November 2027.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7842,
+          "outputTokens": 26,
+          "totalTokens": 7868,
+          "inputTokenDetails": {
+            "noCacheTokens": 7842,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1161
+        }
+      ],
+      "totals": {
+        "inputTokens": 7842,
+        "outputTokens": 26,
+        "totalTokens": 7868,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1328,
+        "inputTokenDetails": {
+          "noCacheTokens": 7842,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031784
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 7635,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, according to the authoritative final record in the document \"transition-calendar.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7846,
+          "outputTokens": 28,
+          "totalTokens": 7874,
+          "inputTokenDetails": {
+            "noCacheTokens": 7846,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1420
+        }
+      ],
+      "totals": {
+        "inputTokens": 7846,
+        "outputTokens": 28,
+        "totalTokens": 7874,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1564,
+        "inputTokenDetails": {
+          "noCacheTokens": 7846,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031832
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7643,
+        "estimatedHistoryTokensAfter": 7643,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, according to the authoritative final record in the document \"transition-calendar.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7842,
+          "outputTokens": 28,
+          "totalTokens": 7870,
+          "inputTokenDetails": {
+            "noCacheTokens": 7842,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1274
+        }
+      ],
+      "totals": {
+        "inputTokens": 7842,
+        "outputTokens": 28,
+        "totalTokens": 7870,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1441,
+        "inputTokenDetails": {
+          "noCacheTokens": 7842,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031816000000000006
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7639,
+        "estimatedHistoryTokensAfter": 7639,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, as stated in the authoritative final record of the transition-calendar.txt document.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7844,
+          "outputTokens": 28,
+          "totalTokens": 7872,
+          "inputTokenDetails": {
+            "noCacheTokens": 7844,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1486
+        }
+      ],
+      "totals": {
+        "inputTokens": 7844,
+        "outputTokens": 28,
+        "totalTokens": 7872,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1652,
+        "inputTokenDetails": {
+          "noCacheTokens": 7844,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031824000000000006
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 7635,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, as stated in the authoritative final record of the transition-calendar.txt document.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7840,
+          "outputTokens": 28,
+          "totalTokens": 7868,
+          "inputTokenDetails": {
+            "noCacheTokens": 7840,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1286
+        }
+      ],
+      "totals": {
+        "inputTokens": 7840,
+        "outputTokens": 28,
+        "totalTokens": 7868,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1447,
+        "inputTokenDetails": {
+          "noCacheTokens": 7840,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031808
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7639,
+        "estimatedHistoryTokensAfter": 7639,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The exact production transition date, according to the approved record, is 2023-12-15. This information is from the approved transition calendar.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1762,
+          "outputTokens": 32,
+          "totalTokens": 1794,
+          "inputTokenDetails": {
+            "noCacheTokens": 1762,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1067
+        }
+      ],
+      "totals": {
+        "inputTokens": 1762,
+        "outputTokens": 32,
+        "totalTokens": 1794,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1267,
+        "inputTokenDetails": {
+          "noCacheTokens": 1762,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007560000000000002
+      },
+      "deterministic": {
+        "mentioned": [],
+        "missing": [
+          "17 November 2027"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7641,
+        "estimatedHistoryTokensAfter": 1299,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The exact production transition date according to the approved record is 2024-07-01. This is from the approved transition calendar.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1758,
+          "outputTokens": 29,
+          "totalTokens": 1787,
+          "inputTokenDetails": {
+            "noCacheTokens": 1758,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1014
+        }
+      ],
+      "totals": {
+        "inputTokens": 1758,
+        "outputTokens": 29,
+        "totalTokens": 1787,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1257,
+        "inputTokenDetails": {
+          "noCacheTokens": 1758,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007496
+      },
+      "deterministic": {
+        "mentioned": [],
+        "missing": [
+          "17 November 2027"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 1296,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt file, the exact production transition date is 17 November 2027.",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 10040,
+          "outputTokens": 59,
+          "totalTokens": 10099,
+          "inputTokenDetails": {
+            "noCacheTokens": 10040,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 4793
+        }
+      ],
+      "totals": {
+        "inputTokens": 10040,
+        "outputTokens": 59,
+        "totalTokens": 10099,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4992,
+        "inputTokenDetails": {
+          "noCacheTokens": 10040,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.004110399999999999
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7633,
+        "estimatedHistoryTokensAfter": 1295,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt, the exact production transition date is 17 November 2027. Earlier planning dates are superseded.",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 10037,
+          "outputTokens": 64,
+          "totalTokens": 10101,
+          "inputTokenDetails": {
+            "noCacheTokens": 8373,
+            "cacheReadTokens": 1664,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 3158
+        }
+      ],
+      "totals": {
+        "inputTokens": 10037,
+        "outputTokens": 64,
+        "totalTokens": 10101,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3440,
+        "inputTokenDetails": {
+          "noCacheTokens": 8373,
+          "cacheReadTokens": 1664,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0036180000000000006
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7633,
+        "estimatedHistoryTokensAfter": 1295,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The exact production transition date according to the approved record is 2023-12-15. This information is from the approved transition calendar.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1761,
+          "outputTokens": 30,
+          "totalTokens": 1791,
+          "inputTokenDetails": {
+            "noCacheTokens": 1761,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1736
+        }
+      ],
+      "totals": {
+        "inputTokens": 1761,
+        "outputTokens": 30,
+        "totalTokens": 1791,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2007,
+        "inputTokenDetails": {
+          "noCacheTokens": 1761,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007524000000000001
+      },
+      "deterministic": {
+        "mentioned": [],
+        "missing": [
+          "17 November 2027"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7639,
+        "estimatedHistoryTokensAfter": 1298,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt, the exact production transition date is 17 November 2027.",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 10036,
+          "outputTokens": 56,
+          "totalTokens": 10092,
+          "inputTokenDetails": {
+            "noCacheTokens": 10036,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 2313
+        }
+      ],
+      "totals": {
+        "inputTokens": 10036,
+        "outputTokens": 56,
+        "totalTokens": 10092,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2546,
+        "inputTokenDetails": {
+          "noCacheTokens": 10036,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.004104
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7631,
+        "estimatedHistoryTokensAfter": 1294,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt, the exact production transition date is 17 November 2027.",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 10044,
+          "outputTokens": 60,
+          "totalTokens": 10104,
+          "inputTokenDetails": {
+            "noCacheTokens": 10044,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 2113
+        }
+      ],
+      "totals": {
+        "inputTokens": 10044,
+        "outputTokens": 60,
+        "totalTokens": 10104,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2356,
+        "inputTokenDetails": {
+          "noCacheTokens": 10044,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0041136
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 1296,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt, the exact production transition date is 17 November 2027. Earlier planning dates are superseded.",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 10037,
+          "outputTokens": 64,
+          "totalTokens": 10101,
+          "inputTokenDetails": {
+            "noCacheTokens": 8373,
+            "cacheReadTokens": 1664,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 2811
+        }
+      ],
+      "totals": {
+        "inputTokens": 10037,
+        "outputTokens": 64,
+        "totalTokens": 10101,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3133,
+        "inputTokenDetails": {
+          "noCacheTokens": 8373,
+          "cacheReadTokens": 1664,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0036180000000000006
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7633,
+        "estimatedHistoryTokensAfter": 1295,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-1",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The exact production transition date according to the approved record is 2024-07-15. This information is from the approved transition calendar.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1756,
+          "outputTokens": 30,
+          "totalTokens": 1786,
+          "inputTokenDetails": {
+            "noCacheTokens": 1756,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1000
+        }
+      ],
+      "totals": {
+        "inputTokens": 1756,
+        "outputTokens": 30,
+        "totalTokens": 1786,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1388,
+        "inputTokenDetails": {
+          "noCacheTokens": 1756,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007504000000000001
+      },
+      "deterministic": {
+        "mentioned": [],
+        "missing": [
+          "17 November 2027"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7629,
+        "estimatedHistoryTokensAfter": 1293,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-1",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt, the exact production transition date is 17 November 2027.",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 10037,
+          "outputTokens": 57,
+          "totalTokens": 10094,
+          "inputTokenDetails": {
+            "noCacheTokens": 10037,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 3120
+        }
+      ],
+      "totals": {
+        "inputTokens": 10037,
+        "outputTokens": 57,
+        "totalTokens": 10094,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3452,
+        "inputTokenDetails": {
+          "noCacheTokens": 10037,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.004106
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 1296,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-2",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt, the exact production transition date is 17 November 2027.",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 10031,
+          "outputTokens": 55,
+          "totalTokens": 10086,
+          "inputTokenDetails": {
+            "noCacheTokens": 10031,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 2284
+        }
+      ],
+      "totals": {
+        "inputTokens": 10031,
+        "outputTokens": 55,
+        "totalTokens": 10086,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2509,
+        "inputTokenDetails": {
+          "noCacheTokens": 10031,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0041004
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7629,
+        "estimatedHistoryTokensAfter": 1293,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-2",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt file, the exact production transition date is 17 November 2027. Earlier planning dates are superseded.",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 10039,
+          "outputTokens": 65,
+          "totalTokens": 10104,
+          "inputTokenDetails": {
+            "noCacheTokens": 10039,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 3803
+        }
+      ],
+      "totals": {
+        "inputTokens": 10039,
+        "outputTokens": 65,
+        "totalTokens": 10104,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4073,
+        "inputTokenDetails": {
+          "noCacheTokens": 10039,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0041196
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7639,
+        "estimatedHistoryTokensAfter": 1298,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-2",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt file, the exact production transition date is 17 November 2027.",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 10049,
+          "outputTokens": 62,
+          "totalTokens": 10111,
+          "inputTokenDetails": {
+            "noCacheTokens": 10049,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 2444
+        }
+      ],
+      "totals": {
+        "inputTokens": 10049,
+        "outputTokens": 62,
+        "totalTokens": 10111,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3072,
+        "inputTokenDetails": {
+          "noCacheTokens": 10049,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.004118800000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7643,
+        "estimatedHistoryTokensAfter": 1300,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-2",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The exact production transition date according to the approved record is 2024-07-01. This information is from the approved transition calendar.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1759,
+          "outputTokens": 30,
+          "totalTokens": 1789,
+          "inputTokenDetails": {
+            "noCacheTokens": 1759,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 968
+        }
+      ],
+      "totals": {
+        "inputTokens": 1759,
+        "outputTokens": 30,
+        "totalTokens": 1789,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1258,
+        "inputTokenDetails": {
+          "noCacheTokens": 1759,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007516000000000001
+      },
+      "deterministic": {
+        "mentioned": [],
+        "missing": [
+          "17 November 2027"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 1296,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-2",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt file, the exact production transition date is 17 November 2027. Earlier planning dates are superseded.",
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 10044,
+          "outputTokens": 68,
+          "totalTokens": 10112,
+          "inputTokenDetails": {
+            "noCacheTokens": 8380,
+            "cacheReadTokens": 1664,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 4492
+        }
+      ],
+      "totals": {
+        "inputTokens": 10044,
+        "outputTokens": 68,
+        "totalTokens": 10112,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4833,
+        "inputTokenDetails": {
+          "noCacheTokens": 8380,
+          "cacheReadTokens": 1664,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0036272
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7637,
+        "estimatedHistoryTokensAfter": 1297,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-4",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt file, the exact production transition date is 17 November 2027.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8090,
+          "outputTokens": 27,
+          "totalTokens": 8117,
+          "inputTokenDetails": {
+            "noCacheTokens": 8090,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1228
+        }
+      ],
+      "totals": {
+        "inputTokens": 8090,
+        "outputTokens": 27,
+        "totalTokens": 8117,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1542,
+        "inputTokenDetails": {
+          "noCacheTokens": 8090,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0032792
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7629,
+        "estimatedHistoryTokensAfter": 7629,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-4",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, according to the authoritative final record in the stored transition calendar.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8096,
+          "outputTokens": 27,
+          "totalTokens": 8123,
+          "inputTokenDetails": {
+            "noCacheTokens": 8096,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1276
+        }
+      ],
+      "totals": {
+        "inputTokens": 8096,
+        "outputTokens": 27,
+        "totalTokens": 8123,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1450,
+        "inputTokenDetails": {
+          "noCacheTokens": 8096,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0032816
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 7635,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-4",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt file, the exact production transition date is 17 November 2027.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8096,
+          "outputTokens": 27,
+          "totalTokens": 8123,
+          "inputTokenDetails": {
+            "noCacheTokens": 8096,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 2011
+        }
+      ],
+      "totals": {
+        "inputTokens": 8096,
+        "outputTokens": 27,
+        "totalTokens": 8123,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2223,
+        "inputTokenDetails": {
+          "noCacheTokens": 8096,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0032816
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 7635,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-4",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt file, the exact production transition date is 17 November 2027.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8094,
+          "outputTokens": 27,
+          "totalTokens": 8121,
+          "inputTokenDetails": {
+            "noCacheTokens": 8094,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1212
+        }
+      ],
+      "totals": {
+        "inputTokens": 8094,
+        "outputTokens": 27,
+        "totalTokens": 8121,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1454,
+        "inputTokenDetails": {
+          "noCacheTokens": 8094,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0032808000000000004
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7637,
+        "estimatedHistoryTokensAfter": 7637,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-4",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt file, the exact production transition date is 17 November 2027.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8096,
+          "outputTokens": 27,
+          "totalTokens": 8123,
+          "inputTokenDetails": {
+            "noCacheTokens": 8096,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1466
+        }
+      ],
+      "totals": {
+        "inputTokens": 8096,
+        "outputTokens": 27,
+        "totalTokens": 8123,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1705,
+        "inputTokenDetails": {
+          "noCacheTokens": 8096,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0032816
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7633,
+        "estimatedHistoryTokensAfter": 7633,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7113,
+          "outputTokens": 5,
+          "totalTokens": 7118,
+          "inputTokenDetails": {
+            "noCacheTokens": 7113,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 817
+        }
+      ],
+      "totals": {
+        "inputTokens": 7113,
+        "outputTokens": 5,
+        "totalTokens": 7118,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 821,
+        "inputTokenDetails": {
+          "noCacheTokens": 7113,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0028532
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7113,
+          "outputTokens": 5,
+          "totalTokens": 7118,
+          "inputTokenDetails": {
+            "noCacheTokens": 201,
+            "cacheReadTokens": 6912,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1082
+        }
+      ],
+      "totals": {
+        "inputTokens": 7113,
+        "outputTokens": 5,
+        "totalTokens": 7118,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1083,
+        "inputTokenDetails": {
+          "noCacheTokens": 201,
+          "cacheReadTokens": 6912,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007796
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7113,
+          "outputTokens": 5,
+          "totalTokens": 7118,
+          "inputTokenDetails": {
+            "noCacheTokens": 201,
+            "cacheReadTokens": 6912,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 766
+        }
+      ],
+      "totals": {
+        "inputTokens": 7113,
+        "outputTokens": 5,
+        "totalTokens": 7118,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 767,
+        "inputTokenDetails": {
+          "noCacheTokens": 201,
+          "cacheReadTokens": 6912,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007796
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7113,
+          "outputTokens": 5,
+          "totalTokens": 7118,
+          "inputTokenDetails": {
+            "noCacheTokens": 201,
+            "cacheReadTokens": 6912,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 738
+        }
+      ],
+      "totals": {
+        "inputTokens": 7113,
+        "outputTokens": 5,
+        "totalTokens": 7118,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 739,
+        "inputTokenDetails": {
+          "noCacheTokens": 201,
+          "cacheReadTokens": 6912,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007796
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7113,
+          "outputTokens": 5,
+          "totalTokens": 7118,
+          "inputTokenDetails": {
+            "noCacheTokens": 201,
+            "cacheReadTokens": 6912,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 918
+        }
+      ],
+      "totals": {
+        "inputTokens": 7113,
+        "outputTokens": 5,
+        "totalTokens": 7118,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 919,
+        "inputTokenDetails": {
+          "noCacheTokens": 201,
+          "cacheReadTokens": 6912,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007796
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8619,
+          "outputTokens": 42,
+          "totalTokens": 8661,
+          "inputTokenDetails": {
+            "noCacheTokens": 8619,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 2527
+        }
+      ],
+      "totals": {
+        "inputTokens": 8619,
+        "outputTokens": 42,
+        "totalTokens": 8661,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2594,
+        "inputTokenDetails": {
+          "noCacheTokens": 8619,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035148
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 605,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8619,
+          "outputTokens": 42,
+          "totalTokens": 8661,
+          "inputTokenDetails": {
+            "noCacheTokens": 8619,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 2980
+        }
+      ],
+      "totals": {
+        "inputTokens": 8619,
+        "outputTokens": 42,
+        "totalTokens": 8661,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3016,
+        "inputTokenDetails": {
+          "noCacheTokens": 8619,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035148
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 605,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8619,
+          "outputTokens": 42,
+          "totalTokens": 8661,
+          "inputTokenDetails": {
+            "noCacheTokens": 8619,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 2046
+        }
+      ],
+      "totals": {
+        "inputTokens": 8619,
+        "outputTokens": 42,
+        "totalTokens": 8661,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2106,
+        "inputTokenDetails": {
+          "noCacheTokens": 8619,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035148
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 605,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8619,
+          "outputTokens": 42,
+          "totalTokens": 8661,
+          "inputTokenDetails": {
+            "noCacheTokens": 8619,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 2111
+        }
+      ],
+      "totals": {
+        "inputTokens": 8619,
+        "outputTokens": 42,
+        "totalTokens": 8661,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2171,
+        "inputTokenDetails": {
+          "noCacheTokens": 8619,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035148
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 605,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8619,
+          "outputTokens": 42,
+          "totalTokens": 8661,
+          "inputTokenDetails": {
+            "noCacheTokens": 8619,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 1894
+        }
+      ],
+      "totals": {
+        "inputTokens": 8619,
+        "outputTokens": 42,
+        "totalTokens": 8661,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2003,
+        "inputTokenDetails": {
+          "noCacheTokens": 8619,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035148
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 605,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 7367,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 993
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 995,
+        "inputTokenDetails": {
+          "noCacheTokens": 7367,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0029564
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 71,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1083
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1084,
+        "inputTokenDetails": {
+          "noCacheTokens": 71,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007676
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 71,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 772
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 775,
+        "inputTokenDetails": {
+          "noCacheTokens": 71,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007676
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-1",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 71,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1211
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1214,
+        "inputTokenDetails": {
+          "noCacheTokens": 71,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007676
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-1",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 71,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 852
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 853,
+        "inputTokenDetails": {
+          "noCacheTokens": 71,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007676
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-2",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 71,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 2652
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2655,
+        "inputTokenDetails": {
+          "noCacheTokens": 71,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007676
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-2",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 71,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 766
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 768,
+        "inputTokenDetails": {
+          "noCacheTokens": 71,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007676
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-2",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 71,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 865
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 867,
+        "inputTokenDetails": {
+          "noCacheTokens": 71,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007676
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-2",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 7367,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1588
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1590,
+        "inputTokenDetails": {
+          "noCacheTokens": 7367,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0029564
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-2",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 71,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1279
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1280,
+        "inputTokenDetails": {
+          "noCacheTokens": 71,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007676
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-4",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 71,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1078
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1080,
+        "inputTokenDetails": {
+          "noCacheTokens": 71,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007676
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-4",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 71,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 777
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 779,
+        "inputTokenDetails": {
+          "noCacheTokens": 71,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007676
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-4",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 71,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 824
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 825,
+        "inputTokenDetails": {
+          "noCacheTokens": 71,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007676
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-4",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 71,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 818
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 820,
+        "inputTokenDetails": {
+          "noCacheTokens": 71,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007676
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-4",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7367,
+          "outputTokens": 6,
+          "totalTokens": 7373,
+          "inputTokenDetails": {
+            "noCacheTokens": 71,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 722
+        }
+      ],
+      "totals": {
+        "inputTokens": 7367,
+        "outputTokens": 6,
+        "totalTokens": 7373,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 724,
+        "inputTokenDetails": {
+          "noCacheTokens": 71,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007676
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9642,
+          "outputTokens": 20,
+          "totalTokens": 9662,
+          "inputTokenDetails": {
+            "noCacheTokens": 170,
+            "cacheReadTokens": 9472,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1015
+        }
+      ],
+      "totals": {
+        "inputTokens": 9642,
+        "outputTokens": 20,
+        "totalTokens": 9662,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1024,
+        "inputTokenDetails": {
+          "noCacheTokens": 170,
+          "cacheReadTokens": 9472,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010472
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 9533,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9642,
+          "outputTokens": 20,
+          "totalTokens": 9662,
+          "inputTokenDetails": {
+            "noCacheTokens": 170,
+            "cacheReadTokens": 9472,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 789
+        }
+      ],
+      "totals": {
+        "inputTokens": 9642,
+        "outputTokens": 20,
+        "totalTokens": 9662,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 790,
+        "inputTokenDetails": {
+          "noCacheTokens": 170,
+          "cacheReadTokens": 9472,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010472
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 9533,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9642,
+          "outputTokens": 20,
+          "totalTokens": 9662,
+          "inputTokenDetails": {
+            "noCacheTokens": 170,
+            "cacheReadTokens": 9472,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1877
+        }
+      ],
+      "totals": {
+        "inputTokens": 9642,
+        "outputTokens": 20,
+        "totalTokens": 9662,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1877,
+        "inputTokenDetails": {
+          "noCacheTokens": 170,
+          "cacheReadTokens": 9472,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010472
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 9533,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9642,
+          "outputTokens": 20,
+          "totalTokens": 9662,
+          "inputTokenDetails": {
+            "noCacheTokens": 170,
+            "cacheReadTokens": 9472,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 915
+        }
+      ],
+      "totals": {
+        "inputTokens": 9642,
+        "outputTokens": 20,
+        "totalTokens": 9662,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 916,
+        "inputTokenDetails": {
+          "noCacheTokens": 170,
+          "cacheReadTokens": 9472,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010472
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 9533,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9642,
+          "outputTokens": 20,
+          "totalTokens": 9662,
+          "inputTokenDetails": {
+            "noCacheTokens": 170,
+            "cacheReadTokens": 9472,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1049
+        }
+      ],
+      "totals": {
+        "inputTokens": 9642,
+        "outputTokens": 20,
+        "totalTokens": 9662,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1051,
+        "inputTokenDetails": {
+          "noCacheTokens": 170,
+          "cacheReadTokens": 9472,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010472
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 9533,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13853,
+          "outputTokens": 57,
+          "totalTokens": 13910,
+          "inputTokenDetails": {
+            "noCacheTokens": 1053,
+            "cacheReadTokens": 12800,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 2102
+        }
+      ],
+      "totals": {
+        "inputTokens": 13853,
+        "outputTokens": 57,
+        "totalTokens": 13910,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2125,
+        "inputTokenDetails": {
+          "noCacheTokens": 1053,
+          "cacheReadTokens": 12800,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0017924
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is not visible in the current summary. I will retrieve the full original ledger reconciliation export message to provide the precise figure including currency and cents.The exact authoritative reconciled balance from the ledger run is EUR 418,275.60. This is the official figure to use. A provisional balance of EUR 481,257.60 was rejected and must not be used. This information is from the ledger reconciliation export.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13897,
+          "outputTokens": 133,
+          "totalTokens": 14030,
+          "inputTokenDetails": {
+            "noCacheTokens": 13897,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 3776
+        }
+      ],
+      "totals": {
+        "inputTokens": 13897,
+        "outputTokens": 133,
+        "totalTokens": 14030,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3791,
+        "inputTokenDetails": {
+          "noCacheTokens": 13897,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0057716
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [
+          "EUR 481,257.60"
+        ],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13853,
+          "outputTokens": 57,
+          "totalTokens": 13910,
+          "inputTokenDetails": {
+            "noCacheTokens": 13853,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 2617
+        }
+      ],
+      "totals": {
+        "inputTokens": 13853,
+        "outputTokens": 57,
+        "totalTokens": 13910,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2637,
+        "inputTokenDetails": {
+          "noCacheTokens": 13853,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.005632400000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13853,
+          "outputTokens": 57,
+          "totalTokens": 13910,
+          "inputTokenDetails": {
+            "noCacheTokens": 10269,
+            "cacheReadTokens": 3584,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 2854
+        }
+      ],
+      "totals": {
+        "inputTokens": 13853,
+        "outputTokens": 57,
+        "totalTokens": 13910,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2874,
+        "inputTokenDetails": {
+          "noCacheTokens": 10269,
+          "cacheReadTokens": 3584,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0045572
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is USD 1,234,567.89.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3732,
+          "outputTokens": 23,
+          "totalTokens": 3755,
+          "inputTokenDetails": {
+            "noCacheTokens": 3732,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 953
+        }
+      ],
+      "totals": {
+        "inputTokens": 3732,
+        "outputTokens": 23,
+        "totalTokens": 3755,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 972,
+        "inputTokenDetails": {
+          "noCacheTokens": 3732,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0015296
+      },
+      "deterministic": {
+        "mentioned": [],
+        "missing": [
+          "EUR 418,275.60"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13853,
+          "outputTokens": 57,
+          "totalTokens": 13910,
+          "inputTokenDetails": {
+            "noCacheTokens": 10269,
+            "cacheReadTokens": 3584,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 2637
+        }
+      ],
+      "totals": {
+        "inputTokens": 13853,
+        "outputTokens": 57,
+        "totalTokens": 13910,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2669,
+        "inputTokenDetails": {
+          "noCacheTokens": 10269,
+          "cacheReadTokens": 3584,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0045572
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "I will retrieve the exact authoritative reconciled balance from the ledger run by accessing the full original ledger reconciliation export message.The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13882,
+          "outputTokens": 82,
+          "totalTokens": 13964,
+          "inputTokenDetails": {
+            "noCacheTokens": 13882,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 4844
+        }
+      ],
+      "totals": {
+        "inputTokens": 13882,
+        "outputTokens": 82,
+        "totalTokens": 13964,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4878,
+        "inputTokenDetails": {
+          "noCacheTokens": 13882,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.005684
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is USD 1,234,567.89. This figure includes currency and cents as specified in the ledger reconciliation export.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3732,
+          "outputTokens": 37,
+          "totalTokens": 3769,
+          "inputTokenDetails": {
+            "noCacheTokens": 3732,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1115
+        }
+      ],
+      "totals": {
+        "inputTokens": 3732,
+        "outputTokens": 37,
+        "totalTokens": 3769,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1152,
+        "inputTokenDetails": {
+          "noCacheTokens": 3732,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0015520000000000002
+      },
+      "deterministic": {
+        "mentioned": [],
+        "missing": [
+          "EUR 418,275.60"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-1",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "I will retrieve the exact authoritative reconciled balance from the ledger run by accessing the full original ledger reconciliation export message.The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13882,
+          "outputTokens": 82,
+          "totalTokens": 13964,
+          "inputTokenDetails": {
+            "noCacheTokens": 13882,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 3397
+        }
+      ],
+      "totals": {
+        "inputTokens": 13882,
+        "outputTokens": 82,
+        "totalTokens": 13964,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3416,
+        "inputTokenDetails": {
+          "noCacheTokens": 13882,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.005684
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-1",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13853,
+          "outputTokens": 57,
+          "totalTokens": 13910,
+          "inputTokenDetails": {
+            "noCacheTokens": 13853,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 2686
+        }
+      ],
+      "totals": {
+        "inputTokens": 13853,
+        "outputTokens": 57,
+        "totalTokens": 13910,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2708,
+        "inputTokenDetails": {
+          "noCacheTokens": 13853,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.005632400000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-2",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is USD 1,234,567.89. This figure includes currency and cents as specified in the ledger reconciliation export.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3732,
+          "outputTokens": 37,
+          "totalTokens": 3769,
+          "inputTokenDetails": {
+            "noCacheTokens": 3732,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1308
+        }
+      ],
+      "totals": {
+        "inputTokens": 3732,
+        "outputTokens": 37,
+        "totalTokens": 3769,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1328,
+        "inputTokenDetails": {
+          "noCacheTokens": 3732,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0015520000000000002
+      },
+      "deterministic": {
+        "mentioned": [],
+        "missing": [
+          "EUR 418,275.60"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-2",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13853,
+          "outputTokens": 57,
+          "totalTokens": 13910,
+          "inputTokenDetails": {
+            "noCacheTokens": 10269,
+            "cacheReadTokens": 3584,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 2042
+        }
+      ],
+      "totals": {
+        "inputTokens": 13853,
+        "outputTokens": 57,
+        "totalTokens": 13910,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2063,
+        "inputTokenDetails": {
+          "noCacheTokens": 10269,
+          "cacheReadTokens": 3584,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0045572
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-2",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "I need to retrieve the exact authoritative reconciled balance from the ledger run. I will get the full original ledger reconciliation export message to provide the precise figure including currency and cents.The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13894,
+          "outputTokens": 94,
+          "totalTokens": 13988,
+          "inputTokenDetails": {
+            "noCacheTokens": 10182,
+            "cacheReadTokens": 3712,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 3341
+        }
+      ],
+      "totals": {
+        "inputTokens": 13894,
+        "outputTokens": 94,
+        "totalTokens": 13988,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3359,
+        "inputTokenDetails": {
+          "noCacheTokens": 10182,
+          "cacheReadTokens": 3712,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.004594399999999999
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-2",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13853,
+          "outputTokens": 57,
+          "totalTokens": 13910,
+          "inputTokenDetails": {
+            "noCacheTokens": 13853,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 2176
+        }
+      ],
+      "totals": {
+        "inputTokens": 13853,
+        "outputTokens": 57,
+        "totalTokens": 13910,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2203,
+        "inputTokenDetails": {
+          "noCacheTokens": 13853,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.005632400000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-2",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13853,
+          "outputTokens": 57,
+          "totalTokens": 13910,
+          "inputTokenDetails": {
+            "noCacheTokens": 10269,
+            "cacheReadTokens": 3584,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 2249
+        }
+      ],
+      "totals": {
+        "inputTokens": 13853,
+        "outputTokens": 57,
+        "totalTokens": 13910,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2273,
+        "inputTokenDetails": {
+          "noCacheTokens": 10269,
+          "cacheReadTokens": 3584,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0045572
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-4",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is USD 1,234,567.89. This figure includes currency and cents as specified in the ledger reconciliation export.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3732,
+          "outputTokens": 37,
+          "totalTokens": 3769,
+          "inputTokenDetails": {
+            "noCacheTokens": 3732,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1570
+        }
+      ],
+      "totals": {
+        "inputTokens": 3732,
+        "outputTokens": 37,
+        "totalTokens": 3769,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1592,
+        "inputTokenDetails": {
+          "noCacheTokens": 3732,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0015520000000000002
+      },
+      "deterministic": {
+        "mentioned": [],
+        "missing": [
+          "EUR 418,275.60"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-4",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "I will retrieve the exact authoritative reconciled balance from the ledger run by accessing the full original ledger reconciliation export message.The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13882,
+          "outputTokens": 82,
+          "totalTokens": 13964,
+          "inputTokenDetails": {
+            "noCacheTokens": 10170,
+            "cacheReadTokens": 3712,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 5574
+        }
+      ],
+      "totals": {
+        "inputTokens": 13882,
+        "outputTokens": 82,
+        "totalTokens": 13964,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 5595,
+        "inputTokenDetails": {
+          "noCacheTokens": 10170,
+          "cacheReadTokens": 3712,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0045704
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-4",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is USD 1,234,567.89. This figure includes currency and cents as specified in the ledger reconciliation export.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3732,
+          "outputTokens": 37,
+          "totalTokens": 3769,
+          "inputTokenDetails": {
+            "noCacheTokens": 3732,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1118
+        }
+      ],
+      "totals": {
+        "inputTokens": 3732,
+        "outputTokens": 37,
+        "totalTokens": 3769,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1144,
+        "inputTokenDetails": {
+          "noCacheTokens": 3732,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0015520000000000002
+      },
+      "deterministic": {
+        "mentioned": [],
+        "missing": [
+          "EUR 418,275.60"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-4",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is not visible in the current summary. I will retrieve the full original ledger reconciliation message to provide the precise figure including currency and cents.The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13896,
+          "outputTokens": 96,
+          "totalTokens": 13992,
+          "inputTokenDetails": {
+            "noCacheTokens": 10184,
+            "cacheReadTokens": 3712,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 3543
+        }
+      ],
+      "totals": {
+        "inputTokens": 13896,
+        "outputTokens": 96,
+        "totalTokens": 13992,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3574,
+        "inputTokenDetails": {
+          "noCacheTokens": 10184,
+          "cacheReadTokens": 3712,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.004598400000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-4",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Include currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is not visible in the current summary. I will retrieve the full original ledger reconciliation export message to provide the precise figure including currency and cents.The exact authoritative reconciled balance from the ledger run is EUR 418,275.60. This is the confirmed figure, and a provisional balance of EUR 481,257.60 was rejected and must not be used. This information is from the ledger reconciliation export.",
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13897,
+          "outputTokens": 132,
+          "totalTokens": 14029,
+          "inputTokenDetails": {
+            "noCacheTokens": 10185,
+            "cacheReadTokens": 3712,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 5270
+        }
+      ],
+      "totals": {
+        "inputTokens": 13897,
+        "outputTokens": 132,
+        "totalTokens": 14029,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 5301,
+        "inputTokenDetails": {
+          "noCacheTokens": 10185,
+          "cacheReadTokens": 3712,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0046564
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [
+          "EUR 481,257.60"
+        ],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9533,
+        "estimatedHistoryTokensAfter": 3221,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9329,
+          "outputTokens": 4,
+          "totalTokens": 9333,
+          "inputTokenDetails": {
+            "noCacheTokens": 9329,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1377
+        }
+      ],
+      "totals": {
+        "inputTokens": 9329,
+        "outputTokens": 4,
+        "totalTokens": 9333,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1383,
+        "inputTokenDetails": {
+          "noCacheTokens": 9329,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0037380000000000004
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 9234,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9329,
+          "outputTokens": 4,
+          "totalTokens": 9333,
+          "inputTokenDetails": {
+            "noCacheTokens": 113,
+            "cacheReadTokens": 9216,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1040
+        }
+      ],
+      "totals": {
+        "inputTokens": 9329,
+        "outputTokens": 4,
+        "totalTokens": 9333,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1041,
+        "inputTokenDetails": {
+          "noCacheTokens": 113,
+          "cacheReadTokens": 9216,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0009732
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 9234,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9329,
+          "outputTokens": 4,
+          "totalTokens": 9333,
+          "inputTokenDetails": {
+            "noCacheTokens": 113,
+            "cacheReadTokens": 9216,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 728
+        }
+      ],
+      "totals": {
+        "inputTokens": 9329,
+        "outputTokens": 4,
+        "totalTokens": 9333,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 729,
+        "inputTokenDetails": {
+          "noCacheTokens": 113,
+          "cacheReadTokens": 9216,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0009732
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 9234,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9329,
+          "outputTokens": 4,
+          "totalTokens": 9333,
+          "inputTokenDetails": {
+            "noCacheTokens": 113,
+            "cacheReadTokens": 9216,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 813
+        }
+      ],
+      "totals": {
+        "inputTokens": 9329,
+        "outputTokens": 4,
+        "totalTokens": 9333,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 815,
+        "inputTokenDetails": {
+          "noCacheTokens": 113,
+          "cacheReadTokens": 9216,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0009732
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 9234,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9329,
+          "outputTokens": 4,
+          "totalTokens": 9333,
+          "inputTokenDetails": {
+            "noCacheTokens": 113,
+            "cacheReadTokens": 9216,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 882
+        }
+      ],
+      "totals": {
+        "inputTokens": 9329,
+        "outputTokens": 4,
+        "totalTokens": 9333,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 883,
+        "inputTokenDetails": {
+          "noCacheTokens": 113,
+          "cacheReadTokens": 9216,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0009732
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 9234,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1436
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1463,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 753
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 771,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1101
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1120,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 957
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 995,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 679
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 693,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 749
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 766,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1304
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1328,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 726
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 761,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-1",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1290
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1324,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-1",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 906
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 925,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-2",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 724
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 742,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-2",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1030
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1057,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-2",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 880
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 907,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-2",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 787
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 814,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-2",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 826
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 854,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-4",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 835
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 853,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-4",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 840
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 867,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-4",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 754
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 779,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-4",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 761
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 777,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-4",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3289,
+          "outputTokens": 5,
+          "totalTokens": 3294,
+          "inputTokenDetails": {
+            "noCacheTokens": 3289,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 719
+        }
+      ],
+      "totals": {
+        "inputTokens": 3289,
+        "outputTokens": 5,
+        "totalTokens": 3294,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 747,
+        "inputTokenDetails": {
+          "noCacheTokens": 3289,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0013236
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2792,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83.\n\nThe accepted service restoration window is 14 business days from verified incident closure.\n\nThese details are from the service registry and the service-acceptance.txt document, respectively.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12410,
+          "outputTokens": 47,
+          "totalTokens": 12457,
+          "inputTokenDetails": {
+            "noCacheTokens": 12410,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1669
+        }
+      ],
+      "totals": {
+        "inputTokens": 12410,
+        "outputTokens": 47,
+        "totalTokens": 12457,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1768,
+        "inputTokenDetails": {
+          "noCacheTokens": 12410,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0050392
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 12213,
+        "estimatedHistoryTokensAfter": 12213,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83.\n\nThe accepted service restoration window is 14 business days from verified incident closure.\n\nThese details are from the service registry and service-acceptance.txt documents respectively.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12414,
+          "outputTokens": 45,
+          "totalTokens": 12459,
+          "inputTokenDetails": {
+            "noCacheTokens": 7422,
+            "cacheReadTokens": 4992,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1423
+        }
+      ],
+      "totals": {
+        "inputTokens": 12414,
+        "outputTokens": 45,
+        "totalTokens": 12459,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1485,
+        "inputTokenDetails": {
+          "noCacheTokens": 7422,
+          "cacheReadTokens": 4992,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00354
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 12215,
+        "estimatedHistoryTokensAfter": 12215,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83.\n\nThe accepted service restoration window is 14 business days from verified incident closure.\n\nThese details are from the service registry and service-acceptance.txt documents respectively.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12412,
+          "outputTokens": 45,
+          "totalTokens": 12457,
+          "inputTokenDetails": {
+            "noCacheTokens": 7420,
+            "cacheReadTokens": 4992,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1310
+        }
+      ],
+      "totals": {
+        "inputTokens": 12412,
+        "outputTokens": 45,
+        "totalTokens": 12457,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1371,
+        "inputTokenDetails": {
+          "noCacheTokens": 7420,
+          "cacheReadTokens": 4992,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035391999999999997
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 12215,
+        "estimatedHistoryTokensAfter": 12215,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83.\n\nThe accepted service restoration window is 14 business days from verified incident closure.\n\nThese details are from the service registry and service-acceptance.txt documents respectively.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12410,
+          "outputTokens": 45,
+          "totalTokens": 12455,
+          "inputTokenDetails": {
+            "noCacheTokens": 7418,
+            "cacheReadTokens": 4992,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1344
+        }
+      ],
+      "totals": {
+        "inputTokens": 12410,
+        "outputTokens": 45,
+        "totalTokens": 12455,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1407,
+        "inputTokenDetails": {
+          "noCacheTokens": 7418,
+          "cacheReadTokens": 4992,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035384000000000006
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 12213,
+        "estimatedHistoryTokensAfter": 12213,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83.\n\nThe accepted service restoration window is 14 business days from verified incident closure.\n\nThese details are from the service registry and service-acceptance.txt documents respectively.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12408,
+          "outputTokens": 45,
+          "totalTokens": 12453,
+          "inputTokenDetails": {
+            "noCacheTokens": 12408,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 3346
+        }
+      ],
+      "totals": {
+        "inputTokens": 12408,
+        "outputTokens": 45,
+        "totalTokens": 12453,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 3419,
+        "inputTokenDetails": {
+          "noCacheTokens": 12408,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.005035200000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 12209,
+        "estimatedHistoryTokensAfter": 12209,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83.\n\nThe accepted restoration window is 14 business days from verified incident closure.\n\nThese details come from the service registry and the service-acceptance.txt document respectively.",
+          "toolCalls": [
+            "context-retrieve__get_message",
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 15061,
+          "outputTokens": 131,
+          "totalTokens": 15192,
+          "inputTokenDetails": {
+            "noCacheTokens": 15061,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message",
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 3152
+        }
+      ],
+      "totals": {
+        "inputTokens": 15061,
+        "outputTokens": 131,
+        "totalTokens": 15192,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 3236,
+        "inputTokenDetails": {
+          "noCacheTokens": 15061,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.006234000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12215,
+        "estimatedHistoryTokensAfter": 1530,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83.\n\nThe accepted restoration window is 14 business days from verified incident closure.\n\nThis information is from the service registry and the service-acceptance.txt document.",
+          "toolCalls": [
+            "context-retrieve__get_message",
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 15050,
+          "outputTokens": 127,
+          "totalTokens": 15177,
+          "inputTokenDetails": {
+            "noCacheTokens": 13130,
+            "cacheReadTokens": 1920,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message",
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 5473
+        }
+      ],
+      "totals": {
+        "inputTokens": 15050,
+        "outputTokens": 127,
+        "totalTokens": 15177,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 5566,
+        "inputTokenDetails": {
+          "noCacheTokens": 13130,
+          "cacheReadTokens": 1920,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0056472
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12207,
+        "estimatedHistoryTokensAfter": 1526,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83.\n\nThe accepted restoration window is 14 business days from verified incident closure.\n\nThis information is from the service registry and the service-acceptance.txt document.",
+          "toolCalls": [
+            "context-retrieve__get_message",
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 15049,
+          "outputTokens": 126,
+          "totalTokens": 15175,
+          "inputTokenDetails": {
+            "noCacheTokens": 15049,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message",
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 2773
+        }
+      ],
+      "totals": {
+        "inputTokens": 15049,
+        "outputTokens": 126,
+        "totalTokens": 15175,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 2857,
+        "inputTokenDetails": {
+          "noCacheTokens": 15049,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0062212000000000005
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12211,
+        "estimatedHistoryTokensAfter": 1528,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83.\n\nThe accepted restoration window is 14 business days from verified incident closure.\n\nThis information is from the service registry and the service-acceptance.txt document.",
+          "toolCalls": [
+            "context-retrieve__get_message",
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 15055,
+          "outputTokens": 128,
+          "totalTokens": 15183,
+          "inputTokenDetails": {
+            "noCacheTokens": 13135,
+            "cacheReadTokens": 1920,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message",
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 2828
+        }
+      ],
+      "totals": {
+        "inputTokens": 15055,
+        "outputTokens": 128,
+        "totalTokens": 15183,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 2914,
+        "inputTokenDetails": {
+          "noCacheTokens": 13135,
+          "cacheReadTokens": 1920,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0056508
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12215,
+        "estimatedHistoryTokensAfter": 1530,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83.\n\nThe accepted restoration window is 14 business days from verified incident closure.\n\nThis information is from the service registry and service-acceptance.txt documents.",
+          "toolCalls": [
+            "context-retrieve__get_message",
+            "context-retrieve__get_file"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 15054,
+          "outputTokens": 126,
+          "totalTokens": 15180,
+          "inputTokenDetails": {
+            "noCacheTokens": 15054,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__get_message",
+            "context-retrieve__get_file"
+          ],
+          "latencyMs": 3372
+        }
+      ],
+      "totals": {
+        "inputTokens": 15054,
+        "outputTokens": 126,
+        "totalTokens": 15180,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 3450,
+        "inputTokenDetails": {
+          "noCacheTokens": 15054,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.006223200000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12211,
+        "estimatedHistoryTokensAfter": 1528,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly visible in the current context.\n\nThe accepted service restoration window is 14 business days from verified incident closure, as stated in the authoritative final record in the file \"service-acceptance.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8613,
+          "outputTokens": 49,
+          "totalTokens": 8662,
+          "inputTokenDetails": {
+            "noCacheTokens": 8613,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1578
+        }
+      ],
+      "totals": {
+        "inputTokens": 8613,
+        "outputTokens": 49,
+        "totalTokens": 8662,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1664,
+        "inputTokenDetails": {
+          "noCacheTokens": 8613,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035236000000000004
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12213,
+        "estimatedHistoryTokensAfter": 8162,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly visible in the current context.\n\nThe accepted service restoration window is 14 business days from verified incident closure, as stated in the authoritative final record of the file \"service-acceptance.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8611,
+          "outputTokens": 49,
+          "totalTokens": 8660,
+          "inputTokenDetails": {
+            "noCacheTokens": 8611,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1923
+        }
+      ],
+      "totals": {
+        "inputTokens": 8611,
+        "outputTokens": 49,
+        "totalTokens": 8660,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2035,
+        "inputTokenDetails": {
+          "noCacheTokens": 8611,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035228
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12209,
+        "estimatedHistoryTokensAfter": 8158,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly visible in the current summary, so I cannot provide it precisely.\n\nThe accepted restoration window is 14 business days from verified incident closure, as stated in the authoritative final record of the file \"service-acceptance.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8617,
+          "outputTokens": 55,
+          "totalTokens": 8672,
+          "inputTokenDetails": {
+            "noCacheTokens": 8617,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 2130
+        }
+      ],
+      "totals": {
+        "inputTokens": 8617,
+        "outputTokens": 55,
+        "totalTokens": 8672,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2188,
+        "inputTokenDetails": {
+          "noCacheTokens": 8617,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035348000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12217,
+        "estimatedHistoryTokensAfter": 8166,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-1",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly visible in the current summary, so I cannot provide it directly.\n\nThe accepted service restoration window is 14 business days from verified incident closure, as stated in the authoritative final record of the \"service-acceptance.txt\" document.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8613,
+          "outputTokens": 57,
+          "totalTokens": 8670,
+          "inputTokenDetails": {
+            "noCacheTokens": 8613,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 2454
+        }
+      ],
+      "totals": {
+        "inputTokens": 8613,
+        "outputTokens": 57,
+        "totalTokens": 8670,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2522,
+        "inputTokenDetails": {
+          "noCacheTokens": 8613,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035364000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12211,
+        "estimatedHistoryTokensAfter": 8160,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-1",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly provided in the visible content.\n\nThe accepted service restoration window is 14 business days from verified incident closure, as stated in the authoritative final record of the file \"service-acceptance.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8615,
+          "outputTokens": 49,
+          "totalTokens": 8664,
+          "inputTokenDetails": {
+            "noCacheTokens": 8615,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1465
+        }
+      ],
+      "totals": {
+        "inputTokens": 8615,
+        "outputTokens": 49,
+        "totalTokens": 8664,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1551,
+        "inputTokenDetails": {
+          "noCacheTokens": 8615,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035244
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12213,
+        "estimatedHistoryTokensAfter": 8162,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-2",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly provided in the visible content.\n\nThe accepted service restoration window is 14 business days from verified incident closure, as stated in the authoritative final record of the file \"service-acceptance.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8611,
+          "outputTokens": 49,
+          "totalTokens": 8660,
+          "inputTokenDetails": {
+            "noCacheTokens": 8611,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1481
+        }
+      ],
+      "totals": {
+        "inputTokens": 8611,
+        "outputTokens": 49,
+        "totalTokens": 8660,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1556,
+        "inputTokenDetails": {
+          "noCacheTokens": 8611,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035228
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12213,
+        "estimatedHistoryTokensAfter": 8162,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-2",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly visible in the current context.\n\nThe accepted service restoration window is 14 business days from verified incident closure, as stated in the authoritative final record of the file \"service-acceptance.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8613,
+          "outputTokens": 49,
+          "totalTokens": 8662,
+          "inputTokenDetails": {
+            "noCacheTokens": 8613,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1478
+        }
+      ],
+      "totals": {
+        "inputTokens": 8613,
+        "outputTokens": 49,
+        "totalTokens": 8662,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1548,
+        "inputTokenDetails": {
+          "noCacheTokens": 8613,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035236000000000004
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12209,
+        "estimatedHistoryTokensAfter": 8158,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-2",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly provided in the visible content.\n\nThe accepted service restoration window is 14 business days from verified incident closure, as stated in the authoritative final record of the file \"service-acceptance.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8615,
+          "outputTokens": 49,
+          "totalTokens": 8664,
+          "inputTokenDetails": {
+            "noCacheTokens": 8615,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 3454
+        }
+      ],
+      "totals": {
+        "inputTokens": 8615,
+        "outputTokens": 49,
+        "totalTokens": 8664,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 3532,
+        "inputTokenDetails": {
+          "noCacheTokens": 8615,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035244
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12215,
+        "estimatedHistoryTokensAfter": 8164,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-2",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly provided in the visible content.\n\nThe accepted service restoration window is 14 business days from verified incident closure, as stated in the authoritative final record of the \"service-acceptance.txt\" document.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8613,
+          "outputTokens": 50,
+          "totalTokens": 8663,
+          "inputTokenDetails": {
+            "noCacheTokens": 8613,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 2242
+        }
+      ],
+      "totals": {
+        "inputTokens": 8613,
+        "outputTokens": 50,
+        "totalTokens": 8663,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2316,
+        "inputTokenDetails": {
+          "noCacheTokens": 8613,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035252000000000005
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12211,
+        "estimatedHistoryTokensAfter": 8160,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-2",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly provided in the visible content.\n\nThe accepted service restoration window is 14 business days from verified incident closure, as stated in the authoritative final record of the \"service-acceptance.txt\" document.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8611,
+          "outputTokens": 50,
+          "totalTokens": 8661,
+          "inputTokenDetails": {
+            "noCacheTokens": 8611,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 2444
+        }
+      ],
+      "totals": {
+        "inputTokens": 8611,
+        "outputTokens": 50,
+        "totalTokens": 8661,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2527,
+        "inputTokenDetails": {
+          "noCacheTokens": 8611,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035244
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12209,
+        "estimatedHistoryTokensAfter": 8158,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 2
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-4",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly stated in the visible content.\n\nThe accepted service restoration window is 14 business days from verified incident closure, as stated in the authoritative final record of the file \"service-acceptance.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8613,
+          "outputTokens": 49,
+          "totalTokens": 8662,
+          "inputTokenDetails": {
+            "noCacheTokens": 8613,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1519
+        }
+      ],
+      "totals": {
+        "inputTokens": 8613,
+        "outputTokens": 49,
+        "totalTokens": 8662,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1599,
+        "inputTokenDetails": {
+          "noCacheTokens": 8613,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035236000000000004
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12215,
+        "estimatedHistoryTokensAfter": 8164,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-4",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly provided in the visible content.\n\nThe accepted service restoration window is 14 business days from verified incident closure, as stated in the authoritative final record of the \"service-acceptance.txt\" document.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8617,
+          "outputTokens": 50,
+          "totalTokens": 8667,
+          "inputTokenDetails": {
+            "noCacheTokens": 8617,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1663
+        }
+      ],
+      "totals": {
+        "inputTokens": 8617,
+        "outputTokens": 50,
+        "totalTokens": 8667,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1735,
+        "inputTokenDetails": {
+          "noCacheTokens": 8617,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035268
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12215,
+        "estimatedHistoryTokensAfter": 8164,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-4",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly provided in the visible content.\n\nThe accepted service restoration window is 14 business days from verified incident closure, as stated in the authoritative final record of the \"service-acceptance.txt\" document.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8613,
+          "outputTokens": 50,
+          "totalTokens": 8663,
+          "inputTokenDetails": {
+            "noCacheTokens": 8613,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1739
+        }
+      ],
+      "totals": {
+        "inputTokens": 8613,
+        "outputTokens": 50,
+        "totalTokens": 8663,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1810,
+        "inputTokenDetails": {
+          "noCacheTokens": 8613,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035252000000000005
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12213,
+        "estimatedHistoryTokensAfter": 8162,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-4",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly provided in the visible content.\n\nThe accepted service restoration window is 14 business days from verified incident closure, as stated in the authoritative final record in the file \"service-acceptance.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8617,
+          "outputTokens": 49,
+          "totalTokens": 8666,
+          "inputTokenDetails": {
+            "noCacheTokens": 8617,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 2029
+        }
+      ],
+      "totals": {
+        "inputTokens": 8617,
+        "outputTokens": 49,
+        "totalTokens": 8666,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2113,
+        "inputTokenDetails": {
+          "noCacheTokens": 8617,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035252000000000005
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12217,
+        "estimatedHistoryTokensAfter": 8166,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 0
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-4",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is not explicitly provided in the visible content.\n\nThe accepted service restoration window is 14 business days from verified incident closure, as stated in the authoritative final record in the file \"service-acceptance.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8611,
+          "outputTokens": 49,
+          "totalTokens": 8660,
+          "inputTokenDetails": {
+            "noCacheTokens": 8611,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1457
+        }
+      ],
+      "totals": {
+        "inputTokens": 8611,
+        "outputTokens": 49,
+        "totalTokens": 8660,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1521,
+        "inputTokenDetails": {
+          "noCacheTokens": 8611,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035228
+      },
+      "deterministic": {
+        "mentioned": [
+          "14 business days"
+        ],
+        "missing": [
+          "LUMEN-83"
+        ],
+        "forbidden": [],
+        "pass": false,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12211,
+        "estimatedHistoryTokensAfter": 8160,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 4
+      },
+      "score": 0
+    }
+  ]
+}

--- a/docs/eval-results/context-compression-prefetch-claude-sonnet-latest-2026-09-10.md
+++ b/docs/eval-results/context-compression-prefetch-claude-sonnet-latest-2026-09-10.md
@@ -1,0 +1,190 @@
+# Evaluation report
+
+## Overall
+
+| arm | runs | success | score | in tok | cache read | out tok | cost | tools |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 18 | 100% | 1.00 | 16552 | 5360 | 167 | $0.0307 | 0.0 |
+| compression-keep-0 | 18 | 100% | 1.00 | 9460 | 5895 | 193 | $0.0120 | 1.2 |
+| compression-prefetch-keep-0 | 18 | 100% | 1.00 | 5825 | 2269 | 86 | $0.0102 | 0.2 |
+| compression-prefetch-keep-1 | 18 | 100% | 1.00 | 15697 | 7727 | 182 | $0.0233 | 0.4 |
+
+## compression-recent-attachment
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 3 | 100% | 1.00 | 13173→13173 | 0.0 | 13638 | 0 | 10 | $0.0342 | 0.0 | 1.0 | — |
+| compression-keep-0 | 3 | 100% | 1.00 | 13173→1230 | 1.0 | 5450 | 3417 | 136 | $0.00712 | 1.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 3 | 100% | 1.00 | 13173→1363 | 1.0 | 2810 | 753 | 10 | $0.00539 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 3 | 100% | 1.00 | 13173→13173 | 0.0 | 14618 | 1129 | 33 | $0.0343 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.02707 (-79%) — 95% CI [$-0.02809, $-0.02523]
+- input tokens per conversation: ▼ -8188 (-60%) — 95% CI [-8191, -8184]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0271 saved per conversation
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.02880 (-84%) — 95% CI [$-0.02967, $-0.02707]
+- input tokens per conversation: ▼ -10827 (-79%) — 95% CI [-10829, -10825]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0288 saved per conversation
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▲ $0.00008 (+0%) — not separable at this sample size — 95% CI [$-0.00015, $0.00054] includes 0
+- input tokens per conversation: ▲ 980 (+7%) — 95% CI [977, 983]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00008 more per conversation, before its $0 of indexing
+
+## compression-middle-attachment
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 3 | 100% | 1.00 | 14034→14034 | 0.0 | 14750 | 0 | 63 | $0.0375 | 0.0 | 1.0 | — |
+| compression-keep-0 | 3 | 100% | 1.00 | 14034→2277 | 1.0 | 7692 | 4931 | 187 | $0.00976 | 1.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 3 | 100% | 1.00 | 14034→2405 | 1.0 | 3930 | 1129 | 86 | $0.00809 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 3 | 100% | 1.00 | 14034→2405 | 1.0 | 3934 | 1129 | 76 | $0.00800 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.02775 (-74%) — 95% CI [$-0.02786, $-0.02755]
+- input tokens per conversation: ▼ -7058 (-48%) — 95% CI [-7065, -7050]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0278 saved per conversation
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.02942 (-78%) — 95% CI [$-0.02948, $-0.02931]
+- input tokens per conversation: ▼ -10820 (-73%) — 95% CI [-10824, -10816]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0294 saved per conversation
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▼ $-0.02951 (-79%) — 95% CI [$-0.02977, $-0.02934]
+- input tokens per conversation: ▼ -10816 (-73%) — 95% CI [-10821, -10811]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0295 saved per conversation
+
+## compression-recent-assistant
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 3 | 100% | 1.00 | 13248→13248 | 0.0 | 13498 | 8997 | 10 | $0.0132 | 0.0 | 1.0 | — |
+| compression-keep-0 | 3 | 100% | 1.00 | 13248→1081 | 1.0 | 5020 | 3587 | 137 | $0.00567 | 1.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 3 | 100% | 1.00 | 13248→1154 | 1.0 | 3374 | 1956 | 138 | $0.00531 | 0.3 | 1.0 | — |
+| compression-prefetch-keep-1 | 3 | 100% | 1.00 | 13248→13248 | 0.0 | 38988 | 34327 | 532 | $0.0238 | 1.7 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00748 (-57%) — not separable at this sample size — 95% CI [$-0.02817, $0.00287] includes 0
+- input tokens per conversation: ▼ -8478 (-63%) — 95% CI [-8478, -8478]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00748 saved per conversation
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00784 (-60%) — not separable at this sample size — 95% CI [$-0.02828, $0.00358] includes 0
+- input tokens per conversation: ▼ -10124 (-75%) — 95% CI [-11015, -8342]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00784 saved per conversation
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▲ $0.0107 (+81%) — not separable at this sample size — 95% CI [$-0.01001, $0.0279] includes 0
+- input tokens per conversation: ▲ 25490 (+189%) — 95% CI [980, 45193]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.0107 more per conversation, before its $0 of indexing
+
+## compression-far-tool-output
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 3 | 100% | 1.00 | 16593→16593 | 0.0 | 17559 | 11705 | 11 | $0.0171 | 0.0 | 1.0 | — |
+| compression-keep-0 | 3 | 100% | 1.00 | 16593→5453 | 1.0 | 14425 | 8292 | 157 | $0.0186 | 1.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 3 | 100% | 1.00 | 16593→5511 | 1.0 | 7180 | 1129 | 26 | $0.0156 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 3 | 100% | 1.00 | 16593→5511 | 1.0 | 7180 | 1129 | 26 | $0.0156 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▲ $0.00147 (+9%) — not separable at this sample size — 95% CI [$-0.02545, $0.0150] includes 0
+- input tokens per conversation: ▼ -3134 (-18%) — 95% CI [-3137, -3133]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00147 more per conversation, before its $0 of indexing
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00147 (-9%) — not separable at this sample size — 95% CI [$-0.02839, $0.0121] includes 0
+- input tokens per conversation: ▼ -10379 (-59%) — 95% CI [-10379, -10379]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00147 saved per conversation
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▼ $-0.00147 (-9%) — not separable at this sample size — 95% CI [$-0.02837, $0.0121] includes 0
+- input tokens per conversation: ▼ -10379 (-59%) — 95% CI [-10379, -10379]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00147 saved per conversation
+
+## compression-irrelevant-old-bulk
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 3 | 100% | 1.00 | 16377→16377 | 0.0 | 17188 | 11457 | 863 | $0.0252 | 0.0 | 1.0 | — |
+| compression-keep-0 | 3 | 100% | 1.00 | 16377→4729 | 1.0 | 15158 | 9663 | 290 | $0.0186 | 1.3 | 1.0 | — |
+| compression-prefetch-keep-0 | 3 | 100% | 1.00 | 16377→4794 | 1.0 | 13078 | 7521 | 208 | $0.0175 | 1.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 3 | 100% | 1.00 | 16377→4794 | 1.0 | 13077 | 7521 | 357 | $0.0190 | 1.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00668 (-26%) — not separable at this sample size — 95% CI [$-0.02837, $0.00868] includes 0
+- input tokens per conversation: ▼ -2030 (-12%) — not separable at this sample size — 95% CI [-4232, 2373] includes 0
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00668 saved per conversation
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00777 (-31%) — not separable at this sample size — 95% CI [$-0.02944, $0.00759] includes 0
+- input tokens per conversation: ▼ -4110 (-24%) — 95% CI [-4110, -4109]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00777 saved per conversation
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▼ $-0.00628 (-25%) — not separable at this sample size — 95% CI [$-0.02755, $0.00908] includes 0
+- input tokens per conversation: ▼ -4111 (-24%) — 95% CI [-4114, -4109]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00628 saved per conversation
+
+## compression-mixed-depth
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 3 | 100% | 1.00 | 21958→21958 | 0.0 | 22678 | 0 | 47 | $0.0572 | 0.0 | 1.0 | — |
+| compression-keep-0 | 3 | 100% | 1.00 | 21958→2745 | 2.0 | 9015 | 5478 | 254 | $0.0125 | 2.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 3 | 100% | 1.00 | 21958→2938 | 2.0 | 4576 | 1129 | 47 | $0.00931 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 3 | 100% | 1.00 | 21958→14524 | 1.0 | 16384 | 1129 | 67 | $0.0390 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.04469 (-78%) — 95% CI [$-0.04488, $-0.04444]
+- input tokens per conversation: ▼ -13663 (-60%) — 95% CI [-13673, -13652]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0447 saved per conversation
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.04786 (-84%) — 95% CI [$-0.04812, $-0.04760]
+- input tokens per conversation: ▼ -18102 (-80%) — 95% CI [-18107, -18097]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0479 saved per conversation
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▼ $-0.01814 (-32%) — 95% CI [$-0.01833, $-0.01789]
+- input tokens per conversation: ▼ -6294 (-28%) — 95% CI [-6300, -6288]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0181 saved per conversation

--- a/docs/eval-results/context-compression-prefetch-claude-sonnet-latest-2026-09-10.runs.json
+++ b/docs/eval-results/context-compression-prefetch-claude-sonnet-latest-2026-09-10.runs.json
@@ -1,0 +1,4736 @@
+{
+  "version": 1,
+  "createdAt": "2026-09-10T07:29:07.523Z",
+  "metadata": {
+    "gitRevision": "e8c21f8736312cb066790ca6d76020fd96639c58",
+    "gitDirty": true,
+    "provider": "anthropic",
+    "assistantModel": "claude-sonnet-latest",
+    "userModel": "claude-sonnet-latest",
+    "baselineArm": "compression-off",
+    "arms": [
+      "compression-off",
+      "compression-keep-0",
+      "compression-prefetch-keep-0",
+      "compression-prefetch-keep-1"
+    ],
+    "scenarios": [
+      "compression-recent-attachment",
+      "compression-middle-attachment",
+      "compression-recent-assistant",
+      "compression-far-tool-output",
+      "compression-irrelevant-old-bulk",
+      "compression-mixed-depth"
+    ],
+    "repeat": 3,
+    "suite": "context-compression"
+  },
+  "runs": [
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13639,
+          "outputTokens": 10,
+          "totalTokens": 13649,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 13637
+          },
+          "toolCalls": [],
+          "latencyMs": 1583
+        }
+      ],
+      "totals": {
+        "inputTokens": 13639,
+        "outputTokens": 10,
+        "totalTokens": 13649,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1709,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 13637
+        },
+        "costUsd": 0.0341965
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 13173,
+        "estimatedHistoryTokensAfter": 13173,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13635,
+          "outputTokens": 10,
+          "totalTokens": 13645,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 13633
+          },
+          "toolCalls": [],
+          "latencyMs": 1384
+        }
+      ],
+      "totals": {
+        "inputTokens": 13635,
+        "outputTokens": 10,
+        "totalTokens": 13645,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1542,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 13633
+        },
+        "costUsd": 0.0341865
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 13173,
+        "estimatedHistoryTokensAfter": 13173,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13639,
+          "outputTokens": 10,
+          "totalTokens": 13649,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 13637
+          },
+          "toolCalls": [],
+          "latencyMs": 1383
+        }
+      ],
+      "totals": {
+        "inputTokens": 13639,
+        "outputTokens": 10,
+        "totalTokens": 13649,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1578,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 13637
+        },
+        "costUsd": 0.0341965
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 13173,
+        "estimatedHistoryTokensAfter": 13173,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 5454,
+          "outputTokens": 140,
+          "totalTokens": 5594,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 2639,
+            "cacheWriteTokens": 2811
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3727
+        }
+      ],
+      "totals": {
+        "inputTokens": 5454,
+        "outputTokens": 140,
+        "totalTokens": 5594,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4046,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 2639,
+          "cacheWriteTokens": 2811
+        },
+        "costUsd": 0.008963299999999999
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13173,
+        "estimatedHistoryTokensAfter": 1230,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 5448,
+          "outputTokens": 124,
+          "totalTokens": 5572,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 3806,
+            "cacheWriteTokens": 1638
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3823
+        }
+      ],
+      "totals": {
+        "inputTokens": 5448,
+        "outputTokens": 124,
+        "totalTokens": 5572,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4128,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 3806,
+          "cacheWriteTokens": 1638
+        },
+        "costUsd": 0.0061042
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13173,
+        "estimatedHistoryTokensAfter": 1230,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "The final release authorization code is **ORCHID-7419**.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 5448,
+          "outputTokens": 144,
+          "totalTokens": 5592,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 3806,
+            "cacheWriteTokens": 1638
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 4039
+        }
+      ],
+      "totals": {
+        "inputTokens": 5448,
+        "outputTokens": 144,
+        "totalTokens": 5592,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4285,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 3806,
+          "cacheWriteTokens": 1638
+        },
+        "costUsd": 0.006304199999999999
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13173,
+        "estimatedHistoryTokensAfter": 1230,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2809,
+          "outputTokens": 10,
+          "totalTokens": 2819,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 2807
+          },
+          "toolCalls": [],
+          "latencyMs": 1774
+        }
+      ],
+      "totals": {
+        "inputTokens": 2809,
+        "outputTokens": 10,
+        "totalTokens": 2819,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1932,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 2807
+        },
+        "costUsd": 0.0071215
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13173,
+        "estimatedHistoryTokensAfter": 1363,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2811,
+          "outputTokens": 10,
+          "totalTokens": 2821,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 1680
+          },
+          "toolCalls": [],
+          "latencyMs": 1869
+        }
+      ],
+      "totals": {
+        "inputTokens": 2811,
+        "outputTokens": 10,
+        "totalTokens": 2821,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2061,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 1680
+        },
+        "costUsd": 0.0045298000000000005
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13173,
+        "estimatedHistoryTokensAfter": 1363,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2811,
+          "outputTokens": 10,
+          "totalTokens": 2821,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 1680
+          },
+          "toolCalls": [],
+          "latencyMs": 2258
+        }
+      ],
+      "totals": {
+        "inputTokens": 2811,
+        "outputTokens": 10,
+        "totalTokens": 2821,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 3889,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 1680
+        },
+        "costUsd": 0.0045298000000000005
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13173,
+        "estimatedHistoryTokensAfter": 1363,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 14617,
+          "outputTokens": 79,
+          "totalTokens": 14696,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 13486
+          },
+          "toolCalls": [],
+          "latencyMs": 2640
+        }
+      ],
+      "totals": {
+        "inputTokens": 14617,
+        "outputTokens": 79,
+        "totalTokens": 14696,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2833,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 13486
+        },
+        "costUsd": 0.0347348
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13173,
+        "estimatedHistoryTokensAfter": 13173,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 14621,
+          "outputTokens": 10,
+          "totalTokens": 14631,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 13490
+          },
+          "toolCalls": [],
+          "latencyMs": 1817
+        }
+      ],
+      "totals": {
+        "inputTokens": 14621,
+        "outputTokens": 10,
+        "totalTokens": 14631,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2051,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 13490
+        },
+        "costUsd": 0.0340548
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13173,
+        "estimatedHistoryTokensAfter": 13173,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 14615,
+          "outputTokens": 10,
+          "totalTokens": 14625,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 13484
+          },
+          "toolCalls": [],
+          "latencyMs": 1810
+        }
+      ],
+      "totals": {
+        "inputTokens": 14615,
+        "outputTokens": 10,
+        "totalTokens": 14625,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1989,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 13484
+        },
+        "costUsd": 0.0340398
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13173,
+        "estimatedHistoryTokensAfter": 13173,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date, per the authoritative final record in transition-calendar.txt, is **17 November 2027**. Earlier planning dates in that document are explicitly superseded by this date.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 14752,
+          "outputTokens": 62,
+          "totalTokens": 14814,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 14750
+          },
+          "toolCalls": [],
+          "latencyMs": 1963
+        }
+      ],
+      "totals": {
+        "inputTokens": 14752,
+        "outputTokens": 62,
+        "totalTokens": 14814,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2108,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 14750
+        },
+        "costUsd": 0.037499
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 14034,
+        "estimatedHistoryTokensAfter": 14034,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is **17 November 2027**, as stated in the \"Authoritative final record\" section of transition-calendar.txt. That document also notes that earlier planning dates are superseded by this date.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 14746,
+          "outputTokens": 66,
+          "totalTokens": 14812,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 14744
+          },
+          "toolCalls": [],
+          "latencyMs": 2054
+        }
+      ],
+      "totals": {
+        "inputTokens": 14746,
+        "outputTokens": 66,
+        "totalTokens": 14812,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2201,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 14744
+        },
+        "costUsd": 0.037524
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 14034,
+        "estimatedHistoryTokensAfter": 14034,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the authoritative final record in transition-calendar.txt, the approved production transition date is **17 November 2027**. Earlier planning dates in that document are explicitly superseded by this date.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 14752,
+          "outputTokens": 62,
+          "totalTokens": 14814,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 14750
+          },
+          "toolCalls": [],
+          "latencyMs": 1803
+        }
+      ],
+      "totals": {
+        "inputTokens": 14752,
+        "outputTokens": 62,
+        "totalTokens": 14814,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1978,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 14750
+        },
+        "costUsd": 0.037499
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 14034,
+        "estimatedHistoryTokensAfter": 14034,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved transition calendar (transition-calendar.txt), the exact production transition date is **17 November 2027**. Note: the document states this supersedes any earlier planning dates.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7695,
+          "outputTokens": 207,
+          "totalTokens": 7902,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 4932,
+            "cacheWriteTokens": 2759
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 5680
+        }
+      ],
+      "totals": {
+        "inputTokens": 7695,
+        "outputTokens": 207,
+        "totalTokens": 7902,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 5878,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 4932,
+          "cacheWriteTokens": 2759
+        },
+        "costUsd": 0.0099619
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 14034,
+        "estimatedHistoryTokensAfter": 2277,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved transition calendar (transition-calendar.txt), the exact production transition date is **17 November 2027**. Note that this supersedes any earlier planning dates.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7683,
+          "outputTokens": 178,
+          "totalTokens": 7861,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 4928,
+            "cacheWriteTokens": 2751
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 4676
+        }
+      ],
+      "totals": {
+        "inputTokens": 7683,
+        "outputTokens": 178,
+        "totalTokens": 7861,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4866,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 4928,
+          "cacheWriteTokens": 2751
+        },
+        "costUsd": 0.009651100000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 14034,
+        "estimatedHistoryTokensAfter": 2277,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in **transition-calendar.txt**, the exact production transition date is **17 November 2027**. This supersedes any earlier planning dates.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7699,
+          "outputTokens": 176,
+          "totalTokens": 7875,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 4934,
+            "cacheWriteTokens": 2761
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 4724
+        }
+      ],
+      "totals": {
+        "inputTokens": 7699,
+        "outputTokens": 176,
+        "totalTokens": 7875,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4941,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 4934,
+          "cacheWriteTokens": 2761
+        },
+        "costUsd": 0.009657299999999999
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 14034,
+        "estimatedHistoryTokensAfter": 2277,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved transition calendar (transition-calendar.txt), the exact approved production transition date is **17 November 2027**. Earlier planning dates are superseded by this record.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3931,
+          "outputTokens": 97,
+          "totalTokens": 4028,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 2800
+          },
+          "toolCalls": [],
+          "latencyMs": 4487
+        }
+      ],
+      "totals": {
+        "inputTokens": 3931,
+        "outputTokens": 97,
+        "totalTokens": 4028,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 4654,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 2800
+        },
+        "costUsd": 0.008199799999999998
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 14034,
+        "estimatedHistoryTokensAfter": 2405,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved transition calendar (transition-calendar.txt), the approved production transition date is **17 November 2027**. Earlier planning dates are superseded.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3927,
+          "outputTokens": 81,
+          "totalTokens": 4008,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 2796
+          },
+          "toolCalls": [],
+          "latencyMs": 2461
+        }
+      ],
+      "totals": {
+        "inputTokens": 3927,
+        "outputTokens": 81,
+        "totalTokens": 4008,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2688,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 2796
+        },
+        "costUsd": 0.0080298
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 14034,
+        "estimatedHistoryTokensAfter": 2405,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved transition calendar (transition-calendar.txt), the exact production transition date is **17 November 2027**. Note: earlier planning dates are explicitly superseded by this approved date.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3931,
+          "outputTokens": 81,
+          "totalTokens": 4012,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 2800
+          },
+          "toolCalls": [],
+          "latencyMs": 2490
+        }
+      ],
+      "totals": {
+        "inputTokens": 3931,
+        "outputTokens": 81,
+        "totalTokens": 4012,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2685,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 2800
+        },
+        "costUsd": 0.0080398
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 14034,
+        "estimatedHistoryTokensAfter": 2405,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is **17 November 2027**, as stated in transition-calendar.txt — earlier planning dates are superseded by this figure.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3939,
+          "outputTokens": 49,
+          "totalTokens": 3988,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 2808
+          },
+          "toolCalls": [],
+          "latencyMs": 2459
+        }
+      ],
+      "totals": {
+        "inputTokens": 3939,
+        "outputTokens": 49,
+        "totalTokens": 3988,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2723,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 2808
+        },
+        "costUsd": 0.0077398
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 14034,
+        "estimatedHistoryTokensAfter": 2405,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved transition calendar (transition-calendar.txt), the approved production transition date is **17 November 2027**. Earlier planning dates are superseded by this record.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3931,
+          "outputTokens": 95,
+          "totalTokens": 4026,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 2800
+          },
+          "toolCalls": [],
+          "latencyMs": 2456
+        }
+      ],
+      "totals": {
+        "inputTokens": 3931,
+        "outputTokens": 95,
+        "totalTokens": 4026,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2618,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 2800
+        },
+        "costUsd": 0.008179800000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 14034,
+        "estimatedHistoryTokensAfter": 2405,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved transition calendar (transition-calendar.txt), the approved production transition date is **17 November 2027**. The document notes that earlier planning dates are superseded by this date.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3931,
+          "outputTokens": 84,
+          "totalTokens": 4015,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 2800
+          },
+          "toolCalls": [],
+          "latencyMs": 2209
+        }
+      ],
+      "totals": {
+        "inputTokens": 3931,
+        "outputTokens": 84,
+        "totalTokens": 4015,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2340,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 2800
+        },
+        "costUsd": 0.0080698
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 14034,
+        "estimatedHistoryTokensAfter": 2405,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13498,
+          "outputTokens": 10,
+          "totalTokens": 13508,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 13496
+          },
+          "toolCalls": [],
+          "latencyMs": 1509
+        }
+      ],
+      "totals": {
+        "inputTokens": 13498,
+        "outputTokens": 10,
+        "totalTokens": 13508,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1511,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 13496
+        },
+        "costUsd": 0.033844
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 13248,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13498,
+          "outputTokens": 10,
+          "totalTokens": 13508,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 13496,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1437
+        }
+      ],
+      "totals": {
+        "inputTokens": 13498,
+        "outputTokens": 10,
+        "totalTokens": 13508,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1439,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 13496,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0028032000000000005
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 13248,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13498,
+          "outputTokens": 10,
+          "totalTokens": 13508,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 13496,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1498
+        }
+      ],
+      "totals": {
+        "inputTokens": 13498,
+        "outputTokens": 10,
+        "totalTokens": 13508,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1499,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 13496,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0028032000000000005
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 13248,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 5020,
+          "outputTokens": 136,
+          "totalTokens": 5156,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 3587,
+            "cacheWriteTokens": 1429
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 4008
+        }
+      ],
+      "totals": {
+        "inputTokens": 5020,
+        "outputTokens": 136,
+        "totalTokens": 5156,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4035,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 3587,
+          "cacheWriteTokens": 1429
+        },
+        "costUsd": 0.0056578999999999996
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 1081,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 5020,
+          "outputTokens": 138,
+          "totalTokens": 5158,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 3587,
+            "cacheWriteTokens": 1429
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3517
+        }
+      ],
+      "totals": {
+        "inputTokens": 5020,
+        "outputTokens": 138,
+        "totalTokens": 5158,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3587,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 3587,
+          "cacheWriteTokens": 1429
+        },
+        "costUsd": 0.0056779
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 1081,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 5020,
+          "outputTokens": 137,
+          "totalTokens": 5157,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 3587,
+            "cacheWriteTokens": 1429
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 6037
+        }
+      ],
+      "totals": {
+        "inputTokens": 5020,
+        "outputTokens": 137,
+        "totalTokens": 5157,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 6093,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 3587,
+          "cacheWriteTokens": 1429
+        },
+        "costUsd": 0.0056679
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 1081,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2483,
+          "outputTokens": 114,
+          "totalTokens": 2597,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 1352
+          },
+          "toolCalls": [],
+          "latencyMs": 2880
+        }
+      ],
+      "totals": {
+        "inputTokens": 2483,
+        "outputTokens": 114,
+        "totalTokens": 2597,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2949,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 1352
+        },
+        "costUsd": 0.0047498
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 1154,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 5156,
+          "outputTokens": 262,
+          "totalTokens": 5418,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 3610,
+            "cacheWriteTokens": 1542
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 5300
+        }
+      ],
+      "totals": {
+        "inputTokens": 5156,
+        "outputTokens": 262,
+        "totalTokens": 5418,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 5343,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 3610,
+          "cacheWriteTokens": 1542
+        },
+        "costUsd": 0.007205
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 1154,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2483,
+          "outputTokens": 37,
+          "totalTokens": 2520,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 1352
+          },
+          "toolCalls": [],
+          "latencyMs": 2161
+        }
+      ],
+      "totals": {
+        "inputTokens": 2483,
+        "outputTokens": 37,
+        "totalTokens": 2520,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2225,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 1352
+        },
+        "costUsd": 0.0039798
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 1154,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 14478,
+          "outputTokens": 194,
+          "totalTokens": 14672,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 13347
+          },
+          "toolCalls": [],
+          "latencyMs": 4435
+        }
+      ],
+      "totals": {
+        "inputTokens": 14478,
+        "outputTokens": 194,
+        "totalTokens": 14672,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 4440,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 13347
+        },
+        "costUsd": 0.0355373
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 13248,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__get_message"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 43795,
+          "outputTokens": 571,
+          "totalTokens": 44366,
+          "inputTokenDetails": {
+            "noCacheTokens": 6,
+            "cacheReadTokens": 43554,
+            "cacheWriteTokens": 235
+          },
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__get_message"
+          ],
+          "latencyMs": 12784
+        }
+      ],
+      "totals": {
+        "inputTokens": 43795,
+        "outputTokens": 571,
+        "totalTokens": 44366,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 12788,
+        "inputTokenDetails": {
+          "noCacheTokens": 6,
+          "cacheReadTokens": 43554,
+          "cacheWriteTokens": 235
+        },
+        "costUsd": 0.0150203
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 13248,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__get_message",
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 58691,
+          "outputTokens": 832,
+          "totalTokens": 59523,
+          "inputTokenDetails": {
+            "noCacheTokens": 8,
+            "cacheReadTokens": 58299,
+            "cacheWriteTokens": 384
+          },
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__get_message",
+            "context-retrieve__search"
+          ],
+          "latencyMs": 20509
+        }
+      ],
+      "totals": {
+        "inputTokens": 58691,
+        "outputTokens": 832,
+        "totalTokens": 59523,
+        "turns": 1,
+        "toolCalls": 3,
+        "wallMs": 20511,
+        "inputTokenDetails": {
+          "noCacheTokens": 8,
+          "cacheReadTokens": 58299,
+          "cacheWriteTokens": 384
+        },
+        "costUsd": 0.020955800000000004
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 13248,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 17559,
+          "outputTokens": 11,
+          "totalTokens": 17570,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 17557
+          },
+          "toolCalls": [],
+          "latencyMs": 1519
+        }
+      ],
+      "totals": {
+        "inputTokens": 17559,
+        "outputTokens": 11,
+        "totalTokens": 17570,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1521,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 17557
+        },
+        "costUsd": 0.0440065
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 16593,
+        "estimatedHistoryTokensAfter": 16593,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 17559,
+          "outputTokens": 11,
+          "totalTokens": 17570,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 17557,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1536
+        }
+      ],
+      "totals": {
+        "inputTokens": 17559,
+        "outputTokens": 11,
+        "totalTokens": 17570,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1538,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 17557,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0036254
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 16593,
+        "estimatedHistoryTokensAfter": 16593,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 17559,
+          "outputTokens": 11,
+          "totalTokens": 17570,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 17557,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1438
+        }
+      ],
+      "totals": {
+        "inputTokens": 17559,
+        "outputTokens": 11,
+        "totalTokens": 17570,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1441,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 17557,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0036254
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 16593,
+        "estimatedHistoryTokensAfter": 16593,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 14422,
+          "outputTokens": 155,
+          "totalTokens": 14577,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 8292,
+            "cacheWriteTokens": 6126
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 5336
+        }
+      ],
+      "totals": {
+        "inputTokens": 14422,
+        "outputTokens": 155,
+        "totalTokens": 14577,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 5417,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 8292,
+          "cacheWriteTokens": 6126
+        },
+        "costUsd": 0.0185314
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16593,
+        "estimatedHistoryTokensAfter": 5453,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 14426,
+          "outputTokens": 152,
+          "totalTokens": 14578,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 8292,
+            "cacheWriteTokens": 6130
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 6903
+        }
+      ],
+      "totals": {
+        "inputTokens": 14426,
+        "outputTokens": 152,
+        "totalTokens": 14578,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 6944,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 8292,
+          "cacheWriteTokens": 6130
+        },
+        "costUsd": 0.0185114
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16593,
+        "estimatedHistoryTokensAfter": 5453,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 14426,
+          "outputTokens": 163,
+          "totalTokens": 14589,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 8292,
+            "cacheWriteTokens": 6130
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 8524
+        }
+      ],
+      "totals": {
+        "inputTokens": 14426,
+        "outputTokens": 163,
+        "totalTokens": 14589,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 8607,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 8292,
+          "cacheWriteTokens": 6130
+        },
+        "costUsd": 0.0186214
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16593,
+        "estimatedHistoryTokensAfter": 5453,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7180,
+          "outputTokens": 56,
+          "totalTokens": 7236,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 6049
+          },
+          "toolCalls": [],
+          "latencyMs": 3245
+        }
+      ],
+      "totals": {
+        "inputTokens": 7180,
+        "outputTokens": 56,
+        "totalTokens": 7236,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 3316,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 6049
+        },
+        "costUsd": 0.0159123
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16593,
+        "estimatedHistoryTokensAfter": 5511,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7180,
+          "outputTokens": 11,
+          "totalTokens": 7191,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 6049
+          },
+          "toolCalls": [],
+          "latencyMs": 2210
+        }
+      ],
+      "totals": {
+        "inputTokens": 7180,
+        "outputTokens": 11,
+        "totalTokens": 7191,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2298,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 6049
+        },
+        "costUsd": 0.0154623
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16593,
+        "estimatedHistoryTokensAfter": 5511,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7180,
+          "outputTokens": 11,
+          "totalTokens": 7191,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 6049
+          },
+          "toolCalls": [],
+          "latencyMs": 2286
+        }
+      ],
+      "totals": {
+        "inputTokens": 7180,
+        "outputTokens": 11,
+        "totalTokens": 7191,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2370,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 6049
+        },
+        "costUsd": 0.0154623
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16593,
+        "estimatedHistoryTokensAfter": 5511,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7180,
+          "outputTokens": 37,
+          "totalTokens": 7217,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 6049
+          },
+          "toolCalls": [],
+          "latencyMs": 2822
+        }
+      ],
+      "totals": {
+        "inputTokens": 7180,
+        "outputTokens": 37,
+        "totalTokens": 7217,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2942,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 6049
+        },
+        "costUsd": 0.015722299999999998
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16593,
+        "estimatedHistoryTokensAfter": 5511,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7180,
+          "outputTokens": 31,
+          "totalTokens": 7211,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 6049
+          },
+          "toolCalls": [],
+          "latencyMs": 2493
+        }
+      ],
+      "totals": {
+        "inputTokens": 7180,
+        "outputTokens": 31,
+        "totalTokens": 7211,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2550,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 6049
+        },
+        "costUsd": 0.0156623
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16593,
+        "estimatedHistoryTokensAfter": 5511,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7180,
+          "outputTokens": 11,
+          "totalTokens": 7191,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 6049
+          },
+          "toolCalls": [],
+          "latencyMs": 2155
+        }
+      ],
+      "totals": {
+        "inputTokens": 7180,
+        "outputTokens": 11,
+        "totalTokens": 7191,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2244,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 6049
+        },
+        "costUsd": 0.0154623
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16593,
+        "estimatedHistoryTokensAfter": 5511,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "I don't have a verified source for that. The earlier \"Falcon Desk\" answer wasn't drawn from any retrieved document, so I can't confirm it as accurate. I'd need to check an actual escalation routing document to give you a reliable name—do you want me to look one up?",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 17188,
+          "outputTokens": 397,
+          "totalTokens": 17585,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 17186
+          },
+          "toolCalls": [],
+          "latencyMs": 5686
+        }
+      ],
+      "totals": {
+        "inputTokens": 17188,
+        "outputTokens": 397,
+        "totalTokens": 17585,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 5688,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 17186
+        },
+        "costUsd": 0.046939
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 16377,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "I can’t confirm that from any document. The earlier mention of “Falcon Desk” wasn’t attributed to a specific source, and the archived observability export explicitly notes it is unrelated to current escalation routing. If you have a document that defines the current escalation channel, please point me to it and I’ll verify the name from there.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 17188,
+          "outputTokens": 1547,
+          "totalTokens": 18735,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 17186,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 19340
+        }
+      ],
+      "totals": {
+        "inputTokens": 17188,
+        "outputTokens": 1547,
+        "totalTokens": 18735,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 19343,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 17186,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0189112
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 16377,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "I don't have a verified source for that. The earlier mention of \"Falcon Desk\" wasn't drawn from any document I have access to — the archived telemetry export explicitly states it is \"unrelated to current escalation routing,\" and no other document in this conversation specifies an escalation channel. I don't want to restate an unverified name as fact.\n\nCould you point me to the specific document that defines the current escalation channel, or would you like me to search for one?",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 17188,
+          "outputTokens": 644,
+          "totalTokens": 17832,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 17186,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 8676
+        }
+      ],
+      "totals": {
+        "inputTokens": 17188,
+        "outputTokens": 644,
+        "totalTokens": 17832,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 8678,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 17186,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.009881200000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 16377,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12956,
+          "outputTokens": 200,
+          "totalTokens": 13156,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 7506,
+            "cacheWriteTokens": 5446
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 5413
+        }
+      ],
+      "totals": {
+        "inputTokens": 12956,
+        "outputTokens": 200,
+        "totalTokens": 13156,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 5491,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 7506,
+          "cacheWriteTokens": 5446
+        },
+        "costUsd": 0.0171242
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 4729,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 19561,
+          "outputTokens": 468,
+          "totalTokens": 20029,
+          "inputTokenDetails": {
+            "noCacheTokens": 6,
+            "cacheReadTokens": 13976,
+            "cacheWriteTokens": 5579
+          },
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ],
+          "latencyMs": 11257
+        }
+      ],
+      "totals": {
+        "inputTokens": 19561,
+        "outputTokens": 468,
+        "totalTokens": 20029,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 11334,
+        "inputTokenDetails": {
+          "noCacheTokens": 6,
+          "cacheReadTokens": 13976,
+          "cacheWriteTokens": 5579
+        },
+        "costUsd": 0.0214347
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 4729,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12957,
+          "outputTokens": 201,
+          "totalTokens": 13158,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 7506,
+            "cacheWriteTokens": 5447
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 5661
+        }
+      ],
+      "totals": {
+        "inputTokens": 12957,
+        "outputTokens": 201,
+        "totalTokens": 13158,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 5679,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 7506,
+          "cacheWriteTokens": 5447
+        },
+        "costUsd": 0.0171367
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 4729,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13078,
+          "outputTokens": 260,
+          "totalTokens": 13338,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 7521,
+            "cacheWriteTokens": 5553
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 4081
+        }
+      ],
+      "totals": {
+        "inputTokens": 13078,
+        "outputTokens": 260,
+        "totalTokens": 13338,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4108,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 7521,
+          "cacheWriteTokens": 5553
+        },
+        "costUsd": 0.017994700000000002
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 4794,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13078,
+          "outputTokens": 186,
+          "totalTokens": 13264,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 7521,
+            "cacheWriteTokens": 5553
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3430
+        }
+      ],
+      "totals": {
+        "inputTokens": 13078,
+        "outputTokens": 186,
+        "totalTokens": 13264,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3534,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 7521,
+          "cacheWriteTokens": 5553
+        },
+        "costUsd": 0.0172547
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 4794,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13079,
+          "outputTokens": 178,
+          "totalTokens": 13257,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 7521,
+            "cacheWriteTokens": 5554
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3209
+        }
+      ],
+      "totals": {
+        "inputTokens": 13079,
+        "outputTokens": 178,
+        "totalTokens": 13257,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3282,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 7521,
+          "cacheWriteTokens": 5554
+        },
+        "costUsd": 0.0171772
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 4794,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13078,
+          "outputTokens": 360,
+          "totalTokens": 13438,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 7521,
+            "cacheWriteTokens": 5553
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 5613
+        }
+      ],
+      "totals": {
+        "inputTokens": 13078,
+        "outputTokens": 360,
+        "totalTokens": 13438,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 5665,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 7521,
+          "cacheWriteTokens": 5553
+        },
+        "costUsd": 0.0189947
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 4794,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13074,
+          "outputTokens": 488,
+          "totalTokens": 13562,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 7521,
+            "cacheWriteTokens": 5549
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 8297
+        }
+      ],
+      "totals": {
+        "inputTokens": 13074,
+        "outputTokens": 488,
+        "totalTokens": 13562,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 8362,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 7521,
+          "cacheWriteTokens": 5549
+        },
+        "costUsd": 0.0202647
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 4794,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13079,
+          "outputTokens": 223,
+          "totalTokens": 13302,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 7521,
+            "cacheWriteTokens": 5554
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3539
+        }
+      ],
+      "totals": {
+        "inputTokens": 13079,
+        "outputTokens": 223,
+        "totalTokens": 13302,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3615,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 7521,
+          "cacheWriteTokens": 5554
+        },
+        "costUsd": 0.0176272
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 4794,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83; 14 business days from verified incident closure.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 22683,
+          "outputTokens": 60,
+          "totalTokens": 22743,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 22681
+          },
+          "toolCalls": [],
+          "latencyMs": 3318
+        }
+      ],
+      "totals": {
+        "inputTokens": 22683,
+        "outputTokens": 60,
+        "totalTokens": 22743,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 3542,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 22681
+        },
+        "costUsd": 0.0573065
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 21958,
+        "estimatedHistoryTokensAfter": 21958,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83; 14 business days from verified incident closure.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 22677,
+          "outputTokens": 58,
+          "totalTokens": 22735,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 22675
+          },
+          "toolCalls": [],
+          "latencyMs": 3448
+        }
+      ],
+      "totals": {
+        "inputTokens": 22677,
+        "outputTokens": 58,
+        "totalTokens": 22735,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 3601,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 22675
+        },
+        "costUsd": 0.0572715
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 21958,
+        "estimatedHistoryTokensAfter": 21958,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83; 14 business days from verified incident closure.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 22675,
+          "outputTokens": 23,
+          "totalTokens": 22698,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 22673
+          },
+          "toolCalls": [],
+          "latencyMs": 3471
+        }
+      ],
+      "totals": {
+        "inputTokens": 22675,
+        "outputTokens": 23,
+        "totalTokens": 22698,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 3584,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 22673
+        },
+        "costUsd": 0.0569165
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 21958,
+        "estimatedHistoryTokensAfter": 21958,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83\n14 business days from verified incident closure",
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9026,
+          "outputTokens": 240,
+          "totalTokens": 9266,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 5482,
+            "cacheWriteTokens": 3540
+          },
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ],
+          "latencyMs": 5953
+        }
+      ],
+      "totals": {
+        "inputTokens": 9026,
+        "outputTokens": 240,
+        "totalTokens": 9266,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 6194,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 5482,
+          "cacheWriteTokens": 3540
+        },
+        "costUsd": 0.0123544
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 21958,
+        "estimatedHistoryTokensAfter": 2745,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "- Active service registry identifier: LUMEN-83\n- Accepted restoration window: 14 business days from verified incident closure",
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9005,
+          "outputTokens": 262,
+          "totalTokens": 9267,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 5475,
+            "cacheWriteTokens": 3526
+          },
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ],
+          "latencyMs": 5856
+        }
+      ],
+      "totals": {
+        "inputTokens": 9005,
+        "outputTokens": 262,
+        "totalTokens": 9267,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 6070,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 5475,
+          "cacheWriteTokens": 3526
+        },
+        "costUsd": 0.012538
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 21958,
+        "estimatedHistoryTokensAfter": 2745,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83\n14 business days from verified incident closure",
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9014,
+          "outputTokens": 260,
+          "totalTokens": 9274,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 5478,
+            "cacheWriteTokens": 3532
+          },
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ],
+          "latencyMs": 7449
+        }
+      ],
+      "totals": {
+        "inputTokens": 9014,
+        "outputTokens": 260,
+        "totalTokens": 9274,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 7668,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 5478,
+          "cacheWriteTokens": 3532
+        },
+        "costUsd": 0.0125336
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 21958,
+        "estimatedHistoryTokensAfter": 2745,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83; 14 business days from verified incident closure.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4571,
+          "outputTokens": 23,
+          "totalTokens": 4594,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 3440
+          },
+          "toolCalls": [],
+          "latencyMs": 1461
+        }
+      ],
+      "totals": {
+        "inputTokens": 4571,
+        "outputTokens": 23,
+        "totalTokens": 4594,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1660,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 3440
+        },
+        "costUsd": 0.0090598
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 21958,
+        "estimatedHistoryTokensAfter": 2938,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83; 14 business days from verified incident closure.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4579,
+          "outputTokens": 60,
+          "totalTokens": 4639,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 3448
+          },
+          "toolCalls": [],
+          "latencyMs": 1884
+        }
+      ],
+      "totals": {
+        "inputTokens": 4579,
+        "outputTokens": 60,
+        "totalTokens": 4639,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2139,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 3448
+        },
+        "costUsd": 0.0094498
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 21958,
+        "estimatedHistoryTokensAfter": 2938,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83; 14 business days from verified incident closure.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4579,
+          "outputTokens": 57,
+          "totalTokens": 4636,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 3448
+          },
+          "toolCalls": [],
+          "latencyMs": 2021
+        }
+      ],
+      "totals": {
+        "inputTokens": 4579,
+        "outputTokens": 57,
+        "totalTokens": 4636,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2284,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 3448
+        },
+        "costUsd": 0.009419799999999999
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 21958,
+        "estimatedHistoryTokensAfter": 2938,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83; 14 business days from verified incident closure.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 16380,
+          "outputTokens": 67,
+          "totalTokens": 16447,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 15249
+          },
+          "toolCalls": [],
+          "latencyMs": 2597
+        }
+      ],
+      "totals": {
+        "inputTokens": 16380,
+        "outputTokens": 67,
+        "totalTokens": 16447,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2782,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 15249
+        },
+        "costUsd": 0.0390223
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 21958,
+        "estimatedHistoryTokensAfter": 14524,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83; 14 business days from verified incident closure.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 16390,
+          "outputTokens": 56,
+          "totalTokens": 16446,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 15259
+          },
+          "toolCalls": [],
+          "latencyMs": 2198
+        }
+      ],
+      "totals": {
+        "inputTokens": 16390,
+        "outputTokens": 56,
+        "totalTokens": 16446,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2406,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 15259
+        },
+        "costUsd": 0.0389373
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 21958,
+        "estimatedHistoryTokensAfter": 14524,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83; 14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 16382,
+          "outputTokens": 77,
+          "totalTokens": 16459,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1129,
+            "cacheWriteTokens": 15251
+          },
+          "toolCalls": [],
+          "latencyMs": 2359
+        }
+      ],
+      "totals": {
+        "inputTokens": 16382,
+        "outputTokens": 77,
+        "totalTokens": 16459,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2553,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1129,
+          "cacheWriteTokens": 15251
+        },
+        "costUsd": 0.039127300000000004
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 21958,
+        "estimatedHistoryTokensAfter": 14524,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    }
+  ]
+}

--- a/docs/eval-results/context-compression-prefetch-gpt-4.1-mini-2026-09-10.md
+++ b/docs/eval-results/context-compression-prefetch-gpt-4.1-mini-2026-09-10.md
@@ -1,0 +1,190 @@
+# Evaluation report
+
+## Overall
+
+| arm | runs | success | score | in tok | cache read | out tok | cost | tools |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 30 | 100% | 1.00 | 8977 | 4868 | 13 | $0.00215 | 0.0 |
+| compression-keep-0 | 30 | 100% | 1.00 | 4230 | 1677 | 58 | $0.00128 | 1.0 |
+| compression-prefetch-keep-0 | 30 | 100% | 1.00 | 2434 | 538 | 13 | $0.00083 | 0.0 |
+| compression-prefetch-keep-1 | 30 | 100% | 1.00 | 5606 | 1399 | 13 | $0.00184 | 0.0 |
+
+## compression-recent-attachment
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 5 | 100% | 1.00 | 7323→7323 | 0.0 | 7510 | 0 | 7 | $0.00302 | 0.0 | 1.0 | — |
+| compression-keep-0 | 5 | 100% | 1.00 | 7325→805 | 1.0 | 2766 | 1280 | 47 | $0.00080 | 1.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 5 | 100% | 1.00 | 7324→920 | 1.0 | 1448 | 0 | 8 | $0.00059 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 5 | 100% | 1.00 | 7325→7325 | 0.0 | 7859 | 0 | 8 | $0.00316 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00222 (-74%) — 95% CI [$-0.00222, $-0.00221]
+- input tokens per conversation: ▼ -4744 (-63%) — 95% CI [-4754, -4733]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00222 saved per conversation
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00242 (-80%) — 95% CI [$-0.00243, $-0.00242]
+- input tokens per conversation: ▼ -6062 (-81%) — 95% CI [-6068, -6056]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00242 saved per conversation
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▲ $0.00014 (+5%) — 95% CI [$0.00014, $0.00014]
+- input tokens per conversation: ▲ 349 (+5%) — 95% CI [346, 352]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00014 more per conversation, before its $0 of indexing
+
+## compression-middle-attachment
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 5 | 100% | 1.00 | 7637→7637 | 0.0 | 7844 | 0 | 28 | $0.00318 | 0.0 | 1.0 | — |
+| compression-keep-0 | 5 | 100% | 1.00 | 7635→1421 | 1.0 | 4036 | 1152 | 63 | $0.00137 | 1.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 5 | 100% | 1.00 | 7635→1522 | 1.0 | 2073 | 0 | 25 | $0.00087 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 5 | 100% | 1.00 | 7634→1520 | 1.0 | 2073 | 0 | 27 | $0.00087 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00181 (-57%) — 95% CI [$-0.00204, $-0.00158]
+- input tokens per conversation: ▼ -3808 (-49%) — 95% CI [-3818, -3800]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00181 saved per conversation
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00231 (-73%) — 95% CI [$-0.00232, $-0.00231]
+- input tokens per conversation: ▼ -5771 (-74%) — 95% CI [-5776, -5766]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00231 saved per conversation
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▼ $-0.00231 (-73%) — 95% CI [$-0.00231, $-0.00231]
+- input tokens per conversation: ▼ -5772 (-74%) — 95% CI [-5777, -5767]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00231 saved per conversation
+
+## compression-recent-assistant
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 5 | 100% | 1.00 | 6926→6926 | 0.0 | 7113 | 5530 | 5 | $0.00119 | 0.0 | 1.0 | — |
+| compression-keep-0 | 5 | 100% | 1.00 | 6926→670 | 1.0 | 2516 | 922 | 49 | $0.00081 | 1.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 5 | 100% | 1.00 | 6926→712 | 1.0 | 1254 | 0 | 6 | $0.00051 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 5 | 100% | 1.00 | 6926→6926 | 0.0 | 7462 | 5837 | 6 | $0.00124 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00039 (-32%) — not separable at this sample size — 95% CI [$-0.00121, $0.00010] includes 0
+- input tokens per conversation: ▼ -4597 (-65%) — 95% CI [-4598, -4596]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00039 saved per conversation
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00068 (-57%) — 95% CI [$-0.00151, $-0.00027]
+- input tokens per conversation: ▼ -5859 (-82%) — 95% CI [-5859, -5859]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00068 saved per conversation
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▲ $0.00005 (+4%) — not separable at this sample size — 95% CI [$-0.00080, $0.00095] includes 0
+- input tokens per conversation: ▲ 349 (+5%) — 95% CI [349, 349]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00005 more per conversation, before its $0 of indexing
+
+## compression-far-tool-output
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 5 | 100% | 1.00 | 9539→9539 | 0.0 | 9648 | 9472 | 8 | $0.00103 | 0.0 | 1.0 | — |
+| compression-keep-0 | 5 | 100% | 1.00 | 9539→3297 | 1.0 | 7892 | 4608 | 59 | $0.00187 | 1.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 5 | 100% | 1.00 | 9539→3330 | 1.0 | 3934 | 1536 | 9 | $0.00113 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 5 | 100% | 1.00 | 9539→3330 | 1.0 | 3934 | 1536 | 9 | $0.00113 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▲ $0.00084 (+81%) — 95% CI [$0.00014, $0.00154]
+- input tokens per conversation: ▼ -1756 (-18%) — 95% CI [-1756, -1756]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00084 more per conversation, before its $0 of indexing
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▲ $0.00010 (+9%) — not separable at this sample size — 95% CI [$-0.00036, $0.00056] includes 0
+- input tokens per conversation: ▼ -5714 (-59%) — 95% CI [-5714, -5714]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00010 more per conversation, before its $0 of indexing
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▲ $0.00010 (+9%) — not separable at this sample size — 95% CI [$-0.00036, $0.00056] includes 0
+- input tokens per conversation: ▼ -5714 (-59%) — 95% CI [-5714, -5714]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00010 more per conversation, before its $0 of indexing
+
+## compression-irrelevant-old-bulk
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 5 | 100% | 1.00 | 9234→9234 | 0.0 | 9329 | 9216 | 4 | $0.00097 | 0.0 | 1.0 | — |
+| compression-keep-0 | 5 | 100% | 1.00 | 9234→2864 | 1.0 | 3455 | 0 | 5 | $0.00139 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 5 | 100% | 1.00 | 9234→2897 | 1.0 | 3487 | 1331 | 5 | $0.00100 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 5 | 100% | 1.00 | 9234→2897 | 1.0 | 3487 | 666 | 5 | $0.00120 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▲ $0.00042 (+43%) — 95% CI [$0.00042, $0.00042]
+- input tokens per conversation: ▼ -5874 (-63%) — 95% CI [-5874, -5874]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00042 more per conversation, before its $0 of indexing
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▲ $0.00003 (+3%) — not separable at this sample size — 95% CI [$-0.00037, $0.00043] includes 0
+- input tokens per conversation: ▼ -5842 (-63%) — 95% CI [-5842, -5842]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00003 more per conversation, before its $0 of indexing
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▲ $0.00023 (+24%) — not separable at this sample size — 95% CI [$-0.00017, $0.00043] includes 0
+- input tokens per conversation: ▼ -5842 (-63%) — 95% CI [-5842, -5842]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00023 more per conversation, before its $0 of indexing
+
+## compression-mixed-depth
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 5 | 100% | 1.00 | 12220→12220 | 0.0 | 12417 | 4992 | 24 | $0.00351 | 0.0 | 1.0 | — |
+| compression-keep-0 | 5 | 100% | 1.00 | 12218→1728 | 2.0 | 4713 | 2099 | 123 | $0.00145 | 2.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 5 | 100% | 1.00 | 12219→1871 | 2.0 | 2410 | 358 | 25 | $0.00090 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 5 | 100% | 1.00 | 12219→8278 | 1.0 | 8824 | 358 | 26 | $0.00346 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00206 (-59%) — 95% CI [$-0.00240, $-0.00169]
+- input tokens per conversation: ▼ -7703 (-62%) — 95% CI [-7709, -7698]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00206 saved per conversation
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00261 (-74%) — 95% CI [$-0.00283, $-0.00250]
+- input tokens per conversation: ▼ -10007 (-81%) — 95% CI [-10013, -10000]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00261 saved per conversation
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▼ $-0.00004 (-1%) — not separable at this sample size — 95% CI [$-0.00026, $0.00006] includes 0
+- input tokens per conversation: ▼ -3593 (-29%) — 95% CI [-3596, -3590]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00004 saved per conversation

--- a/docs/eval-results/context-compression-prefetch-gpt-4.1-mini-2026-09-10.runs.json
+++ b/docs/eval-results/context-compression-prefetch-gpt-4.1-mini-2026-09-10.runs.json
@@ -1,0 +1,7780 @@
+{
+  "version": 1,
+  "createdAt": "2026-09-10T06:37:36.858Z",
+  "metadata": {
+    "gitRevision": "e8c21f8736312cb066790ca6d76020fd96639c58",
+    "gitDirty": true,
+    "provider": "openai",
+    "assistantModel": "gpt-4.1-mini",
+    "userModel": "gpt-4.1-mini",
+    "baselineArm": "compression-off",
+    "arms": [
+      "compression-off",
+      "compression-keep-0",
+      "compression-prefetch-keep-0",
+      "compression-prefetch-keep-1"
+    ],
+    "scenarios": [
+      "compression-recent-attachment",
+      "compression-middle-attachment",
+      "compression-recent-assistant",
+      "compression-far-tool-output",
+      "compression-irrelevant-old-bulk",
+      "compression-mixed-depth"
+    ],
+    "repeat": 5,
+    "suite": "context-compression"
+  },
+  "runs": [
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7510,
+          "outputTokens": 7,
+          "totalTokens": 7517,
+          "inputTokenDetails": {
+            "noCacheTokens": 7510,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 956
+        }
+      ],
+      "totals": {
+        "inputTokens": 7510,
+        "outputTokens": 7,
+        "totalTokens": 7517,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1343,
+        "inputTokenDetails": {
+          "noCacheTokens": 7510,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0030152
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7323,
+        "estimatedHistoryTokensAfter": 7323,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7510,
+          "outputTokens": 7,
+          "totalTokens": 7517,
+          "inputTokenDetails": {
+            "noCacheTokens": 7510,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 920
+        }
+      ],
+      "totals": {
+        "inputTokens": 7510,
+        "outputTokens": 7,
+        "totalTokens": 7517,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1045,
+        "inputTokenDetails": {
+          "noCacheTokens": 7510,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0030152
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7323,
+        "estimatedHistoryTokensAfter": 7323,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7510,
+          "outputTokens": 7,
+          "totalTokens": 7517,
+          "inputTokenDetails": {
+            "noCacheTokens": 7510,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1011
+        }
+      ],
+      "totals": {
+        "inputTokens": 7510,
+        "outputTokens": 7,
+        "totalTokens": 7517,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1123,
+        "inputTokenDetails": {
+          "noCacheTokens": 7510,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0030152
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 7325,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7512,
+          "outputTokens": 7,
+          "totalTokens": 7519,
+          "inputTokenDetails": {
+            "noCacheTokens": 7512,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 823
+        }
+      ],
+      "totals": {
+        "inputTokens": 7512,
+        "outputTokens": 7,
+        "totalTokens": 7519,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 934,
+        "inputTokenDetails": {
+          "noCacheTokens": 7512,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.003016
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 7325,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7506,
+          "outputTokens": 7,
+          "totalTokens": 7513,
+          "inputTokenDetails": {
+            "noCacheTokens": 7506,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1012
+        }
+      ],
+      "totals": {
+        "inputTokens": 7506,
+        "outputTokens": 7,
+        "totalTokens": 7513,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1115,
+        "inputTokenDetails": {
+          "noCacheTokens": 7506,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0030136
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7321,
+        "estimatedHistoryTokensAfter": 7321,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2761,
+          "outputTokens": 46,
+          "totalTokens": 2807,
+          "inputTokenDetails": {
+            "noCacheTokens": 1481,
+            "cacheReadTokens": 1280,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2846
+        }
+      ],
+      "totals": {
+        "inputTokens": 2761,
+        "outputTokens": 46,
+        "totalTokens": 2807,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2990,
+        "inputTokenDetails": {
+          "noCacheTokens": 1481,
+          "cacheReadTokens": 1280,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.000794
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 806,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2761,
+          "outputTokens": 46,
+          "totalTokens": 2807,
+          "inputTokenDetails": {
+            "noCacheTokens": 1481,
+            "cacheReadTokens": 1280,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2375
+        }
+      ],
+      "totals": {
+        "inputTokens": 2761,
+        "outputTokens": 46,
+        "totalTokens": 2807,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2504,
+        "inputTokenDetails": {
+          "noCacheTokens": 1481,
+          "cacheReadTokens": 1280,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.000794
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7323,
+        "estimatedHistoryTokensAfter": 803,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2785,
+          "outputTokens": 50,
+          "totalTokens": 2835,
+          "inputTokenDetails": {
+            "noCacheTokens": 1505,
+            "cacheReadTokens": 1280,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3994
+        }
+      ],
+      "totals": {
+        "inputTokens": 2785,
+        "outputTokens": 50,
+        "totalTokens": 2835,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4127,
+        "inputTokenDetails": {
+          "noCacheTokens": 1505,
+          "cacheReadTokens": 1280,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00081
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7331,
+        "estimatedHistoryTokensAfter": 812,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2749,
+          "outputTokens": 44,
+          "totalTokens": 2793,
+          "inputTokenDetails": {
+            "noCacheTokens": 1469,
+            "cacheReadTokens": 1280,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2002
+        }
+      ],
+      "totals": {
+        "inputTokens": 2749,
+        "outputTokens": 44,
+        "totalTokens": 2793,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2178,
+        "inputTokenDetails": {
+          "noCacheTokens": 1469,
+          "cacheReadTokens": 1280,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.000786
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7319,
+        "estimatedHistoryTokensAfter": 800,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2773,
+          "outputTokens": 48,
+          "totalTokens": 2821,
+          "inputTokenDetails": {
+            "noCacheTokens": 1493,
+            "cacheReadTokens": 1280,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3881
+        }
+      ],
+      "totals": {
+        "inputTokens": 2773,
+        "outputTokens": 48,
+        "totalTokens": 2821,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4023,
+        "inputTokenDetails": {
+          "noCacheTokens": 1493,
+          "cacheReadTokens": 1280,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.000802
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 806,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1458,
+          "outputTokens": 8,
+          "totalTokens": 1466,
+          "inputTokenDetails": {
+            "noCacheTokens": 1458,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 790
+        }
+      ],
+      "totals": {
+        "inputTokens": 1458,
+        "outputTokens": 8,
+        "totalTokens": 1466,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 963,
+        "inputTokenDetails": {
+          "noCacheTokens": 1458,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.000596
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 922,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1446,
+          "outputTokens": 8,
+          "totalTokens": 1454,
+          "inputTokenDetails": {
+            "noCacheTokens": 1446,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 826
+        }
+      ],
+      "totals": {
+        "inputTokens": 1446,
+        "outputTokens": 8,
+        "totalTokens": 1454,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1054,
+        "inputTokenDetails": {
+          "noCacheTokens": 1446,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0005912
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 922,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1438,
+          "outputTokens": 8,
+          "totalTokens": 1446,
+          "inputTokenDetails": {
+            "noCacheTokens": 1438,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 915
+        }
+      ],
+      "totals": {
+        "inputTokens": 1438,
+        "outputTokens": 8,
+        "totalTokens": 1446,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1057,
+        "inputTokenDetails": {
+          "noCacheTokens": 1438,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.000588
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7321,
+        "estimatedHistoryTokensAfter": 914,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1446,
+          "outputTokens": 8,
+          "totalTokens": 1454,
+          "inputTokenDetails": {
+            "noCacheTokens": 1446,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 939
+        }
+      ],
+      "totals": {
+        "inputTokens": 1446,
+        "outputTokens": 8,
+        "totalTokens": 1454,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1116,
+        "inputTokenDetails": {
+          "noCacheTokens": 1446,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0005912
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7323,
+        "estimatedHistoryTokensAfter": 918,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1450,
+          "outputTokens": 8,
+          "totalTokens": 1458,
+          "inputTokenDetails": {
+            "noCacheTokens": 1450,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 943
+        }
+      ],
+      "totals": {
+        "inputTokens": 1450,
+        "outputTokens": 8,
+        "totalTokens": 1458,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1171,
+        "inputTokenDetails": {
+          "noCacheTokens": 1450,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0005928
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 922,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7855,
+          "outputTokens": 8,
+          "totalTokens": 7863,
+          "inputTokenDetails": {
+            "noCacheTokens": 7855,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 957
+        }
+      ],
+      "totals": {
+        "inputTokens": 7855,
+        "outputTokens": 8,
+        "totalTokens": 7863,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1103,
+        "inputTokenDetails": {
+          "noCacheTokens": 7855,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031548
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7321,
+        "estimatedHistoryTokensAfter": 7321,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7861,
+          "outputTokens": 8,
+          "totalTokens": 7869,
+          "inputTokenDetails": {
+            "noCacheTokens": 7861,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 883
+        }
+      ],
+      "totals": {
+        "inputTokens": 7861,
+        "outputTokens": 8,
+        "totalTokens": 7869,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1043,
+        "inputTokenDetails": {
+          "noCacheTokens": 7861,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031572
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7327,
+        "estimatedHistoryTokensAfter": 7327,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7861,
+          "outputTokens": 8,
+          "totalTokens": 7869,
+          "inputTokenDetails": {
+            "noCacheTokens": 7861,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1688
+        }
+      ],
+      "totals": {
+        "inputTokens": 7861,
+        "outputTokens": 8,
+        "totalTokens": 7869,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1826,
+        "inputTokenDetails": {
+          "noCacheTokens": 7861,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031572
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7327,
+        "estimatedHistoryTokensAfter": 7327,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7857,
+          "outputTokens": 8,
+          "totalTokens": 7865,
+          "inputTokenDetails": {
+            "noCacheTokens": 7857,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 927
+        }
+      ],
+      "totals": {
+        "inputTokens": 7857,
+        "outputTokens": 8,
+        "totalTokens": 7865,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1102,
+        "inputTokenDetails": {
+          "noCacheTokens": 7857,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031556
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7323,
+        "estimatedHistoryTokensAfter": 7323,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7859,
+          "outputTokens": 8,
+          "totalTokens": 7867,
+          "inputTokenDetails": {
+            "noCacheTokens": 7859,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1032
+        }
+      ],
+      "totals": {
+        "inputTokens": 7859,
+        "outputTokens": 8,
+        "totalTokens": 7867,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1153,
+        "inputTokenDetails": {
+          "noCacheTokens": 7859,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031564000000000006
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 7325,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, according to the authoritative final record in the document \"transition-calendar.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7840,
+          "outputTokens": 28,
+          "totalTokens": 7868,
+          "inputTokenDetails": {
+            "noCacheTokens": 7840,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1193
+        }
+      ],
+      "totals": {
+        "inputTokens": 7840,
+        "outputTokens": 28,
+        "totalTokens": 7868,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1328,
+        "inputTokenDetails": {
+          "noCacheTokens": 7840,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031808
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7633,
+        "estimatedHistoryTokensAfter": 7633,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, according to the authoritative final record in the document \"transition-calendar.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7844,
+          "outputTokens": 28,
+          "totalTokens": 7872,
+          "inputTokenDetails": {
+            "noCacheTokens": 7844,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1195
+        }
+      ],
+      "totals": {
+        "inputTokens": 7844,
+        "outputTokens": 28,
+        "totalTokens": 7872,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1335,
+        "inputTokenDetails": {
+          "noCacheTokens": 7844,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031824000000000006
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 7635,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, according to the authoritative final record in the document \"transition-calendar.txt.\"",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7850,
+          "outputTokens": 28,
+          "totalTokens": 7878,
+          "inputTokenDetails": {
+            "noCacheTokens": 7850,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1479
+        }
+      ],
+      "totals": {
+        "inputTokens": 7850,
+        "outputTokens": 28,
+        "totalTokens": 7878,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1617,
+        "inputTokenDetails": {
+          "noCacheTokens": 7850,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031848000000000002
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7639,
+        "estimatedHistoryTokensAfter": 7639,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, as stated in the authoritative final record of the transition-calendar.txt document.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7842,
+          "outputTokens": 28,
+          "totalTokens": 7870,
+          "inputTokenDetails": {
+            "noCacheTokens": 7842,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1507
+        }
+      ],
+      "totals": {
+        "inputTokens": 7842,
+        "outputTokens": 28,
+        "totalTokens": 7870,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1647,
+        "inputTokenDetails": {
+          "noCacheTokens": 7842,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0031816000000000006
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7639,
+        "estimatedHistoryTokensAfter": 7639,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt document, the exact production transition date is 17 November 2027.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7846,
+          "outputTokens": 26,
+          "totalTokens": 7872,
+          "inputTokenDetails": {
+            "noCacheTokens": 7846,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1026
+        }
+      ],
+      "totals": {
+        "inputTokens": 7846,
+        "outputTokens": 26,
+        "totalTokens": 7872,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1217,
+        "inputTokenDetails": {
+          "noCacheTokens": 7846,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00318
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7639,
+        "estimatedHistoryTokensAfter": 7639,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition calendar, the exact production transition date is 17 November 2027.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4038,
+          "outputTokens": 63,
+          "totalTokens": 4101,
+          "inputTokenDetails": {
+            "noCacheTokens": 2118,
+            "cacheReadTokens": 1920,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 4118
+        }
+      ],
+      "totals": {
+        "inputTokens": 4038,
+        "outputTokens": 63,
+        "totalTokens": 4101,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4315,
+        "inputTokenDetails": {
+          "noCacheTokens": 2118,
+          "cacheReadTokens": 1920,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00114
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 1420,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition calendar, the exact production transition date is 17 November 2027.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4038,
+          "outputTokens": 63,
+          "totalTokens": 4101,
+          "inputTokenDetails": {
+            "noCacheTokens": 4038,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2066
+        }
+      ],
+      "totals": {
+        "inputTokens": 4038,
+        "outputTokens": 63,
+        "totalTokens": 4101,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2239,
+        "inputTokenDetails": {
+          "noCacheTokens": 4038,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.001716
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7637,
+        "estimatedHistoryTokensAfter": 1422,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt file, the exact production transition date is 17 November 2027.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4018,
+          "outputTokens": 62,
+          "totalTokens": 4080,
+          "inputTokenDetails": {
+            "noCacheTokens": 4018,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3916
+        }
+      ],
+      "totals": {
+        "inputTokens": 4018,
+        "outputTokens": 62,
+        "totalTokens": 4080,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4114,
+        "inputTokenDetails": {
+          "noCacheTokens": 4018,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0017064
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7627,
+        "estimatedHistoryTokensAfter": 1413,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition calendar, the exact production transition date is 17 November 2027.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4050,
+          "outputTokens": 65,
+          "totalTokens": 4115,
+          "inputTokenDetails": {
+            "noCacheTokens": 2130,
+            "cacheReadTokens": 1920,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3773
+        }
+      ],
+      "totals": {
+        "inputTokens": 4050,
+        "outputTokens": 65,
+        "totalTokens": 4115,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3939,
+        "inputTokenDetails": {
+          "noCacheTokens": 2130,
+          "cacheReadTokens": 1920,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.001148
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7641,
+        "estimatedHistoryTokensAfter": 1426,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition calendar, the exact production transition date is 17 November 2027.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4038,
+          "outputTokens": 63,
+          "totalTokens": 4101,
+          "inputTokenDetails": {
+            "noCacheTokens": 2118,
+            "cacheReadTokens": 1920,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2811
+        }
+      ],
+      "totals": {
+        "inputTokens": 4038,
+        "outputTokens": 63,
+        "totalTokens": 4101,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2897,
+        "inputTokenDetails": {
+          "noCacheTokens": 2118,
+          "cacheReadTokens": 1920,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00114
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7637,
+        "estimatedHistoryTokensAfter": 1422,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, according to the transition-calendar.txt document.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2065,
+          "outputTokens": 23,
+          "totalTokens": 2088,
+          "inputTokenDetails": {
+            "noCacheTokens": 2065,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1110
+        }
+      ],
+      "totals": {
+        "inputTokens": 2065,
+        "outputTokens": 23,
+        "totalTokens": 2088,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1202,
+        "inputTokenDetails": {
+          "noCacheTokens": 2065,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0008627999999999999
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 1522,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt file, the exact production transition date is 17 November 2027.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2073,
+          "outputTokens": 27,
+          "totalTokens": 2100,
+          "inputTokenDetails": {
+            "noCacheTokens": 2073,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 971
+        }
+      ],
+      "totals": {
+        "inputTokens": 2073,
+        "outputTokens": 27,
+        "totalTokens": 2100,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1047,
+        "inputTokenDetails": {
+          "noCacheTokens": 2073,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0008724000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7633,
+        "estimatedHistoryTokensAfter": 1518,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt file, the exact production transition date is 17 November 2027.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2079,
+          "outputTokens": 27,
+          "totalTokens": 2106,
+          "inputTokenDetails": {
+            "noCacheTokens": 2079,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1038
+        }
+      ],
+      "totals": {
+        "inputTokens": 2079,
+        "outputTokens": 27,
+        "totalTokens": 2106,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1115,
+        "inputTokenDetails": {
+          "noCacheTokens": 2079,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0008748000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7639,
+        "estimatedHistoryTokensAfter": 1528,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, according to the transition-calendar.txt document.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2077,
+          "outputTokens": 23,
+          "totalTokens": 2100,
+          "inputTokenDetails": {
+            "noCacheTokens": 2077,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1084
+        }
+      ],
+      "totals": {
+        "inputTokens": 2077,
+        "outputTokens": 23,
+        "totalTokens": 2100,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1205,
+        "inputTokenDetails": {
+          "noCacheTokens": 2077,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0008676000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 1522,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, according to the approved record in the transition-calendar.txt file.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2073,
+          "outputTokens": 27,
+          "totalTokens": 2100,
+          "inputTokenDetails": {
+            "noCacheTokens": 2073,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1201
+        }
+      ],
+      "totals": {
+        "inputTokens": 2073,
+        "outputTokens": 27,
+        "totalTokens": 2100,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1280,
+        "inputTokenDetails": {
+          "noCacheTokens": 2073,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0008724000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7633,
+        "estimatedHistoryTokensAfter": 1518,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, according to the transition-calendar.txt document.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2077,
+          "outputTokens": 23,
+          "totalTokens": 2100,
+          "inputTokenDetails": {
+            "noCacheTokens": 2077,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1032
+        }
+      ],
+      "totals": {
+        "inputTokens": 2077,
+        "outputTokens": 23,
+        "totalTokens": 2100,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1120,
+        "inputTokenDetails": {
+          "noCacheTokens": 2077,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0008676000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7637,
+        "estimatedHistoryTokensAfter": 1526,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, according to the approved transition calendar in the file transition-calendar.txt.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2073,
+          "outputTokens": 28,
+          "totalTokens": 2101,
+          "inputTokenDetails": {
+            "noCacheTokens": 2073,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1045
+        }
+      ],
+      "totals": {
+        "inputTokens": 2073,
+        "outputTokens": 28,
+        "totalTokens": 2101,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1127,
+        "inputTokenDetails": {
+          "noCacheTokens": 2073,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.000874
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7633,
+        "estimatedHistoryTokensAfter": 1518,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, according to the approved transition calendar in the file transition-calendar.txt.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2071,
+          "outputTokens": 28,
+          "totalTokens": 2099,
+          "inputTokenDetails": {
+            "noCacheTokens": 2071,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1160
+        }
+      ],
+      "totals": {
+        "inputTokens": 2071,
+        "outputTokens": 28,
+        "totalTokens": 2099,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1252,
+        "inputTokenDetails": {
+          "noCacheTokens": 2071,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0008732000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7633,
+        "estimatedHistoryTokensAfter": 1516,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to the approved record in the transition-calendar.txt file, the exact production transition date is 17 November 2027.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2065,
+          "outputTokens": 27,
+          "totalTokens": 2092,
+          "inputTokenDetails": {
+            "noCacheTokens": 2065,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1253
+        }
+      ],
+      "totals": {
+        "inputTokens": 2065,
+        "outputTokens": 27,
+        "totalTokens": 2092,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1330,
+        "inputTokenDetails": {
+          "noCacheTokens": 2065,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0008692000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7633,
+        "estimatedHistoryTokensAfter": 1518,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is 17 November 2027, according to the approved record in the transition-calendar.txt file.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2077,
+          "outputTokens": 27,
+          "totalTokens": 2104,
+          "inputTokenDetails": {
+            "noCacheTokens": 2077,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1850
+        }
+      ],
+      "totals": {
+        "inputTokens": 2077,
+        "outputTokens": 27,
+        "totalTokens": 2104,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1926,
+        "inputTokenDetails": {
+          "noCacheTokens": 2077,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0008740000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 1522,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7113,
+          "outputTokens": 5,
+          "totalTokens": 7118,
+          "inputTokenDetails": {
+            "noCacheTokens": 7113,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 831
+        }
+      ],
+      "totals": {
+        "inputTokens": 7113,
+        "outputTokens": 5,
+        "totalTokens": 7118,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 838,
+        "inputTokenDetails": {
+          "noCacheTokens": 7113,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0028532
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7113,
+          "outputTokens": 5,
+          "totalTokens": 7118,
+          "inputTokenDetails": {
+            "noCacheTokens": 201,
+            "cacheReadTokens": 6912,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 739
+        }
+      ],
+      "totals": {
+        "inputTokens": 7113,
+        "outputTokens": 5,
+        "totalTokens": 7118,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 741,
+        "inputTokenDetails": {
+          "noCacheTokens": 201,
+          "cacheReadTokens": 6912,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007796
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7113,
+          "outputTokens": 5,
+          "totalTokens": 7118,
+          "inputTokenDetails": {
+            "noCacheTokens": 201,
+            "cacheReadTokens": 6912,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 935
+        }
+      ],
+      "totals": {
+        "inputTokens": 7113,
+        "outputTokens": 5,
+        "totalTokens": 7118,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 937,
+        "inputTokenDetails": {
+          "noCacheTokens": 201,
+          "cacheReadTokens": 6912,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007796
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7113,
+          "outputTokens": 5,
+          "totalTokens": 7118,
+          "inputTokenDetails": {
+            "noCacheTokens": 201,
+            "cacheReadTokens": 6912,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 811
+        }
+      ],
+      "totals": {
+        "inputTokens": 7113,
+        "outputTokens": 5,
+        "totalTokens": 7118,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 811,
+        "inputTokenDetails": {
+          "noCacheTokens": 201,
+          "cacheReadTokens": 6912,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007796
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7113,
+          "outputTokens": 5,
+          "totalTokens": 7118,
+          "inputTokenDetails": {
+            "noCacheTokens": 201,
+            "cacheReadTokens": 6912,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 745
+        }
+      ],
+      "totals": {
+        "inputTokens": 7113,
+        "outputTokens": 5,
+        "totalTokens": 7118,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 746,
+        "inputTokenDetails": {
+          "noCacheTokens": 201,
+          "cacheReadTokens": 6912,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007796
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2517,
+          "outputTokens": 50,
+          "totalTokens": 2567,
+          "inputTokenDetails": {
+            "noCacheTokens": 1365,
+            "cacheReadTokens": 1152,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 1823
+        }
+      ],
+      "totals": {
+        "inputTokens": 2517,
+        "outputTokens": 50,
+        "totalTokens": 2567,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 1836,
+        "inputTokenDetails": {
+          "noCacheTokens": 1365,
+          "cacheReadTokens": 1152,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007412
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 670,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2517,
+          "outputTokens": 50,
+          "totalTokens": 2567,
+          "inputTokenDetails": {
+            "noCacheTokens": 1365,
+            "cacheReadTokens": 1152,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2266
+        }
+      ],
+      "totals": {
+        "inputTokens": 2517,
+        "outputTokens": 50,
+        "totalTokens": 2567,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2277,
+        "inputTokenDetails": {
+          "noCacheTokens": 1365,
+          "cacheReadTokens": 1152,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007412
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 670,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2514,
+          "outputTokens": 47,
+          "totalTokens": 2561,
+          "inputTokenDetails": {
+            "noCacheTokens": 1362,
+            "cacheReadTokens": 1152,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2171
+        }
+      ],
+      "totals": {
+        "inputTokens": 2514,
+        "outputTokens": 47,
+        "totalTokens": 2561,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2225,
+        "inputTokenDetails": {
+          "noCacheTokens": 1362,
+          "cacheReadTokens": 1152,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007352000000000002
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 670,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2517,
+          "outputTokens": 50,
+          "totalTokens": 2567,
+          "inputTokenDetails": {
+            "noCacheTokens": 2517,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2167
+        }
+      ],
+      "totals": {
+        "inputTokens": 2517,
+        "outputTokens": 50,
+        "totalTokens": 2567,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2231,
+        "inputTokenDetails": {
+          "noCacheTokens": 2517,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010868000000000002
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 670,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2517,
+          "outputTokens": 50,
+          "totalTokens": 2567,
+          "inputTokenDetails": {
+            "noCacheTokens": 1365,
+            "cacheReadTokens": 1152,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2168
+        }
+      ],
+      "totals": {
+        "inputTokens": 2517,
+        "outputTokens": 50,
+        "totalTokens": 2567,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2192,
+        "inputTokenDetails": {
+          "noCacheTokens": 1365,
+          "cacheReadTokens": 1152,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0007412
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 670,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1254,
+          "outputTokens": 6,
+          "totalTokens": 1260,
+          "inputTokenDetails": {
+            "noCacheTokens": 1254,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 708
+        }
+      ],
+      "totals": {
+        "inputTokens": 1254,
+        "outputTokens": 6,
+        "totalTokens": 1260,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 730,
+        "inputTokenDetails": {
+          "noCacheTokens": 1254,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0005112000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 712,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1254,
+          "outputTokens": 6,
+          "totalTokens": 1260,
+          "inputTokenDetails": {
+            "noCacheTokens": 1254,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 2237
+        }
+      ],
+      "totals": {
+        "inputTokens": 1254,
+        "outputTokens": 6,
+        "totalTokens": 1260,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2269,
+        "inputTokenDetails": {
+          "noCacheTokens": 1254,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0005112000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 712,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1254,
+          "outputTokens": 6,
+          "totalTokens": 1260,
+          "inputTokenDetails": {
+            "noCacheTokens": 1254,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 928
+        }
+      ],
+      "totals": {
+        "inputTokens": 1254,
+        "outputTokens": 6,
+        "totalTokens": 1260,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 971,
+        "inputTokenDetails": {
+          "noCacheTokens": 1254,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0005112000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 712,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1254,
+          "outputTokens": 6,
+          "totalTokens": 1260,
+          "inputTokenDetails": {
+            "noCacheTokens": 1254,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1007
+        }
+      ],
+      "totals": {
+        "inputTokens": 1254,
+        "outputTokens": 6,
+        "totalTokens": 1260,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1067,
+        "inputTokenDetails": {
+          "noCacheTokens": 1254,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0005112000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 712,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1254,
+          "outputTokens": 6,
+          "totalTokens": 1260,
+          "inputTokenDetails": {
+            "noCacheTokens": 1254,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 664
+        }
+      ],
+      "totals": {
+        "inputTokens": 1254,
+        "outputTokens": 6,
+        "totalTokens": 1260,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 681,
+        "inputTokenDetails": {
+          "noCacheTokens": 1254,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0005112000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 712,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7462,
+          "outputTokens": 6,
+          "totalTokens": 7468,
+          "inputTokenDetails": {
+            "noCacheTokens": 7462,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 880
+        }
+      ],
+      "totals": {
+        "inputTokens": 7462,
+        "outputTokens": 6,
+        "totalTokens": 7468,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 881,
+        "inputTokenDetails": {
+          "noCacheTokens": 7462,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0029944
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7462,
+          "outputTokens": 6,
+          "totalTokens": 7468,
+          "inputTokenDetails": {
+            "noCacheTokens": 166,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 968
+        }
+      ],
+      "totals": {
+        "inputTokens": 7462,
+        "outputTokens": 6,
+        "totalTokens": 7468,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 970,
+        "inputTokenDetails": {
+          "noCacheTokens": 166,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0008056000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7462,
+          "outputTokens": 6,
+          "totalTokens": 7468,
+          "inputTokenDetails": {
+            "noCacheTokens": 166,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 915
+        }
+      ],
+      "totals": {
+        "inputTokens": 7462,
+        "outputTokens": 6,
+        "totalTokens": 7468,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 916,
+        "inputTokenDetails": {
+          "noCacheTokens": 166,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0008056000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7462,
+          "outputTokens": 6,
+          "totalTokens": 7468,
+          "inputTokenDetails": {
+            "noCacheTokens": 166,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 818
+        }
+      ],
+      "totals": {
+        "inputTokens": 7462,
+        "outputTokens": 6,
+        "totalTokens": 7468,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 820,
+        "inputTokenDetails": {
+          "noCacheTokens": 166,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0008056000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7462,
+          "outputTokens": 6,
+          "totalTokens": 7468,
+          "inputTokenDetails": {
+            "noCacheTokens": 166,
+            "cacheReadTokens": 7296,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 742
+        }
+      ],
+      "totals": {
+        "inputTokens": 7462,
+        "outputTokens": 6,
+        "totalTokens": 7468,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 744,
+        "inputTokenDetails": {
+          "noCacheTokens": 166,
+          "cacheReadTokens": 7296,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0008056000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9648,
+          "outputTokens": 8,
+          "totalTokens": 9656,
+          "inputTokenDetails": {
+            "noCacheTokens": 176,
+            "cacheReadTokens": 9472,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 719
+        }
+      ],
+      "totals": {
+        "inputTokens": 9648,
+        "outputTokens": 8,
+        "totalTokens": 9656,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 727,
+        "inputTokenDetails": {
+          "noCacheTokens": 176,
+          "cacheReadTokens": 9472,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010304000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 9539,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9648,
+          "outputTokens": 8,
+          "totalTokens": 9656,
+          "inputTokenDetails": {
+            "noCacheTokens": 176,
+            "cacheReadTokens": 9472,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 877
+        }
+      ],
+      "totals": {
+        "inputTokens": 9648,
+        "outputTokens": 8,
+        "totalTokens": 9656,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 877,
+        "inputTokenDetails": {
+          "noCacheTokens": 176,
+          "cacheReadTokens": 9472,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010304000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 9539,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9648,
+          "outputTokens": 8,
+          "totalTokens": 9656,
+          "inputTokenDetails": {
+            "noCacheTokens": 176,
+            "cacheReadTokens": 9472,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 870
+        }
+      ],
+      "totals": {
+        "inputTokens": 9648,
+        "outputTokens": 8,
+        "totalTokens": 9656,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 872,
+        "inputTokenDetails": {
+          "noCacheTokens": 176,
+          "cacheReadTokens": 9472,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010304000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 9539,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9648,
+          "outputTokens": 8,
+          "totalTokens": 9656,
+          "inputTokenDetails": {
+            "noCacheTokens": 176,
+            "cacheReadTokens": 9472,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1102
+        }
+      ],
+      "totals": {
+        "inputTokens": 9648,
+        "outputTokens": 8,
+        "totalTokens": 9656,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1104,
+        "inputTokenDetails": {
+          "noCacheTokens": 176,
+          "cacheReadTokens": 9472,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010304000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 9539,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9648,
+          "outputTokens": 8,
+          "totalTokens": 9656,
+          "inputTokenDetails": {
+            "noCacheTokens": 176,
+            "cacheReadTokens": 9472,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 815
+        }
+      ],
+      "totals": {
+        "inputTokens": 9648,
+        "outputTokens": 8,
+        "totalTokens": 9656,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 816,
+        "inputTokenDetails": {
+          "noCacheTokens": 176,
+          "cacheReadTokens": 9472,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010304000000000001
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 9539,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7892,
+          "outputTokens": 52,
+          "totalTokens": 7944,
+          "inputTokenDetails": {
+            "noCacheTokens": 212,
+            "cacheReadTokens": 7680,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2251
+        }
+      ],
+      "totals": {
+        "inputTokens": 7892,
+        "outputTokens": 52,
+        "totalTokens": 7944,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2293,
+        "inputTokenDetails": {
+          "noCacheTokens": 212,
+          "cacheReadTokens": 7680,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.000936
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3297,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7892,
+          "outputTokens": 52,
+          "totalTokens": 7944,
+          "inputTokenDetails": {
+            "noCacheTokens": 212,
+            "cacheReadTokens": 7680,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2331
+        }
+      ],
+      "totals": {
+        "inputTokens": 7892,
+        "outputTokens": 52,
+        "totalTokens": 7944,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2352,
+        "inputTokenDetails": {
+          "noCacheTokens": 212,
+          "cacheReadTokens": 7680,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.000936
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3297,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7892,
+          "outputTokens": 64,
+          "totalTokens": 7956,
+          "inputTokenDetails": {
+            "noCacheTokens": 4052,
+            "cacheReadTokens": 3840,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3137
+        }
+      ],
+      "totals": {
+        "inputTokens": 7892,
+        "outputTokens": 64,
+        "totalTokens": 7956,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3157,
+        "inputTokenDetails": {
+          "noCacheTokens": 4052,
+          "cacheReadTokens": 3840,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0021072000000000005
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3297,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7892,
+          "outputTokens": 64,
+          "totalTokens": 7956,
+          "inputTokenDetails": {
+            "noCacheTokens": 4052,
+            "cacheReadTokens": 3840,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2577
+        }
+      ],
+      "totals": {
+        "inputTokens": 7892,
+        "outputTokens": 64,
+        "totalTokens": 7956,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2649,
+        "inputTokenDetails": {
+          "noCacheTokens": 4052,
+          "cacheReadTokens": 3840,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0021072000000000005
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3297,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact authoritative reconciled balance from the ledger run is EUR 418,275.60.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7892,
+          "outputTokens": 64,
+          "totalTokens": 7956,
+          "inputTokenDetails": {
+            "noCacheTokens": 7892,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 1968
+        }
+      ],
+      "totals": {
+        "inputTokens": 7892,
+        "outputTokens": 64,
+        "totalTokens": 7956,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2039,
+        "inputTokenDetails": {
+          "noCacheTokens": 7892,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0032592000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3297,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3934,
+          "outputTokens": 9,
+          "totalTokens": 3943,
+          "inputTokenDetails": {
+            "noCacheTokens": 94,
+            "cacheReadTokens": 3840,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 944
+        }
+      ],
+      "totals": {
+        "inputTokens": 3934,
+        "outputTokens": 9,
+        "totalTokens": 3943,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1036,
+        "inputTokenDetails": {
+          "noCacheTokens": 94,
+          "cacheReadTokens": 3840,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.000436
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3330,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3934,
+          "outputTokens": 9,
+          "totalTokens": 3943,
+          "inputTokenDetails": {
+            "noCacheTokens": 94,
+            "cacheReadTokens": 3840,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 983
+        }
+      ],
+      "totals": {
+        "inputTokens": 3934,
+        "outputTokens": 9,
+        "totalTokens": 3943,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1085,
+        "inputTokenDetails": {
+          "noCacheTokens": 94,
+          "cacheReadTokens": 3840,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.000436
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3330,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3934,
+          "outputTokens": 9,
+          "totalTokens": 3943,
+          "inputTokenDetails": {
+            "noCacheTokens": 3934,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 989
+        }
+      ],
+      "totals": {
+        "inputTokens": 3934,
+        "outputTokens": 9,
+        "totalTokens": 3943,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1105,
+        "inputTokenDetails": {
+          "noCacheTokens": 3934,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0015880000000000002
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3330,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3934,
+          "outputTokens": 9,
+          "totalTokens": 3943,
+          "inputTokenDetails": {
+            "noCacheTokens": 3934,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1481
+        }
+      ],
+      "totals": {
+        "inputTokens": 3934,
+        "outputTokens": 9,
+        "totalTokens": 3943,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1512,
+        "inputTokenDetails": {
+          "noCacheTokens": 3934,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0015880000000000002
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3330,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3934,
+          "outputTokens": 9,
+          "totalTokens": 3943,
+          "inputTokenDetails": {
+            "noCacheTokens": 3934,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 787
+        }
+      ],
+      "totals": {
+        "inputTokens": 3934,
+        "outputTokens": 9,
+        "totalTokens": 3943,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 823,
+        "inputTokenDetails": {
+          "noCacheTokens": 3934,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0015880000000000002
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3330,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3934,
+          "outputTokens": 9,
+          "totalTokens": 3943,
+          "inputTokenDetails": {
+            "noCacheTokens": 94,
+            "cacheReadTokens": 3840,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1106
+        }
+      ],
+      "totals": {
+        "inputTokens": 3934,
+        "outputTokens": 9,
+        "totalTokens": 3943,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1146,
+        "inputTokenDetails": {
+          "noCacheTokens": 94,
+          "cacheReadTokens": 3840,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.000436
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3330,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3934,
+          "outputTokens": 9,
+          "totalTokens": 3943,
+          "inputTokenDetails": {
+            "noCacheTokens": 94,
+            "cacheReadTokens": 3840,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 790
+        }
+      ],
+      "totals": {
+        "inputTokens": 3934,
+        "outputTokens": 9,
+        "totalTokens": 3943,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 850,
+        "inputTokenDetails": {
+          "noCacheTokens": 94,
+          "cacheReadTokens": 3840,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.000436
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3330,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3934,
+          "outputTokens": 9,
+          "totalTokens": 3943,
+          "inputTokenDetails": {
+            "noCacheTokens": 3934,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 801
+        }
+      ],
+      "totals": {
+        "inputTokens": 3934,
+        "outputTokens": 9,
+        "totalTokens": 3943,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2310,
+        "inputTokenDetails": {
+          "noCacheTokens": 3934,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0015880000000000002
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3330,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3934,
+          "outputTokens": 9,
+          "totalTokens": 3943,
+          "inputTokenDetails": {
+            "noCacheTokens": 3934,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1299
+        }
+      ],
+      "totals": {
+        "inputTokens": 3934,
+        "outputTokens": 9,
+        "totalTokens": 3943,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1323,
+        "inputTokenDetails": {
+          "noCacheTokens": 3934,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0015880000000000002
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3330,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3934,
+          "outputTokens": 9,
+          "totalTokens": 3943,
+          "inputTokenDetails": {
+            "noCacheTokens": 3934,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 808
+        }
+      ],
+      "totals": {
+        "inputTokens": 3934,
+        "outputTokens": 9,
+        "totalTokens": 3943,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 850,
+        "inputTokenDetails": {
+          "noCacheTokens": 3934,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0015880000000000002
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3330,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9329,
+          "outputTokens": 4,
+          "totalTokens": 9333,
+          "inputTokenDetails": {
+            "noCacheTokens": 113,
+            "cacheReadTokens": 9216,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 650
+        }
+      ],
+      "totals": {
+        "inputTokens": 9329,
+        "outputTokens": 4,
+        "totalTokens": 9333,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 656,
+        "inputTokenDetails": {
+          "noCacheTokens": 113,
+          "cacheReadTokens": 9216,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0009732
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 9234,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9329,
+          "outputTokens": 4,
+          "totalTokens": 9333,
+          "inputTokenDetails": {
+            "noCacheTokens": 113,
+            "cacheReadTokens": 9216,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 721
+        }
+      ],
+      "totals": {
+        "inputTokens": 9329,
+        "outputTokens": 4,
+        "totalTokens": 9333,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 722,
+        "inputTokenDetails": {
+          "noCacheTokens": 113,
+          "cacheReadTokens": 9216,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0009732
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 9234,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9329,
+          "outputTokens": 4,
+          "totalTokens": 9333,
+          "inputTokenDetails": {
+            "noCacheTokens": 113,
+            "cacheReadTokens": 9216,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1115
+        }
+      ],
+      "totals": {
+        "inputTokens": 9329,
+        "outputTokens": 4,
+        "totalTokens": 9333,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1116,
+        "inputTokenDetails": {
+          "noCacheTokens": 113,
+          "cacheReadTokens": 9216,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0009732
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 9234,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9329,
+          "outputTokens": 4,
+          "totalTokens": 9333,
+          "inputTokenDetails": {
+            "noCacheTokens": 113,
+            "cacheReadTokens": 9216,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 645
+        }
+      ],
+      "totals": {
+        "inputTokens": 9329,
+        "outputTokens": 4,
+        "totalTokens": 9333,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 646,
+        "inputTokenDetails": {
+          "noCacheTokens": 113,
+          "cacheReadTokens": 9216,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0009732
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 9234,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9329,
+          "outputTokens": 4,
+          "totalTokens": 9333,
+          "inputTokenDetails": {
+            "noCacheTokens": 113,
+            "cacheReadTokens": 9216,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 743
+        }
+      ],
+      "totals": {
+        "inputTokens": 9329,
+        "outputTokens": 4,
+        "totalTokens": 9333,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 744,
+        "inputTokenDetails": {
+          "noCacheTokens": 113,
+          "cacheReadTokens": 9216,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0009732
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 9234,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3455,
+          "outputTokens": 5,
+          "totalTokens": 3460,
+          "inputTokenDetails": {
+            "noCacheTokens": 3455,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 781
+        }
+      ],
+      "totals": {
+        "inputTokens": 3455,
+        "outputTokens": 5,
+        "totalTokens": 3460,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 799,
+        "inputTokenDetails": {
+          "noCacheTokens": 3455,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00139
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2864,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3455,
+          "outputTokens": 5,
+          "totalTokens": 3460,
+          "inputTokenDetails": {
+            "noCacheTokens": 3455,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 862
+        }
+      ],
+      "totals": {
+        "inputTokens": 3455,
+        "outputTokens": 5,
+        "totalTokens": 3460,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 883,
+        "inputTokenDetails": {
+          "noCacheTokens": 3455,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00139
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2864,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3455,
+          "outputTokens": 5,
+          "totalTokens": 3460,
+          "inputTokenDetails": {
+            "noCacheTokens": 3455,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 841
+        }
+      ],
+      "totals": {
+        "inputTokens": 3455,
+        "outputTokens": 5,
+        "totalTokens": 3460,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 865,
+        "inputTokenDetails": {
+          "noCacheTokens": 3455,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00139
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2864,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3455,
+          "outputTokens": 5,
+          "totalTokens": 3460,
+          "inputTokenDetails": {
+            "noCacheTokens": 3455,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 961
+        }
+      ],
+      "totals": {
+        "inputTokens": 3455,
+        "outputTokens": 5,
+        "totalTokens": 3460,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 978,
+        "inputTokenDetails": {
+          "noCacheTokens": 3455,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00139
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2864,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3455,
+          "outputTokens": 5,
+          "totalTokens": 3460,
+          "inputTokenDetails": {
+            "noCacheTokens": 3455,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 748
+        }
+      ],
+      "totals": {
+        "inputTokens": 3455,
+        "outputTokens": 5,
+        "totalTokens": 3460,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 786,
+        "inputTokenDetails": {
+          "noCacheTokens": 3455,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00139
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2864,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3487,
+          "outputTokens": 5,
+          "totalTokens": 3492,
+          "inputTokenDetails": {
+            "noCacheTokens": 159,
+            "cacheReadTokens": 3328,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 719
+        }
+      ],
+      "totals": {
+        "inputTokens": 3487,
+        "outputTokens": 5,
+        "totalTokens": 3492,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 740,
+        "inputTokenDetails": {
+          "noCacheTokens": 159,
+          "cacheReadTokens": 3328,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0004044
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2897,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3487,
+          "outputTokens": 5,
+          "totalTokens": 3492,
+          "inputTokenDetails": {
+            "noCacheTokens": 159,
+            "cacheReadTokens": 3328,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 805
+        }
+      ],
+      "totals": {
+        "inputTokens": 3487,
+        "outputTokens": 5,
+        "totalTokens": 3492,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 832,
+        "inputTokenDetails": {
+          "noCacheTokens": 159,
+          "cacheReadTokens": 3328,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0004044
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2897,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3487,
+          "outputTokens": 5,
+          "totalTokens": 3492,
+          "inputTokenDetails": {
+            "noCacheTokens": 3487,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 841
+        }
+      ],
+      "totals": {
+        "inputTokens": 3487,
+        "outputTokens": 5,
+        "totalTokens": 3492,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 860,
+        "inputTokenDetails": {
+          "noCacheTokens": 3487,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0014028000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2897,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3487,
+          "outputTokens": 5,
+          "totalTokens": 3492,
+          "inputTokenDetails": {
+            "noCacheTokens": 3487,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 841
+        }
+      ],
+      "totals": {
+        "inputTokens": 3487,
+        "outputTokens": 5,
+        "totalTokens": 3492,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 863,
+        "inputTokenDetails": {
+          "noCacheTokens": 3487,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0014028000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2897,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3487,
+          "outputTokens": 5,
+          "totalTokens": 3492,
+          "inputTokenDetails": {
+            "noCacheTokens": 3487,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1233
+        }
+      ],
+      "totals": {
+        "inputTokens": 3487,
+        "outputTokens": 5,
+        "totalTokens": 3492,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1254,
+        "inputTokenDetails": {
+          "noCacheTokens": 3487,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0014028000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2897,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3487,
+          "outputTokens": 5,
+          "totalTokens": 3492,
+          "inputTokenDetails": {
+            "noCacheTokens": 159,
+            "cacheReadTokens": 3328,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 972
+        }
+      ],
+      "totals": {
+        "inputTokens": 3487,
+        "outputTokens": 5,
+        "totalTokens": 3492,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 997,
+        "inputTokenDetails": {
+          "noCacheTokens": 159,
+          "cacheReadTokens": 3328,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0004044
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2897,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3487,
+          "outputTokens": 5,
+          "totalTokens": 3492,
+          "inputTokenDetails": {
+            "noCacheTokens": 3487,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1093
+        }
+      ],
+      "totals": {
+        "inputTokens": 3487,
+        "outputTokens": 5,
+        "totalTokens": 3492,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1120,
+        "inputTokenDetails": {
+          "noCacheTokens": 3487,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0014028000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2897,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3487,
+          "outputTokens": 5,
+          "totalTokens": 3492,
+          "inputTokenDetails": {
+            "noCacheTokens": 3487,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 759
+        }
+      ],
+      "totals": {
+        "inputTokens": 3487,
+        "outputTokens": 5,
+        "totalTokens": 3492,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 781,
+        "inputTokenDetails": {
+          "noCacheTokens": 3487,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0014028000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2897,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3487,
+          "outputTokens": 5,
+          "totalTokens": 3492,
+          "inputTokenDetails": {
+            "noCacheTokens": 3487,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1171
+        }
+      ],
+      "totals": {
+        "inputTokens": 3487,
+        "outputTokens": 5,
+        "totalTokens": 3492,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1191,
+        "inputTokenDetails": {
+          "noCacheTokens": 3487,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0014028000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2897,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3487,
+          "outputTokens": 5,
+          "totalTokens": 3492,
+          "inputTokenDetails": {
+            "noCacheTokens": 3487,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 939
+        }
+      ],
+      "totals": {
+        "inputTokens": 3487,
+        "outputTokens": 5,
+        "totalTokens": 3492,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1022,
+        "inputTokenDetails": {
+          "noCacheTokens": 3487,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0014028000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2897,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "Active service registry identifier: LUMEN-83  \nAccepted restoration window: 14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12417,
+          "outputTokens": 24,
+          "totalTokens": 12441,
+          "inputTokenDetails": {
+            "noCacheTokens": 7425,
+            "cacheReadTokens": 4992,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 982
+        }
+      ],
+      "totals": {
+        "inputTokens": 12417,
+        "outputTokens": 24,
+        "totalTokens": 12441,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1128,
+        "inputTokenDetails": {
+          "noCacheTokens": 7425,
+          "cacheReadTokens": 4992,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035076
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 12220,
+        "estimatedHistoryTokensAfter": 12220,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "Active service registry identifier: LUMEN-83  \nAccepted restoration window: 14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12421,
+          "outputTokens": 24,
+          "totalTokens": 12445,
+          "inputTokenDetails": {
+            "noCacheTokens": 7429,
+            "cacheReadTokens": 4992,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1020
+        }
+      ],
+      "totals": {
+        "inputTokens": 12421,
+        "outputTokens": 24,
+        "totalTokens": 12445,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1083,
+        "inputTokenDetails": {
+          "noCacheTokens": 7429,
+          "cacheReadTokens": 4992,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035092
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 12220,
+        "estimatedHistoryTokensAfter": 12220,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "Active service registry identifier: LUMEN-83  \nAccepted restoration window: 14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12413,
+          "outputTokens": 24,
+          "totalTokens": 12437,
+          "inputTokenDetails": {
+            "noCacheTokens": 7421,
+            "cacheReadTokens": 4992,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1750
+        }
+      ],
+      "totals": {
+        "inputTokens": 12413,
+        "outputTokens": 24,
+        "totalTokens": 12437,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1812,
+        "inputTokenDetails": {
+          "noCacheTokens": 7421,
+          "cacheReadTokens": 4992,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035060000000000004
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 12216,
+        "estimatedHistoryTokensAfter": 12216,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "Active service registry identifier: LUMEN-83  \nAccepted restoration window: 14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12419,
+          "outputTokens": 24,
+          "totalTokens": 12443,
+          "inputTokenDetails": {
+            "noCacheTokens": 7427,
+            "cacheReadTokens": 4992,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1130
+        }
+      ],
+      "totals": {
+        "inputTokens": 12419,
+        "outputTokens": 24,
+        "totalTokens": 12443,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1196,
+        "inputTokenDetails": {
+          "noCacheTokens": 7427,
+          "cacheReadTokens": 4992,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035084
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 12224,
+        "estimatedHistoryTokensAfter": 12224,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "Active service registry identifier: LUMEN-83  \nAccepted restoration window: 14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12413,
+          "outputTokens": 24,
+          "totalTokens": 12437,
+          "inputTokenDetails": {
+            "noCacheTokens": 7421,
+            "cacheReadTokens": 4992,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1125
+        }
+      ],
+      "totals": {
+        "inputTokens": 12413,
+        "outputTokens": 24,
+        "totalTokens": 12437,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1181,
+        "inputTokenDetails": {
+          "noCacheTokens": 7421,
+          "cacheReadTokens": 4992,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035060000000000004
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 12218,
+        "estimatedHistoryTokensAfter": 12218,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83.  \nThe accepted restoration window is 14 business days from verified incident closure.",
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4718,
+          "outputTokens": 124,
+          "totalTokens": 4842,
+          "inputTokenDetails": {
+            "noCacheTokens": 750,
+            "cacheReadTokens": 3968,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3187
+        }
+      ],
+      "totals": {
+        "inputTokens": 4718,
+        "outputTokens": 124,
+        "totalTokens": 4842,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 3293,
+        "inputTokenDetails": {
+          "noCacheTokens": 750,
+          "cacheReadTokens": 3968,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0008952
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12218,
+        "estimatedHistoryTokensAfter": 1728,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83.  \nThe accepted restoration window is 14 business days from verified incident closure.",
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4710,
+          "outputTokens": 123,
+          "totalTokens": 4833,
+          "inputTokenDetails": {
+            "noCacheTokens": 2534,
+            "cacheReadTokens": 2176,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ],
+          "latencyMs": 4763
+        }
+      ],
+      "totals": {
+        "inputTokens": 4710,
+        "outputTokens": 123,
+        "totalTokens": 4833,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 4846,
+        "inputTokenDetails": {
+          "noCacheTokens": 2534,
+          "cacheReadTokens": 2176,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.001428
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12220,
+        "estimatedHistoryTokensAfter": 1729,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83.  \nThe accepted restoration window is 14 business days from verified incident closure.",
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4706,
+          "outputTokens": 122,
+          "totalTokens": 4828,
+          "inputTokenDetails": {
+            "noCacheTokens": 2530,
+            "cacheReadTokens": 2176,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2875
+        }
+      ],
+      "totals": {
+        "inputTokens": 4706,
+        "outputTokens": 122,
+        "totalTokens": 4828,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 3007,
+        "inputTokenDetails": {
+          "noCacheTokens": 2530,
+          "cacheReadTokens": 2176,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0014248
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12216,
+        "estimatedHistoryTokensAfter": 1726,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83. The accepted restoration window is 14 business days from verified incident closure.",
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4712,
+          "outputTokens": 122,
+          "totalTokens": 4834,
+          "inputTokenDetails": {
+            "noCacheTokens": 4712,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ],
+          "latencyMs": 4553
+        }
+      ],
+      "totals": {
+        "inputTokens": 4712,
+        "outputTokens": 122,
+        "totalTokens": 4834,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 4659,
+        "inputTokenDetails": {
+          "noCacheTokens": 4712,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00208
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12218,
+        "estimatedHistoryTokensAfter": 1728,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "The exact active service registry identifier is LUMEN-83.  \nThe accepted restoration window is 14 business days from verified incident closure.",
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4721,
+          "outputTokens": 124,
+          "totalTokens": 4845,
+          "inputTokenDetails": {
+            "noCacheTokens": 2545,
+            "cacheReadTokens": 2176,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2698
+        }
+      ],
+      "totals": {
+        "inputTokens": 4721,
+        "outputTokens": 124,
+        "totalTokens": 4845,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 2788,
+        "inputTokenDetails": {
+          "noCacheTokens": 2545,
+          "cacheReadTokens": 2176,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.001434
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12220,
+        "estimatedHistoryTokensAfter": 1730,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "Active service registry identifier: LUMEN-83  \nAccepted restoration window: 14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2415,
+          "outputTokens": 25,
+          "totalTokens": 2440,
+          "inputTokenDetails": {
+            "noCacheTokens": 623,
+            "cacheReadTokens": 1792,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1176
+        }
+      ],
+      "totals": {
+        "inputTokens": 2415,
+        "outputTokens": 25,
+        "totalTokens": 2440,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1264,
+        "inputTokenDetails": {
+          "noCacheTokens": 623,
+          "cacheReadTokens": 1792,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00046840000000000006
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12220,
+        "estimatedHistoryTokensAfter": 1873,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "Active service registry identifier: LUMEN-83  \nAccepted restoration window: 14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2419,
+          "outputTokens": 25,
+          "totalTokens": 2444,
+          "inputTokenDetails": {
+            "noCacheTokens": 2419,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1059
+        }
+      ],
+      "totals": {
+        "inputTokens": 2419,
+        "outputTokens": 25,
+        "totalTokens": 2444,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1148,
+        "inputTokenDetails": {
+          "noCacheTokens": 2419,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010076
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12226,
+        "estimatedHistoryTokensAfter": 1885,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "Active service registry identifier: LUMEN-83  \nAccepted restoration window: 14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2407,
+          "outputTokens": 25,
+          "totalTokens": 2432,
+          "inputTokenDetails": {
+            "noCacheTokens": 2407,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 933
+        }
+      ],
+      "totals": {
+        "inputTokens": 2407,
+        "outputTokens": 25,
+        "totalTokens": 2432,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1025,
+        "inputTokenDetails": {
+          "noCacheTokens": 2407,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010028
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12216,
+        "estimatedHistoryTokensAfter": 1865,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "Active service registry identifier: LUMEN-83  \nAccepted restoration window: 14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2405,
+          "outputTokens": 25,
+          "totalTokens": 2430,
+          "inputTokenDetails": {
+            "noCacheTokens": 2405,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1852
+        }
+      ],
+      "totals": {
+        "inputTokens": 2405,
+        "outputTokens": 25,
+        "totalTokens": 2430,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1955,
+        "inputTokenDetails": {
+          "noCacheTokens": 2405,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.001002
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12216,
+        "estimatedHistoryTokensAfter": 1863,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "Active service registry identifier: LUMEN-83  \nAccepted restoration window: 14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2403,
+          "outputTokens": 25,
+          "totalTokens": 2428,
+          "inputTokenDetails": {
+            "noCacheTokens": 2403,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 988
+        }
+      ],
+      "totals": {
+        "inputTokens": 2403,
+        "outputTokens": 25,
+        "totalTokens": 2428,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1067,
+        "inputTokenDetails": {
+          "noCacheTokens": 2403,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010012
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12218,
+        "estimatedHistoryTokensAfter": 1869,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "The active service registry identifier is LUMEN-83.\nThe accepted restoration window is 14 business days from verified incident closure.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8821,
+          "outputTokens": 28,
+          "totalTokens": 8849,
+          "inputTokenDetails": {
+            "noCacheTokens": 7029,
+            "cacheReadTokens": 1792,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1149
+        }
+      ],
+      "totals": {
+        "inputTokens": 8821,
+        "outputTokens": 28,
+        "totalTokens": 8849,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1210,
+        "inputTokenDetails": {
+          "noCacheTokens": 7029,
+          "cacheReadTokens": 1792,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0030356000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12216,
+        "estimatedHistoryTokensAfter": 8275,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "Active service registry identifier: LUMEN-83  \nAccepted restoration window: 14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8827,
+          "outputTokens": 25,
+          "totalTokens": 8852,
+          "inputTokenDetails": {
+            "noCacheTokens": 8827,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1573
+        }
+      ],
+      "totals": {
+        "inputTokens": 8827,
+        "outputTokens": 25,
+        "totalTokens": 8852,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1638,
+        "inputTokenDetails": {
+          "noCacheTokens": 8827,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035708000000000003
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12224,
+        "estimatedHistoryTokensAfter": 8283,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "The active service registry identifier is LUMEN-83.\nThe accepted restoration window is 14 business days from verified incident closure.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8823,
+          "outputTokens": 28,
+          "totalTokens": 8851,
+          "inputTokenDetails": {
+            "noCacheTokens": 8823,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1721
+        }
+      ],
+      "totals": {
+        "inputTokens": 8823,
+        "outputTokens": 28,
+        "totalTokens": 8851,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1781,
+        "inputTokenDetails": {
+          "noCacheTokens": 8823,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035740000000000004
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12218,
+        "estimatedHistoryTokensAfter": 8277,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 3,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "Active service registry identifier: LUMEN-83  \nAccepted restoration window: 14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8823,
+          "outputTokens": 25,
+          "totalTokens": 8848,
+          "inputTokenDetails": {
+            "noCacheTokens": 8823,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1379
+        }
+      ],
+      "totals": {
+        "inputTokens": 8823,
+        "outputTokens": 25,
+        "totalTokens": 8848,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1452,
+        "inputTokenDetails": {
+          "noCacheTokens": 8823,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0035692000000000002
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12218,
+        "estimatedHistoryTokensAfter": 8277,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 4,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "Active service registry identifier: LUMEN-83  \nAccepted restoration window: 14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8825,
+          "outputTokens": 25,
+          "totalTokens": 8850,
+          "inputTokenDetails": {
+            "noCacheTokens": 8825,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1356
+        }
+      ],
+      "totals": {
+        "inputTokens": 8825,
+        "outputTokens": 25,
+        "totalTokens": 8850,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1426,
+        "inputTokenDetails": {
+          "noCacheTokens": 8825,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00357
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12220,
+        "estimatedHistoryTokensAfter": 8279,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    }
+  ]
+}

--- a/docs/eval-results/context-compression-prefetch-gpt-5-latest-2026-09-10.md
+++ b/docs/eval-results/context-compression-prefetch-gpt-5-latest-2026-09-10.md
@@ -1,0 +1,190 @@
+# Evaluation report
+
+## Overall
+
+| arm | runs | success | score | in tok | cache read | out tok | cost | tools |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 18 | 100% | 1.00 | 8997 | 4361 | 30 | $0.0105 | 0.0 |
+| compression-keep-0 | 18 | 100% | 1.00 | 4741 | 2214 | 84 | $0.00650 | 1.1 |
+| compression-prefetch-keep-0 | 18 | 100% | 1.00 | 2472 | 975 | 32 | $0.00357 | 0.0 |
+| compression-prefetch-keep-1 | 18 | 100% | 1.00 | 5825 | 1022 | 46 | $0.0104 | 0.1 |
+
+## compression-recent-attachment
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 3 | 100% | 1.00 | 7326→7326 | 0.0 | 7517 | 0 | 23 | $0.0153 | 0.0 | 1.0 | — |
+| compression-keep-0 | 3 | 100% | 1.00 | 7322→829 | 1.0 | 2851 | 1372 | 63 | $0.00399 | 1.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 3 | 100% | 1.00 | 7321→956 | 1.0 | 1466 | 0 | 24 | $0.00322 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 3 | 100% | 1.00 | 7320→7320 | 0.0 | 7832 | 0 | 26 | $0.0160 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.01132 (-74%) — 95% CI [$-0.01136, $-0.01128]
+- input tokens per conversation: ▼ -4666 (-62%) — 95% CI [-4673, -4659]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0113 saved per conversation
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.01209 (-79%) — 95% CI [$-0.01212, $-0.01205]
+- input tokens per conversation: ▼ -6051 (-81%) — 95% CI [-6059, -6039]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0121 saved per conversation
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▲ $0.00067 (+4%) — 95% CI [$0.00059, $0.00076]
+- input tokens per conversation: ▲ 315 (+4%) — 95% CI [311, 318]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00067 more per conversation, before its $0 of indexing
+
+## compression-middle-attachment
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 3 | 100% | 1.00 | 7636→7636 | 0.0 | 7855 | 0 | 41 | $0.0162 | 0.0 | 1.0 | — |
+| compression-keep-0 | 3 | 100% | 1.00 | 7636→1447 | 1.0 | 4134 | 2018 | 76 | $0.00555 | 1.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 3 | 100% | 1.00 | 7637→1566 | 1.0 | 2103 | 0 | 31 | $0.00458 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 3 | 100% | 1.00 | 7634→1560 | 1.0 | 2101 | 0 | 45 | $0.00474 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.01065 (-66%) — 95% CI [$-0.01070, $-0.01061]
+- input tokens per conversation: ▼ -3721 (-47%) — 95% CI [-3737, -3709]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0106 saved per conversation
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.01162 (-72%) — 95% CI [$-0.01170, $-0.01149]
+- input tokens per conversation: ▼ -5752 (-73%) — 95% CI [-5754, -5750]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0116 saved per conversation
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▼ $-0.01146 (-71%) — 95% CI [$-0.01152, $-0.01142]
+- input tokens per conversation: ▼ -5754 (-73%) — 95% CI [-5760, -5748]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0115 saved per conversation
+
+## compression-recent-assistant
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 3 | 100% | 1.00 | 6926→6926 | 0.0 | 7118 | 7115 | 22 | $0.00169 | 0.0 | 1.0 | — |
+| compression-keep-0 | 3 | 100% | 1.00 | 6926→683 | 1.0 | 2585 | 1236 | 66 | $0.00374 | 1.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 3 | 100% | 1.00 | 6926→740 | 1.0 | 1266 | 842 | 18 | $0.00124 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 3 | 100% | 1.00 | 6926→6926 | 0.0 | 7438 | 4957 | 23 | $0.00623 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▲ $0.00204 (+121%) — 95% CI [$0.00203, $0.00206]
+- input tokens per conversation: ▼ -4533 (-64%) — 95% CI [-4534, -4533]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00204 more per conversation, before its $0 of indexing
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.00046 (-27%) — not separable at this sample size — 95% CI [$-0.00117, $0.00093] includes 0
+- input tokens per conversation: ▼ -5852 (-82%) — 95% CI [-5852, -5852]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00046 saved per conversation
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▲ $0.00453 (+268%) — 95% CI [$0.00004, $0.0135]
+- input tokens per conversation: ▲ 320 (+4%) — 95% CI [320, 320]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00453 more per conversation, before its $0 of indexing
+
+## compression-far-tool-output
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 3 | 100% | 1.00 | 9539→9539 | 0.0 | 9689 | 9686 | 25 | $0.00225 | 0.0 | 1.0 | — |
+| compression-keep-0 | 3 | 100% | 1.00 | 9539→3317 | 1.0 | 8040 | 3968 | 70 | $0.00978 | 1.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 3 | 100% | 1.00 | 9539→3365 | 1.0 | 3983 | 2653 | 27 | $0.00351 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 3 | 100% | 1.00 | 9539→3365 | 1.0 | 3983 | 0 | 30 | $0.00832 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▲ $0.00754 (+335%) — 95% CI [$0.00751, $0.00756]
+- input tokens per conversation: ▼ -1649 (-17%) — 95% CI [-1650, -1646]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00754 more per conversation, before its $0 of indexing
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▲ $0.00127 (+56%) — not separable at this sample size — 95% CI [$-0.00113, $0.00603] includes 0
+- input tokens per conversation: ▼ -5706 (-59%) — 95% CI [-5706, -5706]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00127 more per conversation, before its $0 of indexing
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▲ $0.00607 (+270%) — 95% CI [$0.00585, $0.00628]
+- input tokens per conversation: ▼ -5706 (-59%) — 95% CI [-5706, -5706]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00607 more per conversation, before its $0 of indexing
+
+## compression-irrelevant-old-bulk
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 3 | 100% | 1.00 | 9234→9234 | 0.0 | 9365 | 9362 | 23 | $0.00215 | 0.0 | 1.0 | — |
+| compression-keep-0 | 3 | 100% | 1.00 | 9234→2884 | 1.0 | 5931 | 2344 | 97 | $0.00881 | 0.7 | 1.0 | — |
+| compression-prefetch-keep-0 | 3 | 100% | 1.00 | 9234→2932 | 1.0 | 3531 | 2352 | 26 | $0.00314 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 3 | 100% | 1.00 | 9234→2932 | 1.0 | 4744 | 1176 | 74 | $0.00826 | 0.3 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▲ $0.00666 (+309%) — 95% CI [$0.00515, $0.00749]
+- input tokens per conversation: ▼ -3434 (-37%) — 95% CI [-5846, -2228]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00666 more per conversation, before its $0 of indexing
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▲ $0.00098 (+46%) — not separable at this sample size — 95% CI [$-0.00116, $0.00520] includes 0
+- input tokens per conversation: ▼ -5834 (-62%) — 95% CI [-5834, -5834]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00098 more per conversation, before its $0 of indexing
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▲ $0.00611 (+284%) — 95% CI [$0.00518, $0.00791]
+- input tokens per conversation: ▼ -4621 (-49%) — 95% CI [-5834, -2196]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: never — this arm costs $0.00611 more per conversation, before its $0 of indexing
+
+## compression-mixed-depth
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-off | 3 | 100% | 1.00 | 12218→12218 | 0.0 | 12438 | 0 | 48 | $0.0255 | 0.0 | 1.0 | — |
+| compression-keep-0 | 3 | 100% | 1.00 | 12219→1774 | 2.0 | 4905 | 2349 | 131 | $0.00716 | 2.0 | 1.0 | — |
+| compression-prefetch-keep-0 | 3 | 100% | 1.00 | 12219→1946 | 2.0 | 2485 | 0 | 64 | $0.00574 | 0.0 | 1.0 | — |
+| compression-prefetch-keep-1 | 3 | 100% | 1.00 | 12219→8313 | 1.0 | 8851 | 0 | 75 | $0.0186 | 0.0 | 1.0 | — |
+
+### compression-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.01830 (-72%) — 95% CI [$-0.01843, $-0.01820]
+- input tokens per conversation: ▼ -7533 (-61%) — 95% CI [-7543, -7524]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0183 saved per conversation
+
+### compression-prefetch-keep-0 vs compression-off
+
+- cost per conversation: ▼ $-0.01972 (-77%) — 95% CI [$-0.01993, $-0.01952]
+- input tokens per conversation: ▼ -9953 (-80%) — 95% CI [-9958, -9950]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.0197 saved per conversation
+
+### compression-prefetch-keep-1 vs compression-off
+
+- cost per conversation: ▼ $-0.00685 (-27%) — 95% CI [$-0.00698, $-0.00673]
+- input tokens per conversation: ▼ -3587 (-29%) — 95% CI [-3593, -3581]
+- score: = 0.00 (0%) — not separable at this sample size — 95% CI [0.00, 0.00] includes 0
+- break-even: 0 conversation(s) — $0 of indexing, repaid at $0.00685 saved per conversation

--- a/docs/eval-results/context-compression-prefetch-gpt-5-latest-2026-09-10.runs.json
+++ b/docs/eval-results/context-compression-prefetch-gpt-5-latest-2026-09-10.runs.json
@@ -1,0 +1,4692 @@
+{
+  "version": 1,
+  "createdAt": "2026-09-10T07:23:34.353Z",
+  "metadata": {
+    "gitRevision": "e8c21f8736312cb066790ca6d76020fd96639c58",
+    "gitDirty": true,
+    "provider": "openai",
+    "assistantModel": "gpt-5-latest",
+    "userModel": "gpt-5-latest",
+    "baselineArm": "compression-off",
+    "arms": [
+      "compression-off",
+      "compression-keep-0",
+      "compression-prefetch-keep-0",
+      "compression-prefetch-keep-1"
+    ],
+    "scenarios": [
+      "compression-recent-attachment",
+      "compression-middle-attachment",
+      "compression-recent-assistant",
+      "compression-far-tool-output",
+      "compression-irrelevant-old-bulk",
+      "compression-mixed-depth"
+    ],
+    "repeat": 3,
+    "suite": "context-compression"
+  },
+  "runs": [
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7519,
+          "outputTokens": 25,
+          "totalTokens": 7544,
+          "inputTokenDetails": {
+            "noCacheTokens": 7519,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 3643
+        }
+      ],
+      "totals": {
+        "inputTokens": 7519,
+        "outputTokens": 25,
+        "totalTokens": 7544,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 4445,
+        "inputTokenDetails": {
+          "noCacheTokens": 7519,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.015338
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7329,
+        "estimatedHistoryTokensAfter": 7329,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7515,
+          "outputTokens": 24,
+          "totalTokens": 7539,
+          "inputTokenDetails": {
+            "noCacheTokens": 7515,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1199
+        }
+      ],
+      "totals": {
+        "inputTokens": 7515,
+        "outputTokens": 24,
+        "totalTokens": 7539,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1409,
+        "inputTokenDetails": {
+          "noCacheTokens": 7515,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.015318
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 7325,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7517,
+          "outputTokens": 20,
+          "totalTokens": 7537,
+          "inputTokenDetails": {
+            "noCacheTokens": 7517,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 4332
+        }
+      ],
+      "totals": {
+        "inputTokens": 7517,
+        "outputTokens": 20,
+        "totalTokens": 7537,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 4502,
+        "inputTokenDetails": {
+          "noCacheTokens": 7517,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.015274
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7325,
+        "estimatedHistoryTokensAfter": 7325,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2859,
+          "outputTokens": 64,
+          "totalTokens": 2923,
+          "inputTokenDetails": {
+            "noCacheTokens": 1484,
+            "cacheReadTokens": 1375,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2664
+        }
+      ],
+      "totals": {
+        "inputTokens": 2859,
+        "outputTokens": 64,
+        "totalTokens": 2923,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2856,
+        "inputTokenDetails": {
+          "noCacheTokens": 1484,
+          "cacheReadTokens": 1375,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.004011
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7327,
+        "estimatedHistoryTokensAfter": 834,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2850,
+          "outputTokens": 63,
+          "totalTokens": 2913,
+          "inputTokenDetails": {
+            "noCacheTokens": 1478,
+            "cacheReadTokens": 1372,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 4181
+        }
+      ],
+      "totals": {
+        "inputTokens": 2850,
+        "outputTokens": 63,
+        "totalTokens": 2913,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4381,
+        "inputTokenDetails": {
+          "noCacheTokens": 1478,
+          "cacheReadTokens": 1372,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0039864
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7321,
+        "estimatedHistoryTokensAfter": 827,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2844,
+          "outputTokens": 62,
+          "totalTokens": 2906,
+          "inputTokenDetails": {
+            "noCacheTokens": 1474,
+            "cacheReadTokens": 1370,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 4825
+        }
+      ],
+      "totals": {
+        "inputTokens": 2844,
+        "outputTokens": 62,
+        "totalTokens": 2906,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4968,
+        "inputTokenDetails": {
+          "noCacheTokens": 1474,
+          "cacheReadTokens": 1370,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.003966
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7319,
+        "estimatedHistoryTokensAfter": 825,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1459,
+          "outputTokens": 24,
+          "totalTokens": 1483,
+          "inputTokenDetails": {
+            "noCacheTokens": 1459,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 2172
+        }
+      ],
+      "totals": {
+        "inputTokens": 1459,
+        "outputTokens": 24,
+        "totalTokens": 1483,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2320,
+        "inputTokenDetails": {
+          "noCacheTokens": 1459,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.003206
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7319,
+        "estimatedHistoryTokensAfter": 953,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1479,
+          "outputTokens": 24,
+          "totalTokens": 1503,
+          "inputTokenDetails": {
+            "noCacheTokens": 1479,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1433
+        }
+      ],
+      "totals": {
+        "inputTokens": 1479,
+        "outputTokens": 24,
+        "totalTokens": 1503,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1551,
+        "inputTokenDetails": {
+          "noCacheTokens": 1479,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.003246
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7327,
+        "estimatedHistoryTokensAfter": 967,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1459,
+          "outputTokens": 25,
+          "totalTokens": 1484,
+          "inputTokenDetails": {
+            "noCacheTokens": 1459,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1696
+        }
+      ],
+      "totals": {
+        "inputTokens": 1459,
+        "outputTokens": 25,
+        "totalTokens": 1484,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1869,
+        "inputTokenDetails": {
+          "noCacheTokens": 1459,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.003218
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7317,
+        "estimatedHistoryTokensAfter": 947,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7831,
+          "outputTokens": 21,
+          "totalTokens": 7852,
+          "inputTokenDetails": {
+            "noCacheTokens": 7831,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1204
+        }
+      ],
+      "totals": {
+        "inputTokens": 7831,
+        "outputTokens": 21,
+        "totalTokens": 7852,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1298,
+        "inputTokenDetails": {
+          "noCacheTokens": 7831,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.015914
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7319,
+        "estimatedHistoryTokensAfter": 7319,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7829,
+          "outputTokens": 36,
+          "totalTokens": 7865,
+          "inputTokenDetails": {
+            "noCacheTokens": 7829,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1924
+        }
+      ],
+      "totals": {
+        "inputTokens": 7829,
+        "outputTokens": 36,
+        "totalTokens": 7865,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2050,
+        "inputTokenDetails": {
+          "noCacheTokens": 7829,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.01609
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7319,
+        "estimatedHistoryTokensAfter": 7319,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the exact final release authorization code? Reply with the code only."
+        },
+        {
+          "role": "assistant",
+          "text": "ORCHID-7419",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7835,
+          "outputTokens": 21,
+          "totalTokens": 7856,
+          "inputTokenDetails": {
+            "noCacheTokens": 7835,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1169
+        }
+      ],
+      "totals": {
+        "inputTokens": 7835,
+        "outputTokens": 21,
+        "totalTokens": 7856,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1277,
+        "inputTokenDetails": {
+          "noCacheTokens": 7835,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.015922
+      },
+      "deterministic": {
+        "mentioned": [
+          "ORCHID-7419"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7323,
+        "estimatedHistoryTokensAfter": 7323,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is **17 November 2027**, according to **transition-calendar.txt**.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7853,
+          "outputTokens": 41,
+          "totalTokens": 7894,
+          "inputTokenDetails": {
+            "noCacheTokens": 7853,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1423
+        }
+      ],
+      "totals": {
+        "inputTokens": 7853,
+        "outputTokens": 41,
+        "totalTokens": 7894,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1514,
+        "inputTokenDetails": {
+          "noCacheTokens": 7853,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.016198
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7637,
+        "estimatedHistoryTokensAfter": 7637,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is **17 November 2027**, according to **transition-calendar.txt**.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7857,
+          "outputTokens": 40,
+          "totalTokens": 7897,
+          "inputTokenDetails": {
+            "noCacheTokens": 7857,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1428
+        }
+      ],
+      "totals": {
+        "inputTokens": 7857,
+        "outputTokens": 40,
+        "totalTokens": 7897,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1552,
+        "inputTokenDetails": {
+          "noCacheTokens": 7857,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.016194
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7637,
+        "estimatedHistoryTokensAfter": 7637,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to **transition-calendar.txt**, the approved production transition date is **17 November 2027**.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7855,
+          "outputTokens": 42,
+          "totalTokens": 7897,
+          "inputTokenDetails": {
+            "noCacheTokens": 7855,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1328
+        }
+      ],
+      "totals": {
+        "inputTokens": 7855,
+        "outputTokens": 42,
+        "totalTokens": 7897,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1435,
+        "inputTokenDetails": {
+          "noCacheTokens": 7855,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.016214
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 7635,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to **transition-calendar.txt**, the approved production transition date is **17 November 2027**.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4139,
+          "outputTokens": 77,
+          "totalTokens": 4216,
+          "inputTokenDetails": {
+            "noCacheTokens": 2120,
+            "cacheReadTokens": 2019,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2300
+        }
+      ],
+      "totals": {
+        "inputTokens": 4139,
+        "outputTokens": 77,
+        "totalTokens": 4216,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2451,
+        "inputTokenDetails": {
+          "noCacheTokens": 2120,
+          "cacheReadTokens": 2019,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0055678
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7639,
+        "estimatedHistoryTokensAfter": 1449,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to **transition-calendar.txt**, the approved production transition date is **17 November 2027**.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4147,
+          "outputTokens": 78,
+          "totalTokens": 4225,
+          "inputTokenDetails": {
+            "noCacheTokens": 2125,
+            "cacheReadTokens": 2022,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3328
+        }
+      ],
+      "totals": {
+        "inputTokens": 4147,
+        "outputTokens": 78,
+        "totalTokens": 4225,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3496,
+        "inputTokenDetails": {
+          "noCacheTokens": 2125,
+          "cacheReadTokens": 2022,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0055904
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7639,
+        "estimatedHistoryTokensAfter": 1450,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to **transition-calendar.txt**, the approved production transition date is **17 November 2027**.",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4117,
+          "outputTokens": 74,
+          "totalTokens": 4191,
+          "inputTokenDetails": {
+            "noCacheTokens": 2105,
+            "cacheReadTokens": 2012,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3312
+        }
+      ],
+      "totals": {
+        "inputTokens": 4117,
+        "outputTokens": 74,
+        "totalTokens": 4191,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3447,
+        "inputTokenDetails": {
+          "noCacheTokens": 2105,
+          "cacheReadTokens": 2012,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0055004
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7631,
+        "estimatedHistoryTokensAfter": 1443,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is **17 November 2027**, according to **transition-calendar.txt**.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2102,
+          "outputTokens": 25,
+          "totalTokens": 2127,
+          "inputTokenDetails": {
+            "noCacheTokens": 2102,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 2015
+        }
+      ],
+      "totals": {
+        "inputTokens": 2102,
+        "outputTokens": 25,
+        "totalTokens": 2127,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2163,
+        "inputTokenDetails": {
+          "noCacheTokens": 2102,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.004504
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7635,
+        "estimatedHistoryTokensAfter": 1561,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is **17 November 2027**, according to **transition-calendar.txt**.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2102,
+          "outputTokens": 43,
+          "totalTokens": 2145,
+          "inputTokenDetails": {
+            "noCacheTokens": 2102,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1510
+        }
+      ],
+      "totals": {
+        "inputTokens": 2102,
+        "outputTokens": 43,
+        "totalTokens": 2145,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1698,
+        "inputTokenDetails": {
+          "noCacheTokens": 2102,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00472
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7639,
+        "estimatedHistoryTokensAfter": 1569,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "According to **transition-calendar.txt**, the approved production transition date is **17 November 2027**.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2104,
+          "outputTokens": 25,
+          "totalTokens": 2129,
+          "inputTokenDetails": {
+            "noCacheTokens": 2104,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1286
+        }
+      ],
+      "totals": {
+        "inputTokens": 2104,
+        "outputTokens": 25,
+        "totalTokens": 2129,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1402,
+        "inputTokenDetails": {
+          "noCacheTokens": 2104,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.004508
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7637,
+        "estimatedHistoryTokensAfter": 1567,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The exact production transition date is **17 November 2027**, according to **transition-calendar.txt**.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2096,
+          "outputTokens": 41,
+          "totalTokens": 2137,
+          "inputTokenDetails": {
+            "noCacheTokens": 2096,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1268
+        }
+      ],
+      "totals": {
+        "inputTokens": 2096,
+        "outputTokens": 41,
+        "totalTokens": 2137,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1468,
+        "inputTokenDetails": {
+          "noCacheTokens": 2096,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.004684
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7631,
+        "estimatedHistoryTokensAfter": 1557,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The exact production transition date is **17 November 2027**, according to **transition-calendar.txt**.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2108,
+          "outputTokens": 45,
+          "totalTokens": 2153,
+          "inputTokenDetails": {
+            "noCacheTokens": 2108,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1363
+        }
+      ],
+      "totals": {
+        "inputTokens": 2108,
+        "outputTokens": 45,
+        "totalTokens": 2153,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1538,
+        "inputTokenDetails": {
+          "noCacheTokens": 2108,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.004756
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7637,
+        "estimatedHistoryTokensAfter": 1567,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-middle-attachment",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "According to the approved record, what is the exact production transition date?"
+        },
+        {
+          "role": "assistant",
+          "text": "The approved production transition date is **17 November 2027**, according to **transition-calendar.txt**.",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2098,
+          "outputTokens": 49,
+          "totalTokens": 2147,
+          "inputTokenDetails": {
+            "noCacheTokens": 2098,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1594
+        }
+      ],
+      "totals": {
+        "inputTokens": 2098,
+        "outputTokens": 49,
+        "totalTokens": 2147,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1765,
+        "inputTokenDetails": {
+          "noCacheTokens": 2098,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.004784
+      },
+      "deterministic": {
+        "mentioned": [
+          "17 November 2027"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 7633,
+        "estimatedHistoryTokensAfter": 1557,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7118,
+          "outputTokens": 23,
+          "totalTokens": 7141,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 7115,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 2009
+        }
+      ],
+      "totals": {
+        "inputTokens": 7118,
+        "outputTokens": 23,
+        "totalTokens": 7141,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2017,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 7115,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.001705
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7118,
+          "outputTokens": 21,
+          "totalTokens": 7139,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 7115,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1544
+        }
+      ],
+      "totals": {
+        "inputTokens": 7118,
+        "outputTokens": 21,
+        "totalTokens": 7139,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1545,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 7115,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.001681
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7118,
+          "outputTokens": 22,
+          "totalTokens": 7140,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 7115,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 2782
+        }
+      ],
+      "totals": {
+        "inputTokens": 7118,
+        "outputTokens": 22,
+        "totalTokens": 7140,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2784,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 7115,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.001693
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2584,
+          "outputTokens": 65,
+          "totalTokens": 2649,
+          "inputTokenDetails": {
+            "noCacheTokens": 1348,
+            "cacheReadTokens": 1236,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2489
+        }
+      ],
+      "totals": {
+        "inputTokens": 2584,
+        "outputTokens": 65,
+        "totalTokens": 2649,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2517,
+        "inputTokenDetails": {
+          "noCacheTokens": 1348,
+          "cacheReadTokens": 1236,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0037232
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 683,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2585,
+          "outputTokens": 66,
+          "totalTokens": 2651,
+          "inputTokenDetails": {
+            "noCacheTokens": 1349,
+            "cacheReadTokens": 1236,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2535
+        }
+      ],
+      "totals": {
+        "inputTokens": 2585,
+        "outputTokens": 66,
+        "totalTokens": 2651,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2606,
+        "inputTokenDetails": {
+          "noCacheTokens": 1349,
+          "cacheReadTokens": 1236,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0037372
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 683,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2585,
+          "outputTokens": 67,
+          "totalTokens": 2652,
+          "inputTokenDetails": {
+            "noCacheTokens": 1349,
+            "cacheReadTokens": 1236,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2237
+        }
+      ],
+      "totals": {
+        "inputTokens": 2585,
+        "outputTokens": 67,
+        "totalTokens": 2652,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2261,
+        "inputTokenDetails": {
+          "noCacheTokens": 1349,
+          "cacheReadTokens": 1236,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0037492
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 683,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1266,
+          "outputTokens": 25,
+          "totalTokens": 1291,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 1263,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1909
+        }
+      ],
+      "totals": {
+        "inputTokens": 1266,
+        "outputTokens": 25,
+        "totalTokens": 1291,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1975,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 1263,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0005586
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 740,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1266,
+          "outputTokens": 22,
+          "totalTokens": 1288,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 1263,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1373
+        }
+      ],
+      "totals": {
+        "inputTokens": 1266,
+        "outputTokens": 22,
+        "totalTokens": 1288,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1397,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 1263,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0005226
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 740,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 1266,
+          "outputTokens": 8,
+          "totalTokens": 1274,
+          "inputTokenDetails": {
+            "noCacheTokens": 1266,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 808
+        }
+      ],
+      "totals": {
+        "inputTokens": 1266,
+        "outputTokens": 8,
+        "totalTokens": 1274,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 853,
+        "inputTokenDetails": {
+          "noCacheTokens": 1266,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.002628
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 740,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7438,
+          "outputTokens": 24,
+          "totalTokens": 7462,
+          "inputTokenDetails": {
+            "noCacheTokens": 7438,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1591
+        }
+      ],
+      "totals": {
+        "inputTokens": 7438,
+        "outputTokens": 24,
+        "totalTokens": 7462,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1594,
+        "inputTokenDetails": {
+          "noCacheTokens": 7438,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.015164
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7438,
+          "outputTokens": 20,
+          "totalTokens": 7458,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 7435,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1521
+        }
+      ],
+      "totals": {
+        "inputTokens": 7438,
+        "outputTokens": 20,
+        "totalTokens": 7458,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1523,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 7435,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.001733
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7438,
+          "outputTokens": 24,
+          "totalTokens": 7462,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 7435,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1265
+        }
+      ],
+      "totals": {
+        "inputTokens": 7438,
+        "outputTokens": 24,
+        "totalTokens": 7462,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1268,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 7435,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.001781
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 6926,
+        "estimatedHistoryTokensAfter": 6926,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 0,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9689,
+          "outputTokens": 26,
+          "totalTokens": 9715,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 9686,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1243
+        }
+      ],
+      "totals": {
+        "inputTokens": 9689,
+        "outputTokens": 26,
+        "totalTokens": 9715,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1256,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 9686,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0022551999999999997
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 9539,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9689,
+          "outputTokens": 26,
+          "totalTokens": 9715,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 9686,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 2385
+        }
+      ],
+      "totals": {
+        "inputTokens": 9689,
+        "outputTokens": 26,
+        "totalTokens": 9715,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2393,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 9686,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0022551999999999997
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 9539,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9689,
+          "outputTokens": 24,
+          "totalTokens": 9713,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 9686,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1409
+        }
+      ],
+      "totals": {
+        "inputTokens": 9689,
+        "outputTokens": 24,
+        "totalTokens": 9713,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1411,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 9686,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0022312
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 9539,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8043,
+          "outputTokens": 72,
+          "totalTokens": 8115,
+          "inputTokenDetails": {
+            "noCacheTokens": 4075,
+            "cacheReadTokens": 3968,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2638
+        }
+      ],
+      "totals": {
+        "inputTokens": 8043,
+        "outputTokens": 72,
+        "totalTokens": 8115,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2688,
+        "inputTokenDetails": {
+          "noCacheTokens": 4075,
+          "cacheReadTokens": 3968,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0098076
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3317,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8039,
+          "outputTokens": 70,
+          "totalTokens": 8109,
+          "inputTokenDetails": {
+            "noCacheTokens": 4071,
+            "cacheReadTokens": 3968,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 4033
+        }
+      ],
+      "totals": {
+        "inputTokens": 8039,
+        "outputTokens": 70,
+        "totalTokens": 8109,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 4080,
+        "inputTokenDetails": {
+          "noCacheTokens": 4071,
+          "cacheReadTokens": 3968,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0097756
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3317,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8039,
+          "outputTokens": 69,
+          "totalTokens": 8108,
+          "inputTokenDetails": {
+            "noCacheTokens": 4071,
+            "cacheReadTokens": 3968,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2520
+        }
+      ],
+      "totals": {
+        "inputTokens": 8039,
+        "outputTokens": 69,
+        "totalTokens": 8108,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 2556,
+        "inputTokenDetails": {
+          "noCacheTokens": 4071,
+          "cacheReadTokens": 3968,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0097636
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3317,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3983,
+          "outputTokens": 29,
+          "totalTokens": 4012,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 3980,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1279
+        }
+      ],
+      "totals": {
+        "inputTokens": 3983,
+        "outputTokens": 29,
+        "totalTokens": 4012,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1332,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 3980,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00115
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3365,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3983,
+          "outputTokens": 26,
+          "totalTokens": 4009,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 3980,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1223
+        }
+      ],
+      "totals": {
+        "inputTokens": 3983,
+        "outputTokens": 26,
+        "totalTokens": 4009,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1272,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 3980,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.001114
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3365,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3983,
+          "outputTokens": 26,
+          "totalTokens": 4009,
+          "inputTokenDetails": {
+            "noCacheTokens": 3983,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1171
+        }
+      ],
+      "totals": {
+        "inputTokens": 3983,
+        "outputTokens": 26,
+        "totalTokens": 4009,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1214,
+        "inputTokenDetails": {
+          "noCacheTokens": 3983,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.008278
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3365,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3983,
+          "outputTokens": 47,
+          "totalTokens": 4030,
+          "inputTokenDetails": {
+            "noCacheTokens": 3983,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1317
+        }
+      ],
+      "totals": {
+        "inputTokens": 3983,
+        "outputTokens": 47,
+        "totalTokens": 4030,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1387,
+        "inputTokenDetails": {
+          "noCacheTokens": 3983,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00853
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3365,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3983,
+          "outputTokens": 31,
+          "totalTokens": 4014,
+          "inputTokenDetails": {
+            "noCacheTokens": 3983,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1623
+        }
+      ],
+      "totals": {
+        "inputTokens": 3983,
+        "outputTokens": 31,
+        "totalTokens": 4014,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1666,
+        "inputTokenDetails": {
+          "noCacheTokens": 3983,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.008338
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3365,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-far-tool-output",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What was the exact authoritative reconciled balance from the ledger run? Reply with the amount only, including currency and cents."
+        },
+        {
+          "role": "assistant",
+          "text": "EUR 418,275.60",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3983,
+          "outputTokens": 11,
+          "totalTokens": 3994,
+          "inputTokenDetails": {
+            "noCacheTokens": 3983,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1877
+        }
+      ],
+      "totals": {
+        "inputTokens": 3983,
+        "outputTokens": 11,
+        "totalTokens": 3994,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1924,
+        "inputTokenDetails": {
+          "noCacheTokens": 3983,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.008098
+      },
+      "deterministic": {
+        "mentioned": [
+          "EUR 418,275.60"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9539,
+        "estimatedHistoryTokensAfter": 3365,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9365,
+          "outputTokens": 27,
+          "totalTokens": 9392,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 9362,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1451
+        }
+      ],
+      "totals": {
+        "inputTokens": 9365,
+        "outputTokens": 27,
+        "totalTokens": 9392,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1463,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 9362,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0022024
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 9234,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9365,
+          "outputTokens": 21,
+          "totalTokens": 9386,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 9362,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 2163
+        }
+      ],
+      "totals": {
+        "inputTokens": 9365,
+        "outputTokens": 21,
+        "totalTokens": 9386,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2165,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 9362,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0021304
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 9234,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 9365,
+          "outputTokens": 21,
+          "totalTokens": 9386,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 9362,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1028
+        }
+      ],
+      "totals": {
+        "inputTokens": 9365,
+        "outputTokens": 21,
+        "totalTokens": 9386,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1032,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 9362,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0021304
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 9234,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3519,
+          "outputTokens": 20,
+          "totalTokens": 3539,
+          "inputTokenDetails": {
+            "noCacheTokens": 3519,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1271
+        }
+      ],
+      "totals": {
+        "inputTokens": 3519,
+        "outputTokens": 20,
+        "totalTokens": 3539,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1314,
+        "inputTokenDetails": {
+          "noCacheTokens": 3519,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.007278
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2884,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7137,
+          "outputTokens": 144,
+          "totalTokens": 7281,
+          "inputTokenDetails": {
+            "noCacheTokens": 3621,
+            "cacheReadTokens": 3516,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 3710
+        }
+      ],
+      "totals": {
+        "inputTokens": 7137,
+        "outputTokens": 144,
+        "totalTokens": 7281,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 3760,
+        "inputTokenDetails": {
+          "noCacheTokens": 3621,
+          "cacheReadTokens": 3516,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.009673200000000002
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2884,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7137,
+          "outputTokens": 128,
+          "totalTokens": 7265,
+          "inputTokenDetails": {
+            "noCacheTokens": 3621,
+            "cacheReadTokens": 3516,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 6087
+        }
+      ],
+      "totals": {
+        "inputTokens": 7137,
+        "outputTokens": 128,
+        "totalTokens": 7265,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 6168,
+        "inputTokenDetails": {
+          "noCacheTokens": 3621,
+          "cacheReadTokens": 3516,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0094812
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2884,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3531,
+          "outputTokens": 24,
+          "totalTokens": 3555,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 3528,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1703
+        }
+      ],
+      "totals": {
+        "inputTokens": 3531,
+        "outputTokens": 24,
+        "totalTokens": 3555,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1790,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 3528,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0009996
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2932,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3531,
+          "outputTokens": 29,
+          "totalTokens": 3560,
+          "inputTokenDetails": {
+            "noCacheTokens": 3,
+            "cacheReadTokens": 3528,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1492
+        }
+      ],
+      "totals": {
+        "inputTokens": 3531,
+        "outputTokens": 29,
+        "totalTokens": 3560,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1568,
+        "inputTokenDetails": {
+          "noCacheTokens": 3,
+          "cacheReadTokens": 3528,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0010596
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2932,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3531,
+          "outputTokens": 24,
+          "totalTokens": 3555,
+          "inputTokenDetails": {
+            "noCacheTokens": 3531,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1058
+        }
+      ],
+      "totals": {
+        "inputTokens": 3531,
+        "outputTokens": 24,
+        "totalTokens": 3555,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1083,
+        "inputTokenDetails": {
+          "noCacheTokens": 3531,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.00735
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2932,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 7169,
+          "outputTokens": 173,
+          "totalTokens": 7342,
+          "inputTokenDetails": {
+            "noCacheTokens": 3641,
+            "cacheReadTokens": 3528,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 5416
+        }
+      ],
+      "totals": {
+        "inputTokens": 7169,
+        "outputTokens": 173,
+        "totalTokens": 7342,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 5490,
+        "inputTokenDetails": {
+          "noCacheTokens": 3641,
+          "cacheReadTokens": 3528,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0100636
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2932,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3531,
+          "outputTokens": 23,
+          "totalTokens": 3554,
+          "inputTokenDetails": {
+            "noCacheTokens": 3531,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1150
+        }
+      ],
+      "totals": {
+        "inputTokens": 3531,
+        "outputTokens": 23,
+        "totalTokens": 3554,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1246,
+        "inputTokenDetails": {
+          "noCacheTokens": 3531,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.007338
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2932,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 3531,
+          "outputTokens": 27,
+          "totalTokens": 3558,
+          "inputTokenDetails": {
+            "noCacheTokens": 3531,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 3148
+        }
+      ],
+      "totals": {
+        "inputTokens": 3531,
+        "outputTokens": 27,
+        "totalTokens": 3558,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 3257,
+        "inputTokenDetails": {
+          "noCacheTokens": 3531,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.007386
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 9234,
+        "estimatedHistoryTokensAfter": 2932,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83  \n14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12435,
+          "outputTokens": 42,
+          "totalTokens": 12477,
+          "inputTokenDetails": {
+            "noCacheTokens": 12435,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1442
+        }
+      ],
+      "totals": {
+        "inputTokens": 12435,
+        "outputTokens": 42,
+        "totalTokens": 12477,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1668,
+        "inputTokenDetails": {
+          "noCacheTokens": 12435,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.025374
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 12214,
+        "estimatedHistoryTokensAfter": 12214,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83  \n14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12443,
+          "outputTokens": 43,
+          "totalTokens": 12486,
+          "inputTokenDetails": {
+            "noCacheTokens": 12443,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1556
+        }
+      ],
+      "totals": {
+        "inputTokens": 12443,
+        "outputTokens": 43,
+        "totalTokens": 12486,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1660,
+        "inputTokenDetails": {
+          "noCacheTokens": 12443,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.025402
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 12222,
+        "estimatedHistoryTokensAfter": 12222,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-off",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83  \n14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 12435,
+          "outputTokens": 60,
+          "totalTokens": 12495,
+          "inputTokenDetails": {
+            "noCacheTokens": 12435,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 3091
+        }
+      ],
+      "totals": {
+        "inputTokens": 12435,
+        "outputTokens": 60,
+        "totalTokens": 12495,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 3200,
+        "inputTokenDetails": {
+          "noCacheTokens": 12435,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.02559
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": false,
+        "estimatedHistoryTokensBefore": 12218,
+        "estimatedHistoryTokensAfter": 12218,
+        "triggered": false,
+        "summarizedMessages": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83  \n14 business days from verified incident closure",
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4909,
+          "outputTokens": 134,
+          "totalTokens": 5043,
+          "inputTokenDetails": {
+            "noCacheTokens": 2559,
+            "cacheReadTokens": 2350,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2920
+        }
+      ],
+      "totals": {
+        "inputTokens": 4909,
+        "outputTokens": 134,
+        "totalTokens": 5043,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 3100,
+        "inputTokenDetails": {
+          "noCacheTokens": 2559,
+          "cacheReadTokens": 2350,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.007196
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12220,
+        "estimatedHistoryTokensAfter": 1775,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83\n14 business days from verified incident closure",
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4894,
+          "outputTokens": 129,
+          "totalTokens": 5023,
+          "inputTokenDetails": {
+            "noCacheTokens": 2549,
+            "cacheReadTokens": 2345,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ],
+          "latencyMs": 2678
+        }
+      ],
+      "totals": {
+        "inputTokens": 4894,
+        "outputTokens": 129,
+        "totalTokens": 5023,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 2861,
+        "inputTokenDetails": {
+          "noCacheTokens": 2549,
+          "cacheReadTokens": 2345,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.007115
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12214,
+        "estimatedHistoryTokensAfter": 1770,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83\n14 business days from verified incident closure",
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 4912,
+          "outputTokens": 131,
+          "totalTokens": 5043,
+          "inputTokenDetails": {
+            "noCacheTokens": 2561,
+            "cacheReadTokens": 2351,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [
+            "context-retrieve__search",
+            "context-retrieve__search"
+          ],
+          "latencyMs": 4072
+        }
+      ],
+      "totals": {
+        "inputTokens": 4912,
+        "outputTokens": 131,
+        "totalTokens": 5043,
+        "turns": 1,
+        "toolCalls": 2,
+        "wallMs": 4245,
+        "inputTokenDetails": {
+          "noCacheTokens": 2561,
+          "cacheReadTokens": 2351,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.0071642
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12222,
+        "estimatedHistoryTokensAfter": 1778,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83  \n14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2484,
+          "outputTokens": 67,
+          "totalTokens": 2551,
+          "inputTokenDetails": {
+            "noCacheTokens": 2484,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 3385
+        }
+      ],
+      "totals": {
+        "inputTokens": 2484,
+        "outputTokens": 67,
+        "totalTokens": 2551,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 3521,
+        "inputTokenDetails": {
+          "noCacheTokens": 2484,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.005772
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12220,
+        "estimatedHistoryTokensAfter": 1947,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83  \n14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2486,
+          "outputTokens": 78,
+          "totalTokens": 2564,
+          "inputTokenDetails": {
+            "noCacheTokens": 2486,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 3611
+        }
+      ],
+      "totals": {
+        "inputTokens": 2486,
+        "outputTokens": 78,
+        "totalTokens": 2564,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 3741,
+        "inputTokenDetails": {
+          "noCacheTokens": 2486,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.005908
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12220,
+        "estimatedHistoryTokensAfter": 1949,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83  \n14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2484,
+          "outputTokens": 47,
+          "totalTokens": 2531,
+          "inputTokenDetails": {
+            "noCacheTokens": 2484,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 1395
+        }
+      ],
+      "totals": {
+        "inputTokens": 2484,
+        "outputTokens": 47,
+        "totalTokens": 2531,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 1602,
+        "inputTokenDetails": {
+          "noCacheTokens": 2484,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.005532
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12216,
+        "estimatedHistoryTokensAfter": 1943,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 2,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83  \n14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8853,
+          "outputTokens": 83,
+          "totalTokens": 8936,
+          "inputTokenDetails": {
+            "noCacheTokens": 8853,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 3560
+        }
+      ],
+      "totals": {
+        "inputTokens": 8853,
+        "outputTokens": 83,
+        "totalTokens": 8936,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 3718,
+        "inputTokenDetails": {
+          "noCacheTokens": 8853,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.018702
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12220,
+        "estimatedHistoryTokensAfter": 8314,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83  \n14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8845,
+          "outputTokens": 71,
+          "totalTokens": 8916,
+          "inputTokenDetails": {
+            "noCacheTokens": 8845,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 3464
+        }
+      ],
+      "totals": {
+        "inputTokens": 8845,
+        "outputTokens": 71,
+        "totalTokens": 8916,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 3656,
+        "inputTokenDetails": {
+          "noCacheTokens": 8845,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.018542
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12216,
+        "estimatedHistoryTokensAfter": 8310,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-mixed-depth",
+      "armName": "compression-prefetch-keep-1",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "Give me the exact active service registry identifier and the accepted restoration window. Reply with those two values only."
+        },
+        {
+          "role": "assistant",
+          "text": "LUMEN-83  \n14 business days from verified incident closure",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 8855,
+          "outputTokens": 72,
+          "totalTokens": 8927,
+          "inputTokenDetails": {
+            "noCacheTokens": 8855,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "toolCalls": [],
+          "latencyMs": 3156
+        }
+      ],
+      "totals": {
+        "inputTokens": 8855,
+        "outputTokens": 72,
+        "totalTokens": 8927,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 3344,
+        "inputTokenDetails": {
+          "noCacheTokens": 8855,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0
+        },
+        "costUsd": 0.018574
+      },
+      "deterministic": {
+        "mentioned": [
+          "LUMEN-83",
+          "14 business days"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 12222,
+        "estimatedHistoryTokensAfter": 8316,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 1
+      },
+      "score": 1
+    }
+  ]
+}

--- a/docs/eval-results/context-compression-v8-regression-claude-sonnet-latest-2026-09-10.md
+++ b/docs/eval-results/context-compression-v8-regression-claude-sonnet-latest-2026-09-10.md
@@ -1,0 +1,19 @@
+# Evaluation report
+
+## Overall
+
+| arm | runs | success | score | in tok | cache read | out tok | cost | tools |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-prefetch-keep-0 | 6 | 100% | 1.00 | 8257 | 4584 | 178 | $0.0119 | 0.7 |
+
+## compression-recent-assistant
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-prefetch-keep-0 | 3 | 100% | 1.00 | 13248→1172 | 1.0 | 3415 | 1601 | 120 | $0.00606 | 0.3 | 1.0 | — |
+
+## compression-irrelevant-old-bulk
+
+| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| compression-prefetch-keep-0 | 3 | 100% | 1.00 | 16377→4812 | 1.0 | 13099 | 7568 | 236 | $0.0177 | 1.0 | 1.0 | — |

--- a/docs/eval-results/context-compression-v8-regression-claude-sonnet-latest-2026-09-10.runs.json
+++ b/docs/eval-results/context-compression-v8-regression-claude-sonnet-latest-2026-09-10.runs.json
@@ -1,0 +1,423 @@
+{
+  "version": 1,
+  "createdAt": "2026-09-10T07:34:36.307Z",
+  "metadata": {
+    "gitRevision": "e8c21f8736312cb066790ca6d76020fd96639c58",
+    "gitDirty": true,
+    "provider": "anthropic",
+    "assistantModel": "claude-sonnet-latest",
+    "userModel": "claude-sonnet-latest",
+    "baselineArm": "compression-prefetch-keep-0",
+    "arms": [
+      "compression-prefetch-keep-0"
+    ],
+    "scenarios": [
+      "compression-recent-assistant",
+      "compression-irrelevant-old-bulk"
+    ],
+    "repeat": 3,
+    "suite": "context-compression"
+  },
+  "runs": [
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2514,
+          "outputTokens": 10,
+          "totalTokens": 2524,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 2512
+          },
+          "toolCalls": [],
+          "latencyMs": 2148
+        }
+      ],
+      "totals": {
+        "inputTokens": 2514,
+        "outputTokens": 10,
+        "totalTokens": 2524,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2210,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 2512
+        },
+        "costUsd": 0.006384
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 1172,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": []
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 2514,
+          "outputTokens": 35,
+          "totalTokens": 2549,
+          "inputTokenDetails": {
+            "noCacheTokens": 2,
+            "cacheReadTokens": 1145,
+            "cacheWriteTokens": 1367
+          },
+          "toolCalls": [],
+          "latencyMs": 2253
+        }
+      ],
+      "totals": {
+        "inputTokens": 2514,
+        "outputTokens": 35,
+        "totalTokens": 2549,
+        "turns": 1,
+        "toolCalls": 0,
+        "wallMs": 2318,
+        "inputTokenDetails": {
+          "noCacheTokens": 2,
+          "cacheReadTokens": 1145,
+          "cacheWriteTokens": 1367
+        },
+        "costUsd": 0.0040005
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 1172,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-recent-assistant",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What exact program codename did you record in the final decision? Reply with the codename only."
+        },
+        {
+          "role": "assistant",
+          "text": "Kestrel Blue",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 5218,
+          "outputTokens": 315,
+          "totalTokens": 5533,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 3657,
+            "cacheWriteTokens": 1557
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 6981
+        }
+      ],
+      "totals": {
+        "inputTokens": 5218,
+        "outputTokens": 315,
+        "totalTokens": 5533,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 7016,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 3657,
+          "cacheWriteTokens": 1557
+        },
+        "costUsd": 0.0077819
+      },
+      "deterministic": {
+        "mentioned": [
+          "Kestrel Blue"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 13248,
+        "estimatedHistoryTokensAfter": 1172,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 0,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13099,
+          "outputTokens": 115,
+          "totalTokens": 13214,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 7568,
+            "cacheWriteTokens": 5527
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 4995
+        }
+      ],
+      "totals": {
+        "inputTokens": 13099,
+        "outputTokens": 115,
+        "totalTokens": 13214,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 5104,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 7568,
+          "cacheWriteTokens": 5527
+        },
+        "costUsd": 0.0164891
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 4812,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 1,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13099,
+          "outputTokens": 334,
+          "totalTokens": 13433,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 7568,
+            "cacheWriteTokens": 5527
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 8047
+        }
+      ],
+      "totals": {
+        "inputTokens": 13099,
+        "outputTokens": 334,
+        "totalTokens": 13433,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 8113,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 7568,
+          "cacheWriteTokens": 5527
+        },
+        "costUsd": 0.018679099999999997
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 4812,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    },
+    {
+      "scenarioId": "compression-irrelevant-old-bulk",
+      "armName": "compression-prefetch-keep-0",
+      "repetition": 2,
+      "outcome": "goal-reached",
+      "transcript": [
+        {
+          "role": "user",
+          "text": "What is the current escalation channel? Reply with its name only."
+        },
+        {
+          "role": "assistant",
+          "text": "Falcon Desk",
+          "toolCalls": [
+            "context-retrieve__search"
+          ]
+        }
+      ],
+      "turns": [
+        {
+          "inputTokens": 13100,
+          "outputTokens": 259,
+          "totalTokens": 13359,
+          "inputTokenDetails": {
+            "noCacheTokens": 4,
+            "cacheReadTokens": 7568,
+            "cacheWriteTokens": 5528
+          },
+          "toolCalls": [
+            "context-retrieve__search"
+          ],
+          "latencyMs": 10338
+        }
+      ],
+      "totals": {
+        "inputTokens": 13100,
+        "outputTokens": 259,
+        "totalTokens": 13359,
+        "turns": 1,
+        "toolCalls": 1,
+        "wallMs": 10360,
+        "inputTokenDetails": {
+          "noCacheTokens": 4,
+          "cacheReadTokens": 7568,
+          "cacheWriteTokens": 5528
+        },
+        "costUsd": 0.0179316
+      },
+      "deterministic": {
+        "mentioned": [
+          "Falcon Desk"
+        ],
+        "missing": [],
+        "forbidden": [],
+        "pass": true,
+        "skipped": false
+      },
+      "compression": {
+        "enabled": true,
+        "estimatedHistoryTokensBefore": 16377,
+        "estimatedHistoryTokensAfter": 4812,
+        "triggerAtTokens": 6000,
+        "triggered": true,
+        "summarizedMessages": 1,
+        "keepRecentTurns": 0
+      },
+      "score": 1
+    }
+  ]
+}

--- a/docs/evaluation-harness.md
+++ b/docs/evaluation-harness.md
@@ -222,22 +222,24 @@ exists, replay never touches the source deployment, S3, or any network beyond th
 
 The replay is not an off/on comparison — it runs each turn once, with whatever configuration you
 give it. The "before" number to compare against is production's own `MessageAudit` input-token
-count, which travels in the bundle.
+count, which travels in the bundle. Replay cost intentionally prices all input tokens at the normal
+input rate: prompt-cache read/write discounts are ignored on both sides.
 
 ### Stage 1 — build the bundle
 
-`eval-build-replay-bundle.ts` ranks `MessageAudit` records of type `user` by their **audited input
-tokens** (the persisted provider count for the invocation, so it selects genuinely costly prompts,
-not merely long-looking messages). For each admitted turn it copies into the bundle: the full
-parent lineage, the `MessageAudit` row, the published assistant configuration (`Assistant` /
-`AssistantVersion` / `Backend`), the saved production reply, and every attachment — `File` /
+`eval-build-replay-bundle.ts` takes exactly one positional conversation id. It does not choose a
+message, calculate a parent lineage, mine traffic, rank turns, or apply cohort filters. Choosing an
+interesting conversation (for example from audited token trends) belongs to the infra discovery
+tools. The builder copies into the bundle the complete conversation: every `Message` and
+`MessageAudit`, the published assistant configuration (`Assistant` / `AssistantVersion` /
+`Backend`), and every attachment referenced anywhere in the conversation — `File` /
 `FileBlob` rows rewritten as `production-replay-user`-owned with encryption cleared, and the bytes
 themselves **decrypted** into a `ReplayFileBlob(path, size, bytes)` table. No provider
 credentials, no storage credentials, no other tenant data.
 
 The builder is infra-agnostic: it reads the source database from `--source-db` (or `$DATABASE_URL`)
 and attachment bytes through the normal storage stack (`FILE_STORAGE_LOCATION` plus the
-`FILE_STORAGE_ENCRYPTION_*` vars, only needed when a selected turn has attachments).
+`FILE_STORAGE_ENCRYPTION_*` vars, only needed when the conversation has attachments).
 
 **Lowest friction — run it on a running instance.** Exec into a Logicle container: `DATABASE_URL`
 and `FILE_STORAGE_LOCATION` are already set to that instance's database and object store, so no
@@ -246,7 +248,7 @@ flags and no proxy are needed. Copy the bundle back out afterwards (`kubectl cp`
 ```bash
 # inside the container (its own env already points at the right DB + storage)
 npx tsx apps/backend/scripts/eval-build-replay-bundle.ts \
-  --out /tmp/expensive.sqlite --min-input-tokens 12000 --limit 25
+  --out /tmp/conversation.sqlite <conversation-id>
 ```
 
 **From a workstation** — point `--source-db` and `FILE_STORAGE_LOCATION` at the tenant through
@@ -258,62 +260,79 @@ FILE_STORAGE_LOCATION=s3://logicle-tenant-42-files \
 FILE_STORAGE_ENCRYPTION_ENABLE=1 FILE_STORAGE_ENCRYPTION_KEY=... \
 npx tsx apps/backend/scripts/eval-build-replay-bundle.ts \
   --source-db postgres://readonly@127.0.0.1:5432/logicle \
-  --out expensive.sqlite --min-input-tokens 12000 --limit 25
+  --out conversation.sqlite <conversation-id>
 ```
 
-The builder only considers turns it can replay **faithfully**, so the numbers mean something:
+The builder rejects conversation-level fidelity failures it cannot represent offline:
 
-- **recent** — sent within the last 90 days (`--since <ISO date>` to change; `--since 1970-01-01`
-  to disable). Old turns ran against assistant configs and model versions that no longer exist.
-- **assistant still current** — the assistant is not deleted, and it still publishes the exact
-  model the turn actually used (`MessageAudit.model == AssistantVersion.model`). A turn whose
-  assistant has since been re-pointed at another model is dropped: replaying it would measure a
-  different assistant than the one that incurred the cost.
+- **assistant available** — the assistant and its published version must still exist.
 - **no tools / knowledge / sub-assistants** — those can't be reproduced offline (a knowledge box
-  needs its index, a tool needs its backend), and they are usually the most expensive cohort, so
-  excluding them in SQL keeps `--limit` counting turns you can actually use.
-- **clean in production** — the turn did not record an error.
+  needs its index, a tool needs its backend).
 
-Turns that pass those and are then skipped during the copy (lineage has saved tool activity, an
-attachment's rows or bytes cannot be resolved) get a reason in `<out>.skipped.json` — so a replay
-never silently omits a file or loses a tool capability. To cover tool conversations, extend the
-builder with a tool-specific fixture adapter.
+If an attachment's rows or bytes cannot be resolved, the builder writes the exact reason to
+`<out>.skipped.json` and exits unsuccessfully. It never silently omits a file. Message-level
+fidelity checks belong to the replay runner, because only the runner knows which message is being
+replayed. To cover tool conversations offline, extend the bundle with a tool-specific fixture
+adapter.
 
 ### Stage 2 — replay the bundle
 
 ```bash
-# Sanity check — the most expensive turn, saved config, nothing changed (should ~match production):
+# Default: replay the latest audited user message with a saved assistant response.
 OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
-  --bundle expensive.sqlite --out replay-results.json --report replay-report.md
+  --bundle conversation.sqlite --out replay-results.json --report replay-report.md
 
-# Mode A — same model, compression on, delta vs production's MessageAudit:
+# Or select one exact message from the bundled conversation.
 OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
-  --bundle expensive.sqlite --out on.json --report on.md --judge \
+  --bundle conversation.sqlite --message <message-id> --out on.json --report on.md --judge \
   --override '{"contextCompression":{"preset":"conservative","retrievalMode":"prefetch"}}'
+
+# Free inspection: select the message, reconstruct its parent lineage, and calculate the exact
+# compression decisions plus tokenizer-based before/after history estimates without an LLM call.
+npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
+  --bundle conversation.sqlite --message <message-id> --inspect-only \
+  --out inspection.json --report inspection.md \
+  --override '{"contextCompression":{"preset":"conservative","retrievalMode":"prefetch"}}'
+
+# The same selector and parent-lineage code can read the configured live DB/storage instead.
+DATABASE_URL=... FILE_STORAGE_LOCATION=... OPENAI_API_KEY=... \
+npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
+  --conversation <conversation-id> --message <message-id> \
+  --out live.json --report live.md
 
 # Mode B — cheap model, off then on, measured by the same ruler:
 LOGICLECLOUD_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
-  --bundle expensive.sqlite --out b-off.json --report b-off.md \
+  --bundle conversation.sqlite --out b-off.json --report b-off.md \
   --model gpt-5.6-luna --override '{"contextCompression":null}'
 LOGICLECLOUD_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
-  --bundle expensive.sqlite --out b-on.json --report b-on.md --judge \
+  --bundle conversation.sqlite --out b-on.json --report b-on.md --judge \
   --model gpt-5.6-luna \
   --override '{"contextCompression":{"preset":"conservative","retrievalMode":"prefetch"}}'
 ```
 
-The runner copies the bundle to a scratch directory, points the app at that copy and at
-`FILE_STORAGE_LOCATION=replaydb:` (`DbBlobStorage` serves attachment bytes straight from
-`ReplayFileBlob`), and for each selected turn rebuilds the saved assistant with `--override` merged
-over its configuration, runs the turn once, and records the response, the real provider token
-usage, and the priced cost. `--override` is a JSON object merged over `model` / `systemPrompt` /
+The runner accepts either `--bundle <sqlite>` or `--conversation <id>` for direct live access.
+It selects `--message <id>`, or defaults to the latest audited user message with a saved assistant
+response, and reconstructs that message's parent lineage. Bundle mode points the app at a scratch
+copy and at `FILE_STORAGE_LOCATION=replaydb:`; live mode uses the already configured DB and storage.
+The `ChatAssistant` receives no persistence callbacks, so live mode does not write messages.
+It can still populate the normal `CompressedMessage` and `FileAnalysis` caches. Use a bundle when
+the source DB must not be mutated; a database read-only role can cause a live compression replay to
+fail on a cold cache rather than silently making it read-only.
+The runner rebuilds the saved assistant with `--override` merged over its configuration, runs the
+turn once, and records the response, provider token usage, and priced cost. `--override` is a JSON
+object merged over `model` / `systemPrompt` /
 `temperature` / `tokenLimit` / `reasoning_effort` / `contextCompression` (use
 `{"contextCompression":null}` to turn it off); its shape follows whatever the running code's schema
 accepts, so newer options work without changing this script.
 
-**It replays one turn per invocation by default** — the most expensive in the bundle — so a run is
-one LLM call and the spend is known before you start. Widen it deliberately: `--case <messageId>`
-(repeat for a handful of specific turns, listed in `replay-report.md` and the bundle's
-`MessageAudit`) or `--limit <n>` for the _n_ most expensive.
+Each runner invocation selects one message and runs one assistant turn. A turn can make multiple
+provider calls when the assistant loops through context-retrieval tools; token usage is summed over
+all of them and the JSON/report records both the provider-call count and tool-call names. `--judge`
+adds another provider request. Before making the call, the runner rejects a production error, a
+missing response or parent, model drift, an unsupported lineage containing tool/auth/error
+activity, and assistant capabilities for which no fixture exists. `--inspect-only` stops after
+selection, lineage reconstruction, compression planning, application, and token estimation: it
+requires no provider key and makes no LLM call.
 
 ### Operating modes — cost/quality testing without a big bill
 
@@ -321,8 +340,8 @@ A replay calls a real provider with a real (often six-figure-token) prompt. Keep
 
 - **Build the bundle once, replay many times.** Stage 1 is the only step that touches production
   and it costs nothing. Iterate on its output.
-- **Default to one turn — the most expensive.** That single case is the interesting one and it is
-  one LLM call. `--case <id>` / `--limit <n>` only when you have a reason.
+- **One bundle, one complete conversation; one selected message per run.** Select conversations with
+  the read-only infra discovery tools before downloading them.
 - **`--judge` roughly doubles the cost** (a second model call over the same prompt). Get the token
   numbers for all your turns first; judge only the ones whose numbers look worth a closer look.
 
@@ -346,10 +365,11 @@ window make that delta meaningless. Mode A keeps the model; Mode B keeps the rul
 **Reading the result:**
 
 - **Saving** — replay input tokens vs the baseline (production for Mode A, the off run for Mode B),
-  as a percentage. Watch for near-zero: if the assistant's `tokenLimit` already truncates history
-  below budget, compression runs after that truncation and saves almost nothing while still
-  swapping verbatim text for lossy summaries — a strict `tokenLimit` and compression work against
-  each other.
+  as a percentage. The actual order is compression first, then `truncateChat`. If an uncompressed
+  chat was already at `tokenLimit`, shrinking its messages can simply let truncation retain more
+  old messages, leaving provider input near the same limit. That cohort does not isolate the value
+  of compression; prefer audited conversations whose input-token series is monotonic and remains
+  below the assistant's limit.
 - **Quality** — `--judge` classifies the response against the saved production reply (a
   **reference, not an answer key** — review every non-equivalent verdict yourself). The failure
   mode to look for: a summary/excerpt that dropped an exact figure the user asked about.

--- a/packages/core/src/types/dto/assistant.ts
+++ b/packages/core/src/types/dto/assistant.ts
@@ -37,6 +37,10 @@ export const contextCompressionConfigSchema = z
   .object({
     preset: contextCompressionPresetSchema,
     triggerAtTokens: z.number().int().positive().optional(),
+    /** Completed turns immediately before the current one that remain verbatim. */
+    keepRecentTurns: z.number().int().min(0).optional(),
+    /** How omitted content is restored when the current request appears to need it. */
+    retrievalMode: z.enum(['tool', 'prefetch']).optional(),
   })
   .nullable()
 

--- a/packages/core/src/types/dto/chat.ts
+++ b/packages/core/src/types/dto/chat.ts
@@ -374,6 +374,11 @@ interface TextStreamPartUsage extends TextStreamPartGeneric {
   inputTokens: number
   outputTokens: number
   totalTokens: number
+  inputTokenDetails?: {
+    noCacheTokens?: number
+    cacheReadTokens?: number
+    cacheWriteTokens?: number
+  }
 }
 
 export type TextStreamPart =


### PR DESCRIPTION
## Summary

Adds query-aware recovery for compressed chat history, production replay tooling, and the evaluated default compression configuration. Historical attachments, long responses, and tool results remain exactly recoverable; attachment-only follow-up turns now retain their conversational task while preserving the large token reduction observed in production replay.

## Details

- Defaults context recovery to deterministic query-aware prefetch with exact `context-retrieve.search`, `get_message`, and `get_file` fallback.
- Keeps compression decisions and cached base summaries turn-stable while appending bounded, query-dependent excerpts.
- Recovers the nearest non-empty user request when the current turn contains only an attachment and adds bounded continuation context in both `prefetch` and `tool` modes.
- Adds synthetic reference chats and cache-aware eval accounting for compression-off, tool-only, prefetch, and recent-turn-window arms.
- Changes production bundle construction to save one complete conversation; replay selects one message, reconstructs its parent lineage, and supports free deterministic inspection.
- Bundles decrypted attachment bytes and extracted-text sidecars for offline replay, with strict HTTP byte-range validation and redacted database connection logging.
- Persists provider/tool-call counts and deliberately prices production replay without prompt-cache discounts.
- Preserves compression configuration through the assistant editor and generated OpenAPI schema.

## Production validation

- Selected conversations had monotonic audited input-token series and stayed below their assistant token limits, avoiding truncation-confounded comparisons.
- Historical attachments, text current turn: `718,733 -> 50,545` input tokens (`92.97%` reduction), manually equivalent-or-better response.
- Historical attachments, attachment-only current turn: `764,383 -> 26,708` (`96.51%` reduction), one provider call, no retrieval tools, manually equivalent response after the continuation fix.
- Long text-only chat: `15,497 -> 8,250` (`46.76%` reduction), usable response with a minor drafting regression.
- Many-short-message control: deterministic no-op; individual messages remain below compression thresholds.
- Knowledge-heavy preambles remain out of scope because history compression does not affect them by design.

## Risks

- The production quality sample contains three reviewed messages; the attachment-only fix has one passing real conversation plus synthetic coverage and should be repeated before claiming broad robustness.
- Production `MessageAudit` preserves model and usage but not an immutable copy of every historical assistant setting, so small production/replay deltas remain susceptible to configuration drift.
- `keepRecentTurns: 0` removes the full-turn exemption; short plain-text messages can still remain verbatim where a recovery marker would be larger.
- Live replay does not persist messages but can populate normal compression/file-analysis caches; bundle mode is the zero-source-mutation path.

## Tests

- `npm run check-types` — passed after the attachment-continuation change.
- `npx vitest run apps/backend/lib/chat/__tests__/compression-planner.test.ts apps/backend/lib/chat/__tests__/conversion-estimation-parity.test.ts apps/backend/lib/storage/__tests__/HttpReadOnlyStorage.test.ts` — 44 tests passed.
- `npm test` — 137 files passed, 1,287 tests passed, 21 skipped before the final focused change; full branch CI reruns this suite.
- `npm run generate:openapi` — passed and regenerated `apps/frontend/public/openapi.yaml`.
- `npx biome check` over all 29 changed TypeScript/TSX files — passed.
- Context-compression synthetic evaluation: 120/120 GPT-4.1 mini, 72/72 GPT-5, and 72/72 Claude Sonnet runs passed; focused Claude v8 regression passed 6/6.
- Production attachment-only replay after the fix — one provider call, no tool calls, task continuity restored at 96.51% fewer input tokens.
- `git diff --check` — passed.
