### PR TITLE
feat(eval): compare knowledge strategies on production chat replays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,11 @@ yarn-error.log*
 # Tests
 /report
 
+# Production chat replay artifacts contain verbatim tenant content, decrypted file bytes, and
+# candidate responses. Keep bundles and raw outputs in this ignored staging directory; publish
+# only sanitized aggregate findings.
+/tmp/production-chat-replays/
+
 # eslint
 .eslintcache
 

--- a/apps/backend/lib/eval/__tests__/productionChatReplay.test.ts
+++ b/apps/backend/lib/eval/__tests__/productionChatReplay.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   collectAttachmentFileIds,
+  defaultReplayKnowledgeQuestions,
   isReplayableLineage,
+  parseKnowledgeReplayArms,
 } from '@/backend/lib/eval/productionChatReplay'
 import type * as dto from '@/types/dto'
 
@@ -83,5 +85,39 @@ describe('collectAttachmentFileIds', () => {
 
   it('returns nothing for a text-only lineage', () => {
     expect(collectAttachmentFileIds([user()])).toEqual([])
+  })
+})
+
+describe('parseKnowledgeReplayArms', () => {
+  it('defaults to the production assistant-knowledge behavior', () => {
+    expect(parseKnowledgeReplayArms(undefined, true)).toEqual(['assistant-knowledge'])
+    expect(parseKnowledgeReplayArms(undefined, false)).toEqual(['assistant-knowledge'])
+  })
+
+  it('parses, validates, and de-duplicates comparison arms', () => {
+    expect(
+      parseKnowledgeReplayArms(
+        'assistant-knowledge, knowledge-box,knowledge-box-no-projections,knowledge-box',
+        true
+      )
+    ).toEqual(['assistant-knowledge', 'knowledge-box', 'knowledge-box-no-projections'])
+  })
+
+  it('rejects unknown arms and box replay without a corpus', () => {
+    expect(() => parseKnowledgeReplayArms('unknown', true)).toThrow('Unknown knowledge arm')
+    expect(() => parseKnowledgeReplayArms('knowledge-box', false)).toThrow(
+      'requires at least one configured assistant knowledge file'
+    )
+  })
+})
+
+describe('defaultReplayKnowledgeQuestions', () => {
+  it('uses stable unique ids and retrieval-oriented prompts', () => {
+    expect(new Set(defaultReplayKnowledgeQuestions.map((question) => question.id)).size).toBe(
+      defaultReplayKnowledgeQuestions.length
+    )
+    expect(defaultReplayKnowledgeQuestions.every((question) => question.prompt.length > 20)).toBe(
+      true
+    )
   })
 })

--- a/apps/backend/lib/eval/productionChatReplay.ts
+++ b/apps/backend/lib/eval/productionChatReplay.ts
@@ -3,13 +3,14 @@ import * as z from 'zod'
 import type { LanguageModelV3 } from '@ai-sdk/provider'
 import type * as dto from '@/types/dto'
 import type { ProviderType } from '@/types/provider'
+import type { KnowledgeBoxQuestion } from '@/lib/tools/schemas'
 
 /**
  * One production turn selected for offline replay.
  *
  * The runner reconstructs this shape from a complete conversation, loaded either from the live
- * database or from a bundle produced by `eval-build-replay-bundle.ts`. Bundle attachment bytes
- * live in `ReplayFileBlob`, already decrypted.
+ * database or from a bundle produced by `eval-build-replay-bundle.ts`. Bundled conversation and
+ * assistant-knowledge file bytes live in `ReplayFileBlob`, already decrypted.
  */
 export interface ProductionReplayCase {
   id: string
@@ -37,8 +38,68 @@ export interface ProductionReplayCase {
   }
   /** The complete saved lineage, ending in the user message that incurred the audited prompt. */
   messages: dto.Message[]
+  /** Knowledge files attached to the published assistant version, in configured order. */
+  knowledgeFiles: dto.AssistantFile[]
   /** Production's next assistant text. It is a reference for the judge, not an answer key. */
   productionReply: string
+}
+
+export const knowledgeReplayArmNames = [
+  'assistant-knowledge',
+  'knowledge-box',
+  'knowledge-box-no-projections',
+] as const
+
+export type KnowledgeReplayArmName = (typeof knowledgeReplayArmNames)[number]
+
+/**
+ * General-purpose projections for replaying an existing assistant knowledge corpus as a box.
+ * Real deployments should still tune questions to their corpus; the chunks-only arm shows how
+ * much these generic projections help or hurt.
+ */
+export const defaultReplayKnowledgeQuestions: KnowledgeBoxQuestion[] = [
+  {
+    id: 'summary',
+    title: 'Summary',
+    prompt:
+      'What is this document, who or what does it concern, and what does it govern or explain?',
+  },
+  {
+    id: 'key-facts',
+    title: 'Key facts',
+    prompt:
+      'List the concrete names, identifiers, figures, dates, deadlines, requirements, and decisions stated by this document, each with what it refers to.',
+  },
+]
+
+export const parseKnowledgeReplayArms = (
+  raw: string | undefined,
+  hasKnowledgeFiles: boolean
+): KnowledgeReplayArmName[] => {
+  if (!raw) return ['assistant-knowledge']
+
+  const names = raw
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean)
+  if (names.length === 0) throw new Error('--knowledge-arms must name at least one arm')
+
+  const known = new Set<string>(knowledgeReplayArmNames)
+  const unknown = names.filter((name) => !known.has(name))
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown knowledge arm(s): ${unknown.join(', ')}. Known: ${knowledgeReplayArmNames.join(
+        ', '
+      )}`
+    )
+  }
+  if (!hasKnowledgeFiles && names.some((name) => name !== 'assistant-knowledge')) {
+    throw new Error(
+      'Knowledge-box replay requires at least one configured assistant knowledge file'
+    )
+  }
+
+  return [...new Set(names)] as KnowledgeReplayArmName[]
 }
 
 export type ReplayVerdict = 'equivalent' | 'minor-regression' | 'major-regression' | 'inconclusive'
@@ -57,7 +118,7 @@ const replayJudgmentSchema = z.object({
 
 const replayJudgePrompt = [
   'Compare a candidate chat response with the production response to the same final user message.',
-  'Decide whether compression caused a material regression in helpfulness, completeness, instruction-following, or unsupported claims.',
+  'Decide whether the candidate configuration caused a material regression in helpfulness, completeness, instruction-following, or unsupported claims.',
   'The production answer is only a reference, not proof that its facts are correct. Do not invent a factual answer key.',
   'Return equivalent when the candidate is at least as useful in substance; minor-regression for a recoverable omission; major-regression when the user would materially fail; inconclusive when the reference is insufficient to judge.',
   'Do not prefer either answer for length, style, or wording alone.',

--- a/apps/backend/scripts/eval-build-replay-bundle.ts
+++ b/apps/backend/scripts/eval-build-replay-bundle.ts
@@ -3,13 +3,14 @@
  *
  * The bundle is a single SQLite file for one conversation: the app schema, plus the selected
  * `Conversation` / `Message` / `MessageAudit` / `Assistant*` / `Backend` / `File` / `FileBlob` /
- * `FileAnalysis` rows, plus a `ReplayFileBlob(path, size, bytes)` table holding every referenced
- * attachment's bytes and its extracted-text sidecar, **decrypted**.
+ * `FileAnalysis` / `AssistantVersionFile` rows, plus a `ReplayFileBlob(path, size, bytes)` table
+ * holding every referenced attachment and assistant-knowledge file (and extracted-text sidecar),
+ * **decrypted**.
  * `eval-replay-production-chats.ts` consumes it with zero network access.
  *
  * This script is infra-agnostic. It reads the source database via `--source-db` (or `DATABASE_URL`)
- * and attachment bytes via the normal storage stack (`FILE_STORAGE_LOCATION` plus the
- * `FILE_STORAGE_ENCRYPTION_*` vars, only needed when the conversation has attachments).
+ * and file bytes via the normal storage stack (`FILE_STORAGE_LOCATION` plus the
+ * `FILE_STORAGE_ENCRYPTION_*` vars, only needed when the conversation or assistant has files).
  * `FILE_STORAGE_LOCATION` may be an `s3://` bucket, a directory, or an `http(s)://` read-only
  * proxy (`HttpReadOnlyStorage`) — wiring any of those to a specific tenant is the job of the ops
  * repo's `download_replay_bundle`, not this script.
