### PR TITLE
chore(eval): offline production-chat compression replay tooling

### DIFF
--- a/apps/backend/lib/eval/__tests__/productionChatReplay.test.ts
+++ b/apps/backend/lib/eval/__tests__/productionChatReplay.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectAttachmentFileIds,
+  isReplayableLineage,
+} from '@/backend/lib/eval/productionChatReplay'
+import type * as dto from '@/types/dto'
+
+const user = (overrides: Partial<dto.UserMessage> = {}): dto.UserMessage => ({
+  id: 'user-1',
+  conversationId: 'conversation-1',
+  parent: null,
+  sentAt: '2026-01-01T00:00:00.000Z',
+  role: 'user' as const,
+  content: 'Question',
+  attachments: [],
+  ...overrides,
+})
+
+describe('isReplayableLineage', () => {
+  it('admits a text-only user/assistant lineage ending at the audited user turn', () => {
+    expect(
+      isReplayableLineage([
+        user(),
+        {
+          id: 'assistant-1',
+          conversationId: 'conversation-1',
+          parent: 'user-1',
+          sentAt: '2026-01-01T00:00:01.000Z',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Answer' }],
+          finishReason: 'stop',
+        },
+        { ...user(), id: 'user-2', parent: 'assistant-1' },
+      ])
+    ).toBeUndefined()
+  })
+
+  it('admits an attachment-bearing user turn (bytes are resolved from object storage)', () => {
+    expect(
+      isReplayableLineage([
+        user({
+          attachments: [{ id: 'file-1', name: 'file.txt', mimetype: 'text/plain', size: 1 }],
+        }),
+      ])
+    ).toBeUndefined()
+  })
+
+  it('rejects tool, authorization, or error activity that cannot be replayed', () => {
+    expect(
+      isReplayableLineage([
+        user(),
+        {
+          id: 'tool-1',
+          conversationId: 'conversation-1',
+          parent: 'user-1',
+          sentAt: '2026-01-01T00:00:01.000Z',
+          role: 'tool',
+          parts: [],
+        },
+      ])
+    ).toContain('tool')
+  })
+})
+
+describe('collectAttachmentFileIds', () => {
+  it('returns every distinct attachment id in first-seen order', () => {
+    expect(
+      collectAttachmentFileIds([
+        user({
+          attachments: [
+            { id: 'file-1', name: 'a.txt', mimetype: 'text/plain', size: 1 },
+            { id: 'file-2', name: 'b.png', mimetype: 'image/png', size: 2 },
+          ],
+        }),
+        {
+          ...user(),
+          id: 'user-2',
+          attachments: [{ id: 'file-1', name: 'a.txt', mimetype: 'text/plain', size: 1 }],
+        },
+      ])
+    ).toEqual(['file-1', 'file-2'])
+  })
+
+  it('returns nothing for a text-only lineage', () => {
+    expect(collectAttachmentFileIds([user()])).toEqual([])
+  })
+})

--- a/apps/backend/lib/eval/productionChatReplay.ts
+++ b/apps/backend/lib/eval/productionChatReplay.ts
@@ -1,0 +1,115 @@
+import * as ai from 'ai'
+import * as z from 'zod'
+import type { LanguageModelV3 } from '@ai-sdk/provider'
+import type * as dto from '@/types/dto'
+import type { ProviderType } from '@/types/provider'
+
+/**
+ * One production turn selected for offline compression replay.
+ *
+ * The bundle builder (`eval-build-replay-bundle.ts`) writes the full lineage, the published
+ * assistant configuration, and the saved production reply into a self-contained SQLite bundle;
+ * attachment bytes travel in the bundle's `ReplayFileBlob` table, already decrypted. The offline
+ * evaluator reconstructs this shape from the bundle and never touches the source deployment.
+ */
+export interface ProductionReplayCase {
+  id: string
+  source: {
+    conversationId: string
+    messageId: string
+    auditedInputTokens: number
+    auditedModel: string
+    sentAt: string
+  }
+  assistant: {
+    id: string
+    versionId: string
+    providerType: ProviderType
+    model: string
+    systemPrompt: string
+    temperature: number
+    tokenLimit: number
+    reasoningEffort: dto.AssistantVersion['reasoning_effort']
+  }
+  /** The complete saved lineage, ending in the user message that incurred the audited prompt. */
+  messages: dto.Message[]
+  /** Production's next assistant text. It is a comparison reference, not an answer key. */
+  productionReply: string
+}
+
+export type ReplayVerdict = 'equivalent' | 'minor-regression' | 'major-regression' | 'inconclusive'
+
+export interface ReplayJudgment {
+  verdict: ReplayVerdict
+  rationale: string
+  failures: string[]
+}
+
+const replayJudgmentSchema = z.object({
+  verdict: z.enum(['equivalent', 'minor-regression', 'major-regression', 'inconclusive']),
+  rationale: z.string(),
+  failures: z.array(z.string()),
+})
+
+const replayJudgePrompt = [
+  'Compare a candidate chat response with the production response to the same final user message.',
+  'Decide whether compression caused a material regression in helpfulness, completeness, instruction-following, or unsupported claims.',
+  'The production answer is only a reference, not proof that its facts are correct. Do not invent a factual answer key.',
+  'Return equivalent when the candidate is at least as useful in substance; minor-regression for a recoverable omission; major-regression when the user would materially fail; inconclusive when the reference is insufficient to judge.',
+  'Do not prefer either answer for length, style, or wording alone.',
+].join('\n')
+
+export const createReplayJudge =
+  (model: LanguageModelV3) =>
+  async (
+    finalUserMessage: string,
+    productionReply: string,
+    candidateReply: string
+  ): Promise<ReplayJudgment> => {
+    const result = await ai.generateObject({
+      model,
+      schema: replayJudgmentSchema,
+      temperature: 0,
+      system: replayJudgePrompt,
+      prompt: [
+        `Final user message:\n${finalUserMessage}`,
+        '',
+        `Production response:\n${productionReply || '[no saved assistant response]'}`,
+        '',
+        `Candidate response:\n${candidateReply || '[no candidate response]'}`,
+      ].join('\n'),
+    })
+    return {
+      verdict: result.object.verdict,
+      rationale: result.object.rationale.trim(),
+      failures: result.object.failures.map((failure) => failure.trim()).filter(Boolean),
+    }
+  }
+
+export const messageHasAttachment = (message: dto.Message): boolean =>
+  (message.role === 'user' || message.role === 'user-response') &&
+  'attachments' in message &&
+  message.attachments.length > 0
+
+/** Every distinct attachment file id referenced anywhere in a lineage, in first-seen order. */
+export const collectAttachmentFileIds = (messages: dto.Message[]): string[] => {
+  const ids = new Set<string>()
+  for (const message of messages) {
+    if ((message.role === 'user' || message.role === 'user-response') && 'attachments' in message) {
+      for (const attachment of message.attachments) ids.add(attachment.id)
+    }
+  }
+  return [...ids]
+}
+
+export const isReplayableLineage = (messages: dto.Message[]): string | undefined => {
+  // Attachments are fine: the bundle carries their bytes. Tool, authorization, and error activity
+  // are not — replaying them would silently drop a capability.
+  if (messages.some((message) => message.role !== 'user' && message.role !== 'assistant')) {
+    return 'history contains tool, authorization, or error activity'
+  }
+  if (messages.length === 0 || messages.at(-1)?.role !== 'user') {
+    return 'audited message does not end a user-message lineage'
+  }
+  return undefined
+}

