### PR TITLE
chore(eval): offline production-chat replay tooling

### DIFF
--- a/apps/backend/lib/eval/__tests__/productionChatReplay.test.ts
+++ b/apps/backend/lib/eval/__tests__/productionChatReplay.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectAttachmentFileIds,
+  isReplayableLineage,
+} from '@/backend/lib/eval/productionChatReplay'
+import type * as dto from '@/types/dto'
+
+const user = (overrides: Partial<dto.UserMessage> = {}): dto.UserMessage => ({
+  id: 'user-1',
+  conversationId: 'conversation-1',
+  parent: null,
+  sentAt: '2026-01-01T00:00:00.000Z',
+  role: 'user' as const,
+  content: 'Question',
+  attachments: [],
+  ...overrides,
+})
+
+describe('isReplayableLineage', () => {
+  it('admits a text-only user/assistant lineage ending at the audited user turn', () => {
+    expect(
+      isReplayableLineage([
+        user(),
+        {
+          id: 'assistant-1',
+          conversationId: 'conversation-1',
+          parent: 'user-1',
+          sentAt: '2026-01-01T00:00:01.000Z',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Answer' }],
+          finishReason: 'stop',
+        },
+        { ...user(), id: 'user-2', parent: 'assistant-1' },
+      ])
+    ).toBeUndefined()
+  })
+
+  it('admits an attachment-bearing user turn (bytes are resolved from object storage)', () => {
+    expect(
+      isReplayableLineage([
+        user({
+          attachments: [{ id: 'file-1', name: 'file.txt', mimetype: 'text/plain', size: 1 }],
+        }),
+      ])
+    ).toBeUndefined()
+  })
+
+  it('rejects tool, authorization, or error activity that cannot be replayed', () => {
+    expect(
+      isReplayableLineage([
+        user(),
+        {
+          id: 'tool-1',
+          conversationId: 'conversation-1',
+          parent: 'user-1',
+          sentAt: '2026-01-01T00:00:01.000Z',
+          role: 'tool',
+          parts: [],
+        },
+      ])
+    ).toContain('tool')
+  })
+})
+
+describe('collectAttachmentFileIds', () => {
+  it('returns every distinct attachment id in first-seen order', () => {
+    expect(
+      collectAttachmentFileIds([
+        user({
+          attachments: [
+            { id: 'file-1', name: 'a.txt', mimetype: 'text/plain', size: 1 },
+            { id: 'file-2', name: 'b.png', mimetype: 'image/png', size: 2 },
+          ],
+        }),
+        {
+          ...user(),
+          id: 'user-2',
+          attachments: [{ id: 'file-1', name: 'a.txt', mimetype: 'text/plain', size: 1 }],
+        },
+      ])
+    ).toEqual(['file-1', 'file-2'])
+  })
+
+  it('returns nothing for a text-only lineage', () => {
+    expect(collectAttachmentFileIds([user()])).toEqual([])
+  })
+})

--- a/apps/backend/lib/eval/productionChatReplay.ts
+++ b/apps/backend/lib/eval/productionChatReplay.ts
@@ -1,0 +1,118 @@
+import * as ai from 'ai'
+import * as z from 'zod'
+import type { LanguageModelV3 } from '@ai-sdk/provider'
+import type * as dto from '@/types/dto'
+import type { ProviderType } from '@/types/provider'
+
+/**
+ * One production turn selected for offline replay.
+ *
+ * The bundle builder (`eval-build-replay-bundle.ts`) writes the full lineage, the published
+ * assistant configuration, and the saved production reply into a self-contained SQLite bundle;
+ * attachment bytes travel in the bundle's `ReplayFileBlob` table, already decrypted. The runner
+ * reconstructs this shape from the bundle and never touches the source deployment.
+ */
+export interface ProductionReplayCase {
+  id: string
+  source: {
+    conversationId: string
+    messageId: string
+    /** Production's own `MessageAudit` input-token count for this turn. */
+    auditedInputTokens: number
+    auditedModel: string
+    sentAt: string
+  }
+  assistant: {
+    id: string
+    versionId: string
+    providerType: ProviderType
+    model: string
+    systemPrompt: string
+    temperature: number
+    tokenLimit: number
+    reasoningEffort: dto.AssistantVersion['reasoning_effort']
+    /** Parsed `AssistantVersion.contextCompression`; shape follows the running code's schema. */
+    contextCompression: Record<string, unknown> | null
+  }
+  /** The complete saved lineage, ending in the user message that incurred the audited prompt. */
+  messages: dto.Message[]
+  /** Production's next assistant text. It is a reference for the judge, not an answer key. */
+  productionReply: string
+}
+
+export type ReplayVerdict = 'equivalent' | 'minor-regression' | 'major-regression' | 'inconclusive'
+
+export interface ReplayJudgment {
+  verdict: ReplayVerdict
+  rationale: string
+  failures: string[]
+}
+
+const replayJudgmentSchema = z.object({
+  verdict: z.enum(['equivalent', 'minor-regression', 'major-regression', 'inconclusive']),
+  rationale: z.string(),
+  failures: z.array(z.string()),
+})
+
+const replayJudgePrompt = [
+  'Compare a candidate chat response with the production response to the same final user message.',
+  'Decide whether compression caused a material regression in helpfulness, completeness, instruction-following, or unsupported claims.',
+  'The production answer is only a reference, not proof that its facts are correct. Do not invent a factual answer key.',
+  'Return equivalent when the candidate is at least as useful in substance; minor-regression for a recoverable omission; major-regression when the user would materially fail; inconclusive when the reference is insufficient to judge.',
+  'Do not prefer either answer for length, style, or wording alone.',
+].join('\n')
+
+export const createReplayJudge =
+  (model: LanguageModelV3) =>
+  async (
+    finalUserMessage: string,
+    productionReply: string,
+    candidateReply: string
+  ): Promise<ReplayJudgment> => {
+    const result = await ai.generateObject({
+      model,
+      schema: replayJudgmentSchema,
+      temperature: 0,
+      system: replayJudgePrompt,
+      prompt: [
+        `Final user message:\n${finalUserMessage}`,
+        '',
+        `Production response:\n${productionReply || '[no saved assistant response]'}`,
+        '',
+        `Candidate response:\n${candidateReply || '[no candidate response]'}`,
+      ].join('\n'),
+    })
+    return {
+      verdict: result.object.verdict,
+      rationale: result.object.rationale.trim(),
+      failures: result.object.failures.map((failure) => failure.trim()).filter(Boolean),
+    }
+  }
+
+export const messageHasAttachment = (message: dto.Message): boolean =>
+  (message.role === 'user' || message.role === 'user-response') &&
+  'attachments' in message &&
+  message.attachments.length > 0
+
+/** Every distinct attachment file id referenced anywhere in a lineage, in first-seen order. */
+export const collectAttachmentFileIds = (messages: dto.Message[]): string[] => {
+  const ids = new Set<string>()
+  for (const message of messages) {
+    if ((message.role === 'user' || message.role === 'user-response') && 'attachments' in message) {
+      for (const attachment of message.attachments) ids.add(attachment.id)
+    }
+  }
+  return [...ids]
+}
+
+export const isReplayableLineage = (messages: dto.Message[]): string | undefined => {
+  // Attachments are fine: the bundle carries their bytes. Tool, authorization, and error activity
+  // are not — replaying them would silently drop a capability.
+  if (messages.some((message) => message.role !== 'user' && message.role !== 'assistant')) {
+    return 'history contains tool, authorization, or error activity'
+  }
+  if (messages.length === 0 || messages.at(-1)?.role !== 'user') {
+    return 'audited message does not end a user-message lineage'
+  }
+  return undefined
+}

