### PR TITLE
Add source-grounded replay judgments

### DIFF
--- a/apps/backend/lib/eval/__tests__/productionChatReplay.test.ts
+++ b/apps/backend/lib/eval/__tests__/productionChatReplay.test.ts
@@ -7,6 +7,7 @@ import {
   isReplayableLineage,
   parseAuditInputTokenDetails,
   parseKnowledgeReplayArms,
+  parseReplaySourceEvidence,
 } from '@/backend/lib/eval/productionChatReplay'
 import type * as dto from '@/types/dto'
 
@@ -177,5 +178,25 @@ describe('defaultReplayKnowledgeQuestions', () => {
     expect(defaultReplayKnowledgeQuestions.every((question) => question.prompt.length > 20)).toBe(
       true
     )
+  })
+})
+
+describe('parseReplaySourceEvidence', () => {
+  it('accepts bounded reviewed claims and evidence', () => {
+    expect(
+      parseReplaySourceEvidence(
+        JSON.stringify({ claim: 'The source sets a one-year limit.', evidence: ['Article 26(3).'] })
+      )
+    ).toEqual({ claim: 'The source sets a one-year limit.', evidence: ['Article 26(3).'] })
+  })
+
+  it('rejects empty or missing source evidence', () => {
+    expect(() =>
+      parseReplaySourceEvidence(JSON.stringify({ claim: '', evidence: ['fact'] }))
+    ).toThrow()
+    expect(() =>
+      parseReplaySourceEvidence(JSON.stringify({ claim: 'fact', evidence: [] }))
+    ).toThrow()
+    expect(() => parseReplaySourceEvidence('{')).toThrow()
   })
 })

--- a/apps/backend/lib/eval/productionChatReplay.ts
+++ b/apps/backend/lib/eval/productionChatReplay.ts
@@ -142,8 +142,38 @@ export interface ReplayJudgment {
   failures: string[]
 }
 
+export interface ReplaySourceEvidence {
+  /** A short, human-readable statement of what the reviewed sources establish. */
+  claim: string
+  /** Bounded excerpts or source-grounded facts; never shown to the simulated user. */
+  evidence: string[]
+}
+
+export type ReplaySourceVerdict = 'source-correct' | 'source-incorrect' | 'inconclusive'
+
+export interface ReplaySourceJudgment {
+  verdict: ReplaySourceVerdict
+  rationale: string
+  failures: string[]
+}
+
+const replaySourceEvidenceSchema = z.object({
+  claim: z.string().trim().min(1),
+  evidence: z.array(z.string().trim().min(1)).min(1),
+})
+
+/** Parses private, reviewed source evidence supplied to the optional source-grounded judge. */
+export const parseReplaySourceEvidence = (raw: string): ReplaySourceEvidence =>
+  replaySourceEvidenceSchema.parse(JSON.parse(raw))
+
 const replayJudgmentSchema = z.object({
   verdict: z.enum(['equivalent', 'minor-regression', 'major-regression', 'inconclusive']),
+  rationale: z.string(),
+  failures: z.array(z.string()),
+})
+
+const replaySourceJudgmentSchema = z.object({
+  verdict: z.enum(['source-correct', 'source-incorrect', 'inconclusive']),
   rationale: z.string(),
   failures: z.array(z.string()),
 })
@@ -173,6 +203,46 @@ export const createReplayJudge =
         `Final user message:\n${finalUserMessage}`,
         '',
         `Production response:\n${productionReply || '[no saved assistant response]'}`,
