### PR TITLE
feat(tools): add DeepL document translation tool

### DIFF
--- a/apps/backend/lib/tools/enumerate.ts
+++ b/apps/backend/lib/tools/enumerate.ts
@@ -32,9 +32,11 @@ import { SubAssistantTool } from './subassistant/implementation'
 import { db } from 'db/database'
 import { AudioTranscription } from './audio_transcription/implementation'
 import { SatelliteTool } from './satellite/implementation'
+import { TranslateDeepl } from './translate.deepl/implementation'
 
 const builders: Record<string, ToolBuilder> = {
   [AudioTranscription.toolName]: AudioTranscription.builder,
+  [TranslateDeepl.toolName]: TranslateDeepl.builder,
   [ImageGeneratorPlugin.toolName]: ImageGeneratorPlugin.builder,
   [OpenAiImageGeneratorPlugin.toolName]: OpenAiImageGeneratorPlugin.builder,
   [GoogleImageGeneratorPlugin.toolName]: GoogleImageGeneratorPlugin.builder,

--- a/apps/backend/lib/tools/registry.ts
+++ b/apps/backend/lib/tools/registry.ts
@@ -38,6 +38,8 @@ import {
   TimeOfDayInterface,
   TimeOfDaySchema,
   TogetherImageGeneratorPluginInterface,
+  TranslateDeeplInterface,
+  TranslateDeeplSchema,
   WebSearchInterface,
   WebSearchSchema,
 } from '@/lib/tools/schemas'
@@ -51,6 +53,10 @@ export const toolSchemaRegistry: Record<string, ToolSchemaRegistryEntry> = {
   [AudioTranscriptionInterface.toolName]: {
     toolName: AudioTranscriptionInterface.toolName,
     schema: AudioTranscriptionSchema,
+  },
+  [TranslateDeeplInterface.toolName]: {
+    toolName: TranslateDeeplInterface.toolName,
+    schema: TranslateDeeplSchema,
   },
   [ImageGeneratorPluginInterface.toolName]: {
     toolName: ImageGeneratorPluginInterface.toolName,

--- a/apps/backend/lib/tools/translate.deepl/__tests__/implementation.test.ts
+++ b/apps/backend/lib/tools/translate.deepl/__tests__/implementation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest'
+import type { LlmModel } from '@/lib/chat/models'
+import type { ToolFunction, ToolParams } from '@/lib/chat/tools'
+import {
+  TranslateDeepl,
+  normalizeSourceLang,
+  normalizeTargetLang,
+  translatedFileName,
+} from '../implementation'
+
+const model = { model: 'gpt-4o-mini' } as unknown as LlmModel
+
+const toolParams: ToolParams = {
+  id: 't1',
+  name: 'translate.deepl',
+  promptFragment: '',
+  provisioned: false,
+}
+
+describe('TranslateDeepl tool', () => {
+  test('builder parses the configuration and applies defaults', () => {
+    const tool = TranslateDeepl.builder(
+      toolParams,
+      { apiKey: 'key' },
+      model.model
+    ) as TranslateDeepl
+    expect(tool).toBeInstanceOf(TranslateDeepl)
+    expect(tool.supportedMedia).toContain('application/pdf')
+    expect(tool.supportedMedia).toContain(
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    )
+  })
+
+  test('exposes a document and a text translation function', async () => {
+    const tool = TranslateDeepl.builder(
+      toolParams,
+      { apiKey: 'key' },
+      model.model
+    ) as TranslateDeepl
+    const functions = await tool.functions(model, { userId: 'u1' })
+    expect(Object.keys(functions).sort()).toEqual(['translate_document', 'translate_text'])
+  })
+
+  test('rejects a document translation without a file id', async () => {
+    const tool = TranslateDeepl.builder(
+      toolParams,
+      { apiKey: 'key' },
+      model.model
+    ) as TranslateDeepl
+    const functions = await tool.functions(model, { userId: 'u1' })
+    const translateDocument = functions.translate_document as ToolFunction
+    const result = await translateDocument.invoke({
+      params: { targetLang: 'IT' },
+      userId: 'u1',
+    } as never)
+    expect(result).toEqual({ type: 'error-text', value: 'fileId is required' })
+  })
+
+  test('rejects a text translation without a target language', async () => {
+    const tool = TranslateDeepl.builder(
+      toolParams,
+      { apiKey: 'key' },
+      model.model
+    ) as TranslateDeepl
+    const functions = await tool.functions(model, { userId: 'u1' })
+    const translateText = functions.translate_text as ToolFunction
+    const result = await translateText.invoke({
+      params: { text: 'ciao' },
+      userId: 'u1',
+    } as never)
+    expect(result).toEqual({ type: 'error-text', value: 'targetLang is required' })
+  })
+})
+
+describe('language and file name normalization', () => {
+  test('target languages keep their region, source languages drop it', () => {
+    expect(normalizeTargetLang(' en-gb ')).toBe('EN-GB')
+    expect(normalizeSourceLang(' en-gb ')).toBe('EN')
+  })
+
+  test('the target language is inserted before the extension', () => {
+    expect(translatedFileName('report.docx', 'IT')).toBe('report_IT.docx')
+    expect(translatedFileName('deck.final.pptx', 'EN-GB')).toBe('deck.final_EN-GB.pptx')
+    expect(translatedFileName('README', 'DE')).toBe('README_DE')
+  })
+})

--- a/apps/backend/lib/tools/translate.deepl/implementation.ts
+++ b/apps/backend/lib/tools/translate.deepl/implementation.ts
@@ -1,0 +1,373 @@
+import {
+  ToolBuilder,
+  ToolFunctionContext,
+  ToolFunctions,
+  ToolImplementation,
+  ToolInvokeParams,
+  ToolParams,
+} from '@/lib/chat/tools'
+import {
+  TranslateDeeplInterface,
+  TranslateDeeplParams,
+  TranslateDeeplSchema,
+} from '@/lib/tools/schemas'
+import { LlmModel } from '@/lib/chat/models'
+import * as dto from '@/types/dto'
+import { expandToolParameter } from '@/backend/lib/tools/configSecrets'
+import { getFileWithId } from '@/models/file'
+import { canAccessFile } from '@/backend/lib/files/authorization'
+import { storage } from '@/lib/storage'
+import { logger } from '@/lib/logging'
+import { saveFile } from '@/backend/lib/tools/file-output-normalization'
+
+type DeeplDocumentUploadResponse = {
+  document_id: string
+  document_key: string
+}
+
+type DeeplDocumentStatusResponse = {
+  document_id: string
+  status: 'queued' | 'translating' | 'done' | 'error'
+  seconds_remaining?: number
+  billed_characters?: number
+  error_message?: string
+}
+
+type DeeplTextTranslationResponse = {
+  translations: {
+    detected_source_language: string
+    text: string
+  }[]
+}
+
+const DEFAULT_API_URL = 'https://api.deepl.com'
+
+// Document formats accepted by the DeepL document endpoint. Declaring them here
+// is what allows users to attach these files in a chat where the tool is enabled.
+const supportedDocumentMedia = [
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/pdf',
+  'text/html',
+  'text/plain',
+  'application/xliff+xml',
+  'application/x-subrip',
+]
+
+const sleep = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms))
+
+// DeepL target languages may carry a region (EN-GB, PT-BR); source languages may not.
+export const normalizeTargetLang = (lang: string) => lang.trim().toUpperCase()
+export const normalizeSourceLang = (lang: string) => lang.trim().toUpperCase().split('-')[0]
+
+export const translatedFileName = (fileName: string, targetLang: string) => {
+  const dotIndex = fileName.lastIndexOf('.')
+  const base = dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName
+  const extension = dotIndex > 0 ? fileName.slice(dotIndex) : ''
+  return `${base}_${targetLang}${extension}`
+}
+
+export class TranslateDeepl extends TranslateDeeplInterface implements ToolImplementation {
+  static builder: ToolBuilder = (toolParams: ToolParams, params: Record<string, unknown>) =>
+    new TranslateDeepl(toolParams, TranslateDeeplSchema.parse(params))
+
+  supportedMedia = supportedDocumentMedia
+
+  constructor(
+    public toolParams: ToolParams,
+    private params: TranslateDeeplParams
+  ) {
+    super()
+  }
+
+  functions = async (_model: LlmModel, _context: ToolFunctionContext) => this.functions_
+
+  private functions_: ToolFunctions = {
+    translate_document: {
+      description:
+        'Translate an uploaded document (docx, pptx, xlsx, pdf, html, txt, xliff, srt) by file ID, preserving its formatting. Returns the translated document as a file.',
+      parameters: {
+        type: 'object',
+        properties: {
+          fileId: {
+            type: 'string',
+            description: 'ID of the uploaded file to translate.',
+            minLength: 1,
+          },
+          targetLang: {
+            type: 'string',
+            description:
+              'Target language code, for example IT, DE, FR, EN-GB, EN-US, PT-BR. Ask the user if it is not clear from the conversation.',
+          },
+          sourceLang: {
+            type: 'string',
+            description:
+              'Source language code, for example IT, DE, EN. Omit it to let DeepL detect the language.',
+          },
+        },
+        required: ['fileId', 'targetLang'],
+        additionalProperties: false,
+      },
+      requireConfirm: false,
+      invoke: this.invokeTranslateDocument.bind(this),
+    },
+    translate_text: {
+      description:
+        'Translate a short text with DeepL. Use translate_document for uploaded files, never this function.',
+      parameters: {
+        type: 'object',
+        properties: {
+          text: {
+            type: 'string',
+            description: 'The text to translate.',
+            minLength: 1,
+          },
+          targetLang: {
+            type: 'string',
+            description:
+              'Target language code, for example IT, DE, FR, EN-GB, EN-US, PT-BR. Ask the user if it is not clear from the conversation.',
+          },
+          sourceLang: {
+            type: 'string',
+            description:
+              'Source language code, for example IT, DE, EN. Omit it to let DeepL detect the language.',
+          },
+        },
+        required: ['text', 'targetLang'],
+        additionalProperties: false,
+      },
+      requireConfirm: false,
+      invoke: this.invokeTranslateText.bind(this),
+    },
+  }
+
+  private getApiUrl() {
+    return this.params.apiUrl ?? DEFAULT_API_URL
+  }
+
+  private async getAuthHeaders() {
+    const apiKey = await expandToolParameter(this.toolParams, this.params.apiKey)
+    return {
+      authorization: `DeepL-Auth-Key ${apiKey}`,
+    }
+  }
+
+  private resolveTargetLang(params: Record<string, unknown>) {
+    const requested = `${params.targetLang ?? ''}`.trim() || this.params.defaultTargetLang || ''
+    return requested ? normalizeTargetLang(requested) : ''
+  }
+
+  private async invokeTranslateDocument({
+    params,
+    userId,
+    conversationId,
+    assistantId,
+    rootOwner,
+  }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> {
+    const fileId = `${params.fileId ?? ''}`.trim()
+    if (!fileId) {
+      return { type: 'error-text', value: 'fileId is required' }
+    }
+
+    const targetLang = this.resolveTargetLang(params)
+    if (!targetLang) {
+      return { type: 'error-text', value: 'targetLang is required' }
+    }
+
+    if (!(await canAccessFile({ userId }, fileId))) {
+      return { type: 'error-text', value: `You are not authorized to access file: ${fileId}` }
+    }
+
+    const fileEntry = await getFileWithId(fileId)
+    if (!fileEntry) {
+      return { type: 'error-text', value: `File not found: ${fileId}` }
+    }
+
+    try {
+      const headers = await this.getAuthHeaders()
+      const fileContent = await storage.readBuffer(fileEntry.path, fileEntry.encryption)
+
+      const form = new FormData()
+      form.append('target_lang', targetLang)
+      if (params.sourceLang) {
+        form.append('source_lang', normalizeSourceLang(`${params.sourceLang}`))
+      }
+      if (this.params.formality) {
+        form.append('formality', this.params.formality)
+      }
+      if (this.params.glossaryId) {
+        form.append('glossary_id', this.params.glossaryId)
+      }
+      form.append(
+        'file',
+        new Blob([new Uint8Array(fileContent)], {
+          type: fileEntry.type || 'application/octet-stream',
+        }),
+        fileEntry.name
+      )
+
+      const uploadResponse = await fetch(`${this.getApiUrl()}/v2/document`, {
+        method: 'POST',
+        headers,
+        body: form,
+      })
+      if (!uploadResponse.ok) {
+        return {
+          type: 'error-text',
+          value: `DeepL document upload failed: ${
+            uploadResponse.status
+          } ${await uploadResponse.text()}`,
+        }
+      }
+      const upload = (await uploadResponse.json()) as DeeplDocumentUploadResponse
+
+      const status = await this.pollDocument(upload, headers)
+      if (status.status === 'error') {
+        return {
+          type: 'error-text',
+          value: `DeepL translation failed: ${status.error_message ?? 'unknown error'}`,
+        }
+      }
+
+      const resultResponse = await fetch(
+        `${this.getApiUrl()}/v2/document/${upload.document_id}/result`,
+        {
+          method: 'POST',
+          headers: { ...headers, 'content-type': 'application/json' },
+          body: JSON.stringify({ document_key: upload.document_key }),
+        }
+      )
+      if (!resultResponse.ok) {
+        return {
+          type: 'error-text',
+          value: `DeepL document download failed: ${
+            resultResponse.status
+          } ${await resultResponse.text()}`,
+        }
+      }
+
+      const translatedContent = Buffer.from(await resultResponse.arrayBuffer())
+      const fileName = translatedFileName(fileEntry.name, targetLang)
+      logger.info('DeepL document translated', {
+        toolId: this.toolParams.id,
+        targetLang,
+        billedCharacters: status.billed_characters ?? null,
+        size: translatedContent.byteLength,
+      })
+
+      const persisted = await saveFile({
+        rootOwner,
+        conversationId,
+        userId,
+        assistantId,
+        content: translatedContent,
+        mimeType:
+          resultResponse.headers.get('content-type') ??
+          fileEntry.type ??
+          'application/octet-stream',
+        nameHint: fileName,
+        source: 'DeepL',
+      })
+
+      return {
+        type: 'content',
+        value: [
+          {
+            type: 'text',
+            text: `The document has been translated to ${targetLang} and attached as ${fileName}. Do not provide a download link, it is already available in the UI.`,
+          },
+          persisted,
+        ],
+      }
+    } catch (error) {
+      return {
+        type: 'error-text',
+        value: error instanceof Error ? error.message : 'Document translation failed',
+      }
+    }
+  }
+
+  private async invokeTranslateText({
+    params,
+  }: ToolInvokeParams): Promise<dto.ToolCallResultOutput> {
+    const text = `${params.text ?? ''}`
+    if (!text.trim()) {
+      return { type: 'error-text', value: 'text is required' }
+    }
+
+    const targetLang = this.resolveTargetLang(params)
+    if (!targetLang) {
+      return { type: 'error-text', value: 'targetLang is required' }
+    }
+
+    try {
+      const headers = await this.getAuthHeaders()
+      const response = await fetch(`${this.getApiUrl()}/v2/translate`, {
+        method: 'POST',
+        headers: { ...headers, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          text: [text],
+          target_lang: targetLang,
+          ...(params.sourceLang
+            ? { source_lang: normalizeSourceLang(`${params.sourceLang}`) }
+            : {}),
+          ...(this.params.formality ? { formality: this.params.formality } : {}),
+          ...(this.params.glossaryId ? { glossary_id: this.params.glossaryId } : {}),
+        }),
+      })
+      if (!response.ok) {
+        return {
+          type: 'error-text',
+          value: `DeepL text translation failed: ${response.status} ${await response.text()}`,
+        }
+      }
+
+      const body = (await response.json()) as DeeplTextTranslationResponse
+      const translation = body.translations?.[0]
+      if (!translation) {
+        return { type: 'error-text', value: 'DeepL returned no translation' }
+      }
+      return {
+        type: 'json',
+        value: {
+          translatedText: translation.text,
+          detectedSourceLanguage: translation.detected_source_language,
+          targetLanguage: targetLang,
+        },
+      }
+    } catch (error) {
+      return {
+        type: 'error-text',
+        value: error instanceof Error ? error.message : 'Text translation failed',
+      }
+    }
+  }
+
+  private async pollDocument(
+    upload: DeeplDocumentUploadResponse,
+    headers: Record<string, string>
+  ): Promise<DeeplDocumentStatusResponse> {
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < this.params.timeoutMs) {
+      const response = await fetch(`${this.getApiUrl()}/v2/document/${upload.document_id}`, {
+        method: 'POST',
+        headers: { ...headers, 'content-type': 'application/json' },
+        body: JSON.stringify({ document_key: upload.document_key }),
+      })
+      if (!response.ok) {
+        throw new Error(
+          `DeepL document status check failed: ${response.status} ${await response.text()}`
+        )
+      }
+
+      const body = (await response.json()) as DeeplDocumentStatusResponse
+      if (body.status === 'done' || body.status === 'error') {
+        return body
+      }
+      await sleep(this.params.pollIntervalMs)
+    }
+
+    throw new Error(`Document translation timed out after ${this.params.timeoutMs} ms`)
+  }
+}