--- a/apps/backend/lib/storage/DbBlobStorage.ts
+++ b/apps/backend/lib/storage/DbBlobStorage.ts
@@ -1,0 +1,48 @@
+import { sql } from 'kysely'
+import { BaseStorage } from './api'
+import type { StorageEncryption, StorageReadOptions } from './api'
+import { bufferToReadableStream } from './utils'
+
+/**
+ * Read-only storage backed by a `ReplayFileBlob(path, size, bytes)` table in the app database.
+ *
+ * The offline compression-replay evaluator sets `FILE_STORAGE_LOCATION=replaydb:` so that
+ * attachment bytes bundled into its throwaway replay database are served with no external object
+ * store and no network. The table is created by the bundle builder
+ * (`eval-build-replay-bundle.ts`), never by a migration — it does not exist in a real deployment.
+ * Bytes are stored already decrypted, so reads ignore the encryption argument. Writes and deletes
+ * throw.
+ */
+export class DbBlobStorage extends BaseStorage {
+  async readStream(
+    filePath: string,
+    _encryption: StorageEncryption,
+    options?: StorageReadOptions
+  ): Promise<ReadableStream<Uint8Array>> {
+    const { db } = await import('@/db/database')
+    const result = await sql<{ bytes: Buffer | Uint8Array }>`
+      SELECT "bytes" FROM "ReplayFileBlob" WHERE "path" = ${filePath}
+    `.execute(db)
+    const row = result.rows[0]
+    if (!row) {
+      throw new Error(`No ReplayFileBlob row for path ${filePath}`)
+    }
+    let bytes = Buffer.isBuffer(row.bytes) ? row.bytes : Buffer.from(row.bytes)
+    const { rangeStart, rangeEnd } = options ?? {}
+    if (typeof rangeStart === 'number' || typeof rangeEnd === 'number') {
+      bytes = bytes.subarray(
+        rangeStart ?? 0,
+        typeof rangeEnd === 'number' ? rangeEnd + 1 : undefined
+      )
+    }
+    return bufferToReadableStream(bytes)
+  }
+
+  async writeStream(): Promise<void> {
+    throw new Error('DbBlobStorage is read-only')
+  }
+
+  async rm(): Promise<void> {
+    throw new Error('DbBlobStorage is read-only')
+  }
+}

--- a/apps/backend/lib/storage/index.ts
+++ b/apps/backend/lib/storage/index.ts
@@ -2,6 +2,7 @@ import env from '@/lib/env'
 import { Storage } from './api'
 import { CachingStorage } from './CachingStorage'
 import { AeadEncryptingStorage } from '../../ee/AeadEncryptingStorage'
+import { DbBlobStorage } from './DbBlobStorage'
 import { FsStorage } from './FsStorage'
 import { S3Storage } from './S3Storage'
 import { PgpEncryptingStorage } from '../../ee/PgpEncryptingStorage'
@@ -14,6 +15,9 @@ function createBasicStorage(location: string) {
       throw new Error('Invalid S3 URL. Must be in the format s3://bucket')
     }
     return new S3Storage(bucket)
+  } else if (location === 'replaydb:') {
+    // Offline compression-replay evaluator only: bytes come from the replay database itself.
+    return new DbBlobStorage()
   } else {
     return new FsStorage(location)
   }

