### PR TITLE
fix: preserve context for response reformat requests

### DIFF
--- a/apps/backend/lib/chat/__tests__/compression-planner.test.ts
+++ b/apps/backend/lib/chat/__tests__/compression-planner.test.ts
@@ -439,7 +439,16 @@ describe('response-preference prefetch guard', () => {
   test('recognizes a format-only instruction without treating every short query as a preference', () => {
     expect(isLikelyResponsePreferenceQuery('solo tabella differenze')).toBe(true)
     expect(isLikelyResponsePreferenceQuery('From now on, only a table')).toBe(true)
+    expect(isLikelyResponsePreferenceQuery('non la vedo bene la tabella la puoi rifare?')).toBe(
+      true
+    )
+    expect(isLikelyResponsePreferenceQuery('Puoi riscrivere la risposta in formato tabella?')).toBe(
+      true
+    )
     expect(isLikelyResponsePreferenceQuery('What are the differences between the policies?')).toBe(
+      false
+    )
+    expect(isLikelyResponsePreferenceQuery('What is the table for risk classification?')).toBe(
       false
     )
   })
@@ -448,6 +457,17 @@ describe('response-preference prefetch guard', () => {
     expect(
       shouldPrefetchHistoricalContext([
         { ...base, id: 'u1', role: 'user', content: 'solo tabella differenze', attachments: [] },
+      ])
+    ).toBe(false)
+    expect(
+      shouldPrefetchHistoricalContext([
+        {
+          ...base,
+          id: 'u1',
+          role: 'user',
+          content: 'non la vedo bene la tabella la puoi rifare?',
+          attachments: [],
+        },
       ])
     ).toBe(false)
     expect(

--- a/apps/backend/lib/chat/compression-planner.ts
+++ b/apps/backend/lib/chat/compression-planner.ts
@@ -52,9 +52,9 @@ export function resolveCompressionUserQuery(messages: dto.Message[]): string | u
 }
 
 /**
- * Detects a narrow class of turns that changes the response contract instead of asking for the
- * result of an earlier task. Prefetching old attachments for these turns can turn a harmless
- * preference such as "solo tabella differenze" into an answer to stale historical data.
+ * Detects a narrow class of turns that changes the response contract or asks for a previous
+ * response to be reformatted. Prefetching old material for these turns can either answer stale
+ * historical data or omit the exact response the user is asking to have reformatted.
  */
 export function isLikelyResponsePreferenceQuery(query: string): boolean {
   const normalized = query.trim().toLocaleLowerCase()
@@ -64,6 +64,9 @@ export function isLikelyResponsePreferenceQuery(query: string): boolean {
     /^(solo|soltanto|only|just)\s+(?:la\s+|il\s+|the\s+)?(?:tabella|table|lista|list|formato|format)\b/,
     /\b(?:da ora|d['’]ora in poi|in futuro|from now on|going forward|a partir de ahora)\b/,
     /^(?:senza|without|sin)\s+(?:spiegazioni|explanations|explicaciones|testo aggiuntivo|extra text)\b/,
+    /\b(?:rifai|rifare|rifalla|rifarlo|rifarla|rifammi|riscrivi|riscrivere|riscrivila|riformatta|riformattare|riformattala|redo|rewrite|reformat|rephrase|reword)\b.*\b(?:tabella|table|lista|list|formato|format|risposta|answer|response)\b/,
+    /\b(?:tabella|table|lista|list|formato|format|risposta|answer|response)\b.*\b(?:rifai|rifare|rifalla|rifarlo|rifarla|rifammi|riscrivi|riscrivere|riscrivila|riformatta|riformattare|riformattala|redo|rewrite|reformat|rephrase|reword)\b/,
+    /\b(?:non\s+(?:la\s+)?vedo|non\s+si\s+legge|illeggibile|not\s+readable|hard\s+to\s+read)\b.*\b(?:tabella|table|lista|list)\b/,
   ].some((pattern) => pattern.test(normalized))
 }
 

--- a/docs/context-compression.md
+++ b/docs/context-compression.md
@@ -249,13 +249,17 @@ A message that mentions a historical file by name (`"what's on page 2 of report.
 current message's content. With `keepRecentTurns > 0`, an eligible turn changes once from `full` to
 `summary` when it ages out of the recent window. The cached base summary remains stable after that.
 
-This is deliberate, for two reasons:
+This is deliberate, with one explicit exception: turns that only change the response format or
+ask to reformat a previous response skip compression entirely when the threshold is reached, so
+the exact material being reformatted remains visible. For ordinary substantive turns, the stable
+policy has two benefits:
 
 - **Prompt caching.** The policy and cached base summary remain stable. In default `prefetch` mode,
   only the small excerpts appended to that base depend on the current request, so the provider may
   lose part of the shared prefix. This trade-off is included in reported cache-read tokens and was
   still cheaper in the measured suite. `retrievalMode: 'tool'` keeps the base prefix stable.
-- **Simplicity.** A per-turn, content-dependent override is one more thing to reason about, test,
+- **Simplicity.** Apart from the narrow response-format/reformat guard, a per-turn,
+  content-dependent override is one more thing to reason about, test,
   and get wrong (fuzzy name matching, false positives on common words, etc.) for a case the model
   can already handle itself.
 

--- a/docs/evaluation-harness.md
+++ b/docs/evaluation-harness.md
@@ -162,10 +162,12 @@ stochastic model tool use and the cost of retaining a recent turn. Wider
 `compression-keep-{1,2,4}` arms remain selectable explicitly.
 
 Compression has one intentional no-op guard: when the current user message is only a response
-format/language/style preference (for example, "solo tabella differenze"), the threshold may be
+format/language/style preference or asks to reformat a previous response (for example, "solo
+tabella differenze" or "non la vedo bene la tabella, la puoi rifare?"), the threshold may be
 reached but historical compression and retrieval are skipped for that turn. Prefetching stale
 material in response to a preference can make the assistant answer an earlier task instead of
-acknowledging the new instruction. The replay inspection reports this as
+acknowledging the new instruction; reformat requests also need the exact previous response intact.
+The replay inspection reports this as
 `compressionThresholdReached: true`, `triggered: false`, and
 `compressionSkippedReason: "response-preference-turn"`.
 


### PR DESCRIPTION
## Summary
Response reformatting requests now skip context compression when the compression threshold is reached, preserving the exact previous answer the user is asking to reformat.

## Details
- Extends the existing response-preference guard to Italian and English reformat/readability requests.
- Keeps substantive questions on the normal compression path.
- Records the skip as `response-preference-turn` in replay inspection.
- Adds the real production-derived reformat regression as private dataset case `case-015`.

## Risks
- The guard is deliberately lexical and narrow; it may leave a small number of reformat turns uncompressed, trading a little cost for answer preservation.

## Tests
- `pnpm vitest run apps/backend/lib/chat/__tests__/compression-planner.test.ts` — 32 tests passed.
- `pnpm check-types` — passed.
- `pnpm exec prettier --check apps/backend/lib/chat/compression-planner.ts apps/backend/lib/chat/__tests__/compression-planner.test.ts` — passed.
- `git diff --check` — passed.
- Manual replay of the same private production bundle before the fix: compression on preserved the requested table in 1/3 runs versus 3/3 off; after the fix, inspection reports a deliberate no-op and compression on preserved it in 3/3 runs with no tool calls or errors.