--- a/apps/frontend/app/admin/tools/components/ToolForm.tsx
+++ b/apps/frontend/app/admin/tools/components/ToolForm.tsx
@@ -23,6 +23,9 @@ import {
   SatelliteInterface,
   SatelliteSchema,
   TogetherImageGeneratorPluginInterface,
+  TranslateDeeplInterface,
+  TranslateDeeplParams,
+  TranslateDeeplSchema,
 } from '@/lib/tools/schemas'
 import { OpenApiInterface } from '@/lib/tools/schemas'
 import { ToolType } from '@/lib/tools/tools'
@@ -50,6 +53,7 @@ import { ToolKnowledgeSection } from './ToolKnowledgeSection'
 import { DummyToolInterface, KnowledgeBoxInterface, KnowledgeBoxSchema } from '@/lib/tools/schemas'
 import KnowledgeBoxToolFields from './KnowledgeBoxToolFields'
 import AudioTranscriptionToolFields from './AudioTranscriptionToolFields'
+import TranslateDeeplToolFields from './TranslateDeeplToolFields'
 
 interface Props {
   className?: string
@@ -64,6 +68,8 @@ const configurationSchema = (type: ToolType, apiKeys: string[]) => {
     return ImageGeneratorSchema
   } else if (type === AudioTranscriptionInterface.toolName) {
     return AudioTranscriptionSchema
+  } else if (type === TranslateDeeplInterface.toolName) {
+    return TranslateDeeplSchema
   } else if (type === OpenAiImageGeneratorPluginInterface.toolName) {
     return DirectImageGeneratorSchema
   } else if (type === GoogleImageGeneratorPluginInterface.toolName) {
@@ -216,6 +222,12 @@ const ToolForm: FC<Props> = ({ className, type, tool, toolId, onSubmit }) => {
       {type === AudioTranscriptionInterface.toolName && (
         <AudioTranscriptionToolFields
           form={form as unknown as UseFormReturn<ToolFormWithConfig<AudioTranscriptionParams>>}
+        />
+      )}
+
+      {type === TranslateDeeplInterface.toolName && (
+        <TranslateDeeplToolFields
+          form={form as unknown as UseFormReturn<ToolFormWithConfig<TranslateDeeplParams>>}
         />
       )}
 

--- a/apps/frontend/app/admin/tools/components/TranslateDeeplToolFields.tsx
+++ b/apps/frontend/app/admin/tools/components/TranslateDeeplToolFields.tsx
@@ -1,0 +1,139 @@
+'use client'
+import { useTranslation } from 'react-i18next'
+import { UseFormReturn } from 'react-hook-form'
+import { FormField, FormItem } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { ToolFormWithConfig } from './toolFormTypes'
+import { TranslateDeeplParams } from '@/lib/tools/schemas'
+import { SecretEditor } from './SecretEditor'
+
+interface Props {
+  form: UseFormReturn<ToolFormWithConfig<TranslateDeeplParams>>
+}
+
+const formalityValues = ['default', 'more', 'less', 'prefer_more', 'prefer_less'] as const
+
+const TranslateDeeplToolFields = ({ form }: Props) => {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <FormField
+        control={form.control}
+        name="configuration.apiKey"
+        render={({ field }) => (
+          <FormItem label={t('api-key')}>
+            <SecretEditor
+              placeholder={t('insert-apikey-placeholder')}
+              onChange={(value) => field.onChange(value)}
+              value={field.value ? (field.value as string) : null}
+              disabled={field.disabled}
+            />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="configuration.apiUrl"
+        render={({ field }) => (
+          <FormItem label={t('api-url')}>
+            <Input
+              placeholder={t('translate-deepl-api-url-placeholder')}
+              value={typeof field.value === 'string' ? field.value : ''}
+              onChange={(evt) => field.onChange(evt.currentTarget.value || undefined)}
+            />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="configuration.defaultTargetLang"
+        render={({ field }) => (
+          <FormItem label={t('translate-deepl-default-target-lang')}>
+            <Input
+              placeholder={t('translate-deepl-default-target-lang-placeholder')}
+              value={typeof field.value === 'string' ? field.value : ''}
+              onChange={(evt) => field.onChange(evt.currentTarget.value || undefined)}
+            />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="configuration.formality"
+        render={({ field }) => (
+          <FormItem label={t('translate-deepl-formality')}>
+            <Select
+              value={typeof field.value === 'string' ? field.value : 'default'}
+              onValueChange={(value) => field.onChange(value)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {formalityValues.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {value}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="configuration.glossaryId"
+        render={({ field }) => (
+          <FormItem label={t('translate-deepl-glossary-id')}>
+            <Input
+              value={typeof field.value === 'string' ? field.value : ''}
+              onChange={(evt) => field.onChange(evt.currentTarget.value || undefined)}
+            />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="configuration.pollIntervalMs"
+        render={({ field }) => (
+          <FormItem label={t('translate-deepl-poll-interval-ms')}>
+            <Input
+              type="number"
+              value={typeof field.value === 'number' ? `${field.value}` : ''}
+              onChange={(evt) => {
+                const nextValue = evt.currentTarget.value
+                field.onChange(nextValue ? Number.parseInt(nextValue, 10) : undefined)
+              }}
+            />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="configuration.timeoutMs"
+        render={({ field }) => (
+          <FormItem label={t('translate-deepl-timeout-ms')}>
+            <Input
+              type="number"
+              value={typeof field.value === 'number' ? `${field.value}` : ''}
+              onChange={(evt) => {
+                const nextValue = evt.currentTarget.value
+                field.onChange(nextValue ? Number.parseInt(nextValue, 10) : undefined)
+              }}
+            />
+          </FormItem>
+        )}
+      />
+    </>
+  )
+}
+
+export default TranslateDeeplToolFields

--- a/apps/frontend/app/admin/tools/page.tsx
+++ b/apps/frontend/app/admin/tools/page.tsx
@@ -36,9 +36,11 @@ import { Badge } from '@/components/ui/badge'
 import { McpInterface } from '@/lib/tools/schemas'
 import { DummyToolInterface } from '@/lib/tools/schemas'
 import { AudioTranscriptionInterface } from '@/lib/tools/schemas'
+import { TranslateDeeplInterface } from '@/lib/tools/schemas'
 
 const creatableTools: ToolType[] = [
   AudioTranscriptionInterface.toolName,
+  TranslateDeeplInterface.toolName,
   OpenApiInterface.toolName,
   ImageGeneratorPluginInterface.toolName,
   OpenAiImageGeneratorPluginInterface.toolName,

--- a/apps/frontend/locales/en/logicle.json
+++ b/apps/frontend/locales/en/logicle.json
@@ -741,5 +741,12 @@
   "edit-image": "Edit image",
   "edit-image-prompt-placeholder": "Describe what to change…",
   "word-wrap-off": "Wrap off",
-  "word-wrap-on": "Wrap on"
+  "word-wrap-on": "Wrap on",
+  "translate-deepl-api-url-placeholder": "Leave blank for https://api.deepl.com, use https://api-free.deepl.com for free accounts",
+  "translate-deepl-default-target-lang": "Default target language",
+  "translate-deepl-default-target-lang-placeholder": "Optional target language, for example IT, DE, EN-GB",
+  "translate-deepl-formality": "Formality",
+  "translate-deepl-glossary-id": "Glossary ID",
+  "translate-deepl-poll-interval-ms": "Poll interval (ms)",
+  "translate-deepl-timeout-ms": "Timeout (ms)"
 }

--- a/apps/frontend/locales/en/tools.json
+++ b/apps/frontend/locales/en/tools.json
@@ -15,5 +15,6 @@
   "openapi": "OpenAPI",
   "satellite": "Satellite",
   "timeofday": "Time of day",
-  "websearch": "Web search"
+  "websearch": "Web search",
+  "translate.deepl": "Document translation (DeepL)"
 }

--- a/apps/frontend/locales/it/logicle.json
+++ b/apps/frontend/locales/it/logicle.json
@@ -741,5 +741,12 @@
   "edit-image": "Modifica immagine",
   "edit-image-prompt-placeholder": "Descrivi cosa modificare…",
   "word-wrap-off": "A capo disattivato",
-  "word-wrap-on": "A capo attivo"
+  "word-wrap-on": "A capo attivo",
+  "translate-deepl-api-url-placeholder": "Lascia vuoto per https://api.deepl.com, usa https://api-free.deepl.com per gli account free",
+  "translate-deepl-default-target-lang": "Lingua di destinazione predefinita",
+  "translate-deepl-default-target-lang-placeholder": "Lingua di destinazione opzionale, per esempio IT, DE, EN-GB",
+  "translate-deepl-formality": "Formalità",
+  "translate-deepl-glossary-id": "ID glossario",
+  "translate-deepl-poll-interval-ms": "Intervallo di polling (ms)",
+  "translate-deepl-timeout-ms": "Timeout (ms)"
 }

--- a/apps/frontend/locales/it/tools.json
+++ b/apps/frontend/locales/it/tools.json
@@ -15,5 +15,6 @@
   "openapi": "OpenAPI",
   "satellite": "Satellite",
   "timeofday": "Ora corrente",
-  "websearch": "Ricerca web"
+  "websearch": "Ricerca web",
+  "translate.deepl": "Traduzione documenti (DeepL)"
 }

--- a/packages/core/src/tools/schemas.ts
+++ b/packages/core/src/tools/schemas.ts
@@ -272,6 +272,23 @@ export class TimeOfDayInterface {
   static toolName = 'timeofday'
 }
 
+export const TranslateDeeplSchema = z
+  .object({
+    apiKey: z.string().describe('secret'),
+    // DeepL free accounts must use https://api-free.deepl.com
+    apiUrl: z.string().url().optional(),
+    defaultTargetLang: z.string().optional(),
+    formality: z.enum(['default', 'more', 'less', 'prefer_more', 'prefer_less']).optional(),
+    glossaryId: z.string().optional(),
+    pollIntervalMs: z.number().int().positive().optional().default(2000),
+    timeoutMs: z.number().int().positive().optional().default(600000),
+  })
+  .strict()
+export type TranslateDeeplParams = z.infer<typeof TranslateDeeplSchema>
+export class TranslateDeeplInterface {
+  static toolName = 'translate.deepl'
+}
+
 export const WebSearchSchema = z.object({
   apiKey: z.string().describe('secret'),
   apiUrl: z.string().nullable().default(null),

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -11,6 +11,7 @@ import {
   SatelliteInterface,
   TimeOfDayInterface,
   TogetherImageGeneratorPluginInterface,
+  TranslateDeeplInterface,
   WebSearchInterface,
 } from './schemas'
 
@@ -24,6 +25,7 @@ export const imageGenToolNames = new Set([
 
 export const toolNames = [
   AudioTranscriptionInterface.toolName,
+  TranslateDeeplInterface.toolName,
   ImageGeneratorPluginInterface.toolName,
   OpenAiImageGeneratorPluginInterface.toolName,
   GoogleImageGeneratorPluginInterface.toolName,


### PR DESCRIPTION
## Summary

Adds a native `translate.deepl` tool that translates uploaded documents (and short texts) with DeepL. Admins configure it from the tools page like any other built-in tool; users attach a document in chat and get the translated file back, named after the target language. It replaces the OpenAPI-plus-sidecar setup whose only purpose was to hide DeepL's asynchronous document API behind one synchronous call, so tenants no longer need to deploy and secure a separate translator service.

## Details

- `translate_document(fileId, targetLang, sourceLang?)` runs the whole DeepL document sequence server-side: authorize the file, upload, poll until `done`/`error`, download the result, and persist it under the conversation's owner. The model makes one tool call instead of driving a polling loop, and the per-document `document_key` never enters the model context.
- `translate_text(text, targetLang, sourceLang?)` covers the synchronous `/v2/translate` endpoint and returns the translation with the detected source language.
- The tool declares the document formats DeepL accepts (`docx`, `pptx`, `xlsx`, `pdf`, `html`, `txt`, `xliff`, `srt`) as `supportedMedia`, which is what allows users to attach those files in a chat where the tool is enabled.
- Translated files are named with the target language before the extension (`report.docx` → `report_IT.docx`), so translating one document into several languages does not collide.
- Target languages keep their region (`EN-GB`); source languages are stripped to the base code, since DeepL rejects a region on `source_lang`.
- Configuration: `apiKey` (stored as a secret), `apiUrl` (blank uses `https://api.deepl.com`; DeepL free accounts need `https://api-free.deepl.com`), `defaultTargetLang`, `formality`, `glossaryId`, `pollIntervalMs`, `timeoutMs`.
- Polling stops at `timeoutMs` (10 minutes by default), and DeepL failures surface as typed `error-text` results carrying DeepL's own message.
- English and Italian labels added for the new tool type and its configuration fields.

## Risks

- DeepL usage is logged (`billed_characters`) but not ingested into OpenMeter; metering for this tool would need a new event type.
- No client-side file-size pre-check: oversized uploads surface as a DeepL error rather than an early one.

## Tests

- `npm run check-types` — clean.
- `npx vitest run apps/backend/lib/tools/translate.deepl` — 6 tests passing, covering builder defaults, the exposed function set, missing-argument handling, and language/file-name normalization.
- `npx prettier --check` on all added and modified files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