@@ -128,7 +129,13 @@ const copyBlobBytes = async (blobPath: string, encryption: 'pgp' | 'aead' | null
 }
 
 let copied:
-  | { messages: number; audits: number; attachments: number; replayableTargets: number }
+  | {
+      messages: number
+      audits: number
+      attachments: number
+      knowledgeFiles: number
+      replayableTargets: number
+    }
   | undefined
 let failure: string | undefined
 try {
@@ -184,16 +191,11 @@ try {
   if (configuredTool) {
     throw new Error('Assistant has configured tools, which the offline replay cannot reconstruct')
   }
-  const configuredKnowledgeFile = await source
+  const knowledgeAssociations = await source
     .selectFrom('AssistantVersionFile')
-    .select('fileId')
+    .selectAll()
     .where('assistantVersionId', '=', assistant.versionId)
-    .executeTakeFirst()
-  if (configuredKnowledgeFile) {
-    throw new Error(
-      'Assistant has configured knowledge files, which the offline replay cannot reconstruct'
-    )
-  }
+    .execute()
 
   let replayMessages: ReturnType<typeof dtoMessageFromDbMessage>[]
   try {
@@ -202,9 +204,13 @@ try {
     throw new Error(`A saved message cannot be converted: ${errText(error)}`)
   }
 
-  // Resolve every attachment in the complete conversation before writing the relational rows.
+  // Resolve every attachment and assistant-knowledge file before writing relational rows. A file
+  // may appear in both sets; bundle it once and preserve the assistant association separately.
   const attachmentFileIds = collectAttachmentFileIds(replayMessages)
-  const attachmentRows: Array<{
+  const knowledgeFileIds = knowledgeAssociations.map((association) => association.fileId)
+  const knowledgeFileIdSet = new Set(knowledgeFileIds)
+  const referencedFileIds = [...new Set([...attachmentFileIds, ...knowledgeFileIds])]
+  const fileRows: Array<{
     file: {
       id: string
       name: string
@@ -233,14 +239,15 @@ try {
       updatedAt: string
     } | null
   }> = []
-  for (const fileId of attachmentFileIds) {
+  for (const fileId of referencedFileIds) {
+    const kind = knowledgeFileIdSet.has(fileId) ? 'Knowledge file' : 'Attachment'
     const fileRow = await source
       .selectFrom('File')
       .select(['id', 'name', 'path', 'type', 'origin', 'createdAt', 'fileBlobId'])
       .where('id', '=', fileId)
       .executeTakeFirst()
     if (!fileRow) {
-      throw new Error(`Attachment ${fileId} has no File row`)
+      throw new Error(`${kind} ${fileId} has no File row`)
     }
     const blobRow = fileRow.fileBlobId
       ? await source
@@ -250,7 +257,7 @@ try {
           .executeTakeFirst()
       : undefined
     if (fileRow.fileBlobId && !blobRow) {
-      throw new Error(`Attachment ${fileId} FileBlob ${fileRow.fileBlobId} is missing`)
+      throw new Error(`${kind} ${fileId} FileBlob ${fileRow.fileBlobId} is missing`)
     }
     // Production's cached file analysis (extracted PDF/office text) — carry it so the replay
     // reuses it instead of re-analyzing (which would fail on the read-only replay storage and,
@@ -275,7 +282,7 @@ try {
         await copyBlobBytes(blobRow.path, blobRow.encryption, blobRow.size)
       } catch (error) {
         throw new Error(
-          `Attachment ${fileId} blob ${blobRow.path} could not be read: ${errText(error)}`
+          `${kind} ${fileId} blob ${blobRow.path} could not be read: ${errText(error)}`
         )
       }
     }
@@ -284,13 +291,13 @@ try {
         await copyBlobBytes(extractedTextPath, blobRow?.encryption ?? null, 0)
       } catch (error) {
         throw new Error(
-          `Attachment ${fileId} extracted-text sidecar ${extractedTextPath} could not be read: ${errText(
+          `${kind} ${fileId} extracted-text sidecar ${extractedTextPath} could not be read: ${errText(
             error
           )}`
         )
       }
     }
-    attachmentRows.push({ file: fileRow, blob: blobRow ?? null, analysis: analysisRow ?? null })
+    fileRows.push({ file: fileRow, blob: blobRow ?? null, analysis: analysisRow ?? null })
   }
 
   const backend = await source
@@ -303,7 +310,21 @@ try {
     .selectAll()
     .where('id', '=', assistant.versionId)
     .executeTakeFirstOrThrow()
-  await bundle.insertInto('Backend').values(backend).execute()
+  let backendEndpoint: string | undefined
+  try {
+    const configuration = JSON.parse(backend.configuration) as { endPoint?: unknown }
+    if (typeof configuration.endPoint === 'string') backendEndpoint = configuration.endPoint
+  } catch {
+    // The replay still gets provider/model identity from the relational columns. An invalid source
+    // configuration should not make the bundle retain opaque values that may contain credentials.
+  }
+  await bundle
+    .insertInto('Backend')
+    .values({
+      ...backend,
+      configuration: JSON.stringify(backendEndpoint ? { endPoint: backendEndpoint } : {}),
+    })
+    .execute()
   await bundle
     .insertInto('AssistantVersion')
     .values({ ...version, imageId: null })
@@ -325,7 +346,7 @@ try {
   for (const row of messages) await bundle.insertInto('Message').values(row).execute()
   for (const audit of audits) await bundle.insertInto('MessageAudit').values(audit).execute()
 
-  for (const { file, blob, analysis } of attachmentRows) {
+  for (const { file, blob, analysis } of fileRows) {
     if (blob && !seenBlobIds.has(blob.id)) {
       await bundle
         .insertInto('FileBlob')
@@ -377,6 +398,9 @@ try {
         .execute()
     }
   }
+  for (const association of knowledgeAssociations) {
+    await bundle.insertInto('AssistantVersionFile').values(association).execute()
+  }
 
   const messageIds = new Set(messages.map((message) => message.id))
   const replayableTargets = audits.filter(
@@ -394,6 +418,7 @@ try {
     messages: messages.length,
     audits: audits.length,
     attachments: attachmentFileIds.length,
+    knowledgeFiles: knowledgeFileIds.length,
     replayableTargets,
   }
 } catch (error) {
@@ -417,6 +442,7 @@ if (failure || !copied) {
   console.error(
     `Wrote conversation ${conversationId} to ${out}: ${copied.messages} messages, ` +
       `${copied.audits} audits, ${copied.attachments} attachments, ` +
+      `${copied.knowledgeFiles} assistant knowledge files, ` +
       `${copied.replayableTargets} candidate replay messages.`
   )
 }

--- a/apps/backend/scripts/eval-replay-production-chats.ts
+++ b/apps/backend/scripts/eval-replay-production-chats.ts
@@ -7,11 +7,11 @@
  * parent lineage from the complete saved conversation.
  *
  * For each turn the runner rebuilds the saved assistant, applies `--override` on top of its
- * configuration, runs the turn once, and records the response plus the real provider token usage
- * and priced cost. It does not run an off/on comparison — the "before" number is production's own
- * `MessageAudit` input-token count, already in the bundle. To evaluate a change (a compression
- * preset, a different model, a new build) run it with the corresponding `--override` — or from a
- * checkout / deployment that has the change — and read the delta against production.
+ * configuration, and records the response plus real provider token usage and priced cost. It can
+ * compare knowledge arms directly; for other changes, the "before" number is production's own
+ * `MessageAudit` input-token count, already in the bundle. To evaluate a compression preset,
+ * different model, or new build, run it with the corresponding `--override` — or from a checkout /
+ * deployment that has the change — and read the delta against production.
  *
  * In bundle mode, the runner copies the SQLite bundle to a scratch dir and serves attachment bytes
  * from `ReplayFileBlob`. In live mode it reads the already-configured database and storage. The
@@ -42,6 +42,9 @@
  *   --model <id>           shorthand for --override '{"model":"<id>"}' (Mode B: a cheap model for
  *                          an off/on pair — see docs/evaluation-harness.md; ids in
  *                          REPLAY_EXTRA_MODELS below are dev-only and not user-visible)
+ *   --knowledge-arms <...> comma-separated assistant-knowledge, knowledge-box, and/or
+ *                          knowledge-box-no-projections (default: assistant-knowledge)
+ *   --repeat <n>           replay each knowledge arm n times; box ingestion happens once (default: 1)
  *   --inspect-only         calculate compression decisions/token estimates without an LLM call
  *   --judge                also classify each response against the saved production reply
  *   --judge-model <id>     judge model (default: the replay model)
@@ -55,7 +58,12 @@ import type * as dto from '@/types/dto'
 import type { Message as DbMessage } from '@/db/schema'
 import type { ProviderType } from '@/types/provider'
 import { computeCostUsd, formatCostUsd } from '@/backend/lib/eval/cost'
-import type { ProductionReplayCase, ReplayJudgment } from '@/backend/lib/eval/productionChatReplay'
+import type {
+  KnowledgeReplayArmName,
+  ProductionReplayCase,
+  ReplayJudgment,
+} from '@/backend/lib/eval/productionChatReplay'
+import type { SetupCost } from '@/backend/lib/eval/types'
 
 const args = process.argv.slice(2).filter((arg) => arg !== '--')
 const flag = (name: string): string | undefined => {
@@ -67,6 +75,7 @@ const bundlePath = flag('bundle')
 const liveConversationId = flag('conversation')
 const out = flag('out')
 const reportPath = flag('report')
+const repeat = Number(flag('repeat') ?? 1)
 if (
   (!bundlePath && !liveConversationId) ||
   (bundlePath && liveConversationId) ||
@@ -77,6 +86,10 @@ if (
     'Usage: (--bundle <bundle.sqlite> | --conversation <id>) [--message <id>] ' +
       '--out <results.json> --report <report.md>'
   )
+  process.exit(1)
+}
+if (!Number.isInteger(repeat) || repeat < 1) {
+  console.error('--repeat must be a positive integer')
   process.exit(1)
 }
 
@@ -108,6 +121,7 @@ if (bundlePath && workdir) {
 
 const { db } = await import('@/db/database')
 const { dtoMessageFromDbMessage } = await import('@/models/utils')
+const { assistantVersionFiles } = await import('@/models/assistant')
 const { renderMessagePlainText } = await import('@/backend/lib/chat/message-projection')
 const { ChatAssistant } = await import('@/backend/lib/chat')
 const { EvalSink } = await import('@/backend/lib/eval/sink')
@@ -123,9 +137,13 @@ const {
   resolveCompressionRetrievalMode,
   resolveCompressionTriggerTokens,
 } = await import('@/backend/lib/chat/compression-planner')
-const { createReplayJudge, isReplayableLineage } = await import(
-  '@/backend/lib/eval/productionChatReplay'
-)
+const {
+  createReplayJudge,
+  defaultReplayKnowledgeQuestions,
+  isReplayableLineage,
+  parseKnowledgeReplayArms,
+} = await import('@/backend/lib/eval/productionChatReplay')
+const { allInContextArm, createKnowledgeBoxArm } = await import('@/backend/lib/eval/arms')
 type LlmModel = (typeof llmModels)[number]
 
 setTokenizerCounter({
@@ -257,6 +275,7 @@ const assistant = await db
   .select([
     'Assistant.deleted as deleted',
     'AssistantVersion.id as versionId',
+    'AssistantVersion.backendId as backendId',
     'AssistantVersion.model as model',
     'AssistantVersion.systemPrompt as systemPrompt',
     'AssistantVersion.temperature as temperature',
@@ -298,16 +317,7 @@ if (configuredTool) {
     `Assistant ${selectedAudit.assistantId} has configured tools; replay has no fixture.`
   )
 }
-const configuredKnowledgeFile = await db
-  .selectFrom('AssistantVersionFile')
-  .select('fileId')
-  .where('assistantVersionId', '=', selectedAssistant.versionId)
-  .executeTakeFirst()
-if (configuredKnowledgeFile) {
-  await abortReplay(
-    `Assistant ${selectedAudit.assistantId} has configured knowledge files; replay has no index fixture.`
-  )
-}
+const knowledgeFiles = await assistantVersionFiles(selectedAssistant.versionId)
 
 const productionResponseRow = conversationMessages
   .filter((message) => message.parent === selectedAudit.messageId && message.role === 'assistant')
@@ -341,10 +351,29 @@ const cases: ProductionReplayCase[] = [
         : undefined,
     },
     messages: replayMessages,
+    knowledgeFiles,
     productionReply,
   },
 ]
 const replayUser = bundlePath ? 'production-replay-user' : conversation.ownerId
+
+const knowledgeArmNames: KnowledgeReplayArmName[] = await (async () => {
+  try {
+    return parseKnowledgeReplayArms(flag('knowledge-arms'), cases[0]!.knowledgeFiles.length > 0)
+  } catch (error) {
+    return abortReplay(error instanceof Error ? error.message : String(error))
+  }
+})()
+if (
+  !bundlePath &&
+  knowledgeArmNames.some(
+    (name) => name === 'knowledge-box' || name === 'knowledge-box-no-projections'
+  )
+) {
+  await abortReplay(
+    'Knowledge-box arms require --bundle because indexing writes evaluation rows. Build an offline bundle first.'
+  )
+}
 
 const providerType = flag('provider') ?? cases[0]!.assistant.providerType
 const resolveModel = (id: string) => {
@@ -454,6 +483,7 @@ if (bool('inspect-only')) {
     `Model: \`${inspection.model}\``,
     `Saved token limit: **${tokenLimit}**`,
     `Production input tokens: **${selectedAudit.tokens}**`,
+    `Assistant knowledge files: **${cases[0]!.knowledgeFiles.length}**.`,
     '',
     `Compression: **${inspection.compressionEnabled ? 'enabled' : 'disabled'}**` +
       (compression
@@ -487,13 +517,15 @@ if (bool('inspect-only')) {
     out,
     JSON.stringify(
       {
-        version: 3,
+        version: 4,
         createdAt: new Date().toISOString(),
         source: bundlePath
           ? { mode: 'bundle', bundle: bundlePath }
           : { mode: 'live', conversationId: replayConversationId },
         selectedMessageId: selectedAudit.messageId,
         override,
+        knowledgeArms: knowledgeArmNames,
+        knowledgeFiles: cases[0]!.knowledgeFiles,
         inspection,
       },
       null,
@@ -527,8 +559,27 @@ const providerConfig = {
   ...(backendEndpoint ? { endPoint: backendEndpoint } : {}),
 } as Parameters<typeof ChatAssistant.build>[0]
 
+// Projection ingestion resolves a backend from the database rather than from ChatAssistant's
+// explicit replay config. In bundle mode this row is a scratch copy, so point it at the same
+// provider credentials used for the replay and avoid depending on secrets from production.
+if (knowledgeArmNames.includes('knowledge-box')) {
+  await db
+    .updateTable('Backend')
+    .set({
+      providerType: providerType as never,
+      configuration: JSON.stringify({
+        apiKey,
+        ...(backendEndpoint ? { endPoint: backendEndpoint } : {}),
+      }),
+    })
+    .where('id', '=', selectedAssistant.backendId)
+    .execute()
+}
+
 interface ReplayResult {
   caseId: string
+  knowledgeArm: KnowledgeReplayArmName
+  repetition: number
   source: ProductionReplayCase['source']
   model: string
   assistantConfig: Record<string, unknown>
@@ -543,10 +594,31 @@ interface ReplayResult {
   judgment?: ReplayJudgment
 }
 
+interface KnowledgeArmSetupResult {
+  knowledgeArm: KnowledgeReplayArmName
+  setupCost?: SetupCost
+  setupCostUsd?: number
+  error?: string
+}
+
 const cloneMessages = (messages: dto.Message[]) =>
   JSON.parse(JSON.stringify(messages)) as dto.Message[]
 
 const results: ReplayResult[] = []
+const armSetups: KnowledgeArmSetupResult[] = []
+const replayScenario = {
+  id: `production-replay-${selectedAudit.messageId}`,
+  description: 'A fixed production conversation replay.',
+  corpus: [],
+  goal: 'Answer the final real user message.',
+  maxTurns: 1,
+  rubric: 'Preserve the usefulness and factual content of the production response.',
+}
+const knowledgeArmRegistry = {
+  'assistant-knowledge': allInContextArm,
+  'knowledge-box': createKnowledgeBoxArm({ questions: defaultReplayKnowledgeQuestions }),
+  'knowledge-box-no-projections': createKnowledgeBoxArm({ questions: [] }),
+}
 try {
   for (const entry of cases) {
     if (entry.assistant.providerType !== providerType && !flag('provider')) {
@@ -554,82 +626,131 @@ try {
         `Bundle mixes providers; rerun with --provider and a matching --model for case ${entry.id}`
       )
     }
-    const assistantConfig: Record<string, unknown> = {
-      assistantId: `production-replay-${entry.id}`,
-      model: entry.assistant.model,
-      systemPrompt: entry.assistant.systemPrompt,
-      temperature: entry.assistant.temperature,
-      tokenLimit: entry.assistant.tokenLimit,
-      reasoning_effort: entry.assistant.reasoningEffort,
-      contextCompression: entry.assistant.contextCompression,
-      ...override,
-    }
-    const model = resolveModel(String(assistantConfig.model))
+    for (const knowledgeArmName of knowledgeArmNames) {
+      const arm = knowledgeArmRegistry[knowledgeArmName]
+      let setup: Awaited<ReturnType<typeof arm.setup>> | undefined
+      let setupError: string | undefined
+      try {
+        setup = await arm.setup({
+          scenario: replayScenario,
+          files: entry.knowledgeFiles,
+          runId: `${entry.id}-${knowledgeArmName}`.replace(/[^a-zA-Z0-9-]/g, ''),
+        })
+      } catch (caught) {
+        setupError = caught instanceof Error ? caught.message : String(caught)
+      }
 
-    process.stderr.write(
-      `Replaying ${entry.id} (production input ${entry.source.auditedInputTokens})\n`
-    )
-    const sink = new EvalSink()
-    let response = ''
-    let usage = { inputTokens: 0, outputTokens: 0 }
-    let providerCalls = 0
-    let toolCalls: string[] = []
-    let error: string | undefined
-    try {
-      const assistant = await ChatAssistant.build(
-        providerConfig,
-        assistantConfig as unknown as Parameters<typeof ChatAssistant.build>[1],
-        {},
-        [],
-        [],
-        { user: replayUser, conversationId: replayConversationId }
-      )
-      await assistant.processUserMessageWithSink(cloneMessages(entry.messages), sink)
-      const raw = sink.getUsage()
-      usage = { inputTokens: raw.inputTokens, outputTokens: raw.outputTokens }
-      providerCalls = sink.events.filter((event) => event.type === 'usage').length
-      toolCalls = sink.getToolCallNames()
-      response = sink.getText().trim() || `[no reply] ${sink.getErrors().join('; ')}`.trim()
-    } catch (caught) {
-      error = caught instanceof Error ? caught.message : String(caught)
-    }
+      armSetups.push({
+        knowledgeArm: knowledgeArmName,
+        setupCost: setup?.setupCost,
+        setupCostUsd:
+          setup?.setupCost?.calls === 0
+            ? 0
+            : setup?.setupCost?.modelId
+            ? computeCostUsd(
+                setup.setupCost.modelId,
+                setup.setupCost.inputTokens,
+                setup.setupCost.outputTokens
+              )
+            : undefined,
+        error: setupError,
+      })
 
-    let judgment: ReplayJudgment | undefined
-    if (bool('judge') && !error) {
-      const judgeModel = resolveModel(flag('judge-model') ?? model.id)
-      judgment = await createReplayJudge(
-        ChatAssistant.createLanguageModel(providerConfig, judgeModel),
-        {
-          supportsTemperature:
-            !modelSupportsReasoning(judgeModel) && judgeModel.capabilities.temperature !== false,
+      try {
+        for (let repetition = 0; repetition < repeat; repetition += 1) {
+          const assistantConfig: Record<string, unknown> = {
+            assistantId: `production-replay-${entry.id}-${knowledgeArmName}-${repetition}`,
+            model: entry.assistant.model,
+            systemPrompt: entry.assistant.systemPrompt,
+            temperature: entry.assistant.temperature,
+            tokenLimit: entry.assistant.tokenLimit,
+            reasoning_effort: entry.assistant.reasoningEffort,
+            contextCompression: entry.assistant.contextCompression,
+            ...override,
+          }
+          if (setup?.systemPromptSuffix) {
+            assistantConfig.systemPrompt = `${String(assistantConfig.systemPrompt)}\n\n${
+              setup.systemPromptSuffix
+            }`
+          }
+          const model = resolveModel(String(assistantConfig.model))
+
+          process.stderr.write(
+            `Replaying ${entry.id} · ${knowledgeArmName} · #${repetition + 1} ` +
+              `(production input ${entry.source.auditedInputTokens})\n`
+          )
+          const sink = new EvalSink()
+          let response = ''
+          let usage = { inputTokens: 0, outputTokens: 0 }
+          let providerCalls = 0
+          let toolCalls: string[] = []
+          let error = setupError
+          if (!error && setup) {
+            try {
+              const assistant = await ChatAssistant.build(
+                providerConfig,
+                assistantConfig as unknown as Parameters<typeof ChatAssistant.build>[1],
+                {},
+                setup.tools,
+                setup.knowledge,
+                { user: replayUser, conversationId: replayConversationId }
+              )
+              await assistant.processUserMessageWithSink(cloneMessages(entry.messages), sink)
+              const raw = sink.getUsage()
+              usage = { inputTokens: raw.inputTokens, outputTokens: raw.outputTokens }
+              providerCalls = sink.events.filter((event) => event.type === 'usage').length
+              toolCalls = sink.getToolCallNames()
+              response = sink.getText().trim() || `[no reply] ${sink.getErrors().join('; ')}`.trim()
+            } catch (caught) {
+              error = caught instanceof Error ? caught.message : String(caught)
+            }
+          }
+
+          let judgment: ReplayJudgment | undefined
+          if (bool('judge') && !error) {
+            const judgeModel = resolveModel(flag('judge-model') ?? model.id)
+            judgment = await createReplayJudge(
+              ChatAssistant.createLanguageModel(providerConfig, judgeModel),
+              {
+                supportsTemperature:
+                  !modelSupportsReasoning(judgeModel) &&
+                  judgeModel.capabilities.temperature !== false,
+              }
+            )((entry.messages.at(-1) as dto.UserMessage).content, entry.productionReply, response)
+          }
+
+          results.push({
+            caseId: entry.id,
+            knowledgeArm: knowledgeArmName,
+            repetition,
+            source: entry.source,
+            model: model.id,
+            assistantConfig: { contextCompression: assistantConfig.contextCompression },
+            response,
+            usage,
+            providerCalls,
+            toolCalls,
+            // Deliberately omit provider cache details: comparisons price every input token at
+            // the ordinary rate, so a warm/cold prompt cache cannot manufacture a saving.
+            costUsd: error
+              ? undefined
+              : computeCostUsd(model.id, usage.inputTokens, usage.outputTokens),
+            productionInputCostUsd: computeCostUsd(model.id, entry.source.auditedInputTokens, 0),
+            inputTokensVsProduction: entry.source.auditedInputTokens - usage.inputTokens,
+            error,
+            judgment,
+          })
         }
-      )((entry.messages.at(-1) as dto.UserMessage).content, entry.productionReply, response)
+      } finally {
+        await setup?.teardown?.().catch(() => undefined)
+      }
     }
-
-    results.push({
-      caseId: entry.id,
-      source: entry.source,
-      model: model.id,
-      assistantConfig: { contextCompression: assistantConfig.contextCompression },
-      response,
-      usage,
-      providerCalls,
-      toolCalls,
-      // Deliberately omit provider cache details: replay comparisons price every input token at
-      // the ordinary rate, so a warm/cold prompt cache cannot manufacture a compression saving.
-      costUsd: computeCostUsd(model.id, usage.inputTokens, usage.outputTokens),
-      productionInputCostUsd: computeCostUsd(model.id, entry.source.auditedInputTokens, 0),
-      inputTokensVsProduction: entry.source.auditedInputTokens - usage.inputTokens,
-      error,
-      judgment,
-    })
   }
 } finally {
   await db.destroy()
   if (workdir) rmSync(workdir, { recursive: true, force: true })
 }
 
-const totalInputDelta = results.reduce((total, r) => total + r.inputTokensVsProduction, 0)
 const verdicts = new Map<string, number>()
 for (const result of results) {
   if (result.judgment) {
@@ -637,14 +758,70 @@ for (const result of results) {
   }
 }
 
+const successfulResults = results.filter((result) => !result.error)
+const mean = (values: number[]): number | undefined =>
+  values.length > 0 ? values.reduce((sum, value) => sum + value, 0) / values.length : undefined
+const baselineResults = successfulResults.filter(
+  (result) => result.knowledgeArm === 'assistant-knowledge'
+)
+const baselineMeanInput = mean(baselineResults.map((result) => result.usage.inputTokens))
+const baselineMeanCost = mean(
+  baselineResults.flatMap((result) => (result.costUsd === undefined ? [] : [result.costUsd]))
+)
+const armSummaries = knowledgeArmNames.map((knowledgeArm) => {
+  const armResults = successfulResults.filter((result) => result.knowledgeArm === knowledgeArm)
+  const meanInputTokens = mean(armResults.map((result) => result.usage.inputTokens))
+  const meanOutputTokens = mean(armResults.map((result) => result.usage.outputTokens))
+  const meanCostUsd = mean(
+    armResults.flatMap((result) => (result.costUsd === undefined ? [] : [result.costUsd]))
+  )
+  const setup = armSetups.find((entry) => entry.knowledgeArm === knowledgeArm)
+  const perRunSavingUsd =
+    baselineMeanCost !== undefined && meanCostUsd !== undefined
+      ? baselineMeanCost - meanCostUsd
+      : undefined
+  return {
+    knowledgeArm,
+    successfulRuns: armResults.length,
+    failedRuns: results.filter((result) => result.knowledgeArm === knowledgeArm && result.error)
+      .length,
+    meanInputTokens,
+    meanOutputTokens,
+    meanCostUsd,
+    inputTokensSavedVsAssistantKnowledge:
+      baselineMeanInput !== undefined && meanInputTokens !== undefined
+        ? baselineMeanInput - meanInputTokens
+        : undefined,
+    setupCost: setup?.setupCost,
+    setupCostUsd: setup?.setupCostUsd,
+    breakEvenConversations:
+      setup?.setupCostUsd !== undefined && perRunSavingUsd !== undefined && perRunSavingUsd > 0
+        ? setup.setupCostUsd / perRunSavingUsd
+        : undefined,
+  }
+})
+
+const formatMean = (value: number | undefined) =>
+  value === undefined ? 'n/a' : Math.round(value).toLocaleString('en-US')
+const formatSignedMean = (value: number | undefined) =>
+  value === undefined
+    ? 'n/a'
+    : `${value >= 0 ? '+' : ''}${Math.round(value).toLocaleString('en-US')}`
+const formatBreakEven = (value: number | undefined) =>
+  value === undefined ? 'n/a' : Math.ceil(value).toLocaleString('en-US')
+
 const markdown = [
-  '# Production chat replay',
+  '# Production knowledge replay',
   '',
   `Replayed message \`${selectedAudit.messageId}\` from conversation \`${replayConversationId}\` ` +
     (bundlePath
       ? `using offline bundle \`${path.basename(bundlePath)}\`.`
       : 'using the configured live database and storage.') +
     ' Production input tokens are from `MessageAudit` (input only).',
+  '',
+  `Assistant knowledge corpus: **${cases[0]!.knowledgeFiles.length} file(s)**. ` +
+    `Arms: ${knowledgeArmNames.map((name) => `\`${name}\``).join(', ')}. ` +
+    `Repetitions: **${repeat}**.`,
   '',
   override && Object.keys(override).length > 0
     ? `Config override: \`${JSON.stringify(override)}\``
@@ -654,11 +831,28 @@ const markdown = [
     `${inspection.estimatedHistoryTokensAfter}**; summarized messages: ` +
     `**${inspection.summarizedMessages.length}**.`,
   '',
-  '| message | production input | replay input | replay output | provider calls | tool calls | replay cost | input Δ vs prod | verdict |',
-  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
+  '## Arm summary',
+  '',
+  '| arm | successful / failed | mean input | mean output | input saved vs assistant knowledge | mean run cost | setup cost | break-even conversations |',
+  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+  ...armSummaries.map(
+    (summary) =>
+      `| ${summary.knowledgeArm} | ${summary.successfulRuns} / ${summary.failedRuns} | ` +
+      `${formatMean(summary.meanInputTokens)} | ${formatMean(summary.meanOutputTokens)} | ` +
+      `${formatSignedMean(summary.inputTokensSavedVsAssistantKnowledge)} | ` +
+      `${formatCostUsd(summary.meanCostUsd)} | ${formatCostUsd(summary.setupCostUsd)} | ` +
+      `${formatBreakEven(summary.breakEvenConversations)} |`
+  ),
+  '',
+  'Setup cost is paid once per knowledge corpus. Break-even uses total replay cost and is shown only when the `assistant-knowledge` baseline was run and the arm is cheaper.',
+  '',
+  '## Runs',
+  '',
+  '| arm | repetition | production input | replay input | replay output | provider calls | tool calls | replay cost | input Δ vs prod | verdict |',
+  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
   ...results.map(
     (r) =>
-      `| ${r.caseId} | ${r.source.auditedInputTokens} | ${
+      `| ${r.knowledgeArm} | ${r.repetition + 1} | ${r.source.auditedInputTokens} | ${
         r.error ? 'error' : r.usage.inputTokens
       } | ${r.error ? '—' : r.usage.outputTokens} | ${r.error ? '—' : r.providerCalls} | ${
         r.error ? '—' : r.toolCalls.length
@@ -667,8 +861,7 @@ const markdown = [
       } |`
   ),
   '',
-  `Total input-token delta vs production: **${totalInputDelta}** ` +
-    `(positive = replay used fewer input tokens than production recorded).`,
+  '_Judgments compare each replay with the saved production response, which is a reference rather than a factual answer key. Review regressions against the source documents._',
   '',
   ...(results.some((r) => r.judgment && r.judgment.verdict !== 'equivalent')
     ? [
@@ -677,9 +870,9 @@ const markdown = [
         ...results.flatMap((r) =>
           r.judgment && r.judgment.verdict !== 'equivalent'
             ? [
-                `- ${r.caseId} — ${r.judgment.verdict}: ${r.judgment.rationale}${
-                  r.judgment.failures.length ? ` (${r.judgment.failures.join('; ')})` : ''
-                }`,
+                `- ${r.knowledgeArm} #${r.repetition + 1} — ${r.judgment.verdict}: ${
+                  r.judgment.rationale
+                }${r.judgment.failures.length ? ` (${r.judgment.failures.join('; ')})` : ''}`,
               ]
             : []
         ),
@@ -692,14 +885,19 @@ await writeFile(
   out,
   JSON.stringify(
     {
-      version: 3,
+      version: 4,
       createdAt: new Date().toISOString(),
       source: bundlePath
         ? { mode: 'bundle', bundle: bundlePath }
         : { mode: 'live', conversationId: replayConversationId },
       selectedMessageId: selectedAudit.messageId,
       override,
+      repeat,
+      knowledgeArms: knowledgeArmNames,
+      knowledgeFiles: cases[0]!.knowledgeFiles,
       inspection,
+      armSetups,
+      armSummaries,
       results,
     },
     null,

--- a/docs/evaluation-harness.md
+++ b/docs/evaluation-harness.md
@@ -220,10 +220,10 @@ use the two-stage replay workflow: **build a bundle**, then **replay it** throug
 to test. The stages are fully separated. The bundle is a self-contained SQLite file; once it
 exists, replay never touches the source deployment, S3, or any network beyond the LLM provider.
 
-The replay is not an off/on comparison — it runs each turn once, with whatever configuration you
-give it. The "before" number to compare against is production's own `MessageAudit` input-token
-count, which travels in the bundle. Replay cost intentionally prices all input tokens at the normal
-input rate: prompt-cache read/write discounts are ignored on both sides.
+Knowledge arms can be compared directly in one replay. For other changes, the "before" number is
+production's own `MessageAudit` input-token count, which travels in the bundle. Replay cost
+intentionally prices all input tokens at the normal input rate: prompt-cache read/write discounts
+are ignored on both sides.
 
 ### Stage 1 — build the bundle
 
@@ -232,14 +232,27 @@ message, calculate a parent lineage, mine traffic, rank turns, or apply cohort f
 interesting conversation (for example from audited token trends) belongs to the infra discovery
 tools. The builder copies into the bundle the complete conversation: every `Message` and
 `MessageAudit`, the published assistant configuration (`Assistant` / `AssistantVersion` /
-`Backend`), and every attachment referenced anywhere in the conversation — `File` /
-`FileBlob` rows rewritten as `production-replay-user`-owned with encryption cleared, and the bytes
-themselves **decrypted** into a `ReplayFileBlob(path, size, bytes)` table. No provider
-credentials, no storage credentials, no other tenant data.
+`Backend`), every conversation attachment, and every knowledge file attached to the published
+assistant version. `File` / `FileBlob` rows are rewritten as `production-replay-user`-owned with
+encryption cleared, and the bytes themselves are **decrypted** into a
+`ReplayFileBlob(path, size, bytes)` table. No provider credentials, no storage credentials, no
+other tenant data.
+
+The bundle is still production data: it contains verbatim conversation content and decrypted file
+bytes. Store, transfer, and delete it under the tenant's data-handling rules.
+
+Keep bundles and raw replay outputs in the ignored `/tmp/production-chat-replays/` directory (or
+another approved location outside the repository). Do not commit real chat bundles, raw responses,
+or unreviewed reports; publish only sanitized aggregate findings later, together with any
+knowledge-box tuning they motivate.
+
+```bash
+mkdir -p /tmp/production-chat-replays
+```
 
 The builder is infra-agnostic: it reads the source database from `--source-db` (or `$DATABASE_URL`)
-and attachment bytes through the normal storage stack (`FILE_STORAGE_LOCATION` plus the
-`FILE_STORAGE_ENCRYPTION_*` vars, only needed when the conversation has attachments).
+and file bytes through the normal storage stack (`FILE_STORAGE_LOCATION` plus the
+`FILE_STORAGE_ENCRYPTION_*` vars, needed when the conversation or assistant has files).
 
 **Lowest friction — run it on a running instance.** Exec into a Logicle container: `DATABASE_URL`
 and `FILE_STORAGE_LOCATION` are already set to that instance's database and object store, so no
@@ -248,7 +261,7 @@ flags and no proxy are needed. Copy the bundle back out afterwards (`kubectl cp`
 ```bash
 # inside the container (its own env already points at the right DB + storage)
 npx tsx apps/backend/scripts/eval-build-replay-bundle.ts \
-  --out /tmp/conversation.sqlite <conversation-id>
+  --out /tmp/production-chat-replays/conversation.sqlite <conversation-id>
 ```
 
 **From a workstation** — point `--source-db` and `FILE_STORAGE_LOCATION` at the tenant through
@@ -260,52 +273,67 @@ FILE_STORAGE_LOCATION=s3://logicle-tenant-42-files \
 FILE_STORAGE_ENCRYPTION_ENABLE=1 FILE_STORAGE_ENCRYPTION_KEY=... \
 npx tsx apps/backend/scripts/eval-build-replay-bundle.ts \
   --source-db postgres://readonly@127.0.0.1:5432/logicle \
-  --out conversation.sqlite <conversation-id>
+  --out /tmp/production-chat-replays/conversation.sqlite <conversation-id>
 ```
 
 The builder rejects conversation-level fidelity failures it cannot represent offline:
 
 - **assistant available** — the assistant and its published version must still exist.
-- **no tools / knowledge / sub-assistants** — those can't be reproduced offline (a knowledge box
-  needs its index, a tool needs its backend).
+- **no configured tools / sub-assistants** — those cannot be reproduced offline without a
+  capability-specific fixture. Assistant knowledge is supported and copied into the bundle.
 
-If an attachment's rows or bytes cannot be resolved, the builder writes the exact reason to
-`<out>.skipped.json` and exits unsuccessfully. It never silently omits a file. Message-level
-fidelity checks belong to the replay runner, because only the runner knows which message is being
-replayed. To cover tool conversations offline, extend the bundle with a tool-specific fixture
-adapter.
+If a conversation attachment or assistant-knowledge file cannot be resolved, the builder writes
+the exact reason to `<out>.skipped.json` and exits unsuccessfully. It never silently omits a file.
+Message-level fidelity checks belong to the replay runner, because only the runner knows which
+message is being replayed. To cover tool conversations offline, extend the bundle with a
+tool-specific fixture adapter.
 
 ### Stage 2 — replay the bundle
 
 ```bash
 # Default: replay the latest audited user message with a saved assistant response.
 OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
-  --bundle conversation.sqlite --out replay-results.json --report replay-report.md
+  --bundle /tmp/production-chat-replays/conversation.sqlite \
+  --out /tmp/production-chat-replays/replay-results.json \
+  --report /tmp/production-chat-replays/replay-report.md
+
+# Compare the exact real turn across knowledge strategies. The knowledge-box index is built once
+# per arm and reused by all repetitions.
+OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
+  --bundle /tmp/production-chat-replays/conversation.sqlite --knowledge-arms \
+  assistant-knowledge,knowledge-box,knowledge-box-no-projections \
+  --repeat 3 --judge \
+  --out /tmp/production-chat-replays/knowledge-results.json \
+  --report /tmp/production-chat-replays/knowledge-report.md
 
 # Or select one exact message from the bundled conversation.
 OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
-  --bundle conversation.sqlite --message <message-id> --out on.json --report on.md --judge \
+  --bundle /tmp/production-chat-replays/conversation.sqlite --message <message-id> \
+  --out /tmp/production-chat-replays/on.json --report /tmp/production-chat-replays/on.md --judge \
   --override '{"contextCompression":{"preset":"conservative","retrievalMode":"prefetch"}}'
 
 # Free inspection: select the message, reconstruct its parent lineage, and calculate the exact
 # compression decisions plus tokenizer-based before/after history estimates without an LLM call.
 npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
-  --bundle conversation.sqlite --message <message-id> --inspect-only \
-  --out inspection.json --report inspection.md \
+  --bundle /tmp/production-chat-replays/conversation.sqlite --message <message-id> --inspect-only \
+  --out /tmp/production-chat-replays/inspection.json \
+  --report /tmp/production-chat-replays/inspection.md \
   --override '{"contextCompression":{"preset":"conservative","retrievalMode":"prefetch"}}'
 
 # The same selector and parent-lineage code can read the configured live DB/storage instead.
 DATABASE_URL=... FILE_STORAGE_LOCATION=... OPENAI_API_KEY=... \
 npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
   --conversation <conversation-id> --message <message-id> \
-  --out live.json --report live.md
+  --out /tmp/production-chat-replays/live.json --report /tmp/production-chat-replays/live.md
 
 # Mode B — cheap model, off then on, measured by the same ruler:
 LOGICLECLOUD_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
-  --bundle conversation.sqlite --out b-off.json --report b-off.md \
+  --bundle /tmp/production-chat-replays/conversation.sqlite \
+  --out /tmp/production-chat-replays/b-off.json --report /tmp/production-chat-replays/b-off.md \
   --model gpt-5.6-luna --override '{"contextCompression":null}'
 LOGICLECLOUD_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
-  --bundle conversation.sqlite --out b-on.json --report b-on.md --judge \
+  --bundle /tmp/production-chat-replays/conversation.sqlite \
+  --out /tmp/production-chat-replays/b-on.json --report /tmp/production-chat-replays/b-on.md --judge \
   --model gpt-5.6-luna \
   --override '{"contextCompression":{"preset":"conservative","retrievalMode":"prefetch"}}'
 ```
@@ -319,20 +347,29 @@ It can still populate the normal `CompressedMessage` and `FileAnalysis` caches. 
 the source DB must not be mutated; a database read-only role can cause a live compression replay to
 fail on a cold cache rather than silently making it read-only.
 The runner rebuilds the saved assistant with `--override` merged over its configuration, runs the
-turn once, and records the response, provider token usage, and priced cost. `--override` is a JSON
-object merged over `model` / `systemPrompt` /
+turn for every selected arm and repetition, and records the response, provider token usage, and
+priced cost. `--override` is a JSON object merged over `model` / `systemPrompt` /
 `temperature` / `tokenLimit` / `reasoning_effort` / `contextCompression` (use
 `{"contextCompression":null}` to turn it off); its shape follows whatever the running code's schema
 accepts, so newer options work without changing this script.
 
-Each runner invocation selects one message and runs one assistant turn. A turn can make multiple
-provider calls when the assistant loops through context-retrieval tools; token usage is summed over
-all of them and the JSON/report records both the provider-call count and tool-call names. `--judge`
-adds another provider request. Before making the call, the runner rejects a production error, a
-missing response or parent, model drift, an unsupported lineage containing tool/auth/error
-activity, and assistant capabilities for which no fixture exists. `--inspect-only` stops after
-selection, lineage reconstruction, compression planning, application, and token estimation: it
-requires no provider key and makes no LLM call.
+By default, replay preserves the published assistant's knowledge files. `--knowledge-arms` turns
+the same fixed production turn into a paired knowledge evaluation. `assistant-knowledge` embeds the
+files exactly as production does; `knowledge-box` indexes the same files with generic summary and
+key-fact projections; `knowledge-box-no-projections` isolates chunk retrieval. Knowledge-box arms
+require bundle mode because indexing writes evaluation rows. `--repeat` reruns each arm while
+reusing its index, and the report shows mean run cost, one-time setup cost, and break-even
+conversations against the assistant-knowledge baseline. The generic projection questions are a
+baseline, not a substitute for corpus-specific administrator questions.
+
+Each runner invocation selects one message and runs one assistant turn per selected arm and
+repetition. A turn can make multiple provider calls when the assistant loops through
+context-retrieval tools; token usage is summed over all of them and the JSON/report records both the
+provider-call count and tool-call names. `--judge` adds another provider request per run. Before
+making the call, the runner rejects a production error, a missing response or parent, model drift,
+an unsupported lineage containing tool/auth/error activity, and assistant capabilities for which
+no fixture exists. `--inspect-only` stops after selection, lineage reconstruction, compression
+planning, application, and token estimation: it requires no provider key and makes no LLM call.
 
 ### Operating modes — cost/quality testing without a big bill
 


### PR DESCRIPTION
## Summary
Adds reusable offline production-chat replay infrastructure for comparing the existing assistant-knowledge path with knowledge-box strategies, including optional projection ingestion, repeated runs, cost/setup accounting, and reference-response judging.

This PR is tooling only. It contains no production chat bundles, raw replay responses, or assessment result. Real bundles and raw outputs belong in the ignored `/tmp/production-chat-replays/` staging directory; only sanitized aggregate findings should be published later, alongside any knowledge-box tuning they motivate.

## Details
- Extends replay bundles to carry assistant knowledge files and decrypted replay blobs without provider/storage credentials.
- Adds `assistant-knowledge`, `knowledge-box`, and `knowledge-box-no-projections` replay arms with `--repeat` and optional `--judge`.
- Documents the two-stage workflow, data-handling boundary, and sanitized-results policy.
- Adds tests for arm parsing and default projection prompts.

## Tests
- `pnpm exec vitest run apps/backend/lib/eval/__tests__/productionChatReplay.test.ts`
- `pnpm run check-types`
- `pnpm exec prettier --check .gitignore docs/evaluation-harness.md apps/backend/lib/eval/productionChatReplay.ts apps/backend/lib/eval/__tests__/productionChatReplay.test.ts apps/backend/scripts/eval-build-replay-bundle.ts apps/backend/scripts/eval-replay-production-chats.ts`