--- a/apps/backend/lib/storage/DbBlobStorage.ts
+++ b/apps/backend/lib/storage/DbBlobStorage.ts
@@ -1,0 +1,48 @@
+import { sql } from 'kysely'
+import { BaseStorage } from './api'
+import type { StorageEncryption, StorageReadOptions } from './api'
+import { bufferToReadableStream } from './utils'
+
+/**
+ * Read-only storage backed by a `ReplayFileBlob(path, size, bytes)` table in the app database.
+ *
+ * The offline compression-replay evaluator sets `FILE_STORAGE_LOCATION=replaydb:` so that
+ * attachment bytes bundled into its throwaway replay database are served with no external object
+ * store and no network. The table is created by the bundle builder
+ * (`eval-build-replay-bundle.ts`), never by a migration — it does not exist in a real deployment.
+ * Bytes are stored already decrypted, so reads ignore the encryption argument. Writes and deletes
+ * throw.
+ */
+export class DbBlobStorage extends BaseStorage {
+  async readStream(
+    filePath: string,
+    _encryption: StorageEncryption,
+    options?: StorageReadOptions
+  ): Promise<ReadableStream<Uint8Array>> {
+    const { db } = await import('@/db/database')
+    const result = await sql<{ bytes: Buffer | Uint8Array }>`
+      SELECT "bytes" FROM "ReplayFileBlob" WHERE "path" = ${filePath}
+    `.execute(db)
+    const row = result.rows[0]
+    if (!row) {
+      throw new Error(`No ReplayFileBlob row for path ${filePath}`)
+    }
+    let bytes = Buffer.isBuffer(row.bytes) ? row.bytes : Buffer.from(row.bytes)
+    const { rangeStart, rangeEnd } = options ?? {}
+    if (typeof rangeStart === 'number' || typeof rangeEnd === 'number') {
+      bytes = bytes.subarray(
+        rangeStart ?? 0,
+        typeof rangeEnd === 'number' ? rangeEnd + 1 : undefined
+      )
+    }
+    return bufferToReadableStream(bytes)
+  }
+
+  async writeStream(): Promise<void> {
+    throw new Error('DbBlobStorage is read-only')
+  }
+
+  async rm(): Promise<void> {
+    throw new Error('DbBlobStorage is read-only')
+  }
+}

--- a/apps/backend/lib/storage/index.ts
+++ b/apps/backend/lib/storage/index.ts
@@ -2,6 +2,7 @@ import env from '@/lib/env'
 import { Storage } from './api'
 import { CachingStorage } from './CachingStorage'
 import { AeadEncryptingStorage } from '../../ee/AeadEncryptingStorage'
+import { DbBlobStorage } from './DbBlobStorage'
 import { FsStorage } from './FsStorage'
 import { S3Storage } from './S3Storage'
 import { PgpEncryptingStorage } from '../../ee/PgpEncryptingStorage'
@@ -14,6 +15,9 @@ function createBasicStorage(location: string) {
       throw new Error('Invalid S3 URL. Must be in the format s3://bucket')
     }
     return new S3Storage(bucket)
+  } else if (location === 'replaydb:') {
+    // Offline compression-replay evaluator only: bytes come from the replay database itself.
+    return new DbBlobStorage()
   } else {
     return new FsStorage(location)
   }