--- a/apps/backend/scripts/eval-build-replay-bundle.ts
+++ b/apps/backend/scripts/eval-build-replay-bundle.ts
@@ -1,0 +1,448 @@
+/**
+ * Builds a self-contained offline replay bundle from a source Logicle database.
+ *
+ * The bundle is a single SQLite file: the app schema, plus only the selected conversations'
+ * `Conversation` / `Message` / `MessageAudit` / `Assistant*` / `Backend` / `File` / `FileBlob`
+ * rows, plus a `ReplayFileBlob(path, size, bytes)` table holding every referenced attachment's
+ * bytes **decrypted**. `eval-replay-production-chats.ts` consumes it with zero network access.
+ *
+ * This script is infra-agnostic. It reads the source database via `--source-db` (or `DATABASE_URL`)
+ * and attachment bytes via the normal storage stack (`FILE_STORAGE_LOCATION` plus the
+ * `FILE_STORAGE_ENCRYPTION_*` vars, only needed when a selected turn has attachments). Pointing
+ * those at a specific tenant — proxy, SSH tunnel, direct — is the job of the ops-repo extractor,
+ * not this script.
+ *
+ * Usage:
+ *   FILE_STORAGE_LOCATION=s3://tenant-bucket FILE_STORAGE_ENCRYPTION_ENABLE=1 \
+ *   FILE_STORAGE_ENCRYPTION_KEY=... \
+ *   npx tsx apps/backend/scripts/eval-build-replay-bundle.ts \
+ *     --source-db postgres://... --out bundle.sqlite --min-input-tokens 12000 --limit 25
+ *
+ * Flags:
+ *   --source-db <path|url>     source SQLite path or DATABASE_URL (default: $DATABASE_URL)
+ *   --out <path>               bundle SQLite file to write (required); <out>.skipped.json is also written
+ *   --min-input-tokens <n>     MessageAudit input-token floor (default: 12000)
+ *   --limit <n>                admitted turns (default: 20)
+ *   --assistant <id>           restrict to one assistant
+ */
+
+export {}
+
+import { rmSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+import { Kysely, Migrator, SqliteDialect, sql } from 'kysely'
+import type { DB, Message as DbMessage } from '@/db/schema'
+
+const errText = (error: unknown): string => (error instanceof Error ? error.message : String(error))
+
+const args = process.argv.slice(2).filter((arg) => arg !== '--')
+const flag = (name: string): string | undefined => {
+  const index = args.indexOf(`--${name}`)
+  return index === -1 ? undefined : args[index + 1]
+}
+
+const sourceDb = flag('source-db') ?? process.env.DATABASE_URL
+const out = flag('out')
+if (!sourceDb || !out) {
+  console.error('Usage: --source-db <path|url> (or $DATABASE_URL) --out <bundle.sqlite>')
+  process.exit(1)
+}
+
+const minimumAuditedInputTokens = Number(flag('min-input-tokens') ?? 12000)
+const limit = Number(flag('limit') ?? 20)
+const assistantFilter = flag('assistant')
+if (!Number.isFinite(minimumAuditedInputTokens) || minimumAuditedInputTokens < 1) {
+  console.error('--min-input-tokens must be a positive number')
+  process.exit(1)
+}
+if (!Number.isInteger(limit) || limit < 1) {
+  console.error('--limit must be a positive integer')
+  process.exit(1)
+}
+
+// The app db/storage singletons must bind to the source. Set this before importing them.
+process.env.DATABASE_URL = sourceDb.includes('://') ? sourceDb : `file://${sourceDb}`
+
+const { db: source } = await import('@/db/database')
+const { dtoMessageFromDbMessage } = await import('@/models/utils')
+const { renderMessagePlainText } = await import('@/backend/lib/chat/message-projection')
+const { isReplayableLineage, collectAttachmentFileIds } = await import(
+  '@/backend/lib/eval/productionChatReplay'
+)
+const { migrationModules } = await import('@/db/migrations.generated')
+
+// Remove any stale bundle so the schema is rebuilt cleanly, then open it as a second connection.
+rmSync(out, { force: true })
+const BetterSqlite = (await import('better-sqlite3')).default
+const bundle = new Kysely<DB>({
+  dialect: new SqliteDialect({ database: new BetterSqlite(out) }),
+})
+
+const migrator = new Migrator({
+  db: bundle,
+  provider: {
+    getMigrations: async () =>
+      Object.fromEntries(
+        Object.entries(migrationModules).map(([key, value]) => [
+          key,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { up: async (d: Kysely<any>) => value.up(d, 'sqlite') },
+        ])
+      ),
+  },
+})
+const migration = await migrator.migrateToLatest()
+if (migration.error) {
+  console.error(`Failed to build bundle schema: ${errText(migration.error)}`)
+  process.exit(1)
+}
+// The bundle is a deliberately partial copy (one lineage per conversation, files re-owned), so
+// foreign-key enforcement would reject valid rows. A migration leaves this connection with keys
+// on; turn it back off for the copy phase.
+await sql`PRAGMA foreign_keys = OFF`.execute(bundle)
+await sql`
+  CREATE TABLE IF NOT EXISTS "ReplayFileBlob" (
+    "path" TEXT PRIMARY KEY NOT NULL,
+    "size" INTEGER NOT NULL,
+    "bytes" BLOB NOT NULL
+  )
+`.execute(bundle)
+
+const REPLAY_OWNER = 'production-replay-user'
+
+const skipped: Array<{
+  messageId: string
+  conversationId: string
+  auditedInputTokens: number
+  reason: string
+}> = []
+const seenBackends = new Set<string>()
+const seenAssistants = new Set<string>()
+const seenAssistantVersions = new Set<string>()
+const seenConversations = new Set<string>()
+const seenMessages = new Set<string>()
+const seenFileIds = new Set<string>()
+const seenBlobIds = new Set<string>()
+const seenBlobPaths = new Set<string>()
+let admitted = 0
+
+let candidates = source
+  .selectFrom('MessageAudit')
+  .innerJoin('Conversation', 'Conversation.id', 'MessageAudit.conversationId')
+  .innerJoin('Assistant', 'Assistant.id', 'Conversation.assistantId')
+  .innerJoin('AssistantVersion', 'AssistantVersion.id', 'Assistant.publishedVersionId')
+  .select([
+    'MessageAudit.messageId',
+    'MessageAudit.conversationId',
+    'MessageAudit.tokens as auditedInputTokens',
+    'MessageAudit.sentAt',
+    'Conversation.assistantId',
+  ])
+  .where('MessageAudit.type', '=', 'user')
+  .where('MessageAudit.tokens', '>=', minimumAuditedInputTokens)
+  // Assistants with tools, sub-assistants, or knowledge files can't be replayed faithfully;
+  // exclude them in SQL so `--limit` counts admissible turns rather than being eaten by the
+  // (often most expensive) tool-using cohort.
+  .where((eb) =>
+    eb.or([
+      eb('AssistantVersion.subAssistants', 'is', null),
+      eb('AssistantVersion.subAssistants', '=', ''),
+    ])
+  )
+  .where((eb) =>
+    eb.not(
+      eb.exists(
+        eb
+          .selectFrom('AssistantVersionToolAssociation')
+          .select('toolId')
+          .whereRef(
+            'AssistantVersionToolAssociation.assistantVersionId',
+            '=',
+            'AssistantVersion.id'
+          )
+      )
+    )
+  )
+  .where((eb) =>
+    eb.not(
+      eb.exists(
+        eb
+          .selectFrom('AssistantVersionFile')
+          .select('fileId')
+          .whereRef('AssistantVersionFile.assistantVersionId', '=', 'AssistantVersion.id')
+      )
+    )
+  )
+  .orderBy('MessageAudit.tokens', 'desc')
+  .orderBy('MessageAudit.sentAt', 'desc')
+  // Lineage shape / attachment resolution can still skip a row, so scan a little past the target.
+  .limit(limit * 10)
+if (assistantFilter) candidates = candidates.where('Conversation.assistantId', '=', assistantFilter)
+
+const skip = (
+  candidate: { messageId: string; conversationId: string; auditedInputTokens: number },
+  reason: string
+) => {
+  skipped.push({
+    messageId: candidate.messageId,
+    conversationId: candidate.conversationId,
+    auditedInputTokens: candidate.auditedInputTokens,
+    reason,
+  })
+}
+
+const copyBlobBytes = async (blobPath: string, encryption: 'pgp' | 'aead' | null, size: number) => {
+  if (seenBlobPaths.has(blobPath)) return
+  const { storage } = await import('@/lib/storage')
+  const bytes = await storage.readBuffer(blobPath, encryption)
+  await sql`
+    INSERT INTO "ReplayFileBlob" ("path", "size", "bytes")
+    VALUES (${blobPath}, ${size || bytes.byteLength}, ${bytes})
+  `.execute(bundle)
+  seenBlobPaths.add(blobPath)
+}
+
+try {
+  for (const candidate of await candidates.execute()) {
+    if (admitted >= limit) break
+
+    const messages = await source
+      .selectFrom('Message')
+      .selectAll()
+      .where('conversationId', '=', candidate.conversationId)
+      .execute()
+    const byId = new Map(messages.map((message) => [message.id, message]))
+
+    const lineageRows: DbMessage[] = []
+    let cursor = byId.get(candidate.messageId)
+    while (cursor) {
+      lineageRows.push(cursor)
+      cursor = cursor.parent ? byId.get(cursor.parent) : undefined
+    }
+    lineageRows.reverse()
+
+    let lineage: ReturnType<typeof dtoMessageFromDbMessage>[]
+    try {
+      lineage = lineageRows.map(dtoMessageFromDbMessage)
+    } catch (error) {
+      skip(candidate, `saved message cannot be converted: ${errText(error)}`)
+      continue
+    }
+    const lineageReason = isReplayableLineage(lineage)
+    if (lineageReason) {
+      skip(candidate, lineageReason)
+      continue
+    }
+
+    // The candidate query already excluded tool / sub-assistant / knowledge-file assistants.
+    const assistant = await source
+      .selectFrom('Assistant')
+      .innerJoin('AssistantVersion', 'AssistantVersion.id', 'Assistant.publishedVersionId')
+      .select([
+        'Assistant.id as assistantId',
+        'Assistant.owner as assistantOwner',
+        'Assistant.provisioned as assistantProvisioned',
+        'Assistant.deleted as assistantDeleted',
+        'Assistant.hidden as assistantHidden',
+        'AssistantVersion.id as versionId',
+        'AssistantVersion.backendId as backendId',
+      ])
+      .where('Assistant.id', '=', candidate.assistantId)
+      .executeTakeFirst()
+    if (!assistant) {
+      skip(candidate, 'assistant or its published version is unavailable')
+      continue
+    }
+
+    const productionResponse = messages
+      .filter((message) => message.parent === candidate.messageId && message.role === 'assistant')
+      .sort((a, b) => a.sentAt.localeCompare(b.sentAt))[0]
+    if (!productionResponse) {
+      skip(candidate, 'no saved assistant response follows the audited user message')
+      continue
+    }
+    try {
+      const productionMessage = dtoMessageFromDbMessage(productionResponse)
+      if (
+        productionMessage.role !== 'assistant' ||
+        productionMessage.parts.some((part) => part.type.includes('tool-call'))
+      ) {
+        skip(candidate, 'production response begins tool activity; a tool fixture is required')
+        continue
+      }
+      renderMessagePlainText(productionMessage)
+    } catch (error) {
+      skip(candidate, `saved production response cannot be converted: ${errText(error)}`)
+      continue
+    }
+
+    // Resolve every attachment's File + FileBlob rows and bytes before writing anything.
+    const attachmentFileIds = collectAttachmentFileIds(lineage)
+    const attachmentRows: Array<{
+      file: {
+        id: string
+        name: string
+        path: string
+        type: string
+        origin: 'uploaded' | 'generated' | null
+        createdAt: string
+        fileBlobId: string | null
+      }
+      blob: {
+        id: string
+        contentHash: string
+        path: string
+        type: string
+        size: number
+        encryption: 'pgp' | 'aead' | null
+        createdAt: string
+      } | null
+    }> = []
+    let attachmentFailure: string | undefined
+    for (const fileId of attachmentFileIds) {
+      const fileRow = await source
+        .selectFrom('File')
+        .select(['id', 'name', 'path', 'type', 'origin', 'createdAt', 'fileBlobId'])
+        .where('id', '=', fileId)
+        .executeTakeFirst()
+      if (!fileRow) {
+        attachmentFailure = `attachment ${fileId} has no File row`
+        break
+      }
+      const blobRow = fileRow.fileBlobId
+        ? await source
+            .selectFrom('FileBlob')
+            .select(['id', 'contentHash', 'path', 'type', 'size', 'encryption', 'createdAt'])
+            .where('id', '=', fileRow.fileBlobId)
+            .executeTakeFirst()
+        : undefined
+      if (fileRow.fileBlobId && !blobRow) {
+        attachmentFailure = `attachment ${fileId} FileBlob ${fileRow.fileBlobId} is missing`
+        break
+      }
+      try {
+        if (blobRow) await copyBlobBytes(blobRow.path, blobRow.encryption, blobRow.size)
+      } catch (error) {
+        attachmentFailure = `attachment ${fileId} bytes could not be read: ${errText(error)}`
+        break
+      }
+      attachmentRows.push({ file: fileRow, blob: blobRow ?? null })
+    }
+    if (attachmentFailure) {
+      skip(candidate, attachmentFailure)
+      continue
+    }
+
+    // --- write the turn into the bundle ---
+    if (!seenBackends.has(assistant.backendId)) {
+      const backend = await source
+        .selectFrom('Backend')
+        .selectAll()
+        .where('id', '=', assistant.backendId)
+        .executeTakeFirstOrThrow()
+      await bundle.insertInto('Backend').values(backend).execute()
+      seenBackends.add(assistant.backendId)
+    }
+    if (!seenAssistantVersions.has(assistant.versionId)) {
+      const version = await source
+        .selectFrom('AssistantVersion')
+        .selectAll()
+        .where('id', '=', assistant.versionId)
+        .executeTakeFirstOrThrow()
+      await bundle
+        .insertInto('AssistantVersion')
+        .values({ ...version, imageId: null })
+        .execute()
+      seenAssistantVersions.add(assistant.versionId)
+    }
+    if (!seenAssistants.has(assistant.assistantId)) {
+      await bundle
+        .insertInto('Assistant')
+        .values({
+          id: assistant.assistantId,
+          owner: assistant.assistantOwner,
+          provisioned: assistant.assistantProvisioned,
+          deleted: assistant.assistantDeleted,
+          hidden: assistant.assistantHidden,
+          publishedVersionId: assistant.versionId,
+          draftVersionId: null,
+        })
+        .execute()
+      seenAssistants.add(assistant.assistantId)
+    }
+    if (!seenConversations.has(candidate.conversationId)) {
+      const conversation = await source
+        .selectFrom('Conversation')
+        .selectAll()
+        .where('id', '=', candidate.conversationId)
+        .executeTakeFirstOrThrow()
+      await bundle.insertInto('Conversation').values(conversation).execute()
+      seenConversations.add(candidate.conversationId)
+    }
+
+    for (const row of [...lineageRows, productionResponse]) {
+      if (seenMessages.has(row.id)) continue
+      await bundle.insertInto('Message').values(row).execute()
+      seenMessages.add(row.id)
+    }
+
+    const audit = await source
+      .selectFrom('MessageAudit')
+      .selectAll()
+      .where('messageId', '=', candidate.messageId)
+      .where('type', '=', 'user')
+      .executeTakeFirstOrThrow()
+    await bundle.insertInto('MessageAudit').values(audit).execute()
+
+    for (const { file, blob } of attachmentRows) {
+      if (blob && !seenBlobIds.has(blob.id)) {
+        await bundle
+          .insertInto('FileBlob')
+          .values({
+            id: blob.id,
+            contentHash: blob.contentHash,
+            path: blob.path,
+            type: blob.type,
+            size: blob.size,
+            encryption: null,
+            createdAt: blob.createdAt,
+          })
+          .execute()
+        seenBlobIds.add(blob.id)
+      }
+      if (seenFileIds.has(file.id)) continue
+      await bundle
+        .insertInto('File')
+        .values({
+          id: file.id,
+          name: file.name,
+          path: file.path,
+          type: file.type,
+          origin: file.origin ?? 'uploaded',
+          size: blob?.size ?? 0,
+          uploaded: blob ? 1 : 0,
+          createdAt: file.createdAt,
+          encrypted: 0,
+          fileBlobId: blob?.id ?? null,
+          ownerType: 'USER',
+          ownerId: REPLAY_OWNER,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any)
+        .execute()
+      seenFileIds.add(file.id)
+    }
+
+    admitted += 1
+    process.stderr.write(
+      `admitted ${candidate.messageId} (${candidate.auditedInputTokens} input tokens)\n`
+    )
+  }
+} finally {
+  await source.destroy()
+  await bundle.destroy()
+}
+
+await writeFile(`${out}.skipped.json`, JSON.stringify(skipped, null, 2), 'utf-8')
+console.error(
+  `Wrote ${admitted} replayable turn(s) to ${out} and ${skipped.length} skipped candidate(s) to ${out}.skipped.json.`
+)

--- a/apps/backend/scripts/eval-replay-production-chats.ts
+++ b/apps/backend/scripts/eval-replay-production-chats.ts
@@ -1,0 +1,368 @@
+/**
+ * Replays the production turns in an offline bundle through the current code.
+ *
+ * For each turn the runner rebuilds the saved assistant, applies `--override` on top of its
+ * configuration, runs the turn once, and records the response plus the real provider token usage
+ * and priced cost. It does not run an off/on comparison — the "before" number is production's own
+ * `MessageAudit` input-token count, already in the bundle. To evaluate a change (a compression
+ * preset, a different model, a new build) run it with the corresponding `--override` — or from a
+ * checkout / deployment that has the change — and read the delta against production.
+ *
+ * Input is a bundle from `eval-build-replay-bundle.ts`. The runner copies it to a scratch dir,
+ * points the app at that copy and at `FILE_STORAGE_LOCATION=replaydb:` (attachment bytes served
+ * straight from the bundle), and never touches any source deployment, S3, or the network beyond
+ * the LLM provider.
+ *
+ * Usage:
+ *   OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
+ *     --bundle bundle.sqlite --out replay-results.json --report replay-report.md \
+ *     --override '{"contextCompression":{"preset":"conservative"}}'
+ *
+ * Flags:
+ *   --bundle <path>        offline bundle from eval-build-replay-bundle.ts (required)
+ *   --out <path>           JSON results, including response text (required)
+ *   --report <path>        human-readable Markdown report (required)
+ *   --override <json>      JSON object merged over each turn's saved assistant config
+ *                          (model, systemPrompt, temperature, tokenLimit, reasoning_effort,
+ *                          contextCompression). Use '{"contextCompression":null}' to disable it.
+ *   --provider <type>      provider for the replay (default: the bundle's) — needs its API key
+ *   --model <id>           shorthand for --override '{"model":"<id>"}'
+ *   --judge                also classify each response against the saved production reply
+ *   --judge-model <id>     judge model (default: the replay model)
+ */
+
+export {}
+
+import { copyFileSync, mkdtempSync, rmSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import type * as dto from '@/types/dto'
+import type { Message as DbMessage } from '@/db/schema'
+import type { ProviderType } from '@/types/provider'
+import { computeCostUsd, formatCostUsd } from '@/backend/lib/eval/cost'
+import type { ProductionReplayCase, ReplayJudgment } from '@/backend/lib/eval/productionChatReplay'
+
+const args = process.argv.slice(2).filter((arg) => arg !== '--')
+const flag = (name: string): string | undefined => {
+  const index = args.indexOf(`--${name}`)
+  return index === -1 ? undefined : args[index + 1]
+}
+const bool = (name: string) => args.includes(`--${name}`)
+
+const bundlePath = flag('bundle')
+const out = flag('out')
+const reportPath = flag('report')
+if (!bundlePath || !out || !reportPath) {
+  console.error('Usage: --bundle <bundle.sqlite> --out <results.json> --report <report.md>')
+  process.exit(1)
+}
+
+let override: Record<string, unknown> = {}
+const overrideRaw = flag('override')
+if (overrideRaw) {
+  try {
+    override = JSON.parse(overrideRaw) as Record<string, unknown>
+  } catch (error) {
+    console.error(
+      `--override must be valid JSON: ${error instanceof Error ? error.message : error}`
+    )
+    process.exit(1)
+  }
+}
+const modelShorthand = flag('model')
+if (modelShorthand) override.model = modelShorthand
+
+// Work on a copy so a failed run never corrupts the bundle. Configure the app before imports.
+const workdir = mkdtempSync(path.join(tmpdir(), 'logicle-production-replay-'))
+const replayDbPath = path.join(workdir, 'replay.sqlite')
+copyFileSync(bundlePath, replayDbPath)
+process.env.DATABASE_URL = `file://${replayDbPath}`
+process.env.FILE_STORAGE_LOCATION = 'replaydb:'
+
+const { db } = await import('@/db/database')
+const { dtoMessageFromDbMessage } = await import('@/models/utils')
+const { renderMessagePlainText } = await import('@/backend/lib/chat/message-projection')
+const { ChatAssistant } = await import('@/backend/lib/chat')
+const { EvalSink } = await import('@/backend/lib/eval/sink')
+const { setTokenizerCounter } = await import('@/backend/lib/chat/prompt-token-counter')
+const { countTextWithTokenizer } = await import('@/lib/chat/tokenizer')
+const { llmModels } = await import('@/lib/models')
+const { createReplayJudge } = await import('@/backend/lib/eval/productionChatReplay')
+
+setTokenizerCounter({
+  countText: async (tokenizer, text) => countTextWithTokenizer(tokenizer, text),
+})
+
+// --- reconstruct the replay cases from the bundle ---
+const cases: ProductionReplayCase[] = []
+const audits = await db
+  .selectFrom('MessageAudit')
+  .selectAll()
+  .where('type', '=', 'user')
+  .orderBy('tokens', 'desc')
+  .execute()
+
+for (const audit of audits) {
+  const conversationMessages = await db
+    .selectFrom('Message')
+    .selectAll()
+    .where('conversationId', '=', audit.conversationId)
+    .execute()
+  const byId = new Map(conversationMessages.map((message) => [message.id, message]))
+
+  const lineageRows: DbMessage[] = []
+  let cursor = byId.get(audit.messageId)
+  while (cursor) {
+    lineageRows.push(cursor)
+    cursor = cursor.parent ? byId.get(cursor.parent) : undefined
+  }
+  lineageRows.reverse()
+  if (lineageRows.length === 0) continue
+  const messages = lineageRows.map(dtoMessageFromDbMessage)
+
+  const assistant = await db
+    .selectFrom('Assistant')
+    .innerJoin('AssistantVersion', 'AssistantVersion.id', 'Assistant.publishedVersionId')
+    .innerJoin('Backend', 'Backend.id', 'AssistantVersion.backendId')
+    .select([
+      'AssistantVersion.id as versionId',
+      'AssistantVersion.model as model',
+      'AssistantVersion.systemPrompt as systemPrompt',
+      'AssistantVersion.temperature as temperature',
+      'AssistantVersion.tokenLimit as tokenLimit',
+      'AssistantVersion.reasoning_effort as reasoningEffort',
+      'AssistantVersion.contextCompression as contextCompression',
+      'Backend.providerType as providerType',
+    ])
+    .where('Assistant.id', '=', audit.assistantId)
+    .executeTakeFirstOrThrow()
+
+  const productionResponseRow = conversationMessages
+    .filter((message) => message.parent === audit.messageId && message.role === 'assistant')
+    .sort((a, b) => a.sentAt.localeCompare(b.sentAt))[0]
+  const productionReply = productionResponseRow
+    ? renderMessagePlainText(dtoMessageFromDbMessage(productionResponseRow))
+    : ''
+
+  cases.push({
+    id: audit.messageId,
+    source: {
+      conversationId: audit.conversationId,
+      messageId: audit.messageId,
+      auditedInputTokens: audit.tokens,
+      auditedModel: audit.model,
+      sentAt: audit.sentAt,
+    },
+    assistant: {
+      id: audit.assistantId,
+      versionId: assistant.versionId,
+      providerType: assistant.providerType as ProviderType,
+      model: assistant.model,
+      systemPrompt: assistant.systemPrompt,
+      temperature: assistant.temperature,
+      tokenLimit: assistant.tokenLimit,
+      reasoningEffort: assistant.reasoningEffort,
+      contextCompression: assistant.contextCompression
+        ? (JSON.parse(assistant.contextCompression) as Record<string, unknown>)
+        : null,
+    },
+    messages,
+    productionReply,
+  })
+}
+
+if (cases.length === 0) {
+  console.error('Bundle contains no replayable turns. Inspect its .skipped.json before retrying.')
+  await db.destroy()
+  rmSync(workdir, { recursive: true, force: true })
+  process.exit(1)
+}
+
+const providerType = flag('provider') ?? cases[0]!.assistant.providerType
+const apiKeyByProvider: Record<string, string | undefined> = {
+  openai: process.env.OPENAI_API_KEY,
+  anthropic: process.env.ANTHROPIC_API_KEY,
+  'google-ai-studio': process.env.GEMINI_API_KEY,
+}
+// The mock provider (ALLOW_MOCK_PROVIDER) is keyless and only used to smoke-test this pipeline.
+const apiKey = providerType === 'mock' ? 'mock' : apiKeyByProvider[providerType]
+if (!apiKey) {
+  console.error(`Missing API key for provider "${providerType}".`)
+  await db.destroy()
+  rmSync(workdir, { recursive: true, force: true })
+  process.exit(1)
+}
+
+const providerConfig = {
+  providerType,
+  name: 'production-replay',
+  apiKey,
+  provisioned: false,
+} as Parameters<typeof ChatAssistant.build>[0]
+
+const resolveModel = (id: string) => {
+  const model = llmModels.find((entry) => entry.id === id && entry.provider === providerType)
+  if (!model) throw new Error(`Model "${id}" is not defined for provider "${providerType}"`)
+  return model
+}
+
+interface ReplayResult {
+  caseId: string
+  source: ProductionReplayCase['source']
+  model: string
+  assistantConfig: Record<string, unknown>
+  response: string
+  usage: { inputTokens: number; outputTokens: number }
+  costUsd?: number
+  productionInputCostUsd?: number
+  inputTokensVsProduction: number
+  error?: string
+  judgment?: ReplayJudgment
+}
+
+const cloneMessages = (messages: dto.Message[]) =>
+  JSON.parse(JSON.stringify(messages)) as dto.Message[]
+
+const results: ReplayResult[] = []
+try {
+  for (const entry of cases) {
+    if (entry.assistant.providerType !== providerType && !flag('provider')) {
+      throw new Error(
+        `Bundle mixes providers; rerun with --provider and a matching --model for case ${entry.id}`
+      )
+    }
+    const assistantConfig: Record<string, unknown> = {
+      assistantId: `production-replay-${entry.id}`,
+      model: entry.assistant.model,
+      systemPrompt: entry.assistant.systemPrompt,
+      temperature: entry.assistant.temperature,
+      tokenLimit: entry.assistant.tokenLimit,
+      reasoning_effort: entry.assistant.reasoningEffort,
+      contextCompression: entry.assistant.contextCompression,
+      ...override,
+    }
+    const model = resolveModel(String(assistantConfig.model))
+
+    process.stderr.write(
+      `Replaying ${entry.id} (production input ${entry.source.auditedInputTokens})\n`
+    )
+    const sink = new EvalSink()
+    let response = ''
+    let usage = { inputTokens: 0, outputTokens: 0 }
+    let error: string | undefined
+    try {
+      const assistant = await ChatAssistant.build(
+        providerConfig,
+        assistantConfig as unknown as Parameters<typeof ChatAssistant.build>[1],
+        {},
+        [],
+        [],
+        { user: 'production-replay-user', conversationId: `production-replay-${entry.id}` }
+      )
+      await assistant.processUserMessageWithSink(cloneMessages(entry.messages), sink)
+      const raw = sink.getUsage()
+      usage = { inputTokens: raw.inputTokens, outputTokens: raw.outputTokens }
+      response = sink.getText().trim() || `[no reply] ${sink.getErrors().join('; ')}`.trim()
+    } catch (caught) {
+      error = caught instanceof Error ? caught.message : String(caught)
+    }
+
+    const judgment =
+      bool('judge') && !error
+        ? await createReplayJudge(
+            ChatAssistant.createLanguageModel(
+              providerConfig,
+              resolveModel(flag('judge-model') ?? model.id)
+            )
+          )((entry.messages.at(-1) as dto.UserMessage).content, entry.productionReply, response)
+        : undefined
+
+    results.push({
+      caseId: entry.id,
+      source: entry.source,
+      model: model.id,
+      assistantConfig: { contextCompression: assistantConfig.contextCompression },
+      response,
+      usage,
+      costUsd: computeCostUsd(model.id, usage.inputTokens, usage.outputTokens),
+      productionInputCostUsd: computeCostUsd(model.id, entry.source.auditedInputTokens, 0),
+      inputTokensVsProduction: entry.source.auditedInputTokens - usage.inputTokens,
+      error,
+      judgment,
+    })
+  }
+} finally {
+  await db.destroy()
+  rmSync(workdir, { recursive: true, force: true })
+}
+
+const totalInputDelta = results.reduce((total, r) => total + r.inputTokensVsProduction, 0)
+const verdicts = new Map<string, number>()
+for (const result of results) {
+  if (result.judgment) {
+    verdicts.set(result.judgment.verdict, (verdicts.get(result.judgment.verdict) ?? 0) + 1)
+  }
+}
+
+const markdown = [
+  '# Production chat replay',
+  '',
+  `Replayed ${results.length} production turn(s) from \`${path.basename(
+    bundlePath
+  )}\` through the ` +
+    'current code. No source deployment was contacted. Production input tokens are from the saved ' +
+    '`MessageAudit` (input only).',
+  '',
+  override && Object.keys(override).length > 0
+    ? `Config override: \`${JSON.stringify(override)}\``
+    : 'No config override — replayed with each turn’s saved assistant configuration.',
+  '',
+  '| message | production input | replay input | replay output | replay cost | input Δ vs prod | verdict |',
+  '| --- | ---: | ---: | ---: | ---: | ---: | --- |',
+  ...results.map(
+    (r) =>
+      `| ${r.caseId} | ${r.source.auditedInputTokens} | ${
+        r.error ? 'error' : r.usage.inputTokens
+      } | ${r.error ? '—' : r.usage.outputTokens} | ${formatCostUsd(r.costUsd)} | ${
+        r.error ? '—' : r.inputTokensVsProduction
+      } | ${r.error ? r.error : r.judgment?.verdict ?? 'not judged'} |`
+  ),
+  '',
+  `Total input-token delta vs production: **${totalInputDelta}** ` +
+    `(positive = replay used fewer input tokens than production recorded).`,
+  '',
+  ...(results.some((r) => r.judgment && r.judgment.verdict !== 'equivalent')
+    ? [
+        '## Response review',
+        '',
+        ...results.flatMap((r) =>
+          r.judgment && r.judgment.verdict !== 'equivalent'
+            ? [
+                `- ${r.caseId} — ${r.judgment.verdict}: ${r.judgment.rationale}${
+                  r.judgment.failures.length ? ` (${r.judgment.failures.join('; ')})` : ''
+                }`,
+              ]
+            : []
+        ),
+        '',
+      ]
+    : []),
+].join('\n')
+
+await writeFile(
+  out,
+  JSON.stringify(
+    { version: 2, createdAt: new Date().toISOString(), bundle: bundlePath, override, results },
+    null,
+    2
+  ),
+  'utf-8'
+)
+await writeFile(reportPath, markdown, 'utf-8')
+console.error(
+  `Wrote ${out} and ${reportPath}.` +
+    (verdicts.size
+      ? ` Verdicts: ${[...verdicts.entries()].map(([k, v]) => `${k}=${v}`).join(', ')}`
+      : '')
+)

--- a/docs/evaluation-harness.md
+++ b/docs/evaluation-harness.md
@@ -17,6 +17,11 @@ An LLM impersonates a user pursuing a goal, and talks to a real Logicle assistan
 the goal is met, gives up, or runs out of turns. The same scenario is replayed against several
 **arms** — alternative assistant configurations — and the arms are compared.
 
+For context-policy comparisons, a scenario can instead provide a saved **reference chat**. The
+harness preloads that fixed history and sends one fixed final user message. Only the final exchange
+is scored. This removes simulated-user trajectory variance and prevents facts already present in
+the saved history from satisfying the answer-key gate.
+
 ```mermaid
 flowchart LR
   S[Scenario: corpus, goal, persona, rubric] --> U[Simulated user LLM]
@@ -78,6 +83,10 @@ with the harness:
 | `all-in-context`               | every document attached as assistant knowledge, sent in the preamble every turn — today's behaviour |
 | `knowledge-box`                | documents reachable only through the `knowledge_box` tool, with ingestion questions                 |
 | `knowledge-box-no-projections` | the same, with no ingestion questions — isolates chunk retrieval from projections                   |
+| `compression-off`              | saved reference history is sent verbatim                                                            |
+| `compression-keep-{0,1,2,4}`   | tool-driven retrieval with an explicit number of recent completed turns kept verbatim               |
+| `compression-prefetch-keep-0`  | query-aware excerpts, with every eligible historical turn compressed                                |
+| `compression-prefetch-keep-1`  | query-aware excerpts, retaining the immediately preceding completed turn verbatim                   |
 
 Anything expressible as "same scenario, different assistant configuration" belongs here. An arm
 can return `assistant.contextCompression` to compare compression on versus off; two chunk sizes
@@ -125,6 +134,24 @@ OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval.ts \
 The runner creates its own SQLite database and storage directory under the system temp dir and
 removes them afterwards. It needs no server and touches no existing database.
 
+Run the fixed-history, single-message context-compression suite with:
+
+```bash
+OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval.ts \
+  --suite context-compression --repeat 5 \
+  --runs-out context-compression-runs.json --out context-compression-report.md
+```
+
+Its reference conversations live in
+`apps/backend/lib/eval/scenarios/contextCompression.ts`. They retain no production content or
+identifiers: only aggregate turn-count cohorts from expensive conversations informed their shape;
+all prose, filenames, tool names and answer facts are synthetic.
+
+The default comparison is `compression-off`, tool-only `compression-keep-0`, and query-aware
+prefetch with windows 0 and 1. This isolates the two effects observed in the baseline run:
+stochastic model tool use and the cost of retaining a recent turn. Wider
+`compression-keep-{1,2,4}` arms remain selectable explicitly.
+
 Flags are documented in the header of `apps/backend/scripts/eval.ts`. The ones that matter:
 `--repeat`, `--arms`, `--baseline`, `--model`, `--user-model`, `--judge-model`, `--no-judge`,
 `--runs-out`, and `--runs-in`.
@@ -157,6 +184,7 @@ Two things about this are deliberate:
 | ---------------------------- | ---------------------------------------- |
 | `lib/eval/types.ts`          | scenario, arm, run result                |
 | `lib/eval/harness.ts`        | drives one (scenario, arm) run           |
+| `lib/eval/referenceChat.ts`  | saved chat → production message DTOs     |
 | `lib/eval/simulatedUser.ts`  | the LLM playing the user                 |
 | `lib/eval/judge.ts`          | the LLM grading transcripts              |
 | `lib/eval/metrics.ts`        | answer key, totals, scoring — pure       |
@@ -171,7 +199,7 @@ Everything marked pure is unit-tested and needs no API key.
 
 ## Open
 
-- **The corpus is synthetic.** `supplierContracts.ts` is built to have the right shape — one needle,
+- **The knowledge corpus is synthetic.** `supplierContracts.ts` is built to have the right shape — one needle,
   four near-identical distractors, realistic boilerplate — but it is not a real corpus. Mining real
   scenarios is the intended next step, and the answer keys they produce need a human pass.
 - **One provider at a time.** The assistant, the simulated user and the judge all run on the same
@@ -180,3 +208,99 @@ Everything marked pure is unit-tested and needs no API key.
 - **Setup cost is paid per repetition.** Ingestion runs once per run rather than once per arm, so
   wall-clock time scales with `--repeat` more than it needs to. It does not distort the reported
   numbers, since setup cost is reported per-arm rather than summed.
+- **Context-compression references are anonymized shape fixtures.** They reproduce aggregate
+  message-count cohorts and failure modes, not any real conversation's wording. Add reviewed,
+  tenant-approved fixtures separately if production semantics need to be represented.
+
+## Replaying expensive production turns
+
+The synthetic context-compression suite proves the policy against known fixtures. To see how a
+change behaves on _real_ expensive traffic — a compression preset, a different model, a new build —
+use the two-stage replay workflow: **build a bundle**, then **replay it** through the code you want
+to test. The stages are fully separated. The bundle is a self-contained SQLite file; once it
+exists, replay never touches the source deployment, S3, or any network beyond the LLM provider.
+
+The replay is not an off/on comparison — it runs each turn once, with whatever configuration you
+give it. The "before" number to compare against is production's own `MessageAudit` input-token
+count, which travels in the bundle.
+
+### Stage 1 — build the bundle
+
+`eval-build-replay-bundle.ts` ranks `MessageAudit` records of type `user` by their **audited input
+tokens** (the persisted provider count for the invocation, so it selects genuinely costly prompts,
+not merely long-looking messages). For each admitted turn it copies into the bundle: the full
+parent lineage, the `MessageAudit` row, the published assistant configuration (`Assistant` /
+`AssistantVersion` / `Backend`), the saved production reply, and every attachment — `File` /
+`FileBlob` rows rewritten as `production-replay-user`-owned with encryption cleared, and the bytes
+themselves **decrypted** into a `ReplayFileBlob(path, size, bytes)` table. No provider
+credentials, no storage credentials, no other tenant data.
+
+The builder is infra-agnostic: it reads the source database from `--source-db` (or `$DATABASE_URL`)
+and attachment bytes through the normal storage stack (`FILE_STORAGE_LOCATION` plus the
+`FILE_STORAGE_ENCRYPTION_*` vars, only needed when a selected turn has attachments).
+
+**Lowest friction — run it on a running instance.** Exec into a Logicle container: `DATABASE_URL`
+and `FILE_STORAGE_LOCATION` are already set to that instance's database and object store, so no
+flags and no proxy are needed. Copy the bundle back out afterwards (`kubectl cp` / `docker cp`).
+
+```bash
+# inside the container (its own env already points at the right DB + storage)
+npx tsx apps/backend/scripts/eval-build-replay-bundle.ts \
+  --out /tmp/expensive.sqlite --min-input-tokens 12000 --limit 25
+```
+
+**From a workstation** — point `--source-db` and `FILE_STORAGE_LOCATION` at the tenant through
+whatever proxy / SSH tunnel your ops tooling provides (that wrapper, not this script, owns the
+tenant plumbing):
+
+```bash
+FILE_STORAGE_LOCATION=s3://logicle-tenant-42-files \
+FILE_STORAGE_ENCRYPTION_ENABLE=1 FILE_STORAGE_ENCRYPTION_KEY=... \
+npx tsx apps/backend/scripts/eval-build-replay-bundle.ts \
+  --source-db postgres://readonly@127.0.0.1:5432/logicle \
+  --out expensive.sqlite --min-input-tokens 12000 --limit 25
+```
+
+Turns are skipped (with a reason, written to `<out>.skipped.json`) when the lineage has saved tool
+activity, the assistant is configured with tools / sub-assistants / knowledge files, or an
+attachment's rows or bytes cannot be resolved — so a replay never silently omits a file or loses a
+tool capability. To cover tool conversations, extend the builder with a tool-specific fixture
+adapter.
+
+### Stage 2 — replay the bundle
+
+```bash
+# Replay with each turn's saved configuration (a sanity check — should roughly match production):
+OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
+  --bundle expensive.sqlite --out replay-results.json --report replay-report.md
+
+# Replay with a change applied — here, a compression preset — and read the delta vs production:
+OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
+  --bundle expensive.sqlite --out compressed-results.json --report compressed-report.md \
+  --override '{"contextCompression":{"preset":"conservative"}}' --judge
+```
+
+The runner copies the bundle to a scratch directory, points the app at that copy and at
+`FILE_STORAGE_LOCATION=replaydb:` (`DbBlobStorage` serves attachment bytes straight from
+`ReplayFileBlob`), and for each turn rebuilds the saved assistant with `--override` merged over its
+configuration, runs the turn once, and records the response, the real provider token usage, and
+the priced cost. `--override` is a JSON object merged over `model` / `systemPrompt` / `temperature`
+/ `tokenLimit` / `reasoning_effort` / `contextCompression` (use `{"contextCompression":null}` to
+turn it off); its shape follows whatever the running code's schema accepts, so newer options work
+without changing this script.
+
+`replay-report.md` shows, per turn, production's audited input tokens next to the replay's input
+tokens, output tokens, priced cost, and the input-token delta. With `--judge`, each response is
+also classified against the saved production reply — a **reference for the judge, not a factual
+answer key**, so review every non-equivalent case.
+
+To test a **new build**, check it out (or deploy it) and run the runner from there — it passes the
+config through and calls whatever `ChatAssistant` is in the tree. Build and replay from the same
+checkout so the bundle schema matches.
+
+### Deploy-then-evaluate
+
+Low-risk rollout for a change like a compression policy: deploy the new build to one tenant with
+the policy **off**, let real traffic accumulate `MessageAudit` rows, build a bundle from that
+instance, then replay it twice — once as-is, once with `--override` enabling the policy — and
+compare cost and judged quality before turning it on for real.


### PR DESCRIPTION
## Summary

Adds a two-stage offline workflow to see how a change behaves on real expensive production traffic — a compression preset, a different model, a whole new build. **Build a bundle** from a source database, then **replay** its turns through the code you want to test. Independent of the compression rework (#1101): the runner just passes the assistant config through to whatever `ChatAssistant` is in the tree.

## Details

- **`apps/backend/scripts/eval-build-replay-bundle.ts`** — builds a self-contained SQLite bundle from a source database. Reads the source via `--source-db` (or `$DATABASE_URL`) and attachment bytes through the normal storage stack (`FILE_STORAGE_LOCATION` + `FILE_STORAGE_ENCRYPTION_*`), so it runs unchanged inside a Logicle container. Ranks `MessageAudit` user turns by audited input tokens and copies only the selected conversations' rows plus each attachment's bytes **decrypted** into a `ReplayFileBlob` table. Tool / sub-assistant / knowledge-file assistants are excluded in SQL; other skips go to `<out>.skipped.json` with a reason.
- **`apps/backend/scripts/eval-replay-production-chats.ts`** — replays a bundle fully offline (`FILE_STORAGE_LOCATION=replaydb:`). For each turn it rebuilds the saved assistant, merges `--override` (a JSON blob — `model`, `systemPrompt`, `temperature`, `tokenLimit`, `reasoning_effort`, `contextCompression`, …) over its config, runs the turn once, and records the response, real provider token usage, and priced cost. The "before" it reports against is production's own `MessageAudit` input-token count, already in the bundle — not a re-run baseline. `--judge` optionally classifies the response against the saved production reply.
- **`apps/backend/lib/storage/DbBlobStorage.ts`** — read-only storage backend selected by the `replaydb:` sentinel; serves bytes from `ReplayFileBlob`. That table is created by the bundle builder with raw DDL and never exists in a real deployment (no migration).
- **`apps/backend/lib/eval/productionChatReplay.ts`** — shared replay-case type, the optional LLM judge, and lineage helpers (`isReplayableLineage`, `collectAttachmentFileIds`).
- **`docs/evaluation-harness.md`** — documents both stages, the run-on-a-running-instance path, `--override`, and deploy-then-evaluate.

## Risks

- No production schema, route, or API changes. `apps/backend/lib/storage/index.ts` gains one branch, reachable only when `FILE_STORAGE_LOCATION` is exactly `replaydb:`.
- Bundles contain cleartext production conversations and attachments — treat them as a production data extract.

## Tests

- `npm run check-types` — clean
- `npx vitest run apps/backend/lib/eval` — passing (5 new in `productionChatReplay.test.ts`)
- `biome check` + `prettier --check` on all touched files — clean
- End-to-end against the local dev database + real `gpt-4o`: built a 3-turn bundle (`--min-input-tokens 2500`), then replayed it offline with `--override '{"contextCompression":{"preset":"conservative"}}'` — per-turn production-vs-replay input tokens, output tokens, priced cost, and input-token delta reported; attachment bytes served from `replaydb:` with no S3 or network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
