### PR TITLE
fix(chat): show tool results by default

### DIFF
--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -140,7 +140,10 @@ const env = {
   chat: {
     enableSharing: process.env.ENABLE_CHAT_SHARING !== '0',
     enableFolders: process.env.ENABLE_CHAT_FOLDERS === '1',
-    enableShowToolResult: process.env.ENABLE_SHOW_TOOL_RESULT === '1',
+    // Tool results are part of the tool-call UI by default. Keep the setting
+    // as an explicit opt-out so deployments that intentionally hide raw
+    // results can still set ENABLE_SHOW_TOOL_RESULT=0.
+    enableShowToolResult: process.env.ENABLE_SHOW_TOOL_RESULT !== '0',
     enableTreeNavigation: process.env.ENABLE_CHAT_TREE_NAVIGATION === '1',
     disableParallelToolCalls: process.env.ENABLE_PARALLEL_TOOL_CALLS === '0',
     contextCompressionTriggerTokens: parseOptionalInt(


### PR DESCRIPTION
## Summary
Tool-call results are visible by default again, while deployments can opt out with `ENABLE_SHOW_TOOL_RESULT=0`.

The regression was introduced when the tracked `.env` setting was removed in #1022 while the code continued defaulting this flag to false.

## Tests
- `npm run check-types`
- `npm test -- --run`
- `git diff --check