+        '',
+        `Candidate response:\n${candidateReply || '[no candidate response]'}`,
+      ].join('\n'),
+    })
+    return {
+      verdict: result.object.verdict,
+      rationale: result.object.rationale.trim(),
+      failures: result.object.failures.map((failure) => failure.trim()).filter(Boolean),
+    }
+  }
+
+const replaySourceJudgePrompt = [
+  'Assess a candidate chat response against reviewed source evidence for the same final user question.',
+  'The source evidence is the authority for the claims it covers. Do not use the production response as an answer key.',
+  'Mark source-correct only when the candidate does not materially contradict the evidence and answers the covered question adequately.',
+  'Mark source-incorrect when the candidate makes a material contradiction, reverses a source distinction, or presents an unsupported operational conclusion as established fact.',
+  'Mark inconclusive when the evidence does not cover the claim or the candidate is too ambiguous to assess.',
+  'Do not penalize wording, length, or harmless omissions outside the reviewed evidence.',
+].join('\n')
+
+export const createSourceGroundedReplayJudge =
+  (model: LanguageModelV3, options: { supportsTemperature?: boolean } = {}) =>
+  async (
+    finalUserMessage: string,
+    sourceEvidence: ReplaySourceEvidence,
+    candidateReply: string
+  ): Promise<ReplaySourceJudgment> => {
+    const result = await ai.generateObject({
+      model,
+      schema: replaySourceJudgmentSchema,
+      ...(options.supportsTemperature === false ? {} : { temperature: 0 }),
+      system: replaySourceJudgePrompt,
+      prompt: [
+        `Final user message:\n${finalUserMessage}`,
+        '',
+        `Reviewed source claim:\n${sourceEvidence.claim}`,
+        '',
+        `Reviewed source evidence:\n${sourceEvidence.evidence
+          .map((excerpt, index) => `[${index + 1}] ${excerpt}`)
+          .join('\n\n')}`,
         '',
         `Candidate response:\n${candidateReply || '[no candidate response]'}`,
       ].join('\n'),

--- a/apps/backend/scripts/eval-replay-production-chats.ts
+++ b/apps/backend/scripts/eval-replay-production-chats.ts
@@ -51,13 +51,14 @@
  *   --inspect-only         calculate compression decisions/token estimates without an LLM call
  *   --judge                also classify each response against the saved production reply
  *   --judge-model <id>     judge model (default: the replay model)
+ *   --judge-source <path>  private JSON source evidence for a source-grounded judgment
  *
  * An explicit --model or override.model permits a paired replay against a saved assistant whose
  * current model has drifted from production. In that mode production token/cost deltas are not
  * comparable; the report still compares the replay arms with each other.
  */
 
-import { copyFileSync, mkdtempSync, rmSync } from 'node:fs'
+import { copyFileSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -70,6 +71,8 @@ import type {
   KnowledgeReplayArmName,
   ProductionReplayCase,
   ReplayJudgment,
+  ReplaySourceEvidence,
+  ReplaySourceJudgment,
 } from '@/backend/lib/eval/productionChatReplay'
 import type { SetupCost, TurnUsage } from '@/backend/lib/eval/types'
 
@@ -84,6 +87,7 @@ const bundlePath = flag('bundle')
 const liveConversationId = flag('conversation')
 const out = flag('out')
 const reportPath = flag('report')
+const judgeSourcePath = flag('judge-source')
 const repeat = Number(flag('repeat') ?? 1)
 if (
   (!bundlePath && !liveConversationId) ||
@@ -110,6 +114,21 @@ if (overrideRaw) {
   } catch (error) {
     console.error(
       `--override must be valid JSON: ${error instanceof Error ? error.message : error}`
+    )
+    process.exit(1)
+  }
+}
+
+let sourceEvidence: ReplaySourceEvidence | undefined
+if (judgeSourcePath) {
+  try {
+    const { parseReplaySourceEvidence } = await import('@/backend/lib/eval/productionChatReplay')
+    sourceEvidence = parseReplaySourceEvidence(readFileSync(judgeSourcePath, 'utf8'))
+  } catch (error) {
+    console.error(
+      `--judge-source must be a JSON file with a non-empty claim and evidence array: ${
+        error instanceof Error ? error.message : error
+      }`
     )
     process.exit(1)
   }
@@ -153,6 +172,7 @@ const {
 } = await import('@/backend/lib/chat/compression-economics')
 const {
   createReplayJudge,
+  createSourceGroundedReplayJudge,
   collectTurnDescendantMessageIds,
   defaultReplayKnowledgeQuestions,
   isSameProductionModel,
@@ -680,6 +700,7 @@ interface ReplayResult {
   inputTokensVsProduction?: number
   error?: string
   judgment?: ReplayJudgment
+  sourceJudgment?: ReplaySourceJudgment
 }
 
 interface KnowledgeArmSetupResult {
@@ -828,6 +849,18 @@ try {
               }
             )((entry.messages.at(-1) as dto.UserMessage).content, entry.productionReply, response)
           }
+          let sourceJudgment: ReplaySourceJudgment | undefined
+          if (sourceEvidence && !error) {
+            const judgeModel = resolveModel(flag('judge-model') ?? model.id)
+            sourceJudgment = await createSourceGroundedReplayJudge(
+              ChatAssistant.createLanguageModel(providerConfig, judgeModel),
+              {
+                supportsTemperature:
+                  !modelSupportsReasoning(judgeModel) &&
+                  judgeModel.capabilities.temperature !== false,
+              }
+            )((entry.messages.at(-1) as dto.UserMessage).content, sourceEvidence, response)
+          }
 
           results.push({
             caseId: entry.id,
@@ -857,6 +890,7 @@ try {
               : undefined,
             error,
             judgment,
+            sourceJudgment,
           })
         }
       } finally {
@@ -952,6 +986,9 @@ const markdown = [
     : disableConfiguredTools
     ? 'No config override — replayed with each turn’s saved assistant configuration except configured tools disabled by the optimizer.'
     : 'No config override — replayed with each turn’s saved assistant configuration.',
+  ...(sourceEvidence
+    ? ['Source-grounded judge: **enabled** (private reviewed evidence supplied separately).']
+    : []),
   `Configured assistant tools: **${configuredToolCount}**; disabled for replay: **${disableConfiguredTools}**; ` +
     `tool call in selected production turn: **${targetTurnHasToolCalls}**.`,
   '',
@@ -1014,13 +1051,38 @@ const markdown = [
         '',
       ]
     : []),
+  ...(results.some((r) => r.sourceJudgment)
+    ? [
+        '## Source-grounded review',
+        '',
+        '_This optional judgment uses private reviewed source evidence. It is separate from the production-response comparison and does not replace manual review._',
+        '',
+        '| arm | repetition | source verdict | rationale | failures |',
+        '| --- | ---: | --- | --- | --- |',
+        ...results.flatMap((r) =>
+          r.sourceJudgment
+            ? [
+                `| ${r.knowledgeArm} | ${r.repetition + 1} | ${
+                  r.sourceJudgment.verdict
+                } | ${r.sourceJudgment.rationale
+                  .replaceAll('\n', ' ')
+                  .replaceAll('|', '\\|')} | ${r.sourceJudgment.failures
+                  .join('; ')
+                  .replaceAll('\n', ' ')
+                  .replaceAll('|', '\\|')} |`,
+              ]
+            : []
+        ),
+        '',
+      ]
+    : []),
 ].join('\n')
 
 await writeFile(
   out,
   JSON.stringify(
     {
-      version: 7,
+      version: 8,
       createdAt: new Date().toISOString(),
       source: bundlePath
         ? { mode: 'bundle', bundle: bundlePath }

--- a/docs/evaluation-harness.md
+++ b/docs/evaluation-harness.md
@@ -720,6 +720,21 @@ A replay calls a real provider with a real (often six-figure-token) prompt. Keep
 - **`--judge` roughly doubles the cost** (a second model call over the same prompt). Get the token
   numbers for all your turns first; judge only the ones whose numbers look worth a closer look.
 
+For source-dependent production replays, an optional source-grounded judge can be run with a
+private JSON file containing reviewed evidence. The file must have this shape:
+
+```json
+{
+  "claim": "The reviewed sources establish ...",
+  "evidence": ["Bounded source excerpt or reviewed fact ...", "Another source-grounded fact ..."]
+}
+```
+
+Pass it as `--judge-source /private/path/source-evidence.json`. The source-grounded verdict is
+reported separately from the production-response comparison; it does not enter the assistant or
+simulated-user prompt and remains only a second opinion. Manual source review is still required,
+and the evidence file must not be published with raw production bundles or responses.
+
 **Two ways to get a saving number**, depending on how much you trust the persisted counts:
 
 - **Mode A — same model, trust `MessageAudit`.** Replay on the assistant's real model with only


### PR DESCRIPTION
## Summary

Add an optional source-grounded judge to production replay evaluation so reviewed source facts can detect factual regressions that production-response comparison misses.

## Details

- Add `--judge-source` private evidence input and separate source verdicts in replay artifacts and reports.
- Keep reviewed evidence out of assistant and simulated-user prompts and out of replay artifacts.
- Document the workflow and validate evidence parsing.

## Tests

- `pnpm vitest run apps/backend/lib/eval/__tests__/productionChatReplay.test.ts apps/backend/lib/eval/__tests__/metrics.test.ts` (48 passed)
- `pnpm check-types`
- `pnpm exec prettier --check apps/backend/lib/eval/productionChatReplay.ts apps/backend/scripts/eval-replay-production-chats.ts apps/backend/lib/eval/__tests__/productionChatReplay.test.ts docs/evaluation-harness.md`
- Manual offline replay on a reviewed real Knowledge Box case: the source-grounded judge returned `source-incorrect` for a factual regression that the production-response comparison marked equivalent.
