### PR TITLE
fix: handle empty extracted text without cache errors

### DIFF
--- a/apps/backend/lib/textextraction/__tests__/cache.test.ts
+++ b/apps/backend/lib/textextraction/__tests__/cache.test.ts
@@ -4,6 +4,7 @@ import { cachingExtractor } from '@/lib/textextraction/cache'
 const extractor = vi.fn(async () => {
   throw new Error('Unencoded <\nLine: 85\nColumn: 83\nChar: 0')
 })
+const emptyExtractor = vi.fn(async () => '')
 
 vi.mock('@/lib/textextraction', () => ({
   findExtractor: vi.fn(() => extractor),
@@ -34,5 +35,21 @@ describe('cachingExtractor', () => {
 
     await expect(cachingExtractor.extractFromFile(fileEntry as any)).resolves.toBeUndefined()
     expect(extractor).toHaveBeenCalledTimes(1)
+  })
+
+  test('returns undefined without caching when extraction produces no text', async () => {
+    const { findExtractor } = await import('@/lib/textextraction')
+    vi.mocked(findExtractor).mockReturnValueOnce(emptyExtractor as any)
+    const fileEntry = {
+      id: 'file-empty',
+      path: '/tmp/file-empty.pdf',
+      name: 'scanned.pdf',
+      type: 'application/pdf',
+      encryption: null,
+      fileBlobId: 'blob-empty',
+    }
+
+    await expect(cachingExtractor.extractFromFile(fileEntry as any)).resolves.toBeUndefined()
+    expect(emptyExtractor).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/backend/lib/textextraction/cache.ts
+++ b/apps/backend/lib/textextraction/cache.ts
@@ -16,6 +16,12 @@ const cache = new LRUCache<string, string>({
   ttl: 1000 * 60 * 5,
 })
 
+const cacheExtractedText = (path: string, text: string): string | undefined => {
+  if (text.trim().length === 0) return undefined
+  cache.set(path, text)
+  return text
+}
+
 export const cachingExtractor = {
   extractFromFile: async (fileEntry: FileDbRow) => {
     const cached = cache.get(fileEntry.path)
@@ -25,21 +31,23 @@ export const cachingExtractor = {
 
     const analysis = await ensureFileAnalysisForFile(fileEntry)
     const analyzedText = await readExtractedTextFromAnalysis(fileEntry, analysis)
-    if (analyzedText) {
-      cache.set(fileEntry.path, analyzedText)
-      return analyzedText
+    if (analyzedText?.trim()) {
+      return cacheExtractedText(fileEntry.path, analyzedText)
     }
 
-    const isUnknownText = analysis?.status === 'ready' && analysis.payload?.kind === 'unknown' && analysis.payload.isText
-    const extractor = findExtractor(fileEntry.type) ?? (isUnknownText ? genericTextExtractor : undefined)
+    const isUnknownText =
+      analysis?.status === 'ready' &&
+      analysis.payload?.kind === 'unknown' &&
+      analysis.payload.isText
+    const extractor =
+      findExtractor(fileEntry.type) ?? (isUnknownText ? genericTextExtractor : undefined)
     if (!extractor) {
       return undefined
     }
     try {
       const fileContent = await storage.readBuffer(fileEntry.path, fileEntry.encryption)
       const text = await extractor(fileContent)
-      cache.set(fileEntry.path, text)
-      return text
+      return cacheExtractedText(fileEntry.path, text)
     } catch (error) {
       logger.warn('File text extraction failed; continuing without extracted text', {
         fileId: fileEntry.id,


### PR DESCRIPTION
## Summary

Empty text extraction results are now treated as unavailable text instead of being inserted into the LRU cache with an invalid zero size. This makes scanned or otherwise non-extractable documents fail with the real extraction diagnostic and avoids a secondary cache error.

## Details

- Do not cache whitespace-only analysis sidecars or extractor results.
- Preserve the existing `undefined` contract for callers when no text is available.
- Add regression coverage for an extractor that returns an empty string.

## Tests

- `npx prettier --write apps/backend/lib/textextraction/cache.ts apps/backend/lib/textextraction/__tests__/cache.test.ts`
- `npm test -- --run apps/backend/lib/textextraction/__tests__/cache.test.ts` — 2 tests passed
- `npm run check-types` — passed
- `git diff --check` — passed