### PR TITLE
Add cost-aware context compression eval campaigns

### DIFF
--- a/apps/backend/lib/chat/__tests__/compression-economics.test.ts
+++ b/apps/backend/lib/chat/__tests__/compression-economics.test.ts
@@ -1,0 +1,321 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type * as dto from '@/types/dto'
+import type { LlmModel } from '@/lib/chat/models'
+import type { ToolFunctions, ToolImplementation } from '@/lib/chat/tools'
+
+const { mockApplyCompressionPlan, mockEstimateHistoryMessageCosts } = vi.hoisted(() => ({
+  mockApplyCompressionPlan: vi.fn(),
+  mockEstimateHistoryMessageCosts: vi.fn(),
+}))
+
+vi.mock('@/backend/lib/chat/compression-planner', () => ({
+  applyCompressionPlan: mockApplyCompressionPlan,
+}))
+
+vi.mock('@/backend/lib/chat/token-estimator', () => ({
+  estimateHistoryMessageCosts: mockEstimateHistoryMessageCosts,
+}))
+
+import {
+  buildCostEffectiveCompressionPlan,
+  MIN_COMPRESSION_MESSAGE_SAVINGS_TOKENS,
+  MIN_COMPRESSION_PLAN_SAVINGS_TOKENS,
+  selectCompressionPromptCapabilities,
+} from '@/backend/lib/chat/compression-economics'
+
+const model = {} as LlmModel
+const application = {}
+
+const message = (id: string, content = id): dto.UserMessage => ({
+  id,
+  role: 'user',
+  content,
+  attachments: [],
+  conversationId: 'conversation',
+  parent: null,
+  sentAt: '2026-09-11T00:00:00.000Z',
+})
+
+const decision = (
+  messageId: string,
+  policy: dto.MessageCompressionDecision['policy'],
+  reason = policy === 'summary' ? 'candidate summary' : 'kept full'
+): dto.MessageCompressionDecision => ({
+  messageId,
+  policy,
+  reason,
+  estimatedTokensBefore: 0,
+  estimatedTokensAfter: 0,
+})
+
+const costs = (
+  ...entries: Array<[string, number]>
+): Array<{
+  messageId: string
+  role: dto.Message['role']
+  tokens: number
+}> => entries.map(([messageId, tokens]) => ({ messageId, role: 'user', tokens }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockApplyCompressionPlan.mockImplementation(
+    async (
+      messages: dto.Message[],
+      decisions: dto.MessageCompressionDecision[],
+      options?: { attachmentContinuationQuery?: string }
+    ) =>
+      messages.map((current) => {
+        const selected = decisions.find((candidate) => candidate.messageId === current.id)
+        if (selected?.policy === 'summary' && current.role === 'user') {
+          return { ...current, content: `summary:${current.id}` }
+        }
+        if (
+          options?.attachmentContinuationQuery?.trim() &&
+          current.role === 'user' &&
+          !current.content.trim() &&
+          current.attachments.length > 0
+        ) {
+          return {
+            ...current,
+            content: `[CONVERSATION CONTINUATION] ${options.attachmentContinuationQuery}`,
+          }
+        }
+        return current
+      })
+  )
+  mockEstimateHistoryMessageCosts.mockImplementation(
+    async (_model: LlmModel, messages: dto.Message[]) =>
+      messages.map((current) => ({
+        messageId: current.id,
+        role: current.role,
+        tokens:
+          (current.role === 'user' ? current.content : '') === 'summary:small'
+            ? 50
+            : (current.role === 'user' ? current.content : '').startsWith('summary:')
+            ? 100
+            : current.id === 'sibling-call' || current.id === 'small'
+            ? 100
+            : 300,
+      }))
+  )
+})
+
+describe('buildCostEffectiveCompressionPlan', () => {
+  test('rejects an individual summary whose saving is below the per-message threshold', async () => {
+    const messages = [message('small')]
+    const result = await buildCostEffectiveCompressionPlan({
+      messages,
+      decisions: [decision('small', 'summary')],
+      model,
+      historyCostsBefore: costs(['small', MIN_COMPRESSION_MESSAGE_SAVINGS_TOKENS + 1]),
+      application,
+    })
+
+    expect(result.applied).toBe(false)
+    expect(result.messages).toEqual(messages)
+    expect(result.decisions[0]).toMatchObject({ policy: 'full' })
+    expect(result.decisions[0]?.reason).toContain('summary rejected')
+  })
+
+  test('returns original messages when no summary is selected', async () => {
+    const messages = [message('full')]
+    const originalDecision = decision('full', 'full', 'recent turn kept full')
+    const result = await buildCostEffectiveCompressionPlan({
+      messages,
+      decisions: [originalDecision],
+      model,
+      historyCostsBefore: costs(['full', 300]),
+      application,
+    })
+
+    expect(result).toMatchObject({
+      messages,
+      decisions: [originalDecision],
+      historyCostsAfter: costs(['full', 300]),
+      estimatedHistoryTokenReduction: 0,
+      applied: false,
+    })
+  })
+
+  test('keeps an attachment continuation annotation and coherent costs when no summary survives', async () => {
+    const messages: dto.UserMessage[] = [
+      {
+        ...message('attachment-turn', ''),
+        attachments: [{ id: 'file-1', name: 'notes.txt', mimetype: 'text/plain', size: 12 }],
+      },
+    ]
+    const attachmentContinuationQuery = 'What does this file say?'
+    const result = await buildCostEffectiveCompressionPlan({
+      messages,
+      decisions: [decision('attachment-turn', 'full', 'attachment continuation')],
+      model,
+      historyCostsBefore: costs(['attachment-turn', 300]),
+      application: { attachmentContinuationQuery },
+    })
+
+    expect(result.applied).toBe(false)
+    expect(result.messages[0]).toMatchObject({
+      id: 'attachment-turn',
+      content: `[CONVERSATION CONTINUATION] ${attachmentContinuationQuery}`,
+    })
+    expect(result.historyCostsAfter).toEqual(costs(['attachment-turn', 300]))
+    expect(result.estimatedHistoryTokenReduction).toBe(0)
+    expect(mockApplyCompressionPlan).toHaveBeenLastCalledWith(messages, expect.any(Array), {
+      attachmentContinuationQuery,
+    })
+  })
+
+  test('applies a plan whose total saving reaches the plan threshold', async () => {
+    const messages = [message('first'), message('second')]
+    const result = await buildCostEffectiveCompressionPlan({
+      messages,
+      decisions: [decision('first', 'summary'), decision('second', 'summary')],
+      model,
+      historyCostsBefore: costs(['first', 292], ['second', 292]),
+      application,
+    })
+
+    expect(result.applied).toBe(true)
+    expect(result.estimatedHistoryTokenReduction).toBe(MIN_COMPRESSION_PLAN_SAVINGS_TOKENS)
+    expect(
+      result.messages.map((current) => (current.role === 'user' ? current.content : undefined))
+    ).toEqual(['summary:first', 'summary:second'])
+  })
+
+  test('rejects a plan below the total saving threshold and restores original messages', async () => {
+    const messages = [message('first'), message('second')]
+    const result = await buildCostEffectiveCompressionPlan({
+      messages,
+      decisions: [decision('first', 'summary'), decision('second', 'summary')],
+      model,
+      historyCostsBefore: costs(['first', 250], ['second', 250]),
+      application,
+    })
+
+    expect(result.applied).toBe(false)
+    expect(result.messages).toEqual(messages)
+    expect(result.estimatedHistoryTokenReduction).toBe(0)
+    expect(result.decisions.every((current) => current.policy === 'full')).toBe(true)
+    expect(result.decisions.every((current) => Boolean(current.reason))).toBe(true)
+  })
+
+  test('preserves non-summary decisions while applying beneficial summaries', async () => {
+    const messages = [message('summary-target'), message('decision')]
+    const fullDecision = decision('decision', 'full', 'protected decision')
+    const result = await buildCostEffectiveCompressionPlan({
+      messages,
+      decisions: [decision('summary-target', 'summary'), fullDecision],
+      model,
+      historyCostsBefore: costs(['summary-target', 500], ['decision', 300]),
+      application,
+    })
+
+    expect(result.applied).toBe(true)
+    expect(result.decisions[1]).toEqual(fullDecision)
+    expect(result.messages[1]).toEqual(messages[1])
+  })
+
+  test('allows a tool summary whose saving is realized on its sibling tool-call', async () => {
+    const messages: dto.Message[] = [
+      {
+        id: 'sibling-call',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-large-result',
+            toolName: 'file-tool',
+            args: { query: 'large result' },
+          },
+        ],
+        conversationId: 'conversation',
+        parent: null,
+        sentAt: '2026-09-11T00:00:00.000Z',
+      },
+      {
+        id: 'tool-result',
+        role: 'tool',
+        parts: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-large-result',
+            toolName: 'file-tool',
+            result: { type: 'text', value: 'large tool result' },
+          },
+        ],
+        conversationId: 'conversation',
+        parent: null,
+        sentAt: '2026-09-11T00:00:00.000Z',
+      },
+    ]
+    const result = await buildCostEffectiveCompressionPlan({
+      messages,
+      decisions: [decision('sibling-call', 'full'), decision('tool-result', 'summary')],
+      model,
+      historyCostsBefore: [
+        { messageId: 'sibling-call', role: 'assistant', tokens: 500 },
+        { messageId: 'tool-result', role: 'tool', tokens: 300 },
+      ],
+      application,
+    })
+
+    expect(result.applied).toBe(true)
+    expect(result.estimatedHistoryTokenReduction).toBe(400)
+    expect(result.decisions.find((current) => current.messageId === 'tool-result')).toMatchObject({
+      policy: 'summary',
+    })
+  })
+})
+
+describe('selectCompressionPromptCapabilities', () => {
+  const tool = (id: string): ToolImplementation => ({
+    supportedMedia: [],
+    toolParams: { id, name: id, provisioned: true, promptFragment: '' },
+    functions: async () => ({}),
+  })
+
+  const capabilities = () => {
+    const functions: ToolFunctions = {
+      retrieveContext: {
+        description: 'retrieve context',
+        invoke: async () => ({ type: 'text', value: '' }),
+      },
+      inspectFile: {
+        description: 'inspect a file',
+        invoke: async () => ({ type: 'text', value: '' }),
+      },
+    }
+    return {
+      tools: [tool('context-retrieve'), tool('file-tools')],
+      functions,
+      functionToolIdMap: new Map([
+        ['retrieveContext', 'context-retrieve'],
+        ['inspectFile', 'file-tools'],
+      ]),
+    }
+  }
+
+  test('removes only context-retrieve tools and functions before compression is applied', () => {
+    const input = capabilities()
+    const result = selectCompressionPromptCapabilities({
+      ...input,
+      compressionConfigured: true,
+      compressionApplied: false,
+    })
+
+    expect(result.tools.map((current) => current.toolParams.id)).toEqual(['file-tools'])
+    expect(Object.keys(result.functions)).toEqual(['inspectFile'])
+  })
+
+  test('keeps all prompt capabilities once compression is applied', () => {
+    const input = capabilities()
+    const result = selectCompressionPromptCapabilities({
+      ...input,
+      compressionConfigured: true,
+      compressionApplied: true,
+    })
+
+    expect(result.tools).toBe(input.tools)
+    expect(result.functions).toBe(input.functions)
+  })
+})

