### PR TITLE
fix(eval): production-tenant support for the replay bundle builder

### DIFF
--- a/apps/backend/lib/eval/productionChatReplay.ts
+++ b/apps/backend/lib/eval/productionChatReplay.ts
@@ -33,6 +33,8 @@ export interface ProductionReplayCase {
     reasoningEffort: dto.AssistantVersion['reasoning_effort']
     /** Parsed `AssistantVersion.contextCompression`; shape follows the running code's schema. */
     contextCompression: Record<string, unknown> | null
+    /** `Backend.configuration.endPoint`, when the backend needs one (e.g. `logiclecloud`). */
+    backendEndpoint?: string
   }
   /** The complete saved lineage, ending in the user message that incurred the audited prompt. */
   messages: dto.Message[]

--- a/apps/backend/lib/storage/HttpReadOnlyStorage.ts
+++ b/apps/backend/lib/storage/HttpReadOnlyStorage.ts
@@ -1,0 +1,73 @@
+import { BaseStorage } from './api'
+import type { StorageEncryption, StorageReadOptions } from './api'
+
+/**
+ * Read-only object storage reached over HTTP(S).
+ *
+ * The offline replay bundle builder uses this when the source tenant's object store is not
+ * directly reachable (production buckets are IP-locked to the tenant VMs). An operator stands up a
+ * narrow read-only proxy that runs where the bucket is reachable — see
+ * `cli/download_replay_bundle` in the ops repo — and points `FILE_STORAGE_LOCATION` at it.
+ *
+ * The proxy is expected to map an appended object path to its upstream storage and return the
+ * bytes verbatim (still encrypted at rest, if the tenant encrypts — the encrypting wrappers around
+ * this storage decrypt locally). Writes and deletes are impossible by construction, so pointing an
+ * evaluator at this backend cannot mutate the tenant's files.
+ */
+export class HttpReadOnlyStorage extends BaseStorage {
+  private readonly baseUrl: URL
+
+  constructor(
+    baseUrl: string,
+    private readonly authorization?: string
+  ) {
+    super()
+    this.baseUrl = new URL(baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`)
+    if (this.baseUrl.username || this.baseUrl.password) {
+      throw new Error('File storage proxy URLs must not embed credentials')
+    }
+  }
+
+  private urlFor(path: string): URL {
+    // Encode one segment at a time so a blob path keeps its hierarchy but cannot escape the
+    // configured proxy prefix through `..`, a query string, or a fragment.
+    const segments = path.split('/').filter(Boolean)
+    if (segments.some((segment) => segment === '.' || segment === '..')) {
+      throw new Error('File storage proxy path contains a traversal segment')
+    }
+    const encoded = segments.map((segment) => encodeURIComponent(segment)).join('/')
+    if (!encoded) throw new Error('File storage proxy path is empty')
+    return new URL(encoded, this.baseUrl)
+  }
+
+  supportsRangeReads(_encryption: StorageEncryption): boolean {
+    return false
+  }
+
+  async readStream(
+    path: string,
+    _encryption: StorageEncryption,
+    options?: StorageReadOptions
+  ): Promise<ReadableStream<Uint8Array>> {
+    const headers = new Headers()
+    if (this.authorization) headers.set('authorization', this.authorization)
+    const response = await fetch(this.urlFor(path), {
+      headers,
+      signal: options?.signal,
+      // Never follow a redirect that could forward the proxy credential to another host.
+      redirect: 'error',
+    })
+    if (!response.ok || !response.body) {
+      throw new Error(`File storage proxy read failed for ${path}: HTTP ${response.status}`)
+    }
+    return response.body
+  }
+
+  async writeStream(): Promise<void> {
+    throw new Error('HTTP file storage proxy is read-only; write is not permitted')
+  }
+
+  async rm(): Promise<void> {
+    throw new Error('HTTP file storage proxy is read-only; delete is not permitted')
+  }
+}

--- a/apps/backend/lib/storage/index.ts
+++ b/apps/backend/lib/storage/index.ts
@@ -4,6 +4,7 @@ import { CachingStorage } from './CachingStorage'
 import { AeadEncryptingStorage } from '../../ee/AeadEncryptingStorage'
 import { DbBlobStorage } from './DbBlobStorage'
 import { FsStorage } from './FsStorage'
+import { HttpReadOnlyStorage } from './HttpReadOnlyStorage'
 import { S3Storage } from './S3Storage'
 import { PgpEncryptingStorage } from '../../ee/PgpEncryptingStorage'
 
@@ -18,6 +19,10 @@ function createBasicStorage(location: string) {
   } else if (location === 'replaydb:') {
     // Offline compression-replay evaluator only: bytes come from the replay database itself.
     return new DbBlobStorage()
+  } else if (location.startsWith('http://') || location.startsWith('https://')) {
+    // Replay bundle builder only: a narrow read-only proxy in front of an otherwise unreachable
+    // object store (see cli/download_replay_bundle in the ops repo).
+    return new HttpReadOnlyStorage(location, process.env.FILE_STORAGE_PROXY_AUTHORIZATION)
   } else {
     return new FsStorage(location)
   }

--- a/apps/backend/scripts/eval-build-replay-bundle.ts
+++ b/apps/backend/scripts/eval-build-replay-bundle.ts
@@ -140,15 +140,10 @@ let candidates = source
   ])
   .where('MessageAudit.type', '=', 'user')
   .where('MessageAudit.tokens', '>=', minimumAuditedInputTokens)
-  // Assistants with tools, sub-assistants, or knowledge files can't be replayed faithfully;
-  // exclude them in SQL so `--limit` counts admissible turns rather than being eaten by the
-  // (often most expensive) tool-using cohort.
-  .where((eb) =>
-    eb.or([
-      eb('AssistantVersion.subAssistants', 'is', null),
-      eb('AssistantVersion.subAssistants', '=', ''),
-    ])
-  )
+  // Assistants with tools or knowledge files can't be replayed faithfully; exclude them in SQL so
+  // `--limit` counts admissible turns rather than being eaten by the (often most expensive)
+  // tool/knowledge cohort. Sub-assistants are checked per row below — `subAssistants` is jsonb on
+  // postgres, so it can't be string-compared here.
   .where((eb) =>
     eb.not(
       eb.exists(
@@ -234,7 +229,7 @@ try {
       continue
     }
 
-    // The candidate query already excluded tool / sub-assistant / knowledge-file assistants.
+    // The candidate query already excluded tool and knowledge-file assistants.
     const assistant = await source
       .selectFrom('Assistant')
       .innerJoin('AssistantVersion', 'AssistantVersion.id', 'Assistant.publishedVersionId')
@@ -246,11 +241,19 @@ try {
         'Assistant.hidden as assistantHidden',
         'AssistantVersion.id as versionId',
         'AssistantVersion.backendId as backendId',
+        'AssistantVersion.subAssistants as subAssistants',
       ])
       .where('Assistant.id', '=', candidate.assistantId)
       .executeTakeFirst()
     if (!assistant) {
       skip(candidate, 'assistant or its published version is unavailable')
+      continue
+    }
+    const subAssistants = assistant.subAssistants
+      ? (JSON.parse(String(assistant.subAssistants)) as unknown[])
+      : []
+    if (Array.isArray(subAssistants) && subAssistants.length > 0) {
+      skip(candidate, 'assistant has sub-assistants')
       continue
     }
 

--- a/apps/backend/scripts/eval-build-replay-bundle.ts
+++ b/apps/backend/scripts/eval-build-replay-bundle.ts
@@ -2,15 +2,17 @@
  * Builds a self-contained offline replay bundle from a source Logicle database.
  *
  * The bundle is a single SQLite file: the app schema, plus only the selected conversations'
- * `Conversation` / `Message` / `MessageAudit` / `Assistant*` / `Backend` / `File` / `FileBlob`
- * rows, plus a `ReplayFileBlob(path, size, bytes)` table holding every referenced attachment's
- * bytes **decrypted**. `eval-replay-production-chats.ts` consumes it with zero network access.
+ * `Conversation` / `Message` / `MessageAudit` / `Assistant*` / `Backend` / `File` / `FileBlob` /
+ * `FileAnalysis` rows, plus a `ReplayFileBlob(path, size, bytes)` table holding every referenced
+ * attachment's bytes and its extracted-text sidecar, **decrypted**.
+ * `eval-replay-production-chats.ts` consumes it with zero network access.
  *
  * This script is infra-agnostic. It reads the source database via `--source-db` (or `DATABASE_URL`)
  * and attachment bytes via the normal storage stack (`FILE_STORAGE_LOCATION` plus the
- * `FILE_STORAGE_ENCRYPTION_*` vars, only needed when a selected turn has attachments). Pointing
- * those at a specific tenant — proxy, SSH tunnel, direct — is the job of the ops-repo extractor,
- * not this script.
+ * `FILE_STORAGE_ENCRYPTION_*` vars, only needed when a selected turn has attachments).
+ * `FILE_STORAGE_LOCATION` may be an `s3://` bucket, a directory, or an `http(s)://` read-only
+ * proxy (`HttpReadOnlyStorage`) — wiring any of those to a specific tenant is the job of the ops
+ * repo's `download_replay_bundle`, not this script.
  *
  * Usage:
  *   FILE_STORAGE_LOCATION=s3://tenant-bucket FILE_STORAGE_ENCRYPTION_ENABLE=1 \
@@ -300,6 +302,15 @@ try {
         encryption: 'pgp' | 'aead' | null
         createdAt: string
       } | null
+      analysis: {
+        fileId: string
+        kind: string
+        status: string
+        payload: string | null
+        error: string | null
+        createdAt: string
+        updatedAt: string
+      } | null
     }> = []
     let attachmentFailure: string | undefined
     for (const fileId of attachmentFileIds) {
@@ -323,13 +334,33 @@ try {
         attachmentFailure = `attachment ${fileId} FileBlob ${fileRow.fileBlobId} is missing`
         break
       }
+      // Production's cached file analysis (extracted PDF/office text) — carry it so the replay
+      // reuses it instead of re-analyzing (which would fail on the read-only replay storage and,
+      // worse, change the prompt: without extracted text a PDF is sent natively, inflating tokens
+      // past what production actually paid).
+      const analysisRow = await source
+        .selectFrom('FileAnalysis')
+        .select(['fileId', 'kind', 'status', 'payload', 'error', 'createdAt', 'updatedAt'])
+        .where('fileId', '=', fileId)
+        .executeTakeFirst()
+      let extractedTextPath: string | undefined
+      if (analysisRow?.status === 'ready' && analysisRow.payload) {
+        try {
+          const parsed = JSON.parse(analysisRow.payload) as { extractedTextPath?: string | null }
+          extractedTextPath = parsed.extractedTextPath ?? undefined
+        } catch {
+          /* leave analysis without a sidecar; it will just re-analyze */
+        }
+      }
       try {
         if (blobRow) await copyBlobBytes(blobRow.path, blobRow.encryption, blobRow.size)
+        if (extractedTextPath)
+          await copyBlobBytes(extractedTextPath, blobRow?.encryption ?? null, 0)
       } catch (error) {
         attachmentFailure = `attachment ${fileId} bytes could not be read: ${errText(error)}`
         break
       }
-      attachmentRows.push({ file: fileRow, blob: blobRow ?? null })
+      attachmentRows.push({ file: fileRow, blob: blobRow ?? null, analysis: analysisRow ?? null })
     }
     if (attachmentFailure) {
       skip(candidate, attachmentFailure)
@@ -397,7 +428,7 @@ try {
       .executeTakeFirstOrThrow()
     await bundle.insertInto('MessageAudit').values(audit).execute()
 
-    for (const { file, blob } of attachmentRows) {
+    for (const { file, blob, analysis } of attachmentRows) {
       if (blob && !seenBlobIds.has(blob.id)) {
         await bundle
           .insertInto('FileBlob')
@@ -433,6 +464,23 @@ try {
         } as any)
         .execute()
       seenFileIds.add(file.id)
+      if (analysis) {
+        await bundle
+          .insertInto('FileAnalysis')
+          .values({
+            fileId: analysis.fileId,
+            kind: analysis.kind,
+            status: analysis.status,
+            // Bump past any analyzer version the replay checkout might expect, so it is reused
+            // verbatim and never re-run.
+            analyzerVersion: 2_000_000_000,
+            payload: analysis.payload,
+            error: analysis.error,
+            createdAt: analysis.createdAt,
+            updatedAt: analysis.updatedAt,
+          })
+          .execute()
+      }
     }
 
     admitted += 1

--- a/apps/backend/scripts/eval-replay-production-chats.ts
+++ b/apps/backend/scripts/eval-replay-production-chats.ts
@@ -134,6 +134,7 @@ for (const audit of audits) {
       'AssistantVersion.reasoning_effort as reasoningEffort',
       'AssistantVersion.contextCompression as contextCompression',
       'Backend.providerType as providerType',
+      'Backend.configuration as backendConfiguration',
     ])
     .where('Assistant.id', '=', audit.assistantId)
     .executeTakeFirstOrThrow()
@@ -166,6 +167,10 @@ for (const audit of audits) {
       contextCompression: assistant.contextCompression
         ? (JSON.parse(assistant.contextCompression) as Record<string, unknown>)
         : null,
+      backendEndpoint: assistant.backendConfiguration
+        ? (JSON.parse(assistant.backendConfiguration) as { endPoint?: string }).endPoint ??
+          undefined
+        : undefined,
     },
     messages,
     productionReply,
@@ -184,6 +189,7 @@ const apiKeyByProvider: Record<string, string | undefined> = {
   openai: process.env.OPENAI_API_KEY,
   anthropic: process.env.ANTHROPIC_API_KEY,
   'google-ai-studio': process.env.GEMINI_API_KEY,
+  logiclecloud: process.env.LOGICLECLOUD_API_KEY,
 }
 // The mock provider (ALLOW_MOCK_PROVIDER) is keyless and only used to smoke-test this pipeline.
 const apiKey = providerType === 'mock' ? 'mock' : apiKeyByProvider[providerType]
@@ -194,11 +200,13 @@ if (!apiKey) {
   process.exit(1)
 }
 
+const backendEndpoint = flag('endpoint') ?? cases[0]!.assistant.backendEndpoint
 const providerConfig = {
   providerType,
   name: 'production-replay',
   apiKey,
   provisioned: false,
+  ...(backendEndpoint ? { endPoint: backendEndpoint } : {}),
 } as Parameters<typeof ChatAssistant.build>[0]
 
 const resolveModel = (id: string) => {


### PR DESCRIPTION
## Summary

Makes the offline replay bundle builder (#1103) usable against a real production tenant: a Postgres source, attachment bytes through a read-only HTTP proxy when the object store isn't directly reachable, cached file analysis carried into the bundle, and `logiclecloud`-backed assistants in the replay runner. The ops-repo counterpart is `logicle-infra`'s `cli/download_replay_bundle`, which sets up the tunnels and the S3 proxy.

## Details

- **Postgres source.** `subAssistants` is `jsonb` on Postgres and can't be string-compared in the candidate query — that clause is dropped and sub-assistants are checked per row after parsing.
- **`HttpReadOnlyStorage`.** New read-only storage backend, selected when `FILE_STORAGE_LOCATION` is an `http(s)://` URL. Only issues `GET`s, refuses redirects, rejects `..` path segments. Lets the builder read a tenant's blobs through a narrow proxy that runs where the bucket is reachable (production buckets are IP-locked to the tenant VMs); the existing encrypting wrappers still decrypt locally.
- **File analysis carried into the bundle.** Without production's extracted PDF/office text, the replay re-runs analysis (which fails on the read-only replay storage) and sends attachments natively, inflating the prompt far past what production paid — some turns then exceed the context window. The builder now copies each attachment's `FileAnalysis` row and its extracted-text sidecar blob, with `analyzerVersion` bumped so the replay reuses it verbatim.
- **`logiclecloud` in the replay runner.** Recognises `LOGICLECLOUD_API_KEY` and reads `Backend.configuration.endPoint` (overridable with `--endpoint`) so turns from a `logiclecloud`-backed assistant replay against the same proxy the tenant uses.

## Risks

- No production schema, route, or API changes. `storage/index.ts` gains one branch, reachable only when `FILE_STORAGE_LOCATION` starts with `http://`/`https://`.
- Replay bundles now also contain extracted document text — same "treat as a production data extract" caveat.

## Tests

- `npm run check-types` — clean
- `npx vitest run apps/backend/lib/eval apps/backend/lib/storage` — 90 passing
- `biome check` + `prettier --check` on touched files — clean
- End-to-end against `dt-vm-prod-evo` via `logicle-infra/cli/download_replay_bundle`: pulled a 10-turn bundle (30 attachment blobs + 29 extracted-text sidecars, decrypted locally through the proxy), then replayed it — 7/10 turns reproduce production's input-token count within ~200 tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
