### PR TITLE
Add Luna and cache-aware evaluation costs

### DIFF
--- a/apps/backend/lib/eval/__tests__/metrics.test.ts
+++ b/apps/backend/lib/eval/__tests__/metrics.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { checkAnswerKey, computeTotals, scoreRun } from '@/backend/lib/eval/metrics'
-import { computeCostUsd, formatCostUsd, resolveModelPrice } from '@/backend/lib/eval/cost'
+import {
+  computeCostUsd,
+  formatCostUsd,
+  LONG_CONTEXT_INPUT_TOKENS,
+  resolveModelPrice,
+} from '@/backend/lib/eval/cost'
 import type { TranscriptEntry, TurnMetrics } from '@/backend/lib/eval/types'
 
 const transcript = (...entries: [string, string][]): TranscriptEntry[] =>
@@ -55,6 +60,30 @@ describe('computeCostUsd', () => {
   it('prices the production latest aliases used by the model registry', () => {
     expect(computeCostUsd('gpt-5-latest', 1000, 100)).toBeCloseTo(0.0032, 10)
     expect(computeCostUsd('claude-sonnet-latest', 1000, 100)).toBeCloseTo(0.003, 10)
+  })
+
+  it('uses short-context gpt-5.6-luna rates at the boundary', () => {
+    expect(computeCostUsd('gpt-5.6-luna', LONG_CONTEXT_INPUT_TOKENS, 100)).toBeCloseTo(
+      (LONG_CONTEXT_INPUT_TOKENS * 0.2 + 100 * 1.2) / 1_000_000,
+      10
+    )
+  })
+
+  it('uses long-context gpt-5.6-luna rates above the boundary', () => {
+    expect(computeCostUsd('gpt-5.6-luna', LONG_CONTEXT_INPUT_TOKENS + 1, 100)).toBeCloseTo(
+      ((LONG_CONTEXT_INPUT_TOKENS + 1) * 0.4 + 100 * 1.8) / 1_000_000,
+      10
+    )
+  })
+
+  it('prices gpt-5.6-luna cache reads and writes in the selected tier', () => {
+    expect(
+      computeCostUsd('gpt-5.6-luna', LONG_CONTEXT_INPUT_TOKENS + 1, 100, {
+        noCacheTokens: 100_000,
+        cacheReadTokens: 100_000,
+        cacheWriteTokens: 72_001,
+      })
+    ).toBeCloseTo((100_000 * 0.4 + 100_000 * 0.04 + 72_001 * 0.5 + 100 * 1.8) / 1_000_000, 10)
   })
 })
 
@@ -172,6 +201,24 @@ describe('computeTotals', () => {
       cacheWriteTokens: 0,
     })
     expect(totals.costUsd).toBeCloseTo((1500 * 0.4 + 1500 * 0.1 + 300 * 1.6) / 1_000_000, 10)
+    expect(totals.undiscountedCostUsd).toBeCloseTo((3000 * 0.4 + 300 * 1.6) / 1_000_000, 10)
+  })
+
+  it('prices each provider request separately for context tiers', () => {
+    const twoShortRequests: TurnMetrics[] = [
+      {
+        ...turns[0]!,
+        inputTokens: 300_000,
+        outputTokens: 100,
+        totalTokens: 300_100,
+        providerUsages: [
+          { inputTokens: 150_000, outputTokens: 50, totalTokens: 150_050 },
+          { inputTokens: 150_000, outputTokens: 50, totalTokens: 150_050 },
+        ],
+      },
+    ]
+    const totals = computeTotals(twoShortRequests, 'gpt-5.6-luna', 0)
+    expect(totals.costUsd).toBeCloseTo((300_000 * 0.2 + 100 * 1.2) / 1_000_000, 10)
   })
 
   it('leaves cost undefined for an unpriced model', () => {

--- a/apps/backend/lib/eval/__tests__/models.test.ts
+++ b/apps/backend/lib/eval/__tests__/models.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { llmModels } from '@/lib/models'
+
+describe('OpenAI model catalog', () => {
+  it('includes GPT-5.6 Luna for eval and normal model resolution', () => {
+    expect(llmModels.find((model) => model.id === 'gpt-5.6-luna')).toMatchObject({
+      id: 'gpt-5.6-luna',
+      model: 'gpt-5.6-luna',
+      provider: 'openai',
+      owned_by: 'openai',
+      context_length: 1_050_000,
+      supportedReasoningEfforts: ['none', 'low', 'medium', 'high', 'xhigh'],
+      defaultReasoning: 'medium',
+      maxOutputTokens: 128_000,
+    })
+  })
+})

--- a/apps/backend/lib/eval/__tests__/productionChatReplay.test.ts
+++ b/apps/backend/lib/eval/__tests__/productionChatReplay.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 import {
   collectAttachmentFileIds,
   defaultReplayKnowledgeQuestions,
+  isSameProductionModel,
   isReplayableLineage,
+  parseAuditInputTokenDetails,
   parseKnowledgeReplayArms,
 } from '@/backend/lib/eval/productionChatReplay'
 import type * as dto from '@/types/dto'
@@ -61,6 +63,29 @@ describe('isReplayableLineage', () => {
         },
       ])
     ).toContain('tool')
+  })
+})
+
+describe('isSameProductionModel', () => {
+  it('allows the saved production baseline only for the exact model id', () => {
+    expect(isSameProductionModel({ auditedModel: 'gpt-5.6-terra' }, 'gpt-5.6-terra')).toBe(true)
+    expect(isSameProductionModel({ auditedModel: 'gpt-5.6-terra' }, 'gpt-5.6-luna')).toBe(false)
+  })
+})
+
+describe('parseAuditInputTokenDetails', () => {
+  it('keeps valid production cache accounting', () => {
+    expect(
+      parseAuditInputTokenDetails(
+        JSON.stringify({ noCacheTokens: 100, cacheReadTokens: 900, cacheWriteTokens: 0 })
+      )
+    ).toEqual({ noCacheTokens: 100, cacheReadTokens: 900, cacheWriteTokens: 0 })
+  })
+
+  it('ignores missing, malformed, and invalid production cache accounting', () => {
+    expect(parseAuditInputTokenDetails(null)).toBeUndefined()
+    expect(parseAuditInputTokenDetails('{')).toBeUndefined()
+    expect(parseAuditInputTokenDetails(JSON.stringify({ cacheReadTokens: -1 }))).toBeUndefined()
   })
 })
 