--- a/apps/backend/lib/chat/compression-economics.ts
+++ b/apps/backend/lib/chat/compression-economics.ts
@@ -1,0 +1,160 @@
+import type * as dto from '@/types/dto'
+import type { LlmModel } from '@/lib/chat/models'
+import type { ToolFunctions, ToolImplementation } from '@/lib/chat/tools'
+import { applyCompressionPlan, type CompressionApplicationOptions } from './compression-planner'
+import { estimateHistoryMessageCosts, type HistoryMessageCost } from './token-estimator'
+
+/**
+ * A compressed message needs some margin over its replacement summary, and the whole plan needs
+ * enough margin to pay for the context-retrieve prompt fragment and function schemas. The plan
+ * threshold is anchored to the 325-token gpt-4o-mini overhead measured by the synthetic boundary
+ * fixtures on 2026-09-11, with room for tokenizer/provider variation.
+ */
+export const MIN_COMPRESSION_MESSAGE_SAVINGS_TOKENS = 64
+export const MIN_COMPRESSION_PLAN_SAVINGS_TOKENS = 384
+
+export interface CostEffectiveCompressionPlan {
+  messages: dto.Message[]
+  decisions: dto.MessageCompressionDecision[]
+  historyCostsAfter: HistoryMessageCost[]
+  estimatedHistoryTokenReduction: number
+  applied: boolean
+}
+
+export const selectCompressionPromptCapabilities = (options: {
+  tools: ToolImplementation[]
+  functions: ToolFunctions
+  functionToolIdMap: Map<string, string>
+  compressionConfigured: boolean
+  compressionApplied: boolean
+}): { tools: ToolImplementation[]; functions: ToolFunctions } => {
+  if (!options.compressionConfigured || options.compressionApplied) {
+    return { tools: options.tools, functions: options.functions }
+  }
+  return {
+    tools: options.tools.filter((tool) => tool.toolParams.id !== 'context-retrieve'),
+    functions: Object.fromEntries(
+      Object.entries(options.functions).filter(
+        ([name]) => options.functionToolIdMap.get(name) !== 'context-retrieve'
+      )
+    ),
+  }
+}
+
+const totalTokens = (costs: HistoryMessageCost[]): number =>
+  costs.reduce((total, cost) => total + cost.tokens, 0)
+
+const keepOnlyBeneficialSummaries = (
+  decisions: dto.MessageCompressionDecision[],
+  before: HistoryMessageCost[],
+  after: HistoryMessageCost[]
+): dto.MessageCompressionDecision[] => {
+  const beforeById = new Map(before.map((cost) => [cost.messageId, cost]))
+  const afterById = new Map(after.map((cost) => [cost.messageId, cost.tokens]))
+
+  return decisions.map((decision) => {
+    if (decision.policy !== 'summary') return decision
+    const beforeCost = beforeById.get(decision.messageId)
+    // A summarized tool result can also redact a large payload from its sibling assistant tool
+    // call. That saving lands on a different message, so a per-message comparison would reject
+    // the decision even when the complete plan is strongly beneficial. Let the aggregate guard
+    // decide tool-result economics.
+    if (beforeCost?.role === 'tool') return decision
+    const saving = (beforeCost?.tokens ?? 0) - (afterById.get(decision.messageId) ?? 0)
+    return saving >= MIN_COMPRESSION_MESSAGE_SAVINGS_TOKENS
+      ? decision
+      : {
+          ...decision,
+          policy: 'full',
+          reason: `summary rejected: estimated saving ${saving} tokens is below ${MIN_COMPRESSION_MESSAGE_SAVINGS_TOKENS}`,
+        }
+  })
+}
+
+/**
+ * Materializes candidate summaries, then keeps them only when both the individual replacement and
+ * the complete plan have a positive economic margin. Rejected summaries may remain warm in the
+ * cache, but are not sent to the provider and do not activate the retrieval tool for this call.
+ */
+export const buildCostEffectiveCompressionPlan = async (options: {
+  messages: dto.Message[]
+  decisions: dto.MessageCompressionDecision[]
+  model: LlmModel
+  historyCostsBefore: HistoryMessageCost[]
+  application: CompressionApplicationOptions
+}): Promise<CostEffectiveCompressionPlan> => {
+  const beforeTokens = totalTokens(options.historyCostsBefore)
+  const noPlanResult = async (
+    decisions: dto.MessageCompressionDecision[]
+  ): Promise<CostEffectiveCompressionPlan> => {
+    // The attachment-only continuation note is behaviorally useful even when no historical
+    // summary survives the economic guards. It does not need context-retrieve, so preserve that
+    // annotation while still reporting `applied: false`.
+    const messages = options.application.attachmentContinuationQuery?.trim()
+      ? await applyCompressionPlan(options.messages, decisions, {
+          attachmentContinuationQuery: options.application.attachmentContinuationQuery,
+        })
+      : options.messages
+    const historyCostsAfter =
+      messages === options.messages
+        ? options.historyCostsBefore
+        : await estimateHistoryMessageCosts(options.model, messages)
+    return {
+      messages,
+      decisions,
+      historyCostsAfter,
+      estimatedHistoryTokenReduction: beforeTokens - totalTokens(historyCostsAfter),
+      applied: false,
+    }
+  }
+  const candidateMessages = await applyCompressionPlan(
+    options.messages,
+    options.decisions,
+    options.application
+  )
+  const candidateCosts = await estimateHistoryMessageCosts(options.model, candidateMessages)
+  const decisions = keepOnlyBeneficialSummaries(
+    options.decisions,
+    options.historyCostsBefore,
+    candidateCosts
+  )
+  const summarizedMessages = decisions.filter((decision) => decision.policy === 'summary').length
+  if (summarizedMessages === 0) {
+    return noPlanResult(decisions)
+  }
+
+  const rejectedAny = decisions.some(
+    (decision, index) =>
+      decision.policy !== options.decisions[index]?.policy ||
+      decision.reason !== options.decisions[index]?.reason
+  )
+  const messages = rejectedAny
+    ? await applyCompressionPlan(options.messages, decisions, options.application)
+    : candidateMessages
+  const historyCostsAfter = rejectedAny
+    ? await estimateHistoryMessageCosts(options.model, messages)
+    : candidateCosts
+  const estimatedHistoryTokenReduction = beforeTokens - totalTokens(historyCostsAfter)
+
+  if (estimatedHistoryTokenReduction < MIN_COMPRESSION_PLAN_SAVINGS_TOKENS) {
+    return noPlanResult(
+      decisions.map((decision) =>
+        decision.policy === 'summary'
+          ? {
+              ...decision,
+              policy: 'full',
+              reason: `summary rejected: plan saves ${estimatedHistoryTokenReduction} tokens, below ${MIN_COMPRESSION_PLAN_SAVINGS_TOKENS}`,
+            }
+          : decision
+      )
+    )
+  }
+
+  return {
+    messages,
+    decisions,
+    historyCostsAfter,
+    estimatedHistoryTokenReduction,
+    applied: true,
+  }
+}

--- a/apps/backend/lib/chat/compression-planner.ts
+++ b/apps/backend/lib/chat/compression-planner.ts
@@ -62,6 +62,11 @@ const REDACTED_ARGS_MARKER =
   '[redacted: content available via context-retrieve, see summarized result]'
 const INLINE_SUMMARY_CONCURRENCY = 2
 
+export interface CompressionApplicationOptions {
+  prefetchQuery?: string
+  attachmentContinuationQuery?: string
+}
+
 const isImageMimeType = (mimetype: string) => mimetype.startsWith('image/')
 const charsToTokens = (chars: number) => Math.ceil(chars / 4)
 