--- a/apps/backend/scripts/eval-build-replay-bundle.ts
+++ b/apps/backend/scripts/eval-build-replay-bundle.ts
@@ -1,0 +1,448 @@
+/**
+ * Builds a self-contained offline replay bundle from a source Logicle database.
+ *
+ * The bundle is a single SQLite file: the app schema, plus only the selected conversations'
+ * `Conversation` / `Message` / `MessageAudit` / `Assistant*` / `Backend` / `File` / `FileBlob`
+ * rows, plus a `ReplayFileBlob(path, size, bytes)` table holding every referenced attachment's
+ * bytes **decrypted**. `eval-replay-production-chats.ts` consumes it with zero network access.
+ *
+ * This script is infra-agnostic. It reads the source database via `--source-db` (or `DATABASE_URL`)
+ * and attachment bytes via the normal storage stack (`FILE_STORAGE_LOCATION` plus the
+ * `FILE_STORAGE_ENCRYPTION_*` vars, only needed when a selected turn has attachments). Pointing
+ * those at a specific tenant — proxy, SSH tunnel, direct — is the job of the ops-repo extractor,
+ * not this script.
+ *
+ * Usage:
+ *   FILE_STORAGE_LOCATION=s3://tenant-bucket FILE_STORAGE_ENCRYPTION_ENABLE=1 \
+ *   FILE_STORAGE_ENCRYPTION_KEY=... \
+ *   npx tsx apps/backend/scripts/eval-build-replay-bundle.ts \
+ *     --source-db postgres://... --out bundle.sqlite --min-input-tokens 12000 --limit 25
+ *
+ * Flags:
+ *   --source-db <path|url>     source SQLite path or DATABASE_URL (default: $DATABASE_URL)
+ *   --out <path>               bundle SQLite file to write (required); <out>.skipped.json is also written
+ *   --min-input-tokens <n>     MessageAudit input-token floor (default: 12000)
+ *   --limit <n>                admitted turns (default: 20)
+ *   --assistant <id>           restrict to one assistant
+ */
+
+export {}
+
+import { rmSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+import { Kysely, Migrator, SqliteDialect, sql } from 'kysely'
+import type { DB, Message as DbMessage } from '@/db/schema'
+
+const errText = (error: unknown): string => (error instanceof Error ? error.message : String(error))
+
+const args = process.argv.slice(2).filter((arg) => arg !== '--')
+const flag = (name: string): string | undefined => {
+  const index = args.indexOf(`--${name}`)
+  return index === -1 ? undefined : args[index + 1]
+}
+
+const sourceDb = flag('source-db') ?? process.env.DATABASE_URL
+const out = flag('out')
+if (!sourceDb || !out) {
+  console.error('Usage: --source-db <path|url> (or $DATABASE_URL) --out <bundle.sqlite>')
+  process.exit(1)
+}
+
+const minimumAuditedInputTokens = Number(flag('min-input-tokens') ?? 12000)
+const limit = Number(flag('limit') ?? 20)
+const assistantFilter = flag('assistant')
+if (!Number.isFinite(minimumAuditedInputTokens) || minimumAuditedInputTokens < 1) {
+  console.error('--min-input-tokens must be a positive number')
+  process.exit(1)
+}
+if (!Number.isInteger(limit) || limit < 1) {
+  console.error('--limit must be a positive integer')
+  process.exit(1)
+}
+
+// The app db/storage singletons must bind to the source. Set this before importing them.
+process.env.DATABASE_URL = sourceDb.includes('://') ? sourceDb : `file://${sourceDb}`
+
+const { db: source } = await import('@/db/database')
+const { dtoMessageFromDbMessage } = await import('@/models/utils')
+const { renderMessagePlainText } = await import('@/backend/lib/chat/message-projection')
+const { isReplayableLineage, collectAttachmentFileIds } = await import(
+  '@/backend/lib/eval/productionChatReplay'
+)
+const { migrationModules } = await import('@/db/migrations.generated')
+
+// Remove any stale bundle so the schema is rebuilt cleanly, then open it as a second connection.
+rmSync(out, { force: true })
+const BetterSqlite = (await import('better-sqlite3')).default
+const bundle = new Kysely<DB>({
+  dialect: new SqliteDialect({ database: new BetterSqlite(out) }),
+})
+
+const migrator = new Migrator({
+  db: bundle,
+  provider: {
+    getMigrations: async () =>
+      Object.fromEntries(
+        Object.entries(migrationModules).map(([key, value]) => [
+          key,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { up: async (d: Kysely<any>) => value.up(d, 'sqlite') },
+        ])
+      ),
+  },
+})
+const migration = await migrator.migrateToLatest()
+if (migration.error) {
+  console.error(`Failed to build bundle schema: ${errText(migration.error)}`)
+  process.exit(1)
+}
+// The bundle is a deliberately partial copy (one lineage per conversation, files re-owned), so
+// foreign-key enforcement would reject valid rows. A migration leaves this connection with keys
+// on; turn it back off for the copy phase.
+await sql`PRAGMA foreign_keys = OFF`.execute(bundle)
+await sql`
+  CREATE TABLE IF NOT EXISTS "ReplayFileBlob" (
+    "path" TEXT PRIMARY KEY NOT NULL,
+    "size" INTEGER NOT NULL,
+    "bytes" BLOB NOT NULL
+  )
+`.execute(bundle)
+
+const REPLAY_OWNER = 'production-replay-user'
+
+const skipped: Array<{
+  messageId: string
+  conversationId: string
+  auditedInputTokens: number
+  reason: string
+}> = []
+const seenBackends = new Set<string>()
+const seenAssistants = new Set<string>()
+const seenAssistantVersions = new Set<string>()
+const seenConversations = new Set<string>()
+const seenMessages = new Set<string>()
+const seenFileIds = new Set<string>()
+const seenBlobIds = new Set<string>()
+const seenBlobPaths = new Set<string>()
+let admitted = 0
+
+let candidates = source
+  .selectFrom('MessageAudit')
+  .innerJoin('Conversation', 'Conversation.id', 'MessageAudit.conversationId')
+  .innerJoin('Assistant', 'Assistant.id', 'Conversation.assistantId')
+  .innerJoin('AssistantVersion', 'AssistantVersion.id', 'Assistant.publishedVersionId')
+  .select([
+    'MessageAudit.messageId',
+    'MessageAudit.conversationId',
+    'MessageAudit.tokens as auditedInputTokens',
+    'MessageAudit.sentAt',
+    'Conversation.assistantId',
+  ])
+  .where('MessageAudit.type', '=', 'user')
+  .where('MessageAudit.tokens', '>=', minimumAuditedInputTokens)
+  // Assistants with tools, sub-assistants, or knowledge files can't be replayed faithfully;
+  // exclude them in SQL so `--limit` counts admissible turns rather than being eaten by the
+  // (often most expensive) tool-using cohort.
+  .where((eb) =>
+    eb.or([
+      eb('AssistantVersion.subAssistants', 'is', null),
+      eb('AssistantVersion.subAssistants', '=', ''),
+    ])
+  )
+  .where((eb) =>
+    eb.not(
+      eb.exists(
+        eb
+          .selectFrom('AssistantVersionToolAssociation')
+          .select('toolId')
+          .whereRef(
+            'AssistantVersionToolAssociation.assistantVersionId',
+            '=',
+            'AssistantVersion.id'
+          )
+      )
+    )
+  )
+  .where((eb) =>
+    eb.not(
+      eb.exists(
+        eb
+          .selectFrom('AssistantVersionFile')
+          .select('fileId')
+          .whereRef('AssistantVersionFile.assistantVersionId', '=', 'AssistantVersion.id')
+      )
+    )
+  )
+  .orderBy('MessageAudit.tokens', 'desc')
+  .orderBy('MessageAudit.sentAt', 'desc')
+  // Lineage shape / attachment resolution can still skip a row, so scan a little past the target.
+  .limit(limit * 10)
+if (assistantFilter) candidates = candidates.where('Conversation.assistantId', '=', assistantFilter)
+
+const skip = (
+  candidate: { messageId: string; conversationId: string; auditedInputTokens: number },
+  reason: string
+) => {
+  skipped.push({
+    messageId: candidate.messageId,
+    conversationId: candidate.conversationId,
+    auditedInputTokens: candidate.auditedInputTokens,
+    reason,
+  })
+}
+
+const copyBlobBytes = async (blobPath: string, encryption: 'pgp' | 'aead' | null, size: number) => {
+  if (seenBlobPaths.has(blobPath)) return
+  const { storage } = await import('@/lib/storage')
+  const bytes = await storage.readBuffer(blobPath, encryption)
+  await sql`
+    INSERT INTO "ReplayFileBlob" ("path", "size", "bytes")
+    VALUES (${blobPath}, ${size || bytes.byteLength}, ${bytes})
+  `.execute(bundle)
+  seenBlobPaths.add(blobPath)
+}
+
+try {
+  for (const candidate of await candidates.execute()) {
+    if (admitted >= limit) break
+
+    const messages = await source
+      .selectFrom('Message')
+      .selectAll()
+      .where('conversationId', '=', candidate.conversationId)
+      .execute()
+    const byId = new Map(messages.map((message) => [message.id, message]))
+
+    const lineageRows: DbMessage[] = []
+    let cursor = byId.get(candidate.messageId)
+    while (cursor) {
+      lineageRows.push(cursor)
+      cursor = cursor.parent ? byId.get(cursor.parent) : undefined
+    }
+    lineageRows.reverse()
+
+    let lineage: ReturnType<typeof dtoMessageFromDbMessage>[]
+    try {
+      lineage = lineageRows.map(dtoMessageFromDbMessage)
+    } catch (error) {
+      skip(candidate, `saved message cannot be converted: ${errText(error)}`)
+      continue
+    }
+    const lineageReason = isReplayableLineage(lineage)
+    if (lineageReason) {
+      skip(candidate, lineageReason)
+      continue
+    }
+
+    // The candidate query already excluded tool / sub-assistant / knowledge-file assistants.
+    const assistant = await source
+      .selectFrom('Assistant')
+      .innerJoin('AssistantVersion', 'AssistantVersion.id', 'Assistant.publishedVersionId')
+      .select([
+        'Assistant.id as assistantId',
+        'Assistant.owner as assistantOwner',
+        'Assistant.provisioned as assistantProvisioned',
+        'Assistant.deleted as assistantDeleted',
+        'Assistant.hidden as assistantHidden',
+        'AssistantVersion.id as versionId',
+        'AssistantVersion.backendId as backendId',
+      ])
+      .where('Assistant.id', '=', candidate.assistantId)
+      .executeTakeFirst()
+    if (!assistant) {
+      skip(candidate, 'assistant or its published version is unavailable')
+      continue
+    }
+
+    const productionResponse = messages
+      .filter((message) => message.parent === candidate.messageId && message.role === 'assistant')
+      .sort((a, b) => a.sentAt.localeCompare(b.sentAt))[0]
+    if (!productionResponse) {
+      skip(candidate, 'no saved assistant response follows the audited user message')
+      continue
+    }
+    try {
+      const productionMessage = dtoMessageFromDbMessage(productionResponse)
+      if (
+        productionMessage.role !== 'assistant' ||
+        productionMessage.parts.some((part) => part.type.includes('tool-call'))
+      ) {
+        skip(candidate, 'production response begins tool activity; a tool fixture is required')
+        continue
+      }
+      renderMessagePlainText(productionMessage)
+    } catch (error) {
+      skip(candidate, `saved production response cannot be converted: ${errText(error)}`)
+      continue
+    }
+
+    // Resolve every attachment's File + FileBlob rows and bytes before writing anything.
+    const attachmentFileIds = collectAttachmentFileIds(lineage)
+    const attachmentRows: Array<{
+      file: {
+        id: string
+        name: string
+        path: string
+        type: string
+        origin: 'uploaded' | 'generated' | null
+        createdAt: string
+        fileBlobId: string | null
+      }
+      blob: {
+        id: string
+        contentHash: string
+        path: string
+        type: string
+        size: number
+        encryption: 'pgp' | 'aead' | null
+        createdAt: string
+      } | null
+    }> = []
+    let attachmentFailure: string | undefined
+    for (const fileId of attachmentFileIds) {
+      const fileRow = await source
+        .selectFrom('File')
+        .select(['id', 'name', 'path', 'type', 'origin', 'createdAt', 'fileBlobId'])
+        .where('id', '=', fileId)
+        .executeTakeFirst()
+      if (!fileRow) {
+        attachmentFailure = `attachment ${fileId} has no File row`
+        break
+      }
+      const blobRow = fileRow.fileBlobId
+        ? await source
+            .selectFrom('FileBlob')
+            .select(['id', 'contentHash', 'path', 'type', 'size', 'encryption', 'createdAt'])
+            .where('id', '=', fileRow.fileBlobId)
+            .executeTakeFirst()
+        : undefined
+      if (fileRow.fileBlobId && !blobRow) {
+        attachmentFailure = `attachment ${fileId} FileBlob ${fileRow.fileBlobId} is missing`
+        break
+      }
+      try {
+        if (blobRow) await copyBlobBytes(blobRow.path, blobRow.encryption, blobRow.size)
+      } catch (error) {
+        attachmentFailure = `attachment ${fileId} bytes could not be read: ${errText(error)}`
+        break
+      }
+      attachmentRows.push({ file: fileRow, blob: blobRow ?? null })
+    }
+    if (attachmentFailure) {
+      skip(candidate, attachmentFailure)
+      continue
+    }
+
+    // --- write the turn into the bundle ---
+    if (!seenBackends.has(assistant.backendId)) {
+      const backend = await source
+        .selectFrom('Backend')
+        .selectAll()
+        .where('id', '=', assistant.backendId)
+        .executeTakeFirstOrThrow()
+      await bundle.insertInto('Backend').values(backend).execute()
+      seenBackends.add(assistant.backendId)
+    }
+    if (!seenAssistantVersions.has(assistant.versionId)) {
+      const version = await source
+        .selectFrom('AssistantVersion')
+        .selectAll()
+        .where('id', '=', assistant.versionId)
+        .executeTakeFirstOrThrow()
+      await bundle
+        .insertInto('AssistantVersion')
+        .values({ ...version, imageId: null })
+        .execute()
+      seenAssistantVersions.add(assistant.versionId)
+    }
+    if (!seenAssistants.has(assistant.assistantId)) {
+      await bundle
+        .insertInto('Assistant')
+        .values({
+          id: assistant.assistantId,
+          owner: assistant.assistantOwner,
+          provisioned: assistant.assistantProvisioned,
+          deleted: assistant.assistantDeleted,
+          hidden: assistant.assistantHidden,
+          publishedVersionId: assistant.versionId,
+          draftVersionId: null,
+        })
+        .execute()
+      seenAssistants.add(assistant.assistantId)
+    }
+    if (!seenConversations.has(candidate.conversationId)) {
+      const conversation = await source
+        .selectFrom('Conversation')
+        .selectAll()
+        .where('id', '=', candidate.conversationId)
+        .executeTakeFirstOrThrow()
+      await bundle.insertInto('Conversation').values(conversation).execute()
+      seenConversations.add(candidate.conversationId)
+    }
+
+    for (const row of [...lineageRows, productionResponse]) {
+      if (seenMessages.has(row.id)) continue
+      await bundle.insertInto('Message').values(row).execute()
+      seenMessages.add(row.id)
+    }
+
+    const audit = await source
+      .selectFrom('MessageAudit')
+      .selectAll()
+      .where('messageId', '=', candidate.messageId)
+      .where('type', '=', 'user')
+      .executeTakeFirstOrThrow()
+    await bundle.insertInto('MessageAudit').values(audit).execute()
+
+    for (const { file, blob } of attachmentRows) {
+      if (blob && !seenBlobIds.has(blob.id)) {
+        await bundle
+          .insertInto('FileBlob')
+          .values({
+            id: blob.id,
+            contentHash: blob.contentHash,
+            path: blob.path,
+            type: blob.type,
+            size: blob.size,
+            encryption: null,
+            createdAt: blob.createdAt,
+          })
+          .execute()
+        seenBlobIds.add(blob.id)
+      }
+      if (seenFileIds.has(file.id)) continue
+      await bundle
+        .insertInto('File')
+        .values({
+          id: file.id,
+          name: file.name,
+          path: file.path,
+          type: file.type,
+          origin: file.origin ?? 'uploaded',
+          size: blob?.size ?? 0,
+          uploaded: blob ? 1 : 0,
+          createdAt: file.createdAt,
+          encrypted: 0,
+          fileBlobId: blob?.id ?? null,
+          ownerType: 'USER',
+          ownerId: REPLAY_OWNER,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any)
+        .execute()
+      seenFileIds.add(file.id)
+    }
+
+    admitted += 1
+    process.stderr.write(
+      `admitted ${candidate.messageId} (${candidate.auditedInputTokens} input tokens)\n`
+    )
+  }
+} finally {
+  await source.destroy()
+  await bundle.destroy()
+}
+
+await writeFile(`${out}.skipped.json`, JSON.stringify(skipped, null, 2), 'utf-8')
+console.error(
+  `Wrote ${admitted} replayable turn(s) to ${out} and ${skipped.length} skipped candidate(s) to ${out}.skipped.json.`
+)

--- a/apps/backend/scripts/eval-replay-production-chats.ts
+++ b/apps/backend/scripts/eval-replay-production-chats.ts
@@ -1,0 +1,432 @@
+/**
+ * Replays the production turns in an offline bundle locally, with compression off and on.
+ *
+ * Input is a bundle built by `eval-build-replay-bundle.ts`: a self-contained SQLite file with the
+ * selected conversations and every attachment's bytes. This runner copies it to a scratch
+ * directory, points the app at that copy and at `FILE_STORAGE_LOCATION=replaydb:` (bytes served
+ * straight from the bundle), and makes fresh provider calls to compare responses and cost. It
+ * never touches any source deployment, S3, or the network beyond the LLM provider.
+ *
+ * Usage:
+ *   OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
+ *     --bundle bundle.sqlite --out replay-results.json --report replay-report.md
+ *
+ * Flags:
+ *   --bundle <path>             offline bundle from eval-build-replay-bundle.ts (required)
+ *   --out <path>                JSON results, including production text (required)
+ *   --report <path>             human-readable Markdown report (required)
+ *   --provider <type>           override bundle provider: openai | anthropic | google-ai-studio
+ *   --model <id>                override the assistant model for every replay
+ *   --judge-model <id>          comparison judge model (default: replay model)
+ *   --no-judge                  record cost/results without LLM failure classification
+ *   --preset <name>             conservative | aggressive (default: conservative)
+ *   --keep-recent-turns <n>     completed turns retained verbatim (default: 0)
+ *   --trigger-at-tokens <n>     compression floor and trigger (default: 6000)
+ *   --retrieval-mode <mode>     prefetch | tool (default: prefetch)
+ */
+
+export {}
+
+import { copyFileSync, mkdtempSync, rmSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import type * as dto from '@/types/dto'
+import type { Message as DbMessage } from '@/db/schema'
+import type { ProviderType } from '@/types/provider'
+import { computeCostUsd, formatCostUsd } from '@/backend/lib/eval/cost'
+import type { ProductionReplayCase, ReplayJudgment } from '@/backend/lib/eval/productionChatReplay'
+import type { TurnUsage } from '@/backend/lib/eval/types'
+
+const args = process.argv.slice(2).filter((arg) => arg !== '--')
+const flag = (name: string): string | undefined => {
+  const index = args.indexOf(`--${name}`)
+  return index === -1 ? undefined : args[index + 1]
+}
+const bool = (name: string) => args.includes(`--${name}`)
+
+const bundlePath = flag('bundle')
+const out = flag('out')
+const reportPath = flag('report')
+if (!bundlePath || !out || !reportPath) {
+  console.error('Usage: --bundle <bundle.sqlite> --out <results.json> --report <report.md>')
+  process.exit(1)
+}
+
+const triggerAtTokens = Number(flag('trigger-at-tokens') ?? 6000)
+const keepRecentTurns = Number(flag('keep-recent-turns') ?? 0)
+const preset = flag('preset') ?? 'conservative'
+const retrievalMode = flag('retrieval-mode') ?? 'prefetch'
+if (!Number.isInteger(triggerAtTokens) || triggerAtTokens < 1) {
+  console.error('--trigger-at-tokens must be a positive integer')
+  process.exit(1)
+}
+if (!Number.isInteger(keepRecentTurns) || keepRecentTurns < 0) {
+  console.error('--keep-recent-turns must be a non-negative integer')
+  process.exit(1)
+}
+if (preset !== 'conservative' && preset !== 'aggressive') {
+  console.error('--preset must be conservative or aggressive')
+  process.exit(1)
+}
+if (retrievalMode !== 'prefetch' && retrievalMode !== 'tool') {
+  console.error('--retrieval-mode must be prefetch or tool')
+  process.exit(1)
+}
+
+// Work on a copy so a failed run never corrupts the bundle. Configure the app before imports.
+const workdir = mkdtempSync(path.join(tmpdir(), 'logicle-production-replay-'))
+const replayDbPath = path.join(workdir, 'replay.sqlite')
+copyFileSync(bundlePath, replayDbPath)
+process.env.DATABASE_URL = `file://${replayDbPath}`
+process.env.FILE_STORAGE_LOCATION = 'replaydb:'
+process.env.CHAT_CONTEXT_COMPRESSION_TRIGGER_TOKENS = String(triggerAtTokens)
+
+const { db } = await import('@/db/database')
+const { dtoMessageFromDbMessage } = await import('@/models/utils')
+const { renderMessagePlainText } = await import('@/backend/lib/chat/message-projection')
+const { ChatAssistant } = await import('@/backend/lib/chat')
+const { EvalSink } = await import('@/backend/lib/eval/sink')
+const { estimateHistoryMessageCosts } = await import('@/backend/lib/chat/token-estimator')
+const { setTokenizerCounter } = await import('@/backend/lib/chat/prompt-token-counter')
+const { countTextWithTokenizer } = await import('@/lib/chat/tokenizer')
+const { llmModels } = await import('@/lib/models')
+const { createReplayJudge } = await import('@/backend/lib/eval/productionChatReplay')
+const { applyCompressionPlan, planMessageCompression } = await import(
+  '@/backend/lib/chat/compression-planner'
+)
+
+setTokenizerCounter({
+  countText: async (tokenizer, text) => countTextWithTokenizer(tokenizer, text),
+})
+
+// --- reconstruct the replay cases from the bundle ---
+const cases: ProductionReplayCase[] = []
+const audits = await db
+  .selectFrom('MessageAudit')
+  .selectAll()
+  .where('type', '=', 'user')
+  .orderBy('tokens', 'desc')
+  .execute()
+
+for (const audit of audits) {
+  const conversationMessages = await db
+    .selectFrom('Message')
+    .selectAll()
+    .where('conversationId', '=', audit.conversationId)
+    .execute()
+  const byId = new Map(conversationMessages.map((message) => [message.id, message]))
+
+  const lineageRows: DbMessage[] = []
+  let cursor = byId.get(audit.messageId)
+  while (cursor) {
+    lineageRows.push(cursor)
+    cursor = cursor.parent ? byId.get(cursor.parent) : undefined
+  }
+  lineageRows.reverse()
+  if (lineageRows.length === 0) continue
+  const messages = lineageRows.map(dtoMessageFromDbMessage)
+
+  const assistant = await db
+    .selectFrom('Assistant')
+    .innerJoin('AssistantVersion', 'AssistantVersion.id', 'Assistant.publishedVersionId')
+    .innerJoin('Backend', 'Backend.id', 'AssistantVersion.backendId')
+    .select([
+      'AssistantVersion.id as versionId',
+      'AssistantVersion.model as model',
+      'AssistantVersion.systemPrompt as systemPrompt',
+      'AssistantVersion.temperature as temperature',
+      'AssistantVersion.tokenLimit as tokenLimit',
+      'AssistantVersion.reasoning_effort as reasoningEffort',
+      'Backend.providerType as providerType',
+    ])
+    .where('Assistant.id', '=', audit.assistantId)
+    .executeTakeFirstOrThrow()
+
+  const productionResponseRow = conversationMessages
+    .filter((message) => message.parent === audit.messageId && message.role === 'assistant')
+    .sort((a, b) => a.sentAt.localeCompare(b.sentAt))[0]
+  const productionReply = productionResponseRow
+    ? renderMessagePlainText(dtoMessageFromDbMessage(productionResponseRow))
+    : ''
+
+  cases.push({
+    id: audit.messageId,
+    source: {
+      conversationId: audit.conversationId,
+      messageId: audit.messageId,
+      auditedInputTokens: audit.tokens,
+      auditedModel: audit.model,
+      sentAt: audit.sentAt,
+    },
+    assistant: {
+      id: audit.assistantId,
+      versionId: assistant.versionId,
+      providerType: assistant.providerType as ProviderType,
+      model: assistant.model,
+      systemPrompt: assistant.systemPrompt,
+      temperature: assistant.temperature,
+      tokenLimit: assistant.tokenLimit,
+      reasoningEffort: assistant.reasoningEffort,
+    },
+    messages,
+    productionReply,
+  })
+}
+
+if (cases.length === 0) {
+  console.error('Bundle contains no replayable turns. Inspect its .skipped.json before retrying.')
+  await db.destroy()
+  rmSync(workdir, { recursive: true, force: true })
+  process.exit(1)
+}
+
+const providerType = flag('provider') ?? cases[0]!.assistant.providerType
+const modelOverride = flag('model')
+const judgeModelOverride = flag('judge-model')
+const apiKeyByProvider: Record<string, string | undefined> = {
+  openai: process.env.OPENAI_API_KEY,
+  anthropic: process.env.ANTHROPIC_API_KEY,
+  'google-ai-studio': process.env.GEMINI_API_KEY,
+}
+// The mock provider (ALLOW_MOCK_PROVIDER) is keyless and only used to smoke-test this pipeline.
+const apiKey = providerType === 'mock' ? 'mock' : apiKeyByProvider[providerType]
+if (!apiKey) {
+  console.error(`Missing API key for provider "${providerType}".`)
+  await db.destroy()
+  rmSync(workdir, { recursive: true, force: true })
+  process.exit(1)
+}
+
+const providerConfig = {
+  providerType,
+  name: 'production-replay',
+  apiKey,
+  provisioned: false,
+} as Parameters<typeof ChatAssistant.build>[0]
+
+const resolveModel = (id: string) => {
+  const model = llmModels.find((entry) => entry.id === id && entry.provider === providerType)
+  if (!model) throw new Error(`Model "${id}" is not defined for provider "${providerType}"`)
+  return model
+}
+
+interface ReplayTurn {
+  text: string
+  usage: TurnUsage
+  costUsd?: number
+  error?: string
+}
+interface ReplayResult {
+  caseId: string
+  source: ProductionReplayCase['source']
+  configuration: {
+    provider: string
+    model: string
+    preset: string
+    keepRecentTurns: number
+    triggerAtTokens: number
+    retrievalMode: string
+  }
+  estimatedHistoryTokens: { before: number; after: number; compressionTriggered: boolean }
+  baseline: ReplayTurn
+  compressed: ReplayTurn
+  savings: { inputTokens: number; costUsd?: number }
+  judgment?: ReplayJudgment
+}
+
+const cloneMessages = (messages: dto.Message[]) =>
+  JSON.parse(JSON.stringify(messages)) as dto.Message[]
+
+const runTurn = async (
+  entry: ProductionReplayCase,
+  modelId: string,
+  compression: dto.ContextCompressionConfig
+): Promise<ReplayTurn> => {
+  const model = resolveModel(modelId)
+  const assistant = await ChatAssistant.build(
+    providerConfig,
+    {
+      assistantId: `production-replay-${entry.id}`,
+      model: model.id,
+      systemPrompt: entry.assistant.systemPrompt,
+      temperature: entry.assistant.temperature,
+      tokenLimit: entry.assistant.tokenLimit,
+      reasoning_effort: entry.assistant.reasoningEffort,
+      contextCompression: compression,
+    },
+    {},
+    [],
+    [],
+    { user: 'production-replay-user', conversationId: `production-replay-${entry.id}` }
+  )
+  const sink = new EvalSink()
+  try {
+    await assistant.processUserMessageWithSink(cloneMessages(entry.messages), sink)
+    const usage = sink.getUsage()
+    const text = sink.getText().trim() || `[no reply] ${sink.getErrors().join('; ')}`.trim()
+    return {
+      text,
+      usage,
+      costUsd: computeCostUsd(
+        model.id,
+        usage.inputTokens,
+        usage.outputTokens,
+        usage.inputTokenDetails
+      ),
+    }
+  } catch (error) {
+    return {
+      text: '',
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+const results: ReplayResult[] = []
+try {
+  for (const entry of cases) {
+    if (entry.assistant.providerType !== providerType && !flag('provider')) {
+      throw new Error(
+        `Bundle contains multiple providers; rerun with --provider and --model for case ${entry.id}`
+      )
+    }
+    const caseModel = resolveModel(modelOverride ?? entry.assistant.model)
+    const compression: dto.ContextCompressionConfig = {
+      preset: preset as 'conservative' | 'aggressive',
+      triggerAtTokens,
+      keepRecentTurns,
+      retrievalMode: retrievalMode as 'prefetch' | 'tool',
+    }
+    const costsBefore = await estimateHistoryMessageCosts(caseModel, entry.messages)
+    const before = costsBefore.reduce((total, cost) => total + cost.tokens, 0)
+    const decisions =
+      before >= triggerAtTokens
+        ? planMessageCompression(entry.messages, compression.preset, { keepRecentTurns })
+        : []
+    const planned =
+      decisions.length > 0
+        ? await applyCompressionPlan(cloneMessages(entry.messages), decisions, {
+            prefetchQuery:
+              retrievalMode === 'prefetch'
+                ? (entry.messages.at(-1) as dto.UserMessage).content
+                : undefined,
+          })
+        : entry.messages
+    const costsAfter = await estimateHistoryMessageCosts(caseModel, planned)
+    const after = costsAfter.reduce((total, cost) => total + cost.tokens, 0)
+
+    process.stderr.write(`Replaying ${entry.id}: ${before} estimated history tokens\n`)
+    const baseline = await runTurn(entry, caseModel.id, null)
+    const compressed = await runTurn(entry, caseModel.id, compression)
+    const judgment =
+      !bool('no-judge') && !compressed.error
+        ? await createReplayJudge(
+            ChatAssistant.createLanguageModel(
+              providerConfig,
+              resolveModel(judgeModelOverride ?? caseModel.id)
+            )
+          )(
+            (entry.messages.at(-1) as dto.UserMessage).content,
+            entry.productionReply,
+            compressed.text
+          )
+        : undefined
+    results.push({
+      caseId: entry.id,
+      source: entry.source,
+      configuration: {
+        provider: providerType,
+        model: caseModel.id,
+        preset,
+        keepRecentTurns,
+        triggerAtTokens,
+        retrievalMode,
+      },
+      estimatedHistoryTokens: { before, after, compressionTriggered: before >= triggerAtTokens },
+      baseline,
+      compressed,
+      savings: {
+        inputTokens: baseline.usage.inputTokens - compressed.usage.inputTokens,
+        costUsd:
+          baseline.costUsd !== undefined && compressed.costUsd !== undefined
+            ? baseline.costUsd - compressed.costUsd
+            : undefined,
+      },
+      judgment,
+    })
+  }
+} finally {
+  await db.destroy()
+  rmSync(workdir, { recursive: true, force: true })
+}
+
+const totalInputSavings = results.reduce((total, result) => total + result.savings.inputTokens, 0)
+const totalCostSavings = results.reduce((total, result) => total + (result.savings.costUsd ?? 0), 0)
+const allCostsKnown = results.every((result) => result.savings.costUsd !== undefined)
+const verdicts = new Map<string, number>()
+for (const result of results) {
+  if (!result.judgment) continue
+  verdicts.set(result.judgment.verdict, (verdicts.get(result.judgment.verdict) ?? 0) + 1)
+}
+const markdown = [
+  '# Production chat compression replay',
+  '',
+  `Replayed ${results.length} production turn(s) from \`${path.basename(bundlePath)}\` using ` +
+    `\`${providerType}/${modelOverride ?? 'each turn’s saved assistant model'}\`. No source ` +
+    'deployment was contacted.',
+  '',
+  '| message | production input | history estimate before→after | baseline in | compressed in | input saved | cost saved | verdict |',
+  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
+  ...results.map(
+    (result) =>
+      `| ${result.caseId} | ${result.source.auditedInputTokens} | ${
+        result.estimatedHistoryTokens.before
+      }→${result.estimatedHistoryTokens.after} | ${result.baseline.usage.inputTokens} | ${
+        result.compressed.usage.inputTokens
+      } | ${result.savings.inputTokens} | ${formatCostUsd(result.savings.costUsd)} | ${
+        result.judgment?.verdict ?? 'not judged'
+      } |`
+  ),
+  '',
+  `Total replay input-token saving: **${totalInputSavings}**. Total priced saving: **${
+    allCostsKnown
+      ? formatCostUsd(totalCostSavings)
+      : 'n/a (one or more replay models have no configured price)'
+  }**.`,
+  '',
+  '## Failure review',
+  '',
+  ...results.flatMap((result) =>
+    result.judgment && result.judgment.verdict !== 'equivalent'
+      ? [
+          `- ${result.caseId} — ${result.judgment.verdict}: ${result.judgment.rationale}${
+            result.judgment.failures.length ? ` (${result.judgment.failures.join('; ')})` : ''
+          }`,
+        ]
+      : []
+  ),
+  ...(results.some((result) => result.judgment && result.judgment.verdict !== 'equivalent')
+    ? []
+    : [
+        '- No judged regressions. Review individual transcript JSON before treating this as a correctness guarantee.',
+      ]),
+  '',
+].join('\n')
+
+await writeFile(
+  out,
+  JSON.stringify(
+    { version: 1, createdAt: new Date().toISOString(), bundle: bundlePath, results },
+    null,
+    2
+  ),
+  'utf-8'
+)
+await writeFile(reportPath, markdown, 'utf-8')
+console.error(
+  `Wrote ${out} and ${reportPath}. Verdicts: ${
+    [...verdicts.entries()].map(([key, value]) => `${key}=${value}`).join(', ') || 'not judged'
+  }`
+)

--- a/docs/evaluation-harness.md
+++ b/docs/evaluation-harness.md
@@ -211,3 +211,79 @@ Everything marked pure is unit-tested and needs no API key.
 - **Context-compression references are anonymized shape fixtures.** They reproduce aggregate
   message-count cohorts and failure modes, not any real conversation's wording. Add reviewed,
   tenant-approved fixtures separately if production semantics need to be represented.
+
+## Replaying expensive production turns
+
+The synthetic context-compression suite proves the policy against known fixtures. To answer the
+operational question — _what would this expensive production prompt have cost with compression, and
+did the response regress?_ — use the two-stage replay workflow: **build a bundle**, then **replay
+it offline**. The two stages are fully separated. The bundle is a self-contained SQLite file; once
+it exists, replay never touches the source deployment, S3, or any network beyond the LLM provider.
+
+### Stage 1 — build the bundle
+
+`eval-build-replay-bundle.ts` ranks `MessageAudit` records of type `user` by their **audited input
+tokens** (the persisted provider count for the invocation, so it selects genuinely costly prompts,
+not merely long-looking messages). For each admitted turn it copies into the bundle: the full
+parent lineage, the `MessageAudit` row, the published assistant configuration (`Assistant` /
+`AssistantVersion` / `Backend`), the saved production reply, and every attachment — `File` /
+`FileBlob` rows rewritten as `production-replay-user`-owned with encryption cleared, and the bytes
+themselves **decrypted** into a `ReplayFileBlob(path, size, bytes)` table. No provider
+credentials, no storage credentials, no other tenant data.
+
+The builder is infra-agnostic: it reads the source database from `--source-db` (or `$DATABASE_URL`)
+and attachment bytes through the normal storage stack (`FILE_STORAGE_LOCATION` plus the
+`FILE_STORAGE_ENCRYPTION_*` vars, only needed when a selected turn has attachments).
+
+**Lowest friction — run it on a running instance.** Exec into a Logicle container: `DATABASE_URL`
+and `FILE_STORAGE_LOCATION` are already set to that instance's database and object store, so no
+flags and no proxy are needed. Copy the bundle back out afterwards (`kubectl cp` / `docker cp`).
+
+```bash
+# inside the container (its own env already points at the right DB + storage)
+npx tsx apps/backend/scripts/eval-build-replay-bundle.ts \
+  --out /tmp/expensive.sqlite --min-input-tokens 12000 --limit 25
+```
+
+**From a workstation** — point `--source-db` and `FILE_STORAGE_LOCATION` at the tenant through
+whatever proxy / SSH tunnel your ops tooling provides (that wrapper, not this script, owns the
+tenant plumbing):
+
+```bash
+FILE_STORAGE_LOCATION=s3://logicle-tenant-42-files \
+FILE_STORAGE_ENCRYPTION_ENABLE=1 FILE_STORAGE_ENCRYPTION_KEY=... \
+npx tsx apps/backend/scripts/eval-build-replay-bundle.ts \
+  --source-db postgres://readonly@127.0.0.1:5432/logicle \
+  --out expensive.sqlite --min-input-tokens 12000 --limit 25
+```
+
+Turns are skipped (with a reason, written to `<out>.skipped.json`) when the lineage has saved tool
+activity, the assistant is configured with tools / sub-assistants / knowledge files, or an
+attachment's rows or bytes cannot be resolved — so a replay never silently omits a file or loses a
+tool capability. To cover tool conversations, extend the builder with a tool-specific fixture
+adapter.
+
+### Stage 2 — replay the bundle
+
+```bash
+OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
+  --bundle expensive.sqlite \
+  --out replay-results.json --report replay-report.md \
+  --preset conservative --keep-recent-turns 0 --trigger-at-tokens 6000
+```
+
+The runner copies the bundle to a scratch directory, points the app at that copy and at
+`FILE_STORAGE_LOCATION=replaydb:` (`DbBlobStorage` serves attachment bytes straight from
+`ReplayFileBlob`), and for each turn makes a fresh baseline call and a fresh compressed call.
+`replay-results.json` keeps each transcript, token usage, and priced cost; `replay-report.md`
+aggregates the input-token and dollar savings and lists the judge's regressions. The judge
+compares the compressed answer with the historical production answer, which is a **reference, not
+a factual answer key** — review every non-equivalent case, and a sample of equivalent ones, before
+enabling a policy. Build and replay from the same checkout so the bundle schema matches.
+
+### Deploy-then-evaluate
+
+If a compression policy looks worth shipping, the low-risk rollout is: deploy the smarter build to
+one tenant with the policy **off**, let real traffic accumulate `MessageAudit` rows, then build a
+bundle from that instance and replay it to compare its own recent expensive turns with and without
+compression before turning the policy on.


### PR DESCRIPTION
## Summary

Adds a repeatable, fully offline workflow to answer: _what would this expensive production turn have cost with context compression, and did the response regress?_ It has two stages — **build a bundle**, then **replay it** — with no network between them beyond the LLM provider.

Stacked on #1101 (base `perf/context-compression-prefetch`) because the replay runner uses that PR's compression-prefetch API, `EvalSink` token details, and cost helpers. Retarget to `main` once #1101 merges.

## Details

- **`apps/backend/scripts/eval-build-replay-bundle.ts`** — builds a self-contained SQLite bundle from a source database. Reads the source via `--source-db` (or `$DATABASE_URL`) and attachment bytes through the normal storage stack (`FILE_STORAGE_LOCATION` + `FILE_STORAGE_ENCRYPTION_*`), so it runs unchanged inside a Logicle container. Ranks `MessageAudit` user turns by audited input tokens and copies only the selected conversations' rows plus each attachment's bytes **decrypted** into a `ReplayFileBlob` table. Tool / sub-assistant / knowledge-file assistants are excluded in SQL; other skips are written to `<out>.skipped.json` with a reason.
- **`apps/backend/scripts/eval-replay-production-chats.ts`** — replays a bundle offline. Copies it to a scratch dir, points the app at that copy and at `FILE_STORAGE_LOCATION=replaydb:`, and makes a fresh baseline call and a fresh compressed call per turn. Emits `results.json` (transcripts, token usage, priced cost) and `report.md` (aggregate input-token / dollar savings + judge regressions). The judge compares against the saved production reply as a reference, not an answer key.
- **`apps/backend/lib/storage/DbBlobStorage.ts`** — read-only storage backend selected by the `replaydb:` sentinel; serves bytes from `ReplayFileBlob`. `ReplayFileBlob` is created by the bundle builder with raw DDL and never exists in a real deployment (no migration).
- **`apps/backend/lib/eval/productionChatReplay.ts`** — shared replay-case type, the LLM judge, and lineage helpers (`isReplayableLineage`, `collectAttachmentFileIds`).
- **`docs/evaluation-harness.md`** — documents both stages, the run-on-a-running-instance path, and deploy-then-evaluate.

## Risks

- No production schema, route, or API changes. `apps/backend/lib/storage/index.ts` gains one branch, reachable only when `FILE_STORAGE_LOCATION` is exactly `replaydb:`.
- Bundles contain cleartext production conversations and attachments — treat them as a production data extract.

## Tests

- `npm run check-types` — clean
- `npx vitest run apps/backend/lib/eval apps/backend/lib/storage` — 96 passing (5 new in `productionChatReplay.test.ts`)
- `biome check` + `prettier --check` on all touched files — clean
- End-to-end against the local dev database + real `gpt-4o`: built a 3-turn bundle (`--min-input-tokens 2500`), replayed it offline (baseline vs compressed calls, cost accounting, LLM judge), `report.md` + `results.json` produced. Attachment bytes served from `replaydb:` with no S3 or network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)