--- a/apps/backend/lib/eval/__tests__/report.test.ts
+++ b/apps/backend/lib/eval/__tests__/report.test.ts
@@ -84,6 +84,15 @@ describe('computeBreakEven', () => {
       rejectedMessages: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
       costUsd: { n: 3, mean: costMean, median: costMean, min: costMean, max: costMean, stdev: 0 },
       costKnown: true,
+      undiscountedCostUsd: {
+        n: 3,
+        mean: costMean,
+        median: costMean,
+        min: costMean,
+        max: costMean,
+        stdev: 0,
+      },
+      undiscountedCostKnown: true,
       turns: { n: 3, mean: 1, median: 1, min: 1, max: 1, stdev: 0 },
       toolCalls: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
       wallMs: { n: 3, mean: 0, median: 0, min: 0, max: 0, stdev: 0 },
@@ -157,6 +166,30 @@ describe('compare', () => {
 })
 
 describe('renderMarkdown', () => {
+  it('keeps every markdown table header aligned with its separator', () => {
+    const markdown = renderMarkdown(
+      [
+        makeRun({
+          armName: 'compression-on',
+          compression: {
+            enabled: true,
+            triggered: true,
+            applied: true,
+            estimatedHistoryTokensBefore: 7000,
+            estimatedHistoryTokensAfter: 4000,
+            summarizedMessages: 1,
+          },
+        }),
+      ],
+      'compression-on'
+    )
+    const lines = markdown.split('\n')
+    for (let index = 0; index < lines.length - 1; index += 1) {
+      if (!lines[index + 1]!.startsWith('| ---')) continue
+      expect(lines[index]!.split('|')).toHaveLength(lines[index + 1]!.split('|').length)
+    }
+  })
+
   it('starts with an overall arm summary across scenarios', () => {
     const markdown = renderMarkdown(
       [

--- a/apps/backend/lib/eval/arms.ts
+++ b/apps/backend/lib/eval/arms.ts
@@ -139,6 +139,10 @@ export const createKnowledgeBoxArm = (options: KnowledgeBoxArmOptions = {}): Arm
         setupCost.inputTokens += result.projectionUsage.inputTokens
         setupCost.outputTokens += result.projectionUsage.outputTokens
         setupCost.calls += result.projectionUsage.calls
+        setupCost.providerUsages = [
+          ...(setupCost.providerUsages ?? []),
+          ...result.projectionUsage.providerUsages,
+        ]
         // Model selection is stable for a configured backend. If that invariant ever changes
         // during setup, leave pricing unknown rather than attach a misleading dollar figure.
         if (!setupCost.modelId) setupCost.modelId = result.projectionUsage.modelId

--- a/apps/backend/lib/eval/cost.ts
+++ b/apps/backend/lib/eval/cost.ts
@@ -1,13 +1,12 @@
 /**
  * Model pricing, used to turn token counts into the number the comparison is actually about.
  *
- * Prices are USD per million tokens and are a copy of the table the ops tooling already uses
- * (`libs/admin_lib.py` in logicle-infra-deploy). They drift: an unknown or stale model must
- * degrade to "no cost", never to a wrong cost, so every consumer treats `undefined` as
- * "report tokens only" rather than as zero.
+ * Prices are USD per million tokens. Prices drift: an unknown or stale model must degrade to
+ * "no cost", never to a wrong cost, so every consumer treats `undefined` as "report tokens only"
+ * rather than as zero.
  */
 
-export interface ModelPrice {
+export interface ModelPriceRates {
   /** USD per million input tokens. */
   input: number
   /** USD per million output tokens. */
@@ -18,6 +17,12 @@ export interface ModelPrice {
   cacheWriteInput?: number
 }
 
+export interface ModelPrice extends ModelPriceRates {
+  longContext?: ModelPriceRates
+}
+
+export const LONG_CONTEXT_INPUT_TOKENS = 272_000
+
 export const modelPrices: Record<string, ModelPrice> = {
   // OpenAI
   'gpt-4o-mini': { input: 0.15, output: 0.6, cacheReadInput: 0.075 },
@@ -26,9 +31,18 @@ export const modelPrices: Record<string, ModelPrice> = {
   'gpt-4.1': { input: 2.0, output: 8.0, cacheReadInput: 0.5 },
   'gpt-5.6-terra': { input: 2.0, output: 12.0, cacheReadInput: 0.2 },
   'gpt-5-latest': { input: 2.0, output: 12.0, cacheReadInput: 0.2 },
-  // Replay-eval-only cheap tier (REPLAY_EXTRA_MODELS in eval-replay-production-chats.ts).
-  // TODO(luca): confirm the real gpt-5.6-luna list price — this is an estimate.
-  'gpt-5.6-luna': { input: 0.25, output: 2.0, cacheReadInput: 0.025 },
+  'gpt-5.6-luna': {
+    input: 0.2,
+    output: 1.2,
+    cacheReadInput: 0.02,
+    cacheWriteInput: 0.25,
+    longContext: {
+      input: 0.4,
+      output: 1.8,
+      cacheReadInput: 0.04,
+      cacheWriteInput: 0.5,
+    },
+  },
   'gpt-4-turbo': { input: 10.0, output: 30.0 },
   'gpt-4': { input: 30.0, output: 60.0 },
   'gpt-3.5-turbo': { input: 0.5, output: 1.5 },
@@ -98,11 +112,13 @@ export const computeCostUsd = (
 ): number | undefined => {
   const price = resolveModelPrice(modelId)
   if (!price) return undefined
+  const rates =
+    price.longContext && inputTokens > LONG_CONTEXT_INPUT_TOKENS ? price.longContext : price
   const hasCacheDetails =
     inputTokenDetails?.cacheReadTokens !== undefined ||
     inputTokenDetails?.cacheWriteTokens !== undefined
   if (!hasCacheDetails) {
-    return (inputTokens * price.input + outputTokens * price.output) / 1_000_000
+    return (inputTokens * rates.input + outputTokens * rates.output) / 1_000_000
   }
   const cacheReadTokens = inputTokenDetails?.cacheReadTokens ?? 0
   const cacheWriteTokens = inputTokenDetails?.cacheWriteTokens ?? 0
@@ -110,13 +126,20 @@ export const computeCostUsd = (
     inputTokenDetails?.noCacheTokens ??
     Math.max(inputTokens - cacheReadTokens - cacheWriteTokens, 0)
   return (
-    (noCacheTokens * price.input +
-      cacheReadTokens * (price.cacheReadInput ?? price.input) +
-      cacheWriteTokens * (price.cacheWriteInput ?? price.input) +
-      outputTokens * price.output) /
+    (noCacheTokens * rates.input +
+      cacheReadTokens * (rates.cacheReadInput ?? rates.input) +
+      cacheWriteTokens * (rates.cacheWriteInput ?? rates.input) +
+      outputTokens * rates.output) /
     1_000_000
   )
 }
+
+/** Full-price counterfactual, ignoring provider prompt-cache discounts. */
+export const computeUndiscountedCostUsd = (
+  modelId: string,
+  inputTokens: number,
+  outputTokens: number
+): number | undefined => computeCostUsd(modelId, inputTokens, outputTokens)
 
 /** Formats a cost for the report, keeping small numbers readable rather than rounding them to 0. */
 export const formatCostUsd = (cost: number | undefined): string => {

--- a/apps/backend/lib/eval/harness.ts
+++ b/apps/backend/lib/eval/harness.ts
@@ -264,7 +264,12 @@ export const runOne = async (options: RunOptions): Promise<RunResult> => {
       }
 
       const toolCalls = sink.getToolCallNames()
-      turns.push({ ...sink.getUsage(), toolCalls, latencyMs })
+      turns.push({
+        ...sink.getUsage(),
+        toolCalls,
+        latencyMs,
+        providerUsages: sink.getUsageEvents(),
+      })
       const reply = assistantText(sink)
       transcript.push({ role: 'assistant', text: reply, toolCalls })
       onProgress?.(
@@ -309,7 +314,30 @@ export const runOne = async (options: RunOptions): Promise<RunResult> => {
       ? setupCost.calls === 0
         ? 0
         : setupCost.modelId
-        ? computeCostUsd(setupCost.modelId, setupCost.inputTokens, setupCost.outputTokens)
+        ? setupCost.providerUsages?.length
+          ? setupCost.providerUsages
+              .map((usage) =>
+                computeCostUsd(
+                  setupCost.modelId!,
+                  usage.inputTokens,
+                  usage.outputTokens,
+                  usage.inputTokenDetails
+                )
+              )
+              .some((cost) => cost === undefined)
+            ? undefined
+            : setupCost.providerUsages.reduce(
+                (total, usage) =>
+                  total +
+                  (computeCostUsd(
+                    setupCost.modelId!,
+                    usage.inputTokens,
+                    usage.outputTokens,
+                    usage.inputTokenDetails
+                  ) ?? 0),
+                0
+              )
+          : computeCostUsd(setupCost.modelId, setupCost.inputTokens, setupCost.outputTokens)
         : undefined
       : undefined,
     compression: compressionDiagnostics,

--- a/apps/backend/lib/eval/metrics.ts
+++ b/apps/backend/lib/eval/metrics.ts
@@ -1,4 +1,4 @@
-import { computeCostUsd } from './cost'
+import { computeCostUsd, computeUndiscountedCostUsd } from './cost'
 import type {
   AnswerKey,
   DeterministicVerdict,
@@ -6,6 +6,7 @@ import type {
   RunTotals,
   TranscriptEntry,
   TurnMetrics,
+  TurnUsage,
 } from './types'
 
 /**
@@ -73,6 +74,22 @@ export const computeTotals = (turns: TurnMetrics[], modelId: string, wallMs: num
         ])
       )
     : undefined
+  const providerUsages = turns.flatMap((turn) => turn.providerUsages ?? [turn])
+  const sumPricedCosts = (counterfactual: boolean): number | undefined => {
+    if (providerUsages.length === 0) {
+      return counterfactual
+        ? computeUndiscountedCostUsd(modelId, inputTokens, outputTokens)
+        : computeCostUsd(modelId, inputTokens, outputTokens, inputTokenDetails)
+    }
+    const costs = providerUsages.map((usage: TurnUsage) =>
+      counterfactual
+        ? computeUndiscountedCostUsd(modelId, usage.inputTokens, usage.outputTokens)
+        : computeCostUsd(modelId, usage.inputTokens, usage.outputTokens, usage.inputTokenDetails)
+    )
+    return costs.some((cost) => cost === undefined)
+      ? undefined
+      : costs.reduce<number>((total, cost) => total + (cost ?? 0), 0)
+  }
   return {
     inputTokens,
     outputTokens,
@@ -81,7 +98,8 @@ export const computeTotals = (turns: TurnMetrics[], modelId: string, wallMs: num
     toolCalls: turns.reduce((total, turn) => total + turn.toolCalls.length, 0),
     wallMs,
     inputTokenDetails,
-    costUsd: computeCostUsd(modelId, inputTokens, outputTokens, inputTokenDetails),
+    costUsd: sumPricedCosts(false),
+    undiscountedCostUsd: sumPricedCosts(true),
   }
 }
 

--- a/apps/backend/lib/eval/productionChatReplay.ts
+++ b/apps/backend/lib/eval/productionChatReplay.ts
@@ -4,6 +4,26 @@ import type { LanguageModelV3 } from '@ai-sdk/provider'
 import type * as dto from '@/types/dto'
 import type { ProviderType } from '@/types/provider'
 import type { KnowledgeBoxQuestion } from '@/lib/tools/schemas'
+import type { TurnUsage } from './types'
+
+const inputTokenDetailsSchema = z.object({
+  noCacheTokens: z.number().nonnegative().optional(),
+  cacheReadTokens: z.number().nonnegative().optional(),
+  cacheWriteTokens: z.number().nonnegative().optional(),
+})
+
+/** Safely reads provider cache accounting persisted in `MessageAudit.tokenDetails`. */
+export const parseAuditInputTokenDetails = (
+  raw: string | null
+): TurnUsage['inputTokenDetails'] | undefined => {
+  if (!raw) return undefined
+  try {
+    const parsed = inputTokenDetailsSchema.safeParse(JSON.parse(raw))
+    return parsed.success ? parsed.data : undefined
+  } catch {
+    return undefined
+  }
+}
 
 /**
  * One production turn selected for offline replay.
@@ -19,6 +39,8 @@ export interface ProductionReplayCase {
     messageId: string
     /** Production's own `MessageAudit` input-token count for this turn. */
     auditedInputTokens: number
+    /** Provider cache accounting saved with the production audit, when available and valid. */
+    auditedInputTokenDetails?: TurnUsage['inputTokenDetails']
     auditedModel: string
     sentAt: string
   }
@@ -43,6 +65,16 @@ export interface ProductionReplayCase {
   /** Production's next assistant text. It is a reference for the judge, not an answer key. */
   productionReply: string
 }
+
+/**
+ * The saved MessageAudit baseline is comparable only when replay uses the exact same model id.
+ * Model overrides (for example a cheaper Luna replay of a Terra production turn) must be
+ * compared as replay arms instead of being presented as a production token/cost delta.
+ */
+export const isSameProductionModel = (
+  source: Pick<ProductionReplayCase['source'], 'auditedModel'>,
+  replayModelId: string
+): boolean => replayModelId === source.auditedModel
 
 export const knowledgeReplayArmNames = [
   'assistant-knowledge',

--- a/apps/backend/lib/eval/report.ts
+++ b/apps/backend/lib/eval/report.ts
@@ -31,6 +31,9 @@ export interface ArmAggregate {
   costUsd: Summary
   /** Undefined when no run had a known price. */
   costKnown: boolean
+  undiscountedCostUsd: Summary
+  /** Undefined when no run had a known model price. */
+  undiscountedCostKnown: boolean
   turns: Summary
   toolCalls: Summary
   wallMs: Summary
@@ -52,6 +55,7 @@ export const aggregate = (runs: RunResult[]): ArmAggregate[] => {
   return [...groups.values()].map((group) => {
     const first = group[0]!
     const withCost = group.filter((run) => run.totals.costUsd !== undefined)
+    const withUndiscountedCost = group.filter((run) => run.totals.undiscountedCostUsd !== undefined)
     const setupRun = group.find((run) => run.setupCost !== undefined)
     return {
       scenarioId: first.scenarioId,
@@ -81,6 +85,10 @@ export const aggregate = (runs: RunResult[]): ArmAggregate[] => {
       rejectedMessages: summarize(group.map((run) => run.compression?.rejectedMessages ?? 0)),
       costUsd: summarize(withCost.map((run) => run.totals.costUsd!)),
       costKnown: withCost.length > 0,
+      undiscountedCostUsd: summarize(
+        withUndiscountedCost.map((run) => run.totals.undiscountedCostUsd!)
+      ),
+      undiscountedCostKnown: withUndiscountedCost.length > 0,
       turns: summarize(group.map((run) => run.totals.turns)),
       toolCalls: summarize(group.map((run) => run.totals.toolCalls)),
       wallMs: summarize(group.map((run) => run.totals.wallMs)),
@@ -217,8 +225,8 @@ export const renderMarkdown = (runs: RunResult[], baselineArmName: string): stri
     lines.push(
       '## Overall',
       '',
-      '| arm | runs | success | score | in tok | cache read | out tok | cost | tools |',
-      '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
+      '| arm | runs | success | score | in tok | cache read | out tok | cost | full cost | tools |',
+      '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
     )
     for (const entry of overall) {
       lines.push(
@@ -230,6 +238,8 @@ export const renderMarkdown = (runs: RunResult[], baselineArmName: string): stri
           0
         )} | ${round(entry.outputTokens.mean, 0)} | ${
           entry.costKnown ? formatCostUsd(entry.costUsd.mean) : 'n/a'
+        } | ${
+          entry.undiscountedCostKnown ? formatCostUsd(entry.undiscountedCostUsd.mean) : 'n/a'
         } | ${round(entry.toolCalls.mean)} |`
       )
     }
@@ -244,11 +254,11 @@ export const renderMarkdown = (runs: RunResult[], baselineArmName: string): stri
     lines.push(`## ${scenarioId}`, '')
     lines.push(
       showCompression
-        ? '| arm | runs | success | score | triggered/applied | history est. before→after | summarized/rejected | in tok | cache read | out tok | cost | tools | turns | setup |'
-        : '| arm | runs | success | score | in tok | cache read | out tok | cost | tools | turns | setup |',
+        ? '| arm | runs | success | score | triggered/applied | history est. before→after | summarized/rejected | in tok | cache read | out tok | cost | full cost | tools | turns | setup |'
+        : '| arm | runs | success | score | in tok | cache read | out tok | cost | full cost | tools | turns | setup |',
       showCompression
-        ? '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
-        : '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
+        ? '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
+        : '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
     )
     for (const entry of scenarioAggregates) {
       const compressionColumns = showCompression
@@ -268,6 +278,8 @@ export const renderMarkdown = (runs: RunResult[], baselineArmName: string): stri
           0
         )} | ${round(entry.outputTokens.mean, 0)} | ${
           entry.costKnown ? formatCostUsd(entry.costUsd.mean) : 'n/a'
+        } | ${
+          entry.undiscountedCostKnown ? formatCostUsd(entry.undiscountedCostUsd.mean) : 'n/a'
         } | ${round(entry.toolCalls.mean)} | ${round(entry.turns.mean)} | ${
           entry.setupCostUsd !== undefined ? formatCostUsd(entry.setupCostUsd) : '—'
         } |`

--- a/apps/backend/lib/eval/sink.ts
+++ b/apps/backend/lib/eval/sink.ts
@@ -76,6 +76,28 @@ export class EvalSink implements ClientSink {
     }
   }
 
+  /** Individual provider usage parts, retained for request-level pricing tiers. */
+  getUsageEvents(): TurnUsage[] {
+    return this.events
+      .filter(
+        (
+          event
+        ): event is dto.TextStreamPart & {
+          type: 'usage'
+          inputTokens: number
+          outputTokens: number
+          totalTokens: number
+          inputTokenDetails?: TurnUsage['inputTokenDetails']
+        } => event.type === 'usage'
+      )
+      .map(({ inputTokens, outputTokens, totalTokens, inputTokenDetails }) => ({
+        inputTokens,
+        outputTokens,
+        totalTokens,
+        inputTokenDetails,
+      }))
+  }
+
   getErrors(): string[] {
     return this.parts()
       .filter((part): part is dto.ErrorPart => part.type === 'error')

--- a/apps/backend/lib/eval/types.ts
+++ b/apps/backend/lib/eval/types.ts
@@ -167,6 +167,12 @@ export interface SetupCost {
   wallMs: number
   /** Model that incurred this cost. Omitted when setup used no model or it is unknown. */
   modelId?: string
+  /** Individual provider requests, used for request-level pricing tiers and cache pricing. */
+  providerUsages?: Array<{
+    inputTokens: number
+    outputTokens: number
+    inputTokenDetails?: TurnUsage['inputTokenDetails']
+  }>
 }
 
 export interface ArmSetup {
@@ -212,6 +218,8 @@ export interface TurnUsage {
 export interface TurnMetrics extends TurnUsage {
   toolCalls: string[]
   latencyMs: number
+  /** Individual provider calls, when available, for request-level pricing tiers. */
+  providerUsages?: TurnUsage[]
 }
 
 export interface CompressionDiagnostics {
@@ -279,6 +287,8 @@ export interface RunTotals extends TurnUsage {
   wallMs: number
   /** USD, when the model's price is known. Undefined means "report tokens only". */
   costUsd?: number
+  /** Full-price counterfactual, ignoring provider prompt-cache discounts. */
+  undiscountedCostUsd?: number
 }
 
 export interface RunResult {

--- a/apps/backend/lib/knowledge/__tests__/projections.test.ts
+++ b/apps/backend/lib/knowledge/__tests__/projections.test.ts
@@ -114,7 +114,28 @@ describe('answerQuestion', () => {
     const { model } = mockModel(['Part one.', 'Part two.', 'Merged answer.'])
     await answerQuestion(model, 'big.pdf', 'x'.repeat(90_000), question, usage)
     // The mock reports 1 input and 1 output token per call; three calls were made.
-    expect(usage).toEqual({ inputTokens: 3, outputTokens: 3, calls: 3 })
+    expect(usage).toEqual({
+      inputTokens: 3,
+      outputTokens: 3,
+      calls: 3,
+      providerUsages: [
+        {
+          inputTokens: 1,
+          outputTokens: 1,
+          inputTokenDetails: { noCacheTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 },
+        },
+        {
+          inputTokens: 1,
+          outputTokens: 1,
+          inputTokenDetails: { noCacheTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 },
+        },
+        {
+          inputTokens: 1,
+          outputTokens: 1,
+          inputTokenDetails: { noCacheTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 },
+        },
+      ],
+    })
   })
 
   it('caps the number of windows for an absurdly large document', async () => {
@@ -130,7 +151,7 @@ describe('computeProjections', () => {
     const { findReasonableSummarizationBackend } = await import('@/backend/lib/chat/summarizer')
     const result = await computeProjections('contract.pdf', 'text', [])
     expect(result.projections).toEqual([])
-    expect(result.usage).toEqual({ inputTokens: 0, outputTokens: 0, calls: 0 })
+    expect(result.usage).toEqual({ inputTokens: 0, outputTokens: 0, calls: 0, providerUsages: [] })
     expect(findReasonableSummarizationBackend).not.toHaveBeenCalled()
   })
 

--- a/apps/backend/lib/knowledge/projections.ts
+++ b/apps/backend/lib/knowledge/projections.ts
@@ -71,18 +71,66 @@ export interface ProjectionUsage {
   calls: number
   /** Model that generated the projections, for accurate ingestion-cost reporting. */
   modelId?: string
+  /** Individual provider requests, retained so pricing tiers are applied per request. */
+  providerUsages: ProjectionRequestUsage[]
+}
+
+export interface ProjectionRequestUsage {
+  inputTokens: number
+  outputTokens: number
+  inputTokenDetails?: {
+    noCacheTokens?: number
+    cacheReadTokens?: number
+    cacheWriteTokens?: number
+  }
 }
 
 export const emptyProjectionUsage = (): ProjectionUsage => ({
   inputTokens: 0,
   outputTokens: 0,
   calls: 0,
+  providerUsages: [],
 })
 
 const addUsage = (into: ProjectionUsage, usage: ai.LanguageModelUsage): void => {
-  into.inputTokens += usage.inputTokens ?? 0
-  into.outputTokens += usage.outputTokens ?? 0
+  // The provider type currently exposes totals as numbers, while providers (and the AI SDK
+  // test model) may return the richer token-detail object at runtime.
+  const rawUsage = usage as unknown as {
+    inputTokens:
+      | number
+      | { total?: number; noCache?: number; cacheRead?: number; cacheWrite?: number }
+    outputTokens: number | { total?: number }
+    inputTokenDetails?: {
+      noCacheTokens?: number
+      cacheReadTokens?: number
+      cacheWriteTokens?: number
+    }
+  }
+  const input = rawUsage.inputTokens as
+    | number
+    | { total?: number; noCache?: number; cacheRead?: number; cacheWrite?: number }
+  const inputTokens = typeof input === 'number' ? input : input?.total ?? 0
+  const output = rawUsage.outputTokens
+  const outputTokens = typeof output === 'number' ? output : output?.total ?? 0
+  const inputTokenDetails =
+    rawUsage.inputTokenDetails ??
+    (typeof input === 'number'
+      ? undefined
+      : {
+          noCacheTokens: input?.noCache,
+          cacheReadTokens: input?.cacheRead,
+          cacheWriteTokens: input?.cacheWrite,
+        })
+  const hasInputTokenDetails =
+    inputTokenDetails && Object.values(inputTokenDetails).some((tokens) => tokens !== undefined)
+  into.inputTokens += inputTokens
+  into.outputTokens += outputTokens
   into.calls += 1
+  into.providerUsages.push({
+    inputTokens,
+    outputTokens,
+    ...(hasInputTokenDetails ? { inputTokenDetails } : {}),
+  })
 }
 
 const generate = async (

--- a/apps/backend/scripts/eval-replay-production-chats.ts
+++ b/apps/backend/scripts/eval-replay-production-chats.ts
@@ -40,8 +40,8 @@
  *                          contextCompression). Use '{"contextCompression":null}' to disable it.
  *   --provider <type>      provider for the replay (default: the bundle's) — needs its API key
  *   --model <id>           shorthand for --override '{"model":"<id>"}' (Mode B: a cheap model for
- *                          an off/on pair — see docs/evaluation-harness.md; ids in
- *                          REPLAY_EXTRA_MODELS below are dev-only and not user-visible)
+ *                          an off/on pair — see docs/evaluation-harness.md; the id must exist in
+ *                          the normal model catalog)
  *   --knowledge-arms <...> comma-separated assistant-knowledge, knowledge-box, and/or
  *                          knowledge-box-no-projections (default: assistant-knowledge)
  *   --repeat <n>           replay each knowledge arm n times; box ingestion happens once (default: 1)
@@ -57,13 +57,13 @@ import path from 'node:path'
 import type * as dto from '@/types/dto'
 import type { Message as DbMessage } from '@/db/schema'
 import type { ProviderType } from '@/types/provider'
-import { computeCostUsd, formatCostUsd } from '@/backend/lib/eval/cost'
+import { computeCostUsd, computeUndiscountedCostUsd, formatCostUsd } from '@/backend/lib/eval/cost'
 import type {
   KnowledgeReplayArmName,
   ProductionReplayCase,
   ReplayJudgment,
 } from '@/backend/lib/eval/productionChatReplay'
-import type { SetupCost } from '@/backend/lib/eval/types'
+import type { SetupCost, TurnUsage } from '@/backend/lib/eval/types'
 
 const args = process.argv.slice(2).filter((arg) => arg !== '--')
 const flag = (name: string): string | undefined => {
@@ -144,34 +144,15 @@ const {
 const {
   createReplayJudge,
   defaultReplayKnowledgeQuestions,
+  isSameProductionModel,
   isReplayableLineage,
+  parseAuditInputTokenDetails,
   parseKnowledgeReplayArms,
 } = await import('@/backend/lib/eval/productionChatReplay')
 const { allInContextArm, createKnowledgeBoxArm } = await import('@/backend/lib/eval/arms')
-type LlmModel = (typeof llmModels)[number]
-
 setTokenizerCounter({
   countText: async (tokenizer, text) => countTextWithTokenizer(tokenizer, text),
 })
-
-// Cheap models for local off/on replay (Mode B in docs/evaluation-harness.md) that are not in the
-// shipped catalog. Dev-only — this list never reaches users. Add a matching price to
-// apps/backend/lib/eval/cost.ts or the cost column stays blank.
-const REPLAY_EXTRA_MODELS: LlmModel[] = [
-  {
-    id: 'gpt-5.6-luna',
-    model: 'gpt-5.6-luna',
-    name: 'GPT-5.6 Luna',
-    description: 'Cheap GPT-5.6 tier — replay eval only, not user-visible.',
-    provider: 'openai',
-    owned_by: 'openai',
-    context_length: 400000,
-    capabilities: { vision: true, function_calling: true, promptCaching: false },
-    supportedReasoningEfforts: ['none', 'low', 'medium', 'high'],
-    defaultReasoning: 'low',
-  },
-]
-const modelCatalog: LlmModel[] = [...llmModels, ...REPLAY_EXTRA_MODELS]
 
 const abortReplay = async (message: string): Promise<never> => {
   console.error(message)
@@ -334,6 +315,7 @@ const cases: ProductionReplayCase[] = [
       conversationId: selectedAudit.conversationId,
       messageId: selectedAudit.messageId,
       auditedInputTokens: selectedAudit.tokens,
+      auditedInputTokenDetails: parseAuditInputTokenDetails(selectedAudit.tokenDetails),
       auditedModel: selectedAudit.model,
       sentAt: selectedAudit.sentAt,
     },
@@ -386,8 +368,8 @@ const resolveModel = (id: string) => {
   // (e.g. a logiclecloud proxy that also serves Gemini for a cheap run), and the registry's
   // `provider` field only gates the tokenizer/capabilities metadata, not API routing.
   const model =
-    modelCatalog.find((entry) => entry.id === id && entry.provider === providerType) ??
-    modelCatalog.find((entry) => entry.id === id)
+    llmModels.find((entry) => entry.id === id && entry.provider === providerType) ??
+    llmModels.find((entry) => entry.id === id)
   if (!model) throw new Error(`Model "${id}" is not defined in this checkout`)
   return model
 }
@@ -536,7 +518,7 @@ if (bool('inspect-only')) {
     out,
     JSON.stringify(
       {
-        version: 5,
+        version: 7,
         createdAt: new Date().toISOString(),
         source: bundlePath
           ? { mode: 'bundle', bundle: bundlePath }
@@ -603,12 +585,15 @@ interface ReplayResult {
   model: string
   assistantConfig: Record<string, unknown>
   response: string
-  usage: { inputTokens: number; outputTokens: number }
+  usage: TurnUsage
+  usageEvents: TurnUsage[]
   providerCalls: number
   toolCalls: string[]
   costUsd?: number
+  /** Full-price counterfactual, intentionally ignoring provider cache discounts. */
+  fullPriceCostUsd?: number
   productionInputCostUsd?: number
-  inputTokensVsProduction: number
+  inputTokensVsProduction?: number
   error?: string
   judgment?: ReplayJudgment
 }
@@ -622,6 +607,23 @@ interface KnowledgeArmSetupResult {
 
 const cloneMessages = (messages: dto.Message[]) =>
   JSON.parse(JSON.stringify(messages)) as dto.Message[]
+
+const sumUsageCosts = (
+  modelId: string,
+  usages: TurnUsage[],
+  undiscounted: boolean
+): number | undefined => {
+  if (usages.length === 0) return undefined
+  let total = 0
+  for (const usage of usages) {
+    const cost = undiscounted
+      ? computeUndiscountedCostUsd(modelId, usage.inputTokens, usage.outputTokens)
+      : computeCostUsd(modelId, usage.inputTokens, usage.outputTokens, usage.inputTokenDetails)
+    if (cost === undefined) return undefined
+    total += cost
+  }
+  return total
+}
 
 const results: ReplayResult[] = []
 const armSetups: KnowledgeArmSetupResult[] = []
@@ -693,6 +695,7 @@ try {
             }`
           }
           const model = resolveModel(String(assistantConfig.model))
+          const sameProductionModel = isSameProductionModel(entry.source, model.id)
 
           process.stderr.write(
             `Replaying ${entry.id} · ${knowledgeArmName} · #${repetition + 1} ` +
@@ -700,7 +703,8 @@ try {
           )
           const sink = new EvalSink()
           let response = ''
-          let usage = { inputTokens: 0, outputTokens: 0 }
+          let usage: TurnUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 }
+          let usageEvents: TurnUsage[] = []
           let providerCalls = 0
           let toolCalls: string[] = []
           let error = setupError
@@ -716,7 +720,8 @@ try {
               )
               await assistant.processUserMessageWithSink(cloneMessages(entry.messages), sink)
               const raw = sink.getUsage()
-              usage = { inputTokens: raw.inputTokens, outputTokens: raw.outputTokens }
+              usage = raw
+              usageEvents = sink.getUsageEvents()
               providerCalls = sink.events.filter((event) => event.type === 'usage').length
               toolCalls = sink.getToolCallNames()
               response = sink.getText().trim() || `[no reply] ${sink.getErrors().join('; ')}`.trim()
@@ -724,6 +729,8 @@ try {
               error = caught instanceof Error ? caught.message : String(caught)
             }
           }
+          const pricedUsages =
+            usageEvents.length > 0 ? usageEvents : usage.totalTokens > 0 ? [usage] : []
 
           let judgment: ReplayJudgment | undefined
           if (bool('judge') && !error) {
@@ -747,15 +754,23 @@ try {
             assistantConfig: { contextCompression: assistantConfig.contextCompression },
             response,
             usage,
+            usageEvents,
             providerCalls,
             toolCalls,
-            // Deliberately omit provider cache details: comparisons price every input token at
-            // the ordinary rate, so a warm/cold prompt cache cannot manufacture a saving.
-            costUsd: error
-              ? undefined
-              : computeCostUsd(model.id, usage.inputTokens, usage.outputTokens),
-            productionInputCostUsd: computeCostUsd(model.id, entry.source.auditedInputTokens, 0),
-            inputTokensVsProduction: entry.source.auditedInputTokens - usage.inputTokens,
+            // Primary cost follows each provider request's cache details and pricing tier.
+            costUsd: error ? undefined : sumUsageCosts(model.id, pricedUsages, false),
+            fullPriceCostUsd: error ? undefined : sumUsageCosts(model.id, pricedUsages, true),
+            productionInputCostUsd: sameProductionModel
+              ? computeCostUsd(
+                  model.id,
+                  entry.source.auditedInputTokens,
+                  0,
+                  entry.source.auditedInputTokenDetails
+                )
+              : undefined,
+            inputTokensVsProduction: sameProductionModel
+              ? entry.source.auditedInputTokens - usage.inputTokens
+              : undefined,
             error,
             judgment,
           })
@@ -794,6 +809,11 @@ const armSummaries = knowledgeArmNames.map((knowledgeArm) => {
   const meanCostUsd = mean(
     armResults.flatMap((result) => (result.costUsd === undefined ? [] : [result.costUsd]))
   )
+  const meanFullPriceCostUsd = mean(
+    armResults.flatMap((result) =>
+      result.fullPriceCostUsd === undefined ? [] : [result.fullPriceCostUsd]
+    )
+  )
   const setup = armSetups.find((entry) => entry.knowledgeArm === knowledgeArm)
   const perRunSavingUsd =
     baselineMeanCost !== undefined && meanCostUsd !== undefined
@@ -807,6 +827,7 @@ const armSummaries = knowledgeArmNames.map((knowledgeArm) => {
     meanInputTokens,
     meanOutputTokens,
     meanCostUsd,
+    meanFullPriceCostUsd,
     inputTokensSavedVsAssistantKnowledge:
       baselineMeanInput !== undefined && meanInputTokens !== undefined
         ? baselineMeanInput - meanInputTokens
@@ -852,14 +873,15 @@ const markdown = [
   '',
   '## Arm summary',
   '',
-  '| arm | successful / failed | mean input | mean output | input saved vs assistant knowledge | mean run cost | setup cost | break-even conversations |',
-  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+  '| arm | successful / failed | mean input | mean output | input saved vs assistant knowledge | mean run cost | mean full-price cost | setup cost | break-even conversations |',
+  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
   ...armSummaries.map(
     (summary) =>
       `| ${summary.knowledgeArm} | ${summary.successfulRuns} / ${summary.failedRuns} | ` +
       `${formatMean(summary.meanInputTokens)} | ${formatMean(summary.meanOutputTokens)} | ` +
       `${formatSignedMean(summary.inputTokensSavedVsAssistantKnowledge)} | ` +
-      `${formatCostUsd(summary.meanCostUsd)} | ${formatCostUsd(summary.setupCostUsd)} | ` +
+      `${formatCostUsd(summary.meanCostUsd)} | ${formatCostUsd(summary.meanFullPriceCostUsd)} | ` +
+      `${formatCostUsd(summary.setupCostUsd)} | ` +
       `${formatBreakEven(summary.breakEvenConversations)} |`
   ),
   '',
@@ -867,20 +889,26 @@ const markdown = [
   '',
   '## Runs',
   '',
-  '| arm | repetition | production input | replay input | replay output | provider calls | tool calls | replay cost | input Δ vs prod | verdict |',
-  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
+  '| arm | repetition | production input | replay input | replay output | provider calls | tool calls | replay cost | full-price cost | input Δ vs prod | verdict |',
+  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
   ...results.map(
     (r) =>
       `| ${r.knowledgeArm} | ${r.repetition + 1} | ${r.source.auditedInputTokens} | ${
         r.error ? 'error' : r.usage.inputTokens
       } | ${r.error ? '—' : r.usage.outputTokens} | ${r.error ? '—' : r.providerCalls} | ${
         r.error ? '—' : r.toolCalls.length
-      } | ${formatCostUsd(r.costUsd)} | ${r.error ? '—' : r.inputTokensVsProduction} | ${
-        r.error ? r.error : r.judgment?.verdict ?? 'not judged'
-      } |`
+      } | ${formatCostUsd(r.costUsd)} | ${formatCostUsd(r.fullPriceCostUsd)} | ${
+        r.error ? '—' : r.inputTokensVsProduction ?? 'n/a'
+      } | ${r.error ? r.error : r.judgment?.verdict ?? 'not judged'} |`
   ),
   '',
   '_Judgments compare each replay with the saved production response, which is a reference rather than a factual answer key. Review regressions against the source documents._',
+  '',
+  ...(results.some((r) => !isSameProductionModel(r.source, r.model))
+    ? [
+        '_Production token/cost deltas are n/a for model overrides. Compare off/on replay arms for those runs._',
+      ]
+    : []),
   '',
   ...(results.some((r) => r.judgment && r.judgment.verdict !== 'equivalent')
     ? [
@@ -904,7 +932,7 @@ await writeFile(
   out,
   JSON.stringify(
     {
-      version: 5,
+      version: 7,
       createdAt: new Date().toISOString(),
       source: bundlePath
         ? { mode: 'bundle', bundle: bundlePath }

--- a/docs/context-compression.md
+++ b/docs/context-compression.md
@@ -599,8 +599,11 @@ OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval.ts \
 
 By default it compares compression off, tool-only retrieval with no recent window, and prefetch
 with recent windows of 0 and 1. Explicit `compression-keep-{1,2,4}` arms remain available for wider
-window sweeps. The report uses provider usage, including prompt-cache read/write token details when
-available, and stores raw runs so the same evidence can be re-reported without another model call.
+window sweeps. The primary cost estimate uses provider usage, including prompt-cache read/write
+token details as cache-aware pricing telemetry when available. Missing cache telemetry degrades
+the affected input to the full configured input price. The report also shows an
+undiscounted/full-price counterfactual; it is not the primary total. Raw runs are stored so the
+same evidence can be re-reported without another model call.
 
 ## Relevant Files
 

--- a/docs/context-strategy-research.md
+++ b/docs/context-strategy-research.md
@@ -148,12 +148,12 @@ The harness measures success, tokens, cost and break-even. The thesis needs thre
   A 70%-mean system that is 70% on every run is a different product from one that is 100% on seven
   runs and 0% on three, and the mean hides it.
 
-The cost model **is** now cache-aware, which matters because Logicle enables prompt caching by
-default and a multi-turn baseline therefore pays for the corpus at a discount from turn two.
-Provider-reported cache reads and writes are carried from the stream through to
-[`computeCostUsd`](../apps/backend/lib/eval/cost.ts) and priced at their own rates, and the report
-shows cache reads as a column. A model whose price table has no cache entry degrades to "report
-tokens only" rather than to a wrong number.
+Provider-reported cache reads and writes remain in the eval totals and report as telemetry used by
+[`computeCostUsd`](../apps/backend/lib/eval/cost.ts). The primary cost estimate is cache-aware so
+tool-heavy strategies receive the economics of their actual prefix-cache usage; when cache
+telemetry is missing, the affected input falls back to the full input price. An undiscounted/full-
+price counterfactual is reported separately, while an unknown model still reports token usage and
+leaves USD unavailable rather than silently using the wrong price.
 
 ## Threats to validity
 
@@ -214,7 +214,8 @@ Done:
 - Arms: `all-in-context`, `knowledge-box`, `knowledge-box-no-projections`.
 - Parametric corpus generator with size, distractor, depth and hop dials.
 - Scenario miner for real conversations.
-- Cache-aware cost, end to end from the provider's usage report to the priced total.
+- Cache-aware provider usage and cost telemetry, end to end from the provider's usage report to the
+  priced total, with full-input fallback when cache details are missing.
 - Flip-test machinery: paired corpora (`--flip`), per-run lexical classification, and the paired
   coverage / value-under-absence verdict. Built, unit-tested, and calibrated on a live synthetic
   run.
@@ -248,8 +249,9 @@ Next, in order:
    thesis. The marker-free 20-document point strongly favours the knowledge box, but one fixed
    corpus can expose a deterministic distractor preference rather than a general coverage property.
 3. **Size sweep** over the generated corpora, to place the crossover and find where the baseline
-   degrades — hypotheses 1 and 2. Now that cost is cache-aware, the multi-turn numbers are
-   trustworthy enough to draw a curve from.
+   degrades — hypotheses 1 and 2. Cache-aware provider usage makes the multi-turn numbers reflect
+   real prefix-cache economics; retain the undiscounted counterfactual for a simple upper-bound
+   comparison.
 4. **Discriminative projections** as a fourth arm — hypothesis 4. The flip test is what makes this
    measurable: exclusion is the thing projections are supposed to buy.
 5. **Compression as a synthetic arm**, then compare its failure mechanisms with the real-chat

--- a/docs/evaluation-harness.md
+++ b/docs/evaluation-harness.md
@@ -336,9 +336,11 @@ to test. The stages are fully separated. The bundle is a self-contained SQLite f
 exists, replay never touches the source deployment, S3, or any network beyond the LLM provider.
 
 Knowledge arms can be compared directly in one replay. For other changes, the "before" number is
-production's own `MessageAudit` input-token count, which travels in the bundle. Replay cost
-intentionally prices all input tokens at the normal input rate: prompt-cache read/write discounts
-are ignored on both sides.
+production's own `MessageAudit` input-token count, which travels in the bundle. Replay cost is
+primarily cache-aware: use provider-reported input, cached-read, cached-write, and output usage
+when available. If cache telemetry is missing, price the affected input at the full input rate.
+The report also shows an undiscounted/full-price counterfactual, but it does not replace the
+primary cache-aware total.
 
 ### Stage 1 — build the bundle
 
@@ -441,15 +443,15 @@ npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
   --conversation <conversation-id> --message <message-id> \
   --out /tmp/production-chat-replays/live.json --report /tmp/production-chat-replays/live.md
 
-# Mode B — cheap model, off then on, measured by the same ruler:
-LOGICLECLOUD_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
+# Mode B — gpt-5.6-luna, off then on, measured by the same ruler:
+OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
   --bundle /tmp/production-chat-replays/conversation.sqlite \
   --out /tmp/production-chat-replays/b-off.json --report /tmp/production-chat-replays/b-off.md \
-  --model gpt-4o-mini --override '{"contextCompression":null}'
-LOGICLECLOUD_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
+  --model gpt-5.6-luna --override '{"contextCompression":null}'
+OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts \
   --bundle /tmp/production-chat-replays/conversation.sqlite \
   --out /tmp/production-chat-replays/b-on.json --report /tmp/production-chat-replays/b-on.md --judge \
-  --model gpt-4o-mini \
+  --model gpt-5.6-luna \
   --override '{"contextCompression":{"preset":"conservative","retrievalMode":"prefetch"}}'
 ```
 
@@ -713,16 +715,20 @@ A replay calls a real provider with a real (often six-figure-token) prompt. Keep
   `MessageAudit` input tokens (in the bundle, shown in the report) — no off run needed. This is
   the cheapest honest measurement: one call per turn. Its limit is that `MessageAudit.tokens` was
   counted by the code as it was then, so treat single-digit-percent deltas as noise.
-- **Mode B — cheap model, run both sides.** When you want an off/on pair measured by the same
+- **Mode B — `gpt-5.6-luna`, run both sides.** When you want an off/on pair measured by the same
   ruler and the real model is expensive, replay twice — `'{"contextCompression":null}'` and
-  `'{"contextCompression":{…}}'` — on a cheap model via `--model`. Two calls per turn, but on a
-  low-cost model that is cents. The delta between the two runs is clean; the absolute cost is not
-  the production cost, so report it as a ratio. The override model must be registered for the
-  selected replay provider; `gpt-4o-mini` is the currently registered low-cost Logicle Cloud
-  option.
+  `'{"contextCompression":{…}}'` — on `gpt-5.6-luna` via `--model`. This is the intended cheap
+  OpenAI replay/eval model for this mode. The authoritative measurements are provider-reported
+  token/usage counts and their off/on delta; USD is a derived estimate, not the ruler. For Luna,
+  use `$0.20/M` input, `$0.02/M` cached input, `$0.25/M` cached write, and `$1.20/M` output;
+  for requests above 272k tokens use `$0.40/M` input, `$0.04/M` cached input, `$0.50/M` cached
+  write, and `$1.80/M` output. If cache telemetry is absent, use the corresponding full input
+  rate. Keep the model/provider fixed across the pair. The override model must be registered for
+  the selected replay provider.
 
-Never change the model **and** compare against `MessageAudit`: a different tokenizer and context
-window make that delta meaningless. Mode A keeps the model; Mode B keeps the ruler.
+Never change the model **and** compare against saved production cost or token counts: a different
+tokenizer and context window make that delta meaningless. If the replay model differs from
+production, compare Luna off/on only. Mode A keeps the model; Mode B keeps the ruler.
 
 **Reading the result:**
 

--- a/packages/core/src/models/openai.ts
+++ b/packages/core/src/models/openai.ts
@@ -489,6 +489,25 @@ export const gpt56TerraModel: LlmModel = {
   defaultReasoning: 'low',
 }
 
+export const gpt56LunaModel: LlmModel = {
+  id: 'gpt-5.6-luna',
+  model: 'gpt-5.6-luna',
+  name: 'GPT-5.6 Luna',
+  description: 'GPT-5.6 Luna, optimized for cost-sensitive, high-volume workloads',
+  provider: 'openai',
+  owned_by: 'openai',
+  context_length: 1_050_000,
+  capabilities: {
+    vision: true,
+    function_calling: true,
+    supportedMedia: ['application/pdf', 'image/png', 'image/jpeg'],
+    promptCaching: false, // caching is automatic and non-configurable on this model
+  },
+  supportedReasoningEfforts: ['none', 'low', 'medium', 'high', 'xhigh'],
+  defaultReasoning: 'medium',
+  maxOutputTokens: 128_000,
+}
+
 export const gptChatLatestModel: LlmModel = {
   ...gpt52ChatModel,
   model: 'chat-latest',
@@ -527,6 +546,7 @@ export const openaiModels: LlmModel[] = [
   gpt55Model,
   gpt55ProModel,
   gpt56TerraModel,
+  gpt56LunaModel,
   o1Model,
   o1MiniModel,
   o3Model,


### PR DESCRIPTION
## Summary

Add GPT-5.6 Luna to the normal Logicle model catalog and make evaluation costs reflect provider-reported prompt-cache usage per request. Reports now show cache-aware cost as the primary metric alongside a full-price counterfactual, avoiding a systematic penalty against tool-heavy compression and knowledge-box strategies.

## Details

- Price Luna requests with the documented short- and long-context input, cache-read, cache-write, and output rates.
- Preserve individual provider usage events through conversations and knowledge-box projection setup so long-context tiers are applied per request rather than to aggregate run tokens.
- Retain an undiscounted cost counterfactual in evaluation artifacts and reports.
- Compare replay results with saved production token and cost baselines only when the model id matches exactly; reuse valid cache details from `MessageAudit` when available.
- Register Luna as a user-visible OpenAI model with its context window, output limit, modalities, and supported reasoning configuration.
- Update evaluation guidance for Luna Mode B replays and cache-aware cost interpretation.

## Risks

- Production replay artifacts are bumped to version 7 because usage and cost fields were extended.
- When provider cache telemetry is absent, pricing intentionally falls back to the full input rate.

## Tests

- `pnpm test` — 145 test files passed, 1,378 tests passed; 2 files / 21 tests skipped as configured.
- `pnpm run check-types` — passed.
- `git diff --check main...HEAD` — passed.

Tracking: logicleai/logicle-issues#304