@@ -309,7 +314,7 @@ export function planMessageCompression(
 export async function applyCompressionPlan(
   messages: dto.Message[],
   decisions: dto.MessageCompressionDecision[],
-  options: { prefetchQuery?: string; attachmentContinuationQuery?: string } = {}
+  options: CompressionApplicationOptions = {}
 ): Promise<dto.Message[]> {
   const decisionByMessageId = new Map(decisions.map((d) => [d.messageId, d]))
   const output: dto.Message[] = []

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -61,11 +61,14 @@ import type { PromptSegment } from './preamble'
 import { prefixToolFunctionNames } from './toolFunctionNames'
 import {
   planMessageCompression,
-  applyCompressionPlan,
   resolveCompressionRetrievalMode,
   resolveCompressionUserQuery,
   resolveCompressionTriggerTokens,
 } from './compression-planner'
+import {
+  buildCostEffectiveCompressionPlan,
+  selectCompressionPromptCapabilities,
+} from './compression-economics'
 
 // Extract a message from:
 // 1) chunk.error.message
@@ -379,8 +382,9 @@ export class ChatAssistant {
     return false
   }
 
-  async createAiTools(): Promise<Record<string, ai.Tool> | undefined> {
-    const functions = this.functions
+  async createAiTools(
+    functions: ToolFunctions = this.functions
+  ): Promise<Record<string, ai.Tool> | undefined> {
     if (Object.keys(functions).length === 0) return undefined
     return Object.fromEntries(
       (Object.entries(functions) as Array<[string, ToolFunction | ToolNative]>).map(
@@ -406,12 +410,15 @@ export class ChatAssistant {
     )
   }
 
-  private providerOptions(_messages: ai.ModelMessage[]): Record<string, any> | undefined {
+  private providerOptions(
+    _messages: ai.ModelMessage[],
+    tools: ToolImplementation[] = this.tools
+  ): Record<string, any> | undefined {
     const assistantParams = this.assistantParams
     const options = this.options
     const vercelProviderType = this.languageModel.provider
     const providerOptions = Object.fromEntries(
-      this.tools.flatMap((tool) =>
+      tools.flatMap((tool) =>
         tool.providerOptions ? Object.entries(tool.providerOptions(this.llmModel)) : []
       )
     )
@@ -494,7 +501,11 @@ export class ChatAssistant {
     return undefined
   }
 
-  async truncateChat(messages: dto.Message[], historyCosts?: HistoryMessageCost[]) {
+  async truncateChat(
+    messages: dto.Message[],
+    historyCosts?: HistoryMessageCost[],
+    tools: ToolImplementation[] = this.tools
+  ) {
     if (messages.length === 0) return messages
     let assistantTokens: number
     let draftTokens: number
@@ -503,7 +514,7 @@ export class ChatAssistant {
       assistantTokens = await estimatePreambleTokens({
         assistantParams: this.assistantParams,
         model: this.llmModel,
-        tools: this.tools,
+        tools,
         parameters: this.parameters,
         knowledgeFiles: this.knowledge,
       })
@@ -513,7 +524,7 @@ export class ChatAssistant {
       const { plan } = await prepareConversationCostPlan({
         assistantParams: this.assistantParams,
         model: this.llmModel,
-        tools: this.tools,
+        tools,
         parameters: this.parameters,
         knowledgeFiles: this.knowledge,
         history: messages,
@@ -589,6 +600,7 @@ export class ChatAssistant {
     const compression = this.assistantParams.contextCompression
     let promptMessages = messages
     let historyCosts: HistoryMessageCost[] | undefined
+    let compressionApplied = false
     if (compression) {
       const triggerAtTokens = resolveCompressionTriggerTokens(compression.triggerAtTokens)
       historyCosts = await estimateHistoryMessageCosts(this.llmModel, messages)
@@ -599,26 +611,37 @@ export class ChatAssistant {
           keepRecentTurns: compression.keepRecentTurns,
         })
         const userQuery = resolveCompressionUserQuery(messages)
-        promptMessages = await applyCompressionPlan(messages, decisions, {
-          prefetchQuery:
-            resolveCompressionRetrievalMode(compression.retrievalMode) === 'prefetch'
-              ? userQuery
-              : undefined,
-          attachmentContinuationQuery: userQuery,
+        const plan = await buildCostEffectiveCompressionPlan({
+          messages,
+          decisions,
+          model: this.llmModel,
+          historyCostsBefore: historyCosts,
+          application: {
+            prefetchQuery:
+              resolveCompressionRetrievalMode(compression.retrievalMode) === 'prefetch'
+                ? userQuery
+                : undefined,
+            attachmentContinuationQuery: userQuery,
+          },
         })
-      } else {
-        historyCosts = undefined
+        promptMessages = plan.messages
+        historyCosts = plan.historyCostsAfter
+        compressionApplied = plan.applied
       }
     }
-    const truncatedChat = await this.truncateChat(
-      promptMessages,
-      promptMessages === messages ? historyCosts : undefined
-    )
+    const { tools: promptTools, functions: promptFunctions } = selectCompressionPromptCapabilities({
+      tools: this.tools,
+      functions: this.functions,
+      functionToolIdMap: this.functionToolIdMap,
+      compressionConfigured: compression !== null,
+      compressionApplied,
+    })
+    const truncatedChat = await this.truncateChat(promptMessages, historyCosts, promptTools)
 
     const preambleSegments = await buildPreambleSegments({
       assistantParams: this.assistantParams,
       llmModel: this.llmModel,
-      tools: this.tools,
+      tools: promptTools,
       parameters: this.parameters,
       knowledge: this.knowledge,
     })
@@ -640,8 +663,8 @@ export class ChatAssistant {
     }
 
     const llmMessages = [...preambleSegments, ...historySegments].map((s) => s.message)
-    const tools = await this.createAiTools()
-    const providerOptions = this.providerOptions(llmMessages)
+    const tools = await this.createAiTools(promptFunctions)
+    const providerOptions = this.providerOptions(llmMessages, promptTools)
     let maxOutputTokens = minOptional(this.llmModel.maxOutputTokens, env.chat.maxOutputTokens)
     if (maxOutputTokens && isAnthropic) {
       const anthropicProviderOptions = providerOptions?.anthropic as
@@ -659,7 +682,7 @@ export class ChatAssistant {
       messages: llmMessages,
       tools: this.llmModelCapabilities.function_calling ? { ...tools } : undefined,
       toolChoice:
-        this.llmModelCapabilities.function_calling && Object.keys(this.functions).length !== 0
+        this.llmModelCapabilities.function_calling && Object.keys(promptFunctions).length !== 0
           ? 'auto'
           : undefined,
       temperature:

--- a/apps/backend/lib/eval/__tests__/campaign.test.ts
+++ b/apps/backend/lib/eval/__tests__/campaign.test.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { initializeCampaign, registerBundle } from '@/backend/lib/eval/campaign'
+
+describe('evaluation campaign directory', () => {
+  it('initializes a documented private layout and rejects reinitialization', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'logicle-campaign-'))
+    const manifest = await initializeCampaign(dir, 'compression smoke')
+    expect(manifest.frozenProtocol.model).toBeNull()
+    expect(
+      (await readFile(path.join(dir, 'candidate-register.csv'), 'utf8')).split('\n')[0]
+    ).toContain('caseId')
+    await expect(initializeCampaign(dir, 'again')).rejects.toThrow('not empty')
+  })
+
+  it('registers a bundle by metadata without copying it and rejects duplicates', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'logicle-campaign-'))
+    await initializeCampaign(dir, 'test')
+    const bundle = path.join(dir, 'input.sqlite')
+    const BetterSqlite = (await import('better-sqlite3')).default
+    const sqlite = new BetterSqlite(bundle)
+    sqlite.exec('CREATE TABLE events (id INTEGER PRIMARY KEY, label TEXT NOT NULL)')
+    sqlite.prepare('INSERT INTO events (label) VALUES (?)').run('first')
+    sqlite.prepare('INSERT INTO events (label) VALUES (?)').run('second')
+    sqlite.prepare('INSERT INTO events (label) VALUES (?)').run('third')
+    sqlite.close()
+    const record = await registerBundle(dir, 'case-a', bundle, 'short')
+    expect(record.bundlePath).toBe('input.sqlite')
+    expect(record.sqliteTables).toEqual({ events: 3 })
+
+    const csv = (await readFile(path.join(dir, 'candidate-register.csv'), 'utf8'))
+      .trimEnd()
+      .split('\n')
+    const header = csv[0].split(',')
+    const row = csv[1].split(',')
+    expect(header).toHaveLength(14)
+    expect(row).toHaveLength(header.length)
+    expect(row[0]).toBe('case-a')
+    expect(row[2]).toBe('short')
+    expect(row[6]).toContain('""events"":3')
+
+    await expect(registerBundle(dir, 'case-a', bundle, 'short')).rejects.toThrow(
+      'already registered'
+    )
+    await expect(registerBundle(dir, 'case-b', bundle, 'short')).rejects.toThrow(
+      'hash already registered'
+    )
+  })
+})

--- a/apps/backend/lib/eval/__tests__/contextCompressionScenarios.test.ts
+++ b/apps/backend/lib/eval/__tests__/contextCompressionScenarios.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import * as dto from '@/types/dto'
+import { llmModels } from '@/lib/models'
+import { countTextWithTokenizer } from '@/lib/chat/tokenizer'
+import { setTokenizerCounter } from '@/backend/lib/chat/prompt-token-counter'
+import { estimateHistoryMessageCosts } from '@/backend/lib/chat/token-estimator'
+import { planMessageCompression } from '@/backend/lib/chat/compression-planner'
+import { materializeReferenceChat } from '@/backend/lib/eval/referenceChat'
+import {
+  aboveTriggerIncompressibleTextScenario,
+  belowTriggerAttachmentScenario,
+  belowTriggerIncompressibleTextScenario,
+  belowTriggerTextScenario,
+  contextCompressionBoundaryScenarios,
+  contextCompressionScenarios,
+  tinyAttachmentOverheadScenario,
+} from '@/backend/lib/eval/scenarios/contextCompression'
+
+setTokenizerCounter({
+  countText: async (tokenizer, text) => countTextWithTokenizer(tokenizer, text),
+})
+
+describe('context-compression boundary scenarios', () => {
+  it('ships below-trigger text and attachment controls plus above-trigger incompressible cases', () => {
+    expect(contextCompressionBoundaryScenarios.map((scenario) => scenario.id)).toEqual([
+      belowTriggerTextScenario.id,
+      belowTriggerAttachmentScenario.id,
+      belowTriggerIncompressibleTextScenario.id,
+      aboveTriggerIncompressibleTextScenario.id,
+      tinyAttachmentOverheadScenario.id,
+    ])
+    expect(contextCompressionScenarios).toEqual(
+      expect.arrayContaining(contextCompressionBoundaryScenarios)
+    )
+  })
+
+  it('declares deterministic trigger expectations for every saved reference chat', () => {
+    for (const scenario of contextCompressionScenarios) {
+      expect(scenario.referenceChat?.compressionExpectation).toBeDefined()
+    }
+    expect(belowTriggerTextScenario.referenceChat?.compressionExpectation?.triggered).toBe(false)
+    expect(belowTriggerAttachmentScenario.referenceChat?.compressionExpectation?.triggered).toBe(
+      false
+    )
+    expect(
+      belowTriggerIncompressibleTextScenario.referenceChat?.compressionExpectation?.triggered
+    ).toBe(false)
+    expect(
+      aboveTriggerIncompressibleTextScenario.referenceChat?.compressionExpectation
+    ).toMatchObject({ triggered: true, maxSummarizedMessages: 0 })
+  })
+
+  it('keeps the tiny attachment genuinely tiny', () => {
+    expect(tinyAttachmentOverheadScenario.corpus).toHaveLength(1)
+    expect(tinyAttachmentOverheadScenario.corpus[0]!.text.length).toBeLessThan(100)
+  })
+
+  it('anchors the text-only boundary fixtures to real gpt-4o-mini token estimates', async () => {
+    const model = llmModels.find(({ id }) => id === 'gpt-4o-mini')
+    if (!model) throw new Error('gpt-4o-mini model is not configured')
+
+    const fixtures = [
+      belowTriggerTextScenario,
+      belowTriggerIncompressibleTextScenario,
+      aboveTriggerIncompressibleTextScenario,
+    ] as const
+    const estimatedTokens: number[] = []
+
+    for (const scenario of fixtures) {
+      const referenceChat = scenario.referenceChat!
+      const history = materializeReferenceChat(referenceChat, {
+        conversationId: `boundary-${scenario.id}`,
+        runId: 'token-estimate',
+        files: [],
+        corpus: scenario.corpus,
+      })
+      const finalUserMessage: dto.UserMessage = {
+        id: `eval-final-${scenario.id}`,
+        conversationId: `boundary-${scenario.id}`,
+        parent: history.at(-1)?.id ?? null,
+        sentAt: '2026-01-01T00:59:00.000Z',
+        role: 'user',
+        content: referenceChat.finalUserMessage,
+        attachments: [],
+      }
+      const messages = [...history, finalUserMessage]
+      const costs = await estimateHistoryMessageCosts(model, messages)
+      const totalTokens = costs.reduce((sum, cost) => sum + cost.tokens, 0)
+      estimatedTokens.push(totalTokens)
+
+      const decisions = planMessageCompression(messages, 'conservative')
+      const summarizedMessages = decisions.filter((decision) => decision.policy === 'summary')
+      expect(summarizedMessages).toHaveLength(0)
+      expect(referenceChat.compressionExpectation?.maxSummarizedMessages).toBe(0)
+    }
+
+    expect(estimatedTokens[0]).toBeLessThan(6000)
+    expect(estimatedTokens[1]).toBeLessThan(6000)
+    expect(estimatedTokens[2]).toBeGreaterThanOrEqual(6000)
+    expect(belowTriggerTextScenario.referenceChat?.compressionExpectation?.triggered).toBe(false)
+    expect(
+      belowTriggerIncompressibleTextScenario.referenceChat?.compressionExpectation?.triggered
+    ).toBe(false)
+    expect(
+      aboveTriggerIncompressibleTextScenario.referenceChat?.compressionExpectation
+    ).toMatchObject({
+      triggered: true,
+      maxSummarizedMessages: 0,
+    })
+  })
+})

--- a/apps/backend/lib/eval/__tests__/report.test.ts
+++ b/apps/backend/lib/eval/__tests__/report.test.ts
@@ -78,7 +78,10 @@ describe('computeBreakEven', () => {
       cacheWriteTokens: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
       estimatedHistoryTokensBefore: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
       estimatedHistoryTokensAfter: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
+      compressionTriggered: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
+      compressionApplied: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
       summarizedMessages: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
+      rejectedMessages: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
       costUsd: { n: 3, mean: costMean, median: costMean, min: costMean, max: costMean, stdev: 0 },
       costKnown: true,
       turns: { n: 3, mean: 1, median: 1, min: 1, max: 1, stdev: 0 },
@@ -210,6 +213,28 @@ describe('renderMarkdown', () => {
       'a'
     )
     expect(markdown).toContain('tokenizer exploded')
+  })
+
+  it('shows whether compression actually triggered', () => {
+    const markdown = renderMarkdown(
+      [
+        makeRun({
+          armName: 'compression-on',
+          compression: {
+            enabled: true,
+            triggered: false,
+            applied: false,
+            triggerAtTokens: 6000,
+            estimatedHistoryTokensBefore: 1200,
+            estimatedHistoryTokensAfter: 1200,
+            summarizedMessages: 0,
+            rejectedMessages: 0,
+          },
+        }),
+      ],
+      'compression-on'
+    )
+    expect(markdown).toContain('| compression-on | 1 | 100% | 1.00 | 0%/0% | 1200→1200 | 0.0/0.0 |')
   })
 
   it('omits the flip section when no scenario was a flip test', () => {

--- a/apps/backend/lib/eval/campaign.ts
+++ b/apps/backend/lib/eval/campaign.ts
@@ -1,0 +1,283 @@
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { chmod, mkdir, readFile, stat, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { createReadStream } from 'node:fs'
+
+export const CAMPAIGN_VERSION = 1
+export const CAMPAIGN_MANIFEST = 'manifest.json'
+export const BUNDLE_REGISTER = 'candidate-register.csv'
+
+export interface CampaignManifest {
+  version: number
+  name: string
+  createdAt: string
+  createdWith: { gitRevision: string | null; gitDirty: boolean | null; command: string }
+  owner: string | null
+  purpose: string
+  scope: {
+    source: string | null
+    cohorts: string[] | null
+    includedContent: string[] | null
+    excludedContent: string[] | null
+    notes: string | null
+  }
+  retention: {
+    owner: string | null
+    rawBundles: string | null
+    runs: string | null
+    sanitized: string | null
+  }
+  frozenProtocol: {
+    provider: string | null
+    model: string | null
+    tokenizer: string | null
+    preset: string | null
+    retrievalMode: string | null
+    keepRecentTurns: number[] | null
+    triggerAtTokens: number | null
+    minimumMessageSavingsTokens: number
+    minimumPlanSavingsTokens: number
+    knowledgeArms: string[] | null
+    repeat: number | null
+    materialGainThreshold: number | null
+    candidateSelectionRule: string | null
+  }
+  sourceReviewStatus: string | null
+  contentPolicy: string
+}
+
+export interface RegisteredBundle {
+  caseId: string
+  bundlePath: string
+  cohort: string
+  sha256: string
+  bytes: number
+  registeredAt: string
+  sqliteTables: Record<string, number> | null
+}
+
+const contentPolicy =
+  'Bundles and raw runs may contain production messages, attachments, filenames, tool results, and model responses. Keep this directory private and local; do not commit, upload, or share it. Put only reviewed, sanitized case metadata and aggregates in sanitized/.'
+
+const git = (args: string[]): string | null => {
+  try {
+    return (
+      execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim() ||
+      null
+    )
+  } catch {
+    return null
+  }
+}
+
+const csvCell = (value: string | number | null): string => {
+  const text = value === null ? '' : String(value)
+  return /[",\n\r]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text
+}
+
+const parseCsvLine = (line: string): string[] => {
+  const values: string[] = []
+  let value = ''
+  let quoted = false
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i]
+    if (char === '"') {
+      if (quoted && line[i + 1] === '"') {
+        value += '"'
+        i += 1
+      } else quoted = !quoted
+    } else if (char === ',' && !quoted) {
+      values.push(value)
+      value = ''
+    } else value += char
+  }
+  values.push(value)
+  return values
+}
+
+const registerHeader = [
+  'caseId',
+  'bundlePath',
+  'cohort',
+  'sha256',
+  'bytes',
+  'registeredAt',
+  'sqliteTables',
+  'reviewedSourceClaim',
+  'answerAbsentFromHistory',
+  'compressionTriggered',
+  'historyReductionTokens',
+  'eligibility',
+  'outcome',
+  'notes',
+]
+
+export const initializeCampaign = async (
+  directory: string,
+  name: string
+): Promise<CampaignManifest> => {
+  if (!name.trim()) throw new Error('Campaign name must not be empty')
+  const dir = path.resolve(directory)
+  let existing: string[] = []
+  try {
+    existing = await (await import('node:fs/promises')).readdir(dir)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+  if (existing.length > 0) throw new Error(`Campaign directory is not empty: ${dir}`)
+  await mkdir(path.join(dir, 'bundles'), { recursive: true, mode: 0o700 })
+  await mkdir(path.join(dir, 'runs'), { mode: 0o700 })
+  await mkdir(path.join(dir, 'sanitized'), { mode: 0o700 })
+  const gitStatus = git(['status', '--porcelain'])
+  const manifest: CampaignManifest = {
+    version: CAMPAIGN_VERSION,
+    name,
+    createdAt: new Date().toISOString(),
+    createdWith: {
+      gitRevision: git(['rev-parse', 'HEAD']),
+      gitDirty: gitStatus === null ? null : gitStatus !== '',
+      command: process.argv.join(' '),
+    },
+    owner: null,
+    purpose:
+      'Evaluate context compression and knowledge-box strategies on reviewed candidate bundles.',
+    scope: {
+      source: null,
+      cohorts: null,
+      includedContent: null,
+      excludedContent: null,
+      notes: null,
+    },
+    retention: { owner: null, rawBundles: null, runs: null, sanitized: null },
+    frozenProtocol: {
+      provider: null,
+      model: null,
+      tokenizer: null,
+      preset: null,
+      retrievalMode: null,
+      keepRecentTurns: null,
+      triggerAtTokens: null,
+      minimumMessageSavingsTokens: 64,
+      minimumPlanSavingsTokens: 384,
+      knowledgeArms: null,
+      repeat: null,
+      materialGainThreshold: null,
+      candidateSelectionRule: null,
+    },
+    sourceReviewStatus: null,
+    contentPolicy,
+  }
+  await writeFile(path.join(dir, CAMPAIGN_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`, {
+    mode: 0o600,
+  })
+  await writeFile(path.join(dir, BUNDLE_REGISTER), `${registerHeader.join(',')}\n`, { mode: 0o600 })
+  await writeFile(
+    path.join(dir, 'README.md'),
+    `# ${name}\n\nThis private directory was initialized for context-compression + knowledge-box evaluation.\n\nCreated: ${
+      manifest.createdAt
+    }\nRevision: ${manifest.createdWith.gitRevision ?? 'unknown'}\nCreated with: ${
+      manifest.createdWith.command
+    }\n\n## Contents\n\n- bundles/: source SQLite bundles with complete conversation histories and decrypted attachment/assistant-knowledge bytes\n- runs/: raw model responses, reports, inspections, and tool-call/token evidence\n- sanitized/: reviewed case ledger and aggregates safe to share\n- candidate-register.csv: checksummed bundle inventory plus source review, eligibility, and outcome columns\n- manifest.json: campaign provenance and protocol fields that must be frozen before replay\n\n## Workflow\n\n1. Fill the null owner, scope, retention, frozenProtocol, and sourceReviewStatus fields in manifest.json before selecting candidates. Record included and deliberately excluded content explicitly.\n2. Build bundles directly into bundles/ with eval-build-replay-bundle.ts --campaign-dir <this-directory> --case <opaque-id> --cohort <shape>.\n3. Complete source-review and inspect-only columns in candidate-register.csv before any paid replay.\n4. Store raw A/B/C/D runs under runs/ and only reviewed, non-sensitive aggregates under sanitized/.\n5. Delete private artifacts according to the retention fields; retain the sanitized ledger if approved.\n\n${contentPolicy}\n`,
+    { mode: 0o600 }
+  )
+  await chmod(dir, 0o700)
+  return manifest
+}
+
+const checksum = async (file: string): Promise<{ sha256: string; bytes: number }> =>
+  new Promise((resolve, reject) => {
+    const hash = createHash('sha256')
+    let bytes = 0
+    const stream = createReadStream(file)
+    stream.on('data', (chunk: string | Buffer) => {
+      const bytesChunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      bytes += bytesChunk.length
+      hash.update(bytesChunk)
+    })
+    stream.on('error', reject)
+    stream.on('end', () => resolve({ sha256: hash.digest('hex'), bytes }))
+  })
+
+const sqliteCounts = async (file: string): Promise<Record<string, number> | null> => {
+  try {
+    const BetterSqlite = (await import('better-sqlite3')).default
+    const db = new BetterSqlite(file, { readonly: true })
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
+      .all() as Array<{ name: string }>
+    const counts: Record<string, number> = {}
+    for (const table of tables) {
+      const identifier = `"${table.name.replaceAll('"', '""')}"`
+      counts[table.name] = Number(
+        (db.prepare(`SELECT COUNT(*) AS count FROM ${identifier}`).get() as { count: number }).count
+      )
+    }
+    db.close()
+    return counts
+  } catch {
+    return null
+  }
+}
+
+export const registerBundle = async (
+  directory: string,
+  caseId: string,
+  bundle: string,
+  cohort: string
+): Promise<RegisteredBundle> => {
+  if (!caseId.trim() || !cohort.trim()) throw new Error('Case id and cohort must not be empty')
+  const dir = path.resolve(directory)
+  const manifest = JSON.parse(
+    await readFile(path.join(dir, CAMPAIGN_MANIFEST), 'utf8')
+  ) as CampaignManifest
+  if (manifest.version !== CAMPAIGN_VERSION)
+    throw new Error('Unsupported campaign manifest version')
+  const bundlePathAbsolute = path.resolve(bundle)
+  const info = await stat(bundlePathAbsolute)
+  if (!info.isFile()) throw new Error(`Bundle is not a file: ${bundlePathAbsolute}`)
+  const digest = await checksum(bundlePathAbsolute)
+  const registerPath = path.join(dir, BUNDLE_REGISTER)
+  const text = await readFile(registerPath, 'utf8')
+  const rows = text.split(/\r?\n/).filter(Boolean).slice(1).map(parseCsvLine)
+  if (rows.some((row) => row[0] === caseId))
+    throw new Error(`Case id already registered: ${caseId}`)
+  if (rows.some((row) => row[3] === digest.sha256))
+    throw new Error(`Bundle hash already registered: ${digest.sha256}`)
+  const relative = path.relative(dir, bundlePathAbsolute)
+  const storedPath =
+    relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+      ? relative
+      : bundlePathAbsolute
+  const result: RegisteredBundle = {
+    caseId,
+    bundlePath: storedPath,
+    cohort,
+    ...digest,
+    registeredAt: new Date().toISOString(),
+    sqliteTables: await sqliteCounts(bundlePathAbsolute),
+  }
+  await writeFile(
+    registerPath,
+    `${text.trimEnd()}\n${[
+      result.caseId,
+      result.bundlePath,
+      result.cohort,
+      result.sha256,
+      result.bytes,
+      result.registeredAt,
+      result.sqliteTables ? JSON.stringify(result.sqliteTables) : '',
+      '',
+      '',
+      '',
+      '',
+      '',
+      '',
+      '',
+    ]
+      .map(csvCell)
+      .join(',')}\n`,
+    { mode: 0o600 }
+  )
+  return result
+}

--- a/apps/backend/lib/eval/harness.ts
+++ b/apps/backend/lib/eval/harness.ts
@@ -4,11 +4,15 @@ import type * as dto from '@/types/dto'
 import { applyStreamPartToMessages } from '@/lib/chat/streamApply'
 import { ChatAssistant, type AssistantParams } from '@/backend/lib/chat'
 import {
-  applyCompressionPlan,
   planMessageCompression,
   resolveCompressionRetrievalMode,
   resolveCompressionTriggerTokens,
 } from '@/backend/lib/chat/compression-planner'
+import {
+  buildCostEffectiveCompressionPlan,
+  MIN_COMPRESSION_MESSAGE_SAVINGS_TOKENS,
+  MIN_COMPRESSION_PLAN_SAVINGS_TOKENS,
+} from '@/backend/lib/chat/compression-economics'
 import { estimateHistoryMessageCosts } from '@/backend/lib/chat/token-estimator'
 import type { LlmModel } from '@/lib/chat/models'
 import type { ProviderConfig } from '@/types/provider'
@@ -166,39 +170,84 @@ export const runOne = async (options: RunOptions): Promise<RunResult> => {
             estimatedHistoryTokensBefore,
             estimatedHistoryTokensAfter: estimatedHistoryTokensBefore,
             triggered: false,
+            applied: false,
             summarizedMessages: 0,
+            rejectedMessages: 0,
           }
         } else {
           const triggerAtTokens = resolveCompressionTriggerTokens(compression.triggerAtTokens)
           const triggered = estimatedHistoryTokensBefore >= triggerAtTokens
-          const decisions = triggered
+          let decisions = triggered
             ? planMessageCompression(messages, compression.preset, {
                 keepRecentTurns: compression.keepRecentTurns,
               })
             : []
-          const plannedMessages = triggered
-            ? await applyCompressionPlan(messages, decisions, {
-                prefetchQuery:
-                  resolveCompressionRetrievalMode(compression.retrievalMode) === 'prefetch'
-                    ? message.content
-                    : undefined,
+          const plan = triggered
+            ? await buildCostEffectiveCompressionPlan({
+                messages,
+                decisions,
+                model: assistant.llmModel,
+                historyCostsBefore: costsBefore,
+                application: {
+                  prefetchQuery:
+                    resolveCompressionRetrievalMode(compression.retrievalMode) === 'prefetch'
+                      ? message.content
+                      : undefined,
+                },
               })
-            : messages
-          const costsAfter = await estimateHistoryMessageCosts(assistant.llmModel, plannedMessages)
+            : undefined
+          if (plan) decisions = plan.decisions
           compressionDiagnostics = {
             enabled: true,
             estimatedHistoryTokensBefore,
-            estimatedHistoryTokensAfter: costsAfter.reduce((total, cost) => total + cost.tokens, 0),
+            estimatedHistoryTokensAfter: plan
+              ? plan.historyCostsAfter.reduce((total, cost) => total + cost.tokens, 0)
+              : estimatedHistoryTokensBefore,
             triggerAtTokens,
             triggered,
+            applied: plan?.applied ?? false,
             summarizedMessages: decisions.filter((decision) => decision.policy === 'summary')
               .length,
+            rejectedMessages: decisions.filter((decision) =>
+              decision.reason.startsWith('summary rejected:')
+            ).length,
+            minimumMessageSavingsTokens: MIN_COMPRESSION_MESSAGE_SAVINGS_TOKENS,
+            minimumPlanSavingsTokens: MIN_COMPRESSION_PLAN_SAVINGS_TOKENS,
             keepRecentTurns: compression.keepRecentTurns,
           }
-          if (!triggered) {
-            throw new Error(
-              `Reference chat estimated at ${estimatedHistoryTokensBefore} tokens, below compression trigger ${triggerAtTokens}`
-            )
+          const expectation = scenario.referenceChat.compressionExpectation
+          if (expectation) {
+            const reduction =
+              compressionDiagnostics.estimatedHistoryTokensBefore -
+              compressionDiagnostics.estimatedHistoryTokensAfter
+            const failures = [
+              expectation.triggered !== triggered
+                ? `expected triggered=${expectation.triggered}, got ${triggered}`
+                : undefined,
+              expectation.applied !== undefined &&
+              expectation.applied !== compressionDiagnostics.applied
+                ? `expected applied=${expectation.applied}, got ${compressionDiagnostics.applied}`
+                : undefined,
+              expectation.minSummarizedMessages !== undefined &&
+              compressionDiagnostics.summarizedMessages < expectation.minSummarizedMessages
+                ? `expected at least ${expectation.minSummarizedMessages} summarized message(s), got ${compressionDiagnostics.summarizedMessages}`
+                : undefined,
+              expectation.maxSummarizedMessages !== undefined &&
+              compressionDiagnostics.summarizedMessages > expectation.maxSummarizedMessages
+                ? `expected at most ${expectation.maxSummarizedMessages} summarized message(s), got ${compressionDiagnostics.summarizedMessages}`
+                : undefined,
+              expectation.minEstimatedHistoryTokenReduction !== undefined &&
+              reduction < expectation.minEstimatedHistoryTokenReduction
+                ? `expected at least ${expectation.minEstimatedHistoryTokenReduction} estimated history tokens saved, got ${reduction}`
+                : undefined,
+              expectation.maxEstimatedHistoryTokenReduction !== undefined &&
+              reduction > expectation.maxEstimatedHistoryTokenReduction
+                ? `expected at most ${expectation.maxEstimatedHistoryTokenReduction} estimated history tokens saved, got ${reduction}`
+                : undefined,
+            ].filter((failure): failure is string => failure !== undefined)
+            if (failures.length > 0) {
+              throw new Error(`Compression fixture precondition failed: ${failures.join('; ')}`)
+            }
           }
         }
       }

--- a/apps/backend/lib/eval/report.ts
+++ b/apps/backend/lib/eval/report.ts
@@ -24,7 +24,10 @@ export interface ArmAggregate {
   cacheWriteTokens: Summary
   estimatedHistoryTokensBefore: Summary
   estimatedHistoryTokensAfter: Summary
+  compressionTriggered: Summary
+  compressionApplied: Summary
   summarizedMessages: Summary
+  rejectedMessages: Summary
   costUsd: Summary
   /** Undefined when no run had a known price. */
   costKnown: boolean
@@ -72,7 +75,10 @@ export const aggregate = (runs: RunResult[]): ArmAggregate[] => {
       estimatedHistoryTokensAfter: summarize(
         group.map((run) => run.compression?.estimatedHistoryTokensAfter ?? 0)
       ),
+      compressionTriggered: summarize(group.map((run) => (run.compression?.triggered ? 1 : 0))),
+      compressionApplied: summarize(group.map((run) => (run.compression?.applied ? 1 : 0))),
       summarizedMessages: summarize(group.map((run) => run.compression?.summarizedMessages ?? 0)),
+      rejectedMessages: summarize(group.map((run) => run.compression?.rejectedMessages ?? 0)),
       costUsd: summarize(withCost.map((run) => run.totals.costUsd!)),
       costKnown: withCost.length > 0,
       turns: summarize(group.map((run) => run.totals.turns)),
@@ -238,18 +244,20 @@ export const renderMarkdown = (runs: RunResult[], baselineArmName: string): stri
     lines.push(`## ${scenarioId}`, '')
     lines.push(
       showCompression
-        ? '| arm | runs | success | score | history est. before→after | summarized | in tok | cache read | out tok | cost | tools | turns | setup |'
+        ? '| arm | runs | success | score | triggered/applied | history est. before→after | summarized/rejected | in tok | cache read | out tok | cost | tools | turns | setup |'
         : '| arm | runs | success | score | in tok | cache read | out tok | cost | tools | turns | setup |',
       showCompression
-        ? '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
+        ? '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
         : '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
     )
     for (const entry of scenarioAggregates) {
       const compressionColumns = showCompression
-        ? ` ${round(entry.estimatedHistoryTokensBefore.mean, 0)}→${round(
+        ? ` ${percent(entry.compressionTriggered.mean)}/${percent(
+            entry.compressionApplied.mean
+          )} | ${round(entry.estimatedHistoryTokensBefore.mean, 0)}→${round(
             entry.estimatedHistoryTokensAfter.mean,
             0
-          )} | ${round(entry.summarizedMessages.mean)} |`
+          )} | ${round(entry.summarizedMessages.mean)}/${round(entry.rejectedMessages.mean)} |`
         : ''
       lines.push(
         `| ${entry.armName} | ${entry.runs} | ${percent(entry.successRate)} | ${round(

--- a/apps/backend/lib/eval/scenarios/contextCompression.ts
+++ b/apps/backend/lib/eval/scenarios/contextCompression.ts
@@ -54,7 +54,10 @@ const scenario = (
   finalUserMessage: string,
   rubric: string,
   answerKey: NonNullable<Scenario['answerKey']>,
-  sourceShape: NonNullable<NonNullable<Scenario['referenceChat']>['sourceShape']>
+  sourceShape: NonNullable<NonNullable<Scenario['referenceChat']>['sourceShape']>,
+  compressionExpectation: NonNullable<
+    NonNullable<Scenario['referenceChat']>['compressionExpectation']
+  > = { triggered: true }
 ): Scenario => ({
   id,
   description,
@@ -69,7 +72,7 @@ const scenario = (
     'When a historical message says its original content is available through a context retrieval function, call the function before answering if the visible summary does not contain the exact fact.',
     'Do not guess or substitute a similar value from another turn.',
   ].join(' '),
-  referenceChat: { history, finalUserMessage, sourceShape },
+  referenceChat: { history, finalUserMessage, sourceShape, compressionExpectation },
 })
 
 const recentAttachmentName = 'release-approval-record.txt'
@@ -247,6 +250,128 @@ export const mixedDepthScenario = scenario(
   { cohort: 'expensive-conversations-30d-p50', messageCount: 16 }
 )
 
+export const belowTriggerTextScenario = scenario(
+  'compression-below-trigger-text',
+  'A short text-only conversation stays verbatim because it is well below the global trigger.',
+  [],
+  [
+    user('Record the room for the launch review.'),
+    assistant('The launch review is in Cedar Room.'),
+    user('Also record the start time.'),
+    assistant('The launch review starts at 09:40.'),
+  ],
+  'Where and when is the launch review? Reply with the room and time only.',
+  'The assistant answers from the short verbatim history while compression remains a no-op.',
+  { mustMention: ['Cedar Room', '09:40'] },
+  { cohort: 'synthetic-below-trigger-text', messageCount: 4 },
+  {
+    triggered: false,
+    applied: false,
+    maxSummarizedMessages: 0,
+    maxEstimatedHistoryTokenReduction: 0,
+  }
+)
+
+const tinyAttachmentName = 'desk-label.txt'
+const tinyAttachment: CorpusDocument = {
+  name: tinyAttachmentName,
+  mimeType: 'text/plain',
+  text: 'Approved support desk label: Juniper Gate.',
+}
+
+export const belowTriggerAttachmentScenario = scenario(
+  'compression-below-trigger-attachment',
+  'A small historical attachment stays native because the whole conversation is below the trigger.',
+  [tinyAttachment],
+  [
+    user('Keep this short support-desk label for later.', [tinyAttachmentName]),
+    assistant('Stored.'),
+  ],
+  'What is the exact approved support desk label? Reply with the label only.',
+  'The assistant reads the small attachment without activating context compression.',
+  { mustMention: ['Juniper Gate'] },
+  { cohort: 'synthetic-below-trigger-attachment', messageCount: 2 },
+  {
+    triggered: false,
+    applied: false,
+    maxSummarizedMessages: 0,
+    maxEstimatedHistoryTokenReduction: 0,
+  }
+)
+
+export const aboveTriggerIncompressibleTextScenario = scenario(
+  'compression-above-trigger-incompressible-text',
+  'A long history made only of individually short text messages crosses the trigger but has nothing worth summarizing.',
+  [],
+  [
+    ...Array.from({ length: 36 }, (_, index) => routineTurn(index + 1)).flat(),
+    user('Record the final routing label.'),
+    assistant('The final routing label is Quartz Relay.'),
+  ],
+  'What is the final routing label? Reply with the label only.',
+  'The assistant answers from recent verbatim text; the planner must find no eligible message to summarize.',
+  { mustMention: ['Quartz Relay'] },
+  { cohort: 'synthetic-above-trigger-no-eligible-content', messageCount: 74 },
+  {
+    triggered: true,
+    applied: false,
+    maxSummarizedMessages: 0,
+    maxEstimatedHistoryTokenReduction: 0,
+  }
+)
+
+export const belowTriggerIncompressibleTextScenario = scenario(
+  'compression-below-trigger-incompressible-text',
+  'A substantial history of individually short messages remains below the trigger and stays verbatim.',
+  [],
+  [
+    ...Array.from({ length: 24 }, (_, index) => routineTurn(index + 1)).flat(),
+    user('Record the final dispatch label.'),
+    assistant('The final dispatch label is Silver Harbor.'),
+  ],
+  'What is the final dispatch label? Reply with the label only.',
+  'The assistant answers from recent verbatim text without activating compression near the trigger boundary.',
+  { mustMention: ['Silver Harbor'] },
+  { cohort: 'synthetic-below-trigger-no-eligible-content', messageCount: 50 },
+  {
+    triggered: false,
+    applied: false,
+    maxSummarizedMessages: 0,
+    maxEstimatedHistoryTokenReduction: 0,
+  }
+)
+
+export const tinyAttachmentOverheadScenario = scenario(
+  'compression-tiny-attachment-overhead',
+  'A tiny historical attachment appears in an otherwise incompressible history above the trigger.',
+  [tinyAttachment],
+  [
+    user('Keep this short support-desk label for later.', [tinyAttachmentName]),
+    assistant('Stored.'),
+    ...Array.from({ length: 36 }, (_, index) => routineTurn(index + 1)).flat(),
+    user('Record the current incident colour.'),
+    assistant('The current incident colour is Amber Violet.'),
+  ],
+  'What is the current incident colour? Reply with the colour only.',
+  'The assistant answers from recent verbatim text without paying to replace a tiny irrelevant attachment with a larger recovery reference.',
+  { mustMention: ['Amber Violet'] },
+  { cohort: 'synthetic-above-trigger-tiny-attachment', messageCount: 76 },
+  {
+    triggered: true,
+    applied: false,
+    maxSummarizedMessages: 0,
+    maxEstimatedHistoryTokenReduction: 0,
+  }
+)
+
+export const contextCompressionBoundaryScenarios: Scenario[] = [
+  belowTriggerTextScenario,
+  belowTriggerAttachmentScenario,
+  belowTriggerIncompressibleTextScenario,
+  aboveTriggerIncompressibleTextScenario,
+  tinyAttachmentOverheadScenario,
+]
+
 export const contextCompressionScenarios: Scenario[] = [
   recentAttachmentScenario,
   middleAttachmentScenario,
@@ -254,4 +379,5 @@ export const contextCompressionScenarios: Scenario[] = [
   farToolScenario,
   irrelevantOldBulkScenario,
   mixedDepthScenario,
+  ...contextCompressionBoundaryScenarios,
 ]

--- a/apps/backend/lib/eval/types.ts
+++ b/apps/backend/lib/eval/types.ts
@@ -84,6 +84,22 @@ export type ReferenceChatMessage =
 export interface ReferenceChat {
   history: ReferenceChatMessage[]
   finalUserMessage: string
+  /**
+   * Deterministic precondition for context-compression arms.
+   *
+   * Quality fixtures normally require compression to trigger. Boundary fixtures deliberately
+   * require the opposite, so a global threshold change cannot silently turn a no-op case into a
+   * compression treatment (or make a treatment stop exercising compression).
+   */
+  compressionExpectation?: {
+    triggered: boolean
+    applied?: boolean
+    /** Optional bounds for fixtures that exercise compressible vs incompressible histories. */
+    minSummarizedMessages?: number
+    maxSummarizedMessages?: number
+    minEstimatedHistoryTokenReduction?: number
+    maxEstimatedHistoryTokenReduction?: number
+  }
   /** Provenance of the shape, never production content or identifiers. */
   sourceShape?: {
     cohort: string
@@ -204,7 +220,12 @@ export interface CompressionDiagnostics {
   estimatedHistoryTokensAfter: number
   triggerAtTokens?: number
   triggered: boolean
+  /** True only when at least one cost-effective summary was actually sent to the provider. */
+  applied?: boolean
   summarizedMessages: number
+  rejectedMessages?: number
+  minimumMessageSavingsTokens?: number
+  minimumPlanSavingsTokens?: number
   keepRecentTurns?: number
 }
 

--- a/apps/backend/scripts/eval-build-replay-bundle.ts
+++ b/apps/backend/scripts/eval-build-replay-bundle.ts
@@ -24,6 +24,9 @@
  * Flags:
  *   --source-db <path|url>     source SQLite path or DATABASE_URL (default: $DATABASE_URL)
  *   --out <path>               bundle SQLite file to write (required); <out>.skipped.json is also written
+ *   --campaign-dir <path>      optionally register the completed bundle in a local eval campaign
+ *   --case <opaque-id>         required with --campaign-dir; never use tenant identifiers here
+ *   --cohort <name>            required with --campaign-dir; sanitized traffic-shape label
  *   <conversation-id>          conversation to replay (required positional argument)
  *
  * The builder does not choose a replay target. It saves the complete conversation; the replay
@@ -38,21 +41,33 @@ import type { DB } from '@/db/schema'
 const errText = (error: unknown): string => (error instanceof Error ? error.message : String(error))
 
 const usage =
-  'Usage: --source-db <path|url> (or $DATABASE_URL) --out <bundle.sqlite> <conversation-id>'
+  'Usage: --source-db <path|url> (or $DATABASE_URL) --out <bundle.sqlite> [--campaign-dir <path> --case <opaque-id> --cohort <name>] <conversation-id>'
 const args = process.argv.slice(2).filter((arg) => arg !== '--')
 let sourceDb = process.env.DATABASE_URL
 let out: string | undefined
+let campaignDir: string | undefined
+let caseId: string | undefined
+let cohort: string | undefined
 const positionals: string[] = []
 for (let index = 0; index < args.length; index += 1) {
   const arg = args[index]
-  if (arg === '--source-db' || arg === '--out') {
+  if (
+    arg === '--source-db' ||
+    arg === '--out' ||
+    arg === '--campaign-dir' ||
+    arg === '--case' ||
+    arg === '--cohort'
+  ) {
     const value = args[index + 1]
     if (!value || value.startsWith('--')) {
       console.error(`${arg} requires a value\n${usage}`)
       process.exit(1)
     }
     if (arg === '--source-db') sourceDb = value
-    else out = value
+    else if (arg === '--out') out = value
+    else if (arg === '--campaign-dir') campaignDir = value
+    else if (arg === '--case') caseId = value
+    else cohort = value
     index += 1
   } else if (arg.startsWith('--')) {
     console.error(`Unknown option: ${arg}\n${usage}`)
@@ -63,7 +78,17 @@ for (let index = 0; index < args.length; index += 1) {
 }
 
 const conversationId = positionals[0]
-if (!sourceDb || !out || !conversationId || positionals.length !== 1) {
+const campaignFlags = [campaignDir, caseId, cohort]
+const incompleteCampaignRegistration =
+  campaignFlags.some((value) => value !== undefined) &&
+  campaignFlags.some((value) => value === undefined)
+if (
+  !sourceDb ||
+  !out ||
+  !conversationId ||
+  positionals.length !== 1 ||
+  incompleteCampaignRegistration
+) {
   console.error(usage)
   process.exit(1)
 }
@@ -439,6 +464,10 @@ if (failure || !copied) {
   )
   process.exitCode = 1
 } else {
+  if (campaignDir && caseId && cohort) {
+    const { registerBundle } = await import('@/backend/lib/eval/campaign')
+    await registerBundle(campaignDir, caseId, out, cohort)
+  }
   console.error(
     `Wrote conversation ${conversationId} to ${out}: ${copied.messages} messages, ` +
       `${copied.audits} audits, ${copied.attachments} attachments, ` +

--- a/apps/backend/scripts/eval-campaign.ts
+++ b/apps/backend/scripts/eval-campaign.ts
@@ -1,0 +1,30 @@
+/** Local campaign directory tooling. It never copies or edits evaluation bundles. */
+import { initializeCampaign, registerBundle } from '@/backend/lib/eval/campaign'
+
+const args = process.argv.slice(2).filter((arg) => arg !== '--')
+const command = args[0]
+const flag = (name: string): string | undefined => {
+  const index = args.indexOf(`--${name}`)
+  return index === -1 ? undefined : args[index + 1]
+}
+const usage =
+  'Usage: eval-campaign.ts init --dir <path> --name <name> | register-bundle --dir <path> --case <opaque-id> --bundle <sqlite> --cohort <name>'
+try {
+  if (command === 'init') {
+    const dir = flag('dir')
+    const name = flag('name')
+    if (!dir || !name) throw new Error(usage)
+    await initializeCampaign(dir, name)
+    console.log(`Initialized campaign at ${dir}`)
+  } else if (command === 'register-bundle') {
+    const dir = flag('dir')
+    const caseId = flag('case')
+    const bundle = flag('bundle')
+    const cohort = flag('cohort')
+    if (!dir || !caseId || !bundle || !cohort) throw new Error(usage)
+    console.log(JSON.stringify(await registerBundle(dir, caseId, bundle, cohort), null, 2))
+  } else throw new Error(usage)
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+}

--- a/apps/backend/scripts/eval-replay-production-chats.ts
+++ b/apps/backend/scripts/eval-replay-production-chats.ts
@@ -131,12 +131,16 @@ const { llmModels } = await import('@/lib/models')
 const { modelSupportsReasoning } = await import('@/lib/chat/models')
 const { estimateHistoryMessageCosts } = await import('@/backend/lib/chat/token-estimator')
 const {
-  applyCompressionPlan,
   planMessageCompression,
   resolveCompressionUserQuery,
   resolveCompressionRetrievalMode,
   resolveCompressionTriggerTokens,
 } = await import('@/backend/lib/chat/compression-planner')
+const {
+  buildCostEffectiveCompressionPlan,
+  MIN_COMPRESSION_MESSAGE_SAVINGS_TOKENS,
+  MIN_COMPRESSION_PLAN_SAVINGS_TOKENS,
+} = await import('@/backend/lib/chat/compression-economics')
 const {
   createReplayJudge,
   defaultReplayKnowledgeQuestions,
@@ -409,7 +413,7 @@ const triggerAtTokens = compression
   ? resolveCompressionTriggerTokens(compression.triggerAtTokens)
   : undefined
 const triggered = !!compression && estimatedHistoryTokensBefore >= triggerAtTokens!
-const decisions = triggered
+let decisions = triggered
   ? planMessageCompression(replayMessages, compression.preset, {
       keepRecentTurns: compression.keepRecentTurns,
     })
@@ -418,16 +422,23 @@ const finalUserMessage = [...replayMessages]
   .reverse()
   .find((message): message is dto.UserMessage => message.role === 'user')
 const userQuery = compression ? resolveCompressionUserQuery(replayMessages) : undefined
-const plannedMessages = triggered
-  ? await applyCompressionPlan(replayMessages, decisions, {
-      prefetchQuery:
-        resolveCompressionRetrievalMode(compression.retrievalMode) === 'prefetch'
-          ? userQuery
-          : undefined,
-      attachmentContinuationQuery: userQuery,
+const compressionPlan = triggered
+  ? await buildCostEffectiveCompressionPlan({
+      messages: replayMessages,
+      decisions,
+      model: inspectedModel,
+      historyCostsBefore,
+      application: {
+        prefetchQuery:
+          resolveCompressionRetrievalMode(compression.retrievalMode) === 'prefetch'
+            ? userQuery
+            : undefined,
+        attachmentContinuationQuery: userQuery,
+      },
     })
-  : replayMessages
-const historyCostsAfter = await estimateHistoryMessageCosts(inspectedModel, plannedMessages)
+  : undefined
+if (compressionPlan) decisions = compressionPlan.decisions
+const historyCostsAfter = compressionPlan?.historyCostsAfter ?? historyCostsBefore
 const estimatedHistoryTokensAfter = historyCostsAfter.reduce(
   (total, entry) => total + entry.tokens,
   0
@@ -441,6 +452,7 @@ const inspection = {
   compressionEnabled: !!compression,
   triggerAtTokens,
   triggered,
+  applied: compressionPlan?.applied ?? false,
   preset: compression?.preset,
   retrievalMode: compression
     ? resolveCompressionRetrievalMode(compression.retrievalMode)
@@ -470,6 +482,11 @@ const inspection = {
       estimatedTokensBefore: decision.estimatedTokensBefore,
       estimatedTokensAfter: decision.estimatedTokensAfter,
     })),
+  rejectedMessages: decisions
+    .filter((decision) => decision.reason.startsWith('summary rejected:'))
+    .map((decision) => ({ messageId: decision.messageId, reason: decision.reason })),
+  minimumMessageSavingsTokens: MIN_COMPRESSION_MESSAGE_SAVINGS_TOKENS,
+  minimumPlanSavingsTokens: MIN_COMPRESSION_PLAN_SAVINGS_TOKENS,
   selectedMessageDecision:
     decisions.find((decision) => decision.messageId === selectedAudit.messageId) ?? null,
 }
@@ -488,11 +505,13 @@ if (bool('inspect-only')) {
     `Compression: **${inspection.compressionEnabled ? 'enabled' : 'disabled'}**` +
       (compression
         ? `; preset \`${compression.preset}\`; retrieval \`${inspection.retrievalMode}\`; ` +
-          `trigger ${triggerAtTokens}; triggered: **${triggered}**`
+          `trigger ${triggerAtTokens}; triggered: **${triggered}**; plan applied: **${inspection.applied}**`
         : ''),
     `Estimated history tokens: **${estimatedHistoryTokensBefore} → ${estimatedHistoryTokensAfter}** ` +
       `(${(inspection.estimatedHistoryReductionRatio * 100).toFixed(1)}% reduction).`,
     `Summarized messages: **${inspection.summarizedMessages.length}**.`,
+    `Economically rejected messages: **${inspection.rejectedMessages.length}** ` +
+      `(message guard ${inspection.minimumMessageSavingsTokens}; plan guard ${inspection.minimumPlanSavingsTokens} tokens).`,
     `Selected/current message policy: **${
       inspection.selectedMessageDecision?.policy ?? 'not planned'
     }**` +
@@ -517,7 +536,7 @@ if (bool('inspect-only')) {
     out,
     JSON.stringify(
       {
-        version: 4,
+        version: 5,
         createdAt: new Date().toISOString(),
         source: bundlePath
           ? { mode: 'bundle', bundle: bundlePath }
@@ -885,7 +904,7 @@ await writeFile(
   out,
   JSON.stringify(
     {
-      version: 4,
+      version: 5,
       createdAt: new Date().toISOString(),
       source: bundlePath
         ? { mode: 'bundle', bundle: bundlePath }

--- a/docs/context-compression.md
+++ b/docs/context-compression.md
@@ -37,6 +37,36 @@ proiezione deterministica, con recupero esplicito del dettaglio quando serve.
 - Summaries are cheap to produce: deterministic text extraction and truncation, never a model call.
 - The current turn is always sent in full. Compression only ever touches history.
 - Small conversations are never compressed, regardless of assistant configuration.
+- Compression must not spend retrieval/tool-prompt budget when the planner does not apply a plan.
+
+## Trigger and economic guards
+
+The trigger expectation is deterministic and must be checked before any provider call. Given the
+same model, message lineage, configuration and tokenizer, `inspect-only` must report the same
+`estimatedHistoryTokens`, resolved trigger, eligible messages, planned policies and
+`estimatedTokensAfter`. A case is an eligible compression fixture only when the resolved trigger
+is crossed _and_ applying the plan reduces the estimated history. A configuration that is enabled
+but does not cross the trigger is a valid **no-plan** case, not a failed compression run.
+
+There are two provisional economic guards for the suite:
+
+- do not summarize an individual message when its estimated saving is below **64 tokens**;
+- do not apply a compression plan when the aggregate estimated saving is below **384 tokens**.
+
+These values are deliberately guardrails, not proven optima. They are motivated by the first
+synthetic boundary sweep (where very small summaries can cost as much as they save once the
+retrieval instruction and tool surface are included). That sweep is an initial baseline only: the
+64/384 values must be revalidated on reviewed real-chat cohorts, with provider/model and tokenizer
+held fixed, before being described as production thresholds. Reports must record both the raw
+estimated saving and whether each guard fired; never infer a final threshold from one synthetic
+run or from a hand-picked successful case.
+
+When the plan guard does not pass, the prompt must be built from the original history and must not
+include `context-retrieve` in the model-visible tool set or system/tool instructions for that
+turn. The same omission applies when compression is disabled or when the resolved trigger is not
+crossed. `context-retrieve` is included only when a compression plan was actually applied, because
+only then can the prompt contain recoverable summaries. This is a prompt-shape invariant to test,
+not an optimization that may vary with model behavior.
 
 ## Configuration
 
@@ -265,8 +295,9 @@ model needs to actually see the image, that only happens via `full` policy or `c
 
 ### The `context-retrieve` Tool
 
-Registered whenever `contextCompression` is set (`apps/backend/lib/tools/context-retrieve/`), this
-is the model's one recovery surface for anything compression touched:
+Constructed whenever `contextCompression` is set (`apps/backend/lib/tools/context-retrieve/`), but
+exposed to the model only on turns where an economic compression plan is actually applied, this is
+the recovery surface for anything compression touched:
 
 - **`get_file(id)`** — read a file's content by id (DB-authorized via `canAccessFile`, same as
   before this tool was renamed from `retrieve-file`).
@@ -481,6 +512,9 @@ prompt build (ChatAssistant.invokeLlm)
   │    no  → send messages as-is
   │    yes ↓
   ├─ planMessageCompression(messages, preset)       → MessageCompressionDecision[]
+  ├─ discard per-message savings < 64 tokens; apply only if aggregate saving >= 384
+  │    no  → send original messages; omit context-retrieve from the prompt/tool set
+  │    yes ↓
   ├─ applyCompressionPlan(messages, decisions, current-query options)
   │    full    → message unchanged
   │    summary → cached CompressedMessage row, or built + cached now
@@ -516,6 +550,13 @@ Covered in `apps/backend/lib/chat/__tests__/compression-planner.test.ts`:
 - `warmCompressionCache` builds/caches eligible messages and no-ops on ineligible ones, without
   throwing on failure.
 - A concurrent build for the same message joins the in-flight one instead of duplicating work.
+- Boundary fixtures just below and just above the resolved trigger, including histories with no
+  eligible messages.
+- Incompressible fixtures: short messages, short attachments, and plans whose
+  per-message saving is below 64 tokens or aggregate saving is below 384 tokens. These must remain
+  `full`/no-plan and must not expose `context-retrieve` to the model.
+- Deterministic expectation fixtures assert trigger/application state, estimated before/after
+  totals, and summary counts; economics unit tests cover the per-message and aggregate guards.
 
 `apps/backend/lib/tools/context-retrieve/__tests__/implementation.test.ts` covers the tool itself:
 `get_file`, `get_message`, and `search`, including targeted lexical search inside one message or

--- a/docs/evaluation-harness.md
+++ b/docs/evaluation-harness.md
@@ -147,6 +147,15 @@ Its reference conversations live in
 identifiers: only aggregate turn-count cohorts from expensive conversations informed their shape;
 all prose, filenames, tool names and answer facts are synthetic.
 
+The suite must include explicit boundary and **incompressible** fixtures, not only long histories:
+short plain-text messages, short attachments, histories well below and above the resolved trigger,
+and histories where the per-message or aggregate economic guard makes
+compression a no-op. These fixtures establish that a small input is not made more expensive by
+planning or by exposing a recovery tool. Expected results are deterministic: record the resolved
+trigger, eligible messages, exact policies, estimated before/after tokens, whether the per-message
+64-token and aggregate 384-token guards pass, and whether `context-retrieve` is visible. A no-plan
+fixture must not be discarded because it produced no retrieval call.
+
 The default comparison is `compression-off`, tool-only `compression-keep-0`, and query-aware
 prefetch with windows 0 and 1. This isolates the two effects observed in the baseline run:
 stochastic model tool use and the cost of retaining a recent turn. Wider
@@ -156,6 +165,58 @@ Flags are documented in the header of `apps/backend/scripts/eval.ts`. The ones t
 `--repeat`, `--arms`, `--baseline`, `--model`, `--user-model`, `--judge-model`, `--no-judge`,
 `--runs-out`, and `--runs-in`. Generated sweeps also accept `--seed`; use more than one seed before
 generalising from a fixed corpus layout.
+
+## Local campaign directories
+
+The evaluation corpus may remain on a developer's machine, but each campaign should be
+self-describing so a later run can resume without reconstructing its provenance.
+`apps/backend/scripts/eval-campaign.ts` provides two mechanical operations:
+
+```bash
+npx tsx apps/backend/scripts/eval-campaign.ts init \
+  --dir /private/path/context-kb-campaign --name context-kb-september
+npx tsx apps/backend/scripts/eval-campaign.ts register-bundle \
+  --dir /private/path/context-kb-campaign --case case-001 \
+  --bundle /private/path/context-kb-campaign/bundles/case-001.sqlite \
+  --cohort attachment-topic-shift
+```
+
+The bundle builder can automatically register successful exports in the same inventory:
+
+```bash
+npx tsx apps/backend/scripts/eval-build-replay-bundle.ts \
+  --source-db <source> \
+  --out /private/path/context-kb-campaign/bundles/case-001.sqlite \
+  --campaign-dir /private/path/context-kb-campaign \
+  --case case-001 --cohort attachment-topic-shift <conversation-id>
+```
+
+The directory contains:
+
+```text
+context-kb-campaign/
+  README.md                 # purpose, creation date, owner, scope, retention and workflow
+  manifest.json             # schema/version, code revision, models, tokenizer, thresholds
+  candidate-register.csv     # checksummed inventory plus review/eligibility/outcome columns
+  bundles/                  # private SQLite bundles, never committed
+  runs/                     # private replay runs/reports, never committed
+  sanitized/                # shareable aggregates and reviewed failure ledger only
+```
+
+`README.md` should describe how the directory was created, what content was collected, from which
+approved cohort, what was intentionally excluded, and how to reproduce or retire it. `manifest.json`
+must freeze the campaign inputs: repository revision, model/provider, tokenizer,
+compression configuration, guard values, repeat count, candidate-selection rule, source-review
+status and retention owner. `candidate-register.csv` is an append-only campaign ledger: bundle id, opaque
+case id, cohort, message selector, source-dependence review, compression inspection result, and
+the final sanitized labels. Keep verbatim chat, documents, decrypted files, raw responses and
+identifiers in the private directories only; the repository may contain fixtures that are synthetic
+or explicitly approved and sanitized.
+
+This workflow is intentionally local and temporary. A ticket or issue can track the campaign, but
+the directory is the durable record of how the evidence was assembled. Do not rely on an issue
+description as the only provenance record, and do not put private bundle paths or raw content in
+the repository.
 
 ## The flip test — measuring what an arm does when the answer is not there
 
@@ -693,3 +754,21 @@ Low-risk rollout for a change like a compression policy: deploy the new build to
 the policy **off**, let real traffic accumulate `MessageAudit` rows, build a bundle from that
 instance, then replay it twice — once as-is, once with `--override` enabling the policy — and
 compare cost and judged quality before turning it on for real.
+
+### Phased plan and delegation
+
+The work can be split so inexpensive coding agents handle deterministic, mechanical throughput,
+while a more capable model or a human retains responsibility for source truth and interpretation:
+
+| phase                | work                                                                                                                                   | suitable delegate                                                                        | review kept with capable model/human                                                                        |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| 1. Fixture inventory | Enumerate synthetic boundary/incompressible shapes, generate candidate message histories, and run unit/inspect-only checks.            | Cheap coding agent: scripted fixture generation and command execution.                   | Confirm that each fixture represents the intended semantic boundary and that no answer key leaks.           |
+| 2. Campaign setup    | Initialize the local directory, write manifest/README boilerplate, register opaque bundle metadata, and enforce ignored/private paths. | Cheap coding agent: filesystem and schema bookkeeping.                                   | Approve privacy boundary, retention policy, cohort definition and frozen thresholds.                        |
+| 3. Bundle collection | Run the approved read-only discovery/export commands and register every candidate, including rejected ones.                            | Cheap coding agent: repetitive command execution and checksum/metadata capture.          | Select the cohort; verify source dependence and answer-key facts against source documents.                  |
+| 4. Replay matrix     | Execute inspect-only, then the fixed A/B/C/D runs and repetitions; collect raw JSON and tool-call metrics.                             | Cheap coding agent: batch runner, retries, and result collation without changing inputs. | Keep denominator fixed; review provider errors, missing retrieval calls, and unexpected tool use.           |
+| 5. Analysis          | Compute reductions, guard rates, bootstrap intervals and failure labels from frozen artifacts.                                         | Cheap coding agent: pure aggregation/report rendering.                                   | Decide correctness from reviewed source facts; distinguish reference-judge disagreement from factual error. |
+| 6. Tuning and rerun  | Propose one threshold/prompt/policy change, then rerun the same registered cases.                                                      | Cheap coding agent: mechanical rerun and diff generation.                                | Choose the hypothesis, inspect regressions, and decide whether evidence supports a change.                  |
+
+Delegation does not authorize an agent to change the corpus after seeing outcomes, rewrite answer
+keys, discard failed or no-call runs, or declare a quality result from a production reply alone.
+Those are source-review and experimental-design decisions and remain with the stronger reviewer.


### PR DESCRIPTION
## Summary

Introduce cost-aware context compression and a reproducible local campaign workflow for evaluating context compression with knowledge boxes. Uneconomic plans now keep the original history and omit `context-retrieve`, while the harness records deterministic trigger, application, rejection, and token-reduction evidence.

## Details

- Add provisional 64-token per-message and 384-token aggregate savings guards, including tool-result sibling-call handling.
- Add below-trigger, incompressible, and tiny-attachment fixtures with explicit compression expectations.
- Extend synthetic and production-replay diagnostics and reports with triggered/applied and summarized/rejected metrics.
- Add private campaign initialization and checksummed SQLite bundle registration, plus automatic registration from the bundle builder.
- Document campaign provenance, retention, 2×2 real-chat evaluation, and phased delegation boundaries.

## Risks

- Conversations near the economic boundaries may now retain original history instead of applying a summary.
- The 64/384 guards are synthetic-baseline guardrails and still require validation on a frozen, reviewed production cohort.
- Production bundles and raw runs remain local, ignored, and outside this PR.

## Tests

- `pnpm run check-types` — passed.
- `pnpm test` — 144 test files and 1,369 tests passed; 2 files/21 tests skipped as configured.
- `pnpm exec vitest run apps/backend/lib/chat/__tests__/compression-economics.test.ts apps/backend/lib/chat/__tests__/compression-planner.test.ts apps/backend/lib/eval/__tests__/campaign.test.ts apps/backend/lib/eval/__tests__/contextCompressionScenarios.test.ts apps/backend/lib/eval/__tests__/report.test.ts` — 67 tests passed.
- `pnpm exec tsx apps/backend/scripts/eval.ts --suite knowledge --scenario supplier-penalty --arms all-in-context,knowledge-box --repeat 1 --no-judge ...` — both arms passed; the knowledge-box arm made two retrieval calls.

Tracking campaign: https://github.com/logicleai/logicle-issues/issues/304
