### PR TITLE
feat: OCR fallback for scanned attachments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,9 @@ jobs:
             mcp-file-analyzer -help >/dev/null
             command -v soffice
             command -v pdftoppm
+            command -v pdfinfo
+            command -v tesseract
+            tesseract --list-langs | grep -qx ita
           '
 
       - name: Run smoke and baseline integration checks

--- a/Dockerfile
+++ b/Dockerfile
@@ -168,6 +168,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-dejavu-core \
     fonts-noto-core \
     poppler-utils \
+    tesseract-ocr \
+    tesseract-ocr-eng \
+    tesseract-ocr-ita \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf \
         /usr/lib/libreoffice/share/gallery \

--- a/apps/backend/lib/textextraction/__tests__/cache.test.ts
+++ b/apps/backend/lib/textextraction/__tests__/cache.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test, vi } from 'vitest'
 import { cachingExtractor } from '@/lib/textextraction/cache'
 
-const extractor = vi.fn(async () => {
+const extractor = vi.fn(async (): Promise<string> => {
   throw new Error('Unencoded <\nLine: 85\nColumn: 83\nChar: 0')
 })
+const mockOcr = vi.fn(
+  (..._args: unknown[]): Promise<string | undefined> => Promise.resolve(undefined)
+)
 
 vi.mock('@/lib/textextraction', () => ({
   findExtractor: vi.fn(() => extractor),
@@ -21,6 +24,12 @@ vi.mock('@/lib/storage', () => ({
   },
 }))
 
+vi.mock('@/lib/textextraction/ocr', () => ({
+  ocrExtractor: {
+    extractFromFile: (file: unknown, analysis: unknown) => mockOcr(file, analysis),
+  },
+}))
+
 describe('cachingExtractor', () => {
   test('returns undefined when the file extractor fails', async () => {
     const fileEntry = {
@@ -34,5 +43,48 @@ describe('cachingExtractor', () => {
 
     await expect(cachingExtractor.extractFromFile(fileEntry as any)).resolves.toBeUndefined()
     expect(extractor).toHaveBeenCalledTimes(1)
+    expect(mockOcr).toHaveBeenCalledWith(fileEntry, undefined)
+  })
+
+  test('uses OCR after a scanned PDF has no extractable text', async () => {
+    const analysis = {
+      status: 'ready',
+      payload: { kind: 'pdf', contentMode: 'scanned' },
+    }
+    const fileEntry = {
+      id: 'file-2',
+      path: '/tmp/file-2.pdf',
+      name: 'scanned.pdf',
+      type: 'application/pdf',
+      encryption: null,
+      fileBlobId: 'blob-2',
+    }
+    mockOcr.mockResolvedValueOnce('[OCR page 1]\nformula')
+
+    const { ensureFileAnalysisForFile } = await import('@/lib/file-analysis')
+    vi.mocked(ensureFileAnalysisForFile).mockResolvedValueOnce(analysis as any)
+
+    await expect(cachingExtractor.extractFromFile(fileEntry as any)).resolves.toBe(
+      '[OCR page 1]\nformula'
+    )
+    expect(mockOcr).toHaveBeenCalledWith(fileEntry, analysis)
+  })
+
+  test('does not invoke OCR when the normal PDF extractor returns text', async () => {
+    mockOcr.mockClear()
+    extractor.mockResolvedValueOnce('native PDF text')
+    const fileEntry = {
+      id: 'file-3',
+      path: '/tmp/file-3.pdf',
+      name: 'text.pdf',
+      type: 'application/pdf',
+      encryption: null,
+      fileBlobId: 'blob-3',
+    }
+
+    await expect(cachingExtractor.extractFromFile(fileEntry as any)).resolves.toBe(
+      'native PDF text'
+    )
+    expect(mockOcr).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/lib/textextraction/cache.ts
+++ b/apps/backend/lib/textextraction/cache.ts
@@ -4,6 +4,7 @@ import { findExtractor, genericTextExtractor } from '.'
 import { storage } from '../storage'
 import { ensureFileAnalysisForFile, readExtractedTextFromAnalysis } from '@/lib/file-analysis'
 import { logger } from '@/lib/logging'
+import { ocrExtractor } from './ocr'
 
 const cacheSizeInMb = 100
 
@@ -30,24 +31,35 @@ export const cachingExtractor = {
       return analyzedText
     }
 
-    const isUnknownText = analysis?.status === 'ready' && analysis.payload?.kind === 'unknown' && analysis.payload.isText
-    const extractor = findExtractor(fileEntry.type) ?? (isUnknownText ? genericTextExtractor : undefined)
-    if (!extractor) {
-      return undefined
+    const isUnknownText =
+      analysis?.status === 'ready' &&
+      analysis.payload?.kind === 'unknown' &&
+      analysis.payload.isText
+    const extractor =
+      findExtractor(fileEntry.type) ?? (isUnknownText ? genericTextExtractor : undefined)
+    if (extractor) {
+      try {
+        const fileContent = await storage.readBuffer(fileEntry.path, fileEntry.encryption)
+        const text = await extractor(fileContent)
+        if (text.trim().length > 0) {
+          cache.set(fileEntry.path, text)
+          return text
+        }
+      } catch (error) {
+        logger.warn('File text extraction failed; trying OCR fallback', {
+          fileId: fileEntry.id,
+          fileName: fileEntry.name,
+          fileType: fileEntry.type,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
     }
-    try {
-      const fileContent = await storage.readBuffer(fileEntry.path, fileEntry.encryption)
-      const text = await extractor(fileContent)
-      cache.set(fileEntry.path, text)
-      return text
-    } catch (error) {
-      logger.warn('File text extraction failed; continuing without extracted text', {
-        fileId: fileEntry.id,
-        fileName: fileEntry.name,
-        fileType: fileEntry.type,
-        error: error instanceof Error ? error.message : String(error),
-      })
-      return undefined
+
+    const ocrText = await ocrExtractor.extractFromFile(fileEntry, analysis)
+    if (ocrText) {
+      cache.set(fileEntry.path, ocrText)
+      return ocrText
     }
+    return undefined
   },
 }

--- a/apps/backend/lib/textextraction/ocr.ts
+++ b/apps/backend/lib/textextraction/ocr.ts
@@ -1,0 +1,143 @@
+import { promisify } from 'node:util'
+import { execFile as execFileCallback } from 'node:child_process'
+import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import type { FileDbRow } from '@/backend/models/file'
+import type * as dto from '@/types/dto'
+import { storage } from '@/lib/storage'
+import { logger } from '@/lib/logging'
+
+const execFile = promisify(execFileCallback)
+
+const DEFAULT_LANGUAGE = 'ita+eng'
+const DEFAULT_DPI = 300
+const MAX_PDF_PAGES = 100
+const COMMAND_TIMEOUT_MS = 5 * 60 * 1000
+const MAX_OUTPUT_BYTES = 8 * 1024 * 1024
+
+const tesseractCommand = () => process.env.TESSERACT_BIN ?? 'tesseract'
+const pdfToPpmCommand = () => process.env.PDFTOPPM_BIN ?? 'pdftoppm'
+const pdfInfoCommand = () => process.env.PDFINFO_BIN ?? 'pdfinfo'
+const ocrLanguage = () => process.env.TESSERACT_LANG ?? DEFAULT_LANGUAGE
+
+const run = async (command: string, args: string[]) =>
+  execFile(command, args, {
+    timeout: COMMAND_TIMEOUT_MS,
+    maxBuffer: MAX_OUTPUT_BYTES,
+    windowsHide: true,
+  })
+
+const runTesseract = async (imagePath: string): Promise<string> => {
+  const { stdout } = await run(tesseractCommand(), [
+    imagePath,
+    'stdout',
+    '--dpi',
+    `${DEFAULT_DPI}`,
+    '--psm',
+    '3',
+    '-l',
+    ocrLanguage(),
+  ])
+  return stdout.trim()
+}
+
+const naturalPageOrder = (left: string, right: string) => {
+  const leftPage = Number(left.match(/-(\d+)\.png$/)?.[1] ?? Number.MAX_SAFE_INTEGER)
+  const rightPage = Number(right.match(/-(\d+)\.png$/)?.[1] ?? Number.MAX_SAFE_INTEGER)
+  return leftPage - rightPage || left.localeCompare(right)
+}
+
+const renderPdfPages = async (pdfPath: string, outputPrefix: string): Promise<string[]> => {
+  const { stdout } = await run(pdfInfoCommand(), [pdfPath])
+  const pageCount = Number(stdout.match(/^Pages:\s+(\d+)/m)?.[1] ?? 0)
+  if (pageCount > MAX_PDF_PAGES) {
+    throw new Error(`OCR is limited to ${MAX_PDF_PAGES} PDF pages (document has ${pageCount})`)
+  }
+
+  await run(pdfToPpmCommand(), [
+    '-r',
+    `${DEFAULT_DPI}`,
+    '-png',
+    '-f',
+    '1',
+    ...(pageCount > 0 ? ['-l', `${pageCount}`] : []),
+    pdfPath,
+    outputPrefix,
+  ])
+
+  const directory = path.dirname(outputPrefix)
+  const prefix = path.basename(outputPrefix)
+  const files = (await readdir(directory))
+    .filter((file) => file.startsWith(`${prefix}-`) && file.endsWith('.png'))
+    .sort(naturalPageOrder)
+  if (files.length === 0) throw new Error('PDF renderer produced no page images')
+  return files.map((file) => path.join(directory, file))
+}
+
+const pageText = (pageNumber: number, text: string) =>
+  [`[OCR page ${pageNumber}]`, text].filter((part) => part.length > 0).join('\n')
+
+const extractPdf = async (data: Buffer, directory: string, fileName: string) => {
+  const inputPath = path.join(directory, fileName)
+  const outputPrefix = path.join(directory, 'page')
+  await writeFile(inputPath, data)
+  const pages = await renderPdfPages(inputPath, outputPrefix)
+  const parts: string[] = []
+  for (const [index, page] of pages.entries()) {
+    const text = await runTesseract(page)
+    if (text) parts.push(pageText(index + 1, text))
+  }
+  return parts.join('\n\n')
+}
+
+const extractImage = async (data: Buffer, directory: string, fileName: string) => {
+  const inputPath = path.join(directory, fileName)
+  await writeFile(inputPath, data)
+  return runTesseract(inputPath)
+}
+
+export const isOcrCandidate = (
+  file: Pick<FileDbRow, 'type'>,
+  analysis: dto.FileAnalysis | undefined
+): boolean => {
+  if (file.type.startsWith('image/')) return true
+  if (file.type !== 'application/pdf') return false
+  if (analysis?.status !== 'ready') return true
+  return analysis.payload?.kind === 'pdf' && analysis.payload.contentMode === 'scanned'
+}
+
+/**
+ * Extracts searchable text locally for image files and scanned PDFs.
+ *
+ * This is intentionally a fallback after the normal file extractor. OCR text is useful for
+ * retrieval, but the original file remains the authoritative source for answering exact questions.
+ */
+export const ocrExtractor = {
+  extractFromFile: async (
+    file: FileDbRow,
+    analysis: dto.FileAnalysis | undefined
+  ): Promise<string | undefined> => {
+    if (!isOcrCandidate(file, analysis)) return undefined
+
+    const directory = await mkdtemp(path.join(tmpdir(), 'logicle-ocr-'))
+    try {
+      const data = await storage.readBuffer(file.path, file.encryption)
+      const text =
+        file.type === 'application/pdf'
+          ? await extractPdf(data, directory, 'document.pdf')
+          : await extractImage(data, directory, 'document')
+      return text.trim() || undefined
+    } catch (error) {
+      logger.warn('[text-extraction] OCR fallback failed', {
+        fileId: file.id,
+        fileName: file.name,
+        fileType: file.type,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return undefined
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  },
+}

--- a/docs/knowledge-box.md
+++ b/docs/knowledge-box.md
@@ -35,7 +35,7 @@ flowchart TD
   A[Files attached to the tool] --> B[syncBoxDocuments]
   B --> C[(KnowledgeBoxDocument: pending)]
   C --> D[Ingestion runtime]
-  D --> E[cachingExtractor: text]
+  D --> E[cachingExtractor: text, then local OCR for scans]
   E --> F[chunkText]
   E --> G[computeProjections: one LLM pass per question]
   F --> H[(KnowledgeChunk)]
@@ -114,6 +114,24 @@ below.
 The ingestion model is not configurable: it reuses the summarizer's "cheap model for internal work"
 choice, falling back to the best-scoring configured backend. With no backend configured, ingestion
 still produces chunks and simply skips projections.
+
+### Scanned documents
+
+Text extraction is always attempted first. When file analysis identifies a scanned PDF (or the
+file is an image) and the normal extractor returns no text, the runtime uses the local OCR
+fallback: Poppler renders PDF pages at 300 DPI and Tesseract produces searchable text. OCR
+is used to build chunks and retrieval indexes; the original file remains the authoritative source
+for exact values, formulas, and other details that OCR may misread.
+
+The PDF is not sent to the model merely because it exists. Retrieval first uses the OCR text to
+identify relevant chunks and the corresponding file; only when the model requests that file is the
+original PDF returned, and then only when the provider supports native PDFs and the page limit
+allows it. Otherwise the existing text fallback is used.
+
+The production image includes Tesseract with Italian and English language data. `TESSERACT_BIN`,
+`PDFTOPPM_BIN`, `PDFINFO_BIN`, and `TESSERACT_LANG` can override the binaries or language set for a
+deployment. OCR is bounded to 100-page PDFs and falls back to the existing unavailable-text
+behavior if a binary is missing or the conversion fails.
 
 ## Open
 


### PR DESCRIPTION
## Summary
Scanned PDFs and images now get a bounded local OCR fallback after normal text extraction fails. Knowledge Box ingestion can therefore index scanned documents for retrieval while the original PDF remains available for exact, native inspection when the model requests the relevant file.

## Details
- Uses Poppler at 300 DPI and Tesseract with Italian and English language data.
- Runs OCR only for images and PDFs identified as scanned or otherwise unavailable to the normal extractor.
- Keeps ordinary text extraction as the first path and does not send every PDF to the model automatically.
- Limits OCR to 100-page PDFs and degrades to the existing unavailable-text behavior on tool/conversion failure.

## Risks
- OCR output is a retrieval aid and can misread formulas or exact values; the source PDF remains authoritative.
- The runtime image grows to include Tesseract and its language packages.

## Tests
- `pnpm vitest run apps/backend/lib/textextraction apps/backend/lib/knowledge` — 55 tests passed.
- `pnpm check-types` — passed.
- `pnpm exec prettier --check apps/backend/lib/textextraction/cache.ts apps/backend/lib/textextraction/ocr.ts apps/backend/lib/textextraction/__tests__/cache.test.ts docs/knowledge-box.md .github/workflows/ci.yml` — passed.
- `docker build -t localhost/logicle-ocr-check:local .` — passed.
- Runtime image inspection confirmed `pdftoppm`, `pdfinfo`, Tesseract 5.3.0, and Italian/English language data.
- Manual inspection of a real scanned technical PDF confirmed useful retrieval anchors, while also confirming that OCR must not be treated as an exact formula/value source.
