### PR TITLE
chore(eval): faithful turn selection and one-shot replay for production-chat eval

### DIFF
--- a/apps/backend/lib/eval/cost.ts
+++ b/apps/backend/lib/eval/cost.ts
@@ -20,6 +20,9 @@ export const modelPrices: Record<string, ModelPrice> = {
   'gpt-4o': { input: 2.5, output: 10.0 },
   'gpt-4.1-mini': { input: 0.4, output: 1.6 },
   'gpt-4.1': { input: 2.0, output: 8.0 },
+  // Replay-eval-only cheap tier (REPLAY_EXTRA_MODELS in eval-replay-production-chats.ts).
+  // TODO(luca): confirm the real gpt-5.6-luna list price — this is an estimate.
+  'gpt-5.6-luna': { input: 0.25, output: 2.0 },
   'gpt-4-turbo': { input: 10.0, output: 30.0 },
   'gpt-4': { input: 30.0, output: 60.0 },
   'gpt-3.5-turbo': { input: 0.5, output: 1.5 },

--- a/apps/backend/lib/eval/productionChatReplay.ts
+++ b/apps/backend/lib/eval/productionChatReplay.ts
@@ -65,7 +65,7 @@ const replayJudgePrompt = [
 ].join('\n')
 
 export const createReplayJudge =
-  (model: LanguageModelV3) =>
+  (model: LanguageModelV3, options: { supportsTemperature?: boolean } = {}) =>
   async (
     finalUserMessage: string,
     productionReply: string,
@@ -74,7 +74,8 @@ export const createReplayJudge =
     const result = await ai.generateObject({
       model,
       schema: replayJudgmentSchema,
-      temperature: 0,
+      // Reasoning models (o-series, gpt-5*) reject an explicit temperature.
+      ...(options.supportsTemperature === false ? {} : { temperature: 0 }),
       system: replayJudgePrompt,
       prompt: [
         `Final user message:\n${finalUserMessage}`,

--- a/apps/backend/scripts/eval-build-replay-bundle.ts
+++ b/apps/backend/scripts/eval-build-replay-bundle.ts
@@ -26,6 +26,12 @@
  *   --min-input-tokens <n>     MessageAudit input-token floor (default: 12000)
  *   --limit <n>                admitted turns (default: 20)
  *   --assistant <id>           restrict to one assistant
+ *   --distinct-conversations   admit at most one turn per conversation
+ *   --since <ISO date>         only turns sent on/after this date (default: 90 days ago)
+ *
+ * Only turns that can be replayed faithfully are considered: the assistant still exists, is not
+ * tool/knowledge/sub-assistant configured, still runs the model the turn actually used, and the
+ * turn did not error in production.
  */
 
 export {}
@@ -53,12 +59,20 @@ if (!sourceDb || !out) {
 const minimumAuditedInputTokens = Number(flag('min-input-tokens') ?? 12000)
 const limit = Number(flag('limit') ?? 20)
 const assistantFilter = flag('assistant')
+const distinctConversations = args.includes('--distinct-conversations')
 if (!Number.isFinite(minimumAuditedInputTokens) || minimumAuditedInputTokens < 1) {
   console.error('--min-input-tokens must be a positive number')
   process.exit(1)
 }
 if (!Number.isInteger(limit) || limit < 1) {
   console.error('--limit must be a positive integer')
+  process.exit(1)
+}
+// Replay is only faithful for turns whose assistant is still configured the way it was then.
+// Default to the last 90 days; pass `--since 1970-01-01` to disable.
+const sinceIso = flag('since') ?? new Date(Date.now() - 90 * 86_400_000).toISOString()
+if (Number.isNaN(Date.parse(sinceIso))) {
+  console.error('--since must be an ISO date')
   process.exit(1)
 }
 
@@ -142,6 +156,13 @@ let candidates = source
   ])
   .where('MessageAudit.type', '=', 'user')
   .where('MessageAudit.tokens', '>=', minimumAuditedInputTokens)
+  .where('MessageAudit.sentAt', '>=', sinceIso)
+  // The turn errored in production — not a clean baseline to compare a replay against.
+  .where('MessageAudit.errors', 'is', null)
+  // The assistant must still exist and still run the model this turn actually used, or the replay
+  // measures a different assistant than the one that incurred the cost.
+  .where('Assistant.deleted', '=', 0)
+  .whereRef('MessageAudit.model', '=', 'AssistantVersion.model')
   // Assistants with tools or knowledge files can't be replayed faithfully; exclude them in SQL so
   // `--limit` counts admissible turns rather than being eaten by the (often most expensive)
   // tool/knowledge cohort. Sub-assistants are checked per row below — `subAssistants` is jsonb on
@@ -202,6 +223,10 @@ const copyBlobBytes = async (blobPath: string, encryption: 'pgp' | 'aead' | null
 try {
   for (const candidate of await candidates.execute()) {
     if (admitted >= limit) break
+    if (distinctConversations && seenConversations.has(candidate.conversationId)) {
+      skip(candidate, 'another turn from this conversation is already admitted')
+      continue
+    }
 
     const messages = await source
       .selectFrom('Message')

--- a/apps/backend/scripts/eval-replay-production-chats.ts
+++ b/apps/backend/scripts/eval-replay-production-chats.ts
@@ -1,5 +1,9 @@
 /**
- * Replays the production turns in an offline bundle through the current code.
+ * Replays production turns from an offline bundle through the current code.
+ *
+ * By default it replays exactly one turn — the most expensive in the bundle — so a single
+ * invocation is a single LLM call and the spend is predictable. Pass `--case <messageId>` (repeat
+ * for a handful) or `--limit <n>` to widen it deliberately.
  *
  * For each turn the runner rebuilds the saved assistant, applies `--override` on top of its
  * configuration, runs the turn once, and records the response plus the real provider token usage
@@ -26,7 +30,11 @@
  *                          (model, systemPrompt, temperature, tokenLimit, reasoning_effort,
  *                          contextCompression). Use '{"contextCompression":null}' to disable it.
  *   --provider <type>      provider for the replay (default: the bundle's) — needs its API key
- *   --model <id>           shorthand for --override '{"model":"<id>"}'
+ *   --model <id>           shorthand for --override '{"model":"<id>"}' (Mode B: a cheap model for
+ *                          an off/on pair — see docs/evaluation-harness.md; ids in
+ *                          REPLAY_EXTRA_MODELS below are dev-only and not user-visible)
+ *   --case <messageId>     replay only this turn; repeat the flag to select several
+ *   --limit <n>            replay the n most expensive turns (default: 1; ignored when --case is used)
  *   --judge                also classify each response against the saved production reply
  *   --judge-model <id>     judge model (default: the replay model)
  */
@@ -49,6 +57,13 @@ const flag = (name: string): string | undefined => {
   return index === -1 ? undefined : args[index + 1]
 }
 const bool = (name: string) => args.includes(`--${name}`)
+const flagAll = (name: string): string[] => {
+  const values: string[] = []
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === `--${name}` && args[index + 1]) values.push(args[index + 1]!)
+  }
+  return values
+}
 
 const bundlePath = flag('bundle')
 const out = flag('out')
@@ -88,20 +103,58 @@ const { EvalSink } = await import('@/backend/lib/eval/sink')
 const { setTokenizerCounter } = await import('@/backend/lib/chat/prompt-token-counter')
 const { countTextWithTokenizer } = await import('@/lib/chat/tokenizer')
 const { llmModels } = await import('@/lib/models')
+const { modelSupportsReasoning } = await import('@/lib/chat/models')
 const { createReplayJudge } = await import('@/backend/lib/eval/productionChatReplay')
+type LlmModel = (typeof llmModels)[number]
 
 setTokenizerCounter({
   countText: async (tokenizer, text) => countTextWithTokenizer(tokenizer, text),
 })
 
+// Cheap models for local off/on replay (Mode B in docs/evaluation-harness.md) that are not in the
+// shipped catalog. Dev-only — this list never reaches users. Add a matching price to
+// apps/backend/lib/eval/cost.ts or the cost column stays blank.
+const REPLAY_EXTRA_MODELS: LlmModel[] = [
+  {
+    id: 'gpt-5.6-luna',
+    model: 'gpt-5.6-luna',
+    name: 'GPT-5.6 Luna',
+    description: 'Cheap GPT-5.6 tier — replay eval only, not user-visible.',
+    provider: 'openai',
+    owned_by: 'openai',
+    context_length: 400000,
+    capabilities: { vision: true, function_calling: true, promptCaching: false },
+    supportedReasoningEfforts: ['none', 'low', 'medium', 'high'],
+    defaultReasoning: 'low',
+  },
+]
+const modelCatalog: LlmModel[] = [...llmModels, ...REPLAY_EXTRA_MODELS]
+
 // --- reconstruct the replay cases from the bundle ---
+// One turn per invocation by default: the most expensive in the bundle. `--case` picks specific
+// turns; `--limit` widens the window. Both are opt-in so an accidental run costs one LLM call.
+const caseIds = flagAll('case')
+const limit = caseIds.length > 0 ? Infinity : Math.max(1, Number(flag('limit') ?? 1))
 const cases: ProductionReplayCase[] = []
-const audits = await db
+let audits = await db
   .selectFrom('MessageAudit')
   .selectAll()
   .where('type', '=', 'user')
   .orderBy('tokens', 'desc')
   .execute()
+if (caseIds.length > 0) {
+  const wanted = new Set(caseIds)
+  audits = audits.filter((audit) => wanted.has(audit.messageId))
+  const missing = caseIds.filter((id) => !audits.some((audit) => audit.messageId === id))
+  if (missing.length > 0) {
+    console.error(`Bundle has no turn for --case ${missing.join(', ')}.`)
+    await db.destroy()
+    rmSync(workdir, { recursive: true, force: true })
+    process.exit(1)
+  }
+} else {
+  audits = audits.slice(0, limit)
+}
 
 for (const audit of audits) {
   const conversationMessages = await db
@@ -210,8 +263,14 @@ const providerConfig = {
 } as Parameters<typeof ChatAssistant.build>[0]
 
 const resolveModel = (id: string) => {
-  const model = llmModels.find((entry) => entry.id === id && entry.provider === providerType)
-  if (!model) throw new Error(`Model "${id}" is not defined for provider "${providerType}"`)
+  // Prefer the definition the replay provider actually lists; otherwise fall back to the model of
+  // that id from any provider. The replay deliberately points the provider config at one backend
+  // (e.g. a logiclecloud proxy that also serves Gemini for a cheap run), and the registry's
+  // `provider` field only gates the tokenizer/capabilities metadata, not API routing.
+  const model =
+    modelCatalog.find((entry) => entry.id === id && entry.provider === providerType) ??
+    modelCatalog.find((entry) => entry.id === id)
+  if (!model) throw new Error(`Model "${id}" is not defined in this checkout`)
   return model
 }
 
@@ -276,15 +335,17 @@ try {
       error = caught instanceof Error ? caught.message : String(caught)
     }
 
-    const judgment =
-      bool('judge') && !error
-        ? await createReplayJudge(
-            ChatAssistant.createLanguageModel(
-              providerConfig,
-              resolveModel(flag('judge-model') ?? model.id)
-            )
-          )((entry.messages.at(-1) as dto.UserMessage).content, entry.productionReply, response)
-        : undefined
+    let judgment: ReplayJudgment | undefined
+    if (bool('judge') && !error) {
+      const judgeModel = resolveModel(flag('judge-model') ?? model.id)
+      judgment = await createReplayJudge(
+        ChatAssistant.createLanguageModel(providerConfig, judgeModel),
+        {
+          supportsTemperature:
+            !modelSupportsReasoning(judgeModel) && judgeModel.capabilities.temperature !== false,
+        }
+      )((entry.messages.at(-1) as dto.UserMessage).content, entry.productionReply, response)
+    }
 
     results.push({
       caseId: entry.id,

--- a/docs/evaluation-harness.md
+++ b/docs/evaluation-harness.md
@@ -261,33 +261,101 @@ npx tsx apps/backend/scripts/eval-build-replay-bundle.ts \
   --out expensive.sqlite --min-input-tokens 12000 --limit 25
 ```
 
-Turns are skipped (with a reason, written to `<out>.skipped.json`) when the lineage has saved tool
-activity, the assistant is configured with tools / sub-assistants / knowledge files, or an
-attachment's rows or bytes cannot be resolved — so a replay never silently omits a file or loses a
-tool capability. To cover tool conversations, extend the builder with a tool-specific fixture
-adapter.
+The builder only considers turns it can replay **faithfully**, so the numbers mean something:
+
+- **recent** — sent within the last 90 days (`--since <ISO date>` to change; `--since 1970-01-01`
+  to disable). Old turns ran against assistant configs and model versions that no longer exist.
+- **assistant still current** — the assistant is not deleted, and it still publishes the exact
+  model the turn actually used (`MessageAudit.model == AssistantVersion.model`). A turn whose
+  assistant has since been re-pointed at another model is dropped: replaying it would measure a
+  different assistant than the one that incurred the cost.
+- **no tools / knowledge / sub-assistants** — those can't be reproduced offline (a knowledge box
+  needs its index, a tool needs its backend), and they are usually the most expensive cohort, so
+  excluding them in SQL keeps `--limit` counting turns you can actually use.
+- **clean in production** — the turn did not record an error.
+
+Turns that pass those and are then skipped during the copy (lineage has saved tool activity, an
+attachment's rows or bytes cannot be resolved) get a reason in `<out>.skipped.json` — so a replay
+never silently omits a file or loses a tool capability. To cover tool conversations, extend the
+builder with a tool-specific fixture adapter.
 
 ### Stage 2 — replay the bundle
 
 ```bash
-# Replay with each turn's saved configuration (a sanity check — should roughly match production):
+# Sanity check — the most expensive turn, saved config, nothing changed (should ~match production):
 OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
   --bundle expensive.sqlite --out replay-results.json --report replay-report.md
 
-# Replay with a change applied — here, a compression preset — and read the delta vs production:
+# Mode A — same model, compression on, delta vs production's MessageAudit:
 OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
-  --bundle expensive.sqlite --out compressed-results.json --report compressed-report.md \
-  --override '{"contextCompression":{"preset":"conservative"}}' --judge
+  --bundle expensive.sqlite --out on.json --report on.md --judge \
+  --override '{"contextCompression":{"preset":"conservative","retrievalMode":"prefetch"}}'
+
+# Mode B — cheap model, off then on, measured by the same ruler:
+LOGICLECLOUD_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
+  --bundle expensive.sqlite --out b-off.json --report b-off.md \
+  --model gpt-5.6-luna --override '{"contextCompression":null}'
+LOGICLECLOUD_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
+  --bundle expensive.sqlite --out b-on.json --report b-on.md --judge \
+  --model gpt-5.6-luna \
+  --override '{"contextCompression":{"preset":"conservative","retrievalMode":"prefetch"}}'
 ```
 
 The runner copies the bundle to a scratch directory, points the app at that copy and at
 `FILE_STORAGE_LOCATION=replaydb:` (`DbBlobStorage` serves attachment bytes straight from
-`ReplayFileBlob`), and for each turn rebuilds the saved assistant with `--override` merged over its
-configuration, runs the turn once, and records the response, the real provider token usage, and
-the priced cost. `--override` is a JSON object merged over `model` / `systemPrompt` / `temperature`
-/ `tokenLimit` / `reasoning_effort` / `contextCompression` (use `{"contextCompression":null}` to
-turn it off); its shape follows whatever the running code's schema accepts, so newer options work
-without changing this script.
+`ReplayFileBlob`), and for each selected turn rebuilds the saved assistant with `--override` merged
+over its configuration, runs the turn once, and records the response, the real provider token
+usage, and the priced cost. `--override` is a JSON object merged over `model` / `systemPrompt` /
+`temperature` / `tokenLimit` / `reasoning_effort` / `contextCompression` (use
+`{"contextCompression":null}` to turn it off); its shape follows whatever the running code's schema
+accepts, so newer options work without changing this script.
+
+**It replays one turn per invocation by default** — the most expensive in the bundle — so a run is
+one LLM call and the spend is known before you start. Widen it deliberately: `--case <messageId>`
+(repeat for a handful of specific turns, listed in `replay-report.md` and the bundle's
+`MessageAudit`) or `--limit <n>` for the _n_ most expensive.
+
+### Operating modes — cost/quality testing without a big bill
+
+A replay calls a real provider with a real (often six-figure-token) prompt. Keep it cheap:
+
+- **Build the bundle once, replay many times.** Stage 1 is the only step that touches production
+  and it costs nothing. Iterate on its output.
+- **Default to one turn — the most expensive.** That single case is the interesting one and it is
+  one LLM call. `--case <id>` / `--limit <n>` only when you have a reason.
+- **`--judge` roughly doubles the cost** (a second model call over the same prompt). Get the token
+  numbers for all your turns first; judge only the ones whose numbers look worth a closer look.
+
+**Two ways to get a saving number**, depending on how much you trust the persisted counts:
+
+- **Mode A — same model, trust `MessageAudit`.** Replay on the assistant's real model with only
+  `--override '{"contextCompression":{…}}'` changed. The "before" is production's own
+  `MessageAudit` input tokens (in the bundle, shown in the report) — no off run needed. This is
+  the cheapest honest measurement: one call per turn. Its limit is that `MessageAudit.tokens` was
+  counted by the code as it was then, so treat single-digit-percent deltas as noise.
+- **Mode B — cheap model, run both sides.** When you want an off/on pair measured by the same
+  ruler and the real model is expensive, replay twice — `'{"contextCompression":null}'` and
+  `'{"contextCompression":{…}}'` — on a cheap model via `--model`. Two calls per turn, but on a
+  $0.10–0.30/1M model that is cents. The delta between the two runs is clean; the absolute cost is
+  not the production cost, so report it as a ratio. (`gpt-5.6-luna` and other cheap ids the eval
+  runner knows are in `REPLAY_EXTRA_MODELS` in the runner — they are not exposed to users.)
+
+Never change the model **and** compare against `MessageAudit`: a different tokenizer and context
+window make that delta meaningless. Mode A keeps the model; Mode B keeps the ruler.
+
+**Reading the result:**
+
+- **Saving** — replay input tokens vs the baseline (production for Mode A, the off run for Mode B),
+  as a percentage. Watch for near-zero: if the assistant's `tokenLimit` already truncates history
+  below budget, compression runs after that truncation and saves almost nothing while still
+  swapping verbatim text for lossy summaries — a strict `tokenLimit` and compression work against
+  each other.
+- **Quality** — `--judge` classifies the response against the saved production reply (a
+  **reference, not an answer key** — review every non-equivalent verdict yourself). The failure
+  mode to look for: a summary/excerpt that dropped an exact figure the user asked about.
+- **Doesn't fit** — `conservative` often can't pull a 700k-token turn under a 400k window; it
+  errors rather than truncate silently. Try `aggressive`, or record the turn as "compression
+  insufficient at this preset".
 
 `replay-report.md` shows, per turn, production's audited input tokens next to the replay's input
 tokens, output tokens, priced cost, and the input-token delta. With `--judge`, each response is


### PR DESCRIPTION
## Summary

Sharpens the offline production-chat replay tooling so a run is cheap and its numbers are trustworthy. The bundle builder now only picks turns that can be replayed faithfully (recent, assistant unchanged, no production error), the runner replays a single turn per invocation by default, and the harness doc gains a section on how to measure compression cost/quality without a large provider bill.

No product behaviour changes — everything here is under `apps/backend/scripts/eval-*` and `apps/backend/lib/eval/`.

## Details

- **Builder turn selection** (`eval-build-replay-bundle.ts`): candidates are now restricted in SQL to turns sent within the last 90 days (`--since <ISO date>` to change), whose assistant is not deleted and still publishes the exact model the turn used (`MessageAudit.model == AssistantVersion.model`), and which did not record a production error. Adds `--distinct-conversations` to admit at most one turn per conversation.
- **Runner one-shot default** (`eval-replay-production-chats.ts`): replays only the most expensive turn in the bundle unless `--case <messageId>` (repeatable) or `--limit <n>` is given, so an accidental run is one LLM call.
- **Runner model resolution**: `resolveModel` falls back to an id-only match when the replay provider doesn't list that id, so a replay can point its provider config at a proxy that serves another provider's models.
- **Judge temperature**: the `--judge` call omits `temperature` for reasoning models (o-series / gpt-5\*), which reject an explicit temperature.
- **Dev-only cheap models**: `REPLAY_EXTRA_MODELS` in the runner carries ids for local off/on runs (`gpt-5.6-luna`) that are not in the shipped catalog and never reach users. Its price in `eval/cost.ts` is an estimate — see the `TODO`.
- **Docs** (`docs/evaluation-harness.md`): the replay section documents the faithfulness filters and an "Operating modes" subsection — Mode A (same model, compare against `MessageAudit`) vs Mode B (cheap model, run off and on) — plus what to read from the saving and the judge verdict.

## Tests

- `npx tsc --noEmit` — clean
- `npx vitest run apps/backend/lib/eval` — 90 passed
- Builder exercised end-to-end against a production tenant: the new filters correctly drop a turn whose assistant was since re-pointed at a different model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)