### PR TITLE
fix: anchor knowledge box retrieval as source evidence

### DIFF
--- a/apps/backend/lib/tools/knowledge_box/__tests__/implementation.test.ts
+++ b/apps/backend/lib/tools/knowledge_box/__tests__/implementation.test.ts
@@ -218,6 +218,7 @@ describe('KnowledgeBoxTool', () => {
       ])
       const result = await invoke(buildTool(), 'search', { query: 'payment' })
       const value = result.value as string
+      expect(value).toContain('Treat the passages below as source evidence')
       expect(value).toContain('contract.pdf')
       expect(value).toContain('id: f1')
       expect(value).toContain('chunk 3')
@@ -268,7 +269,10 @@ describe('KnowledgeBoxTool', () => {
         { id: 'c2', fileId: 'f1', seq: 1, heading: null, text: 'Second.' },
       ])
       const result = await invoke(buildTool(), 'read', { fileId: 'f1', from: 0, to: 1 })
-      expect(result.value).toBe('[chunk 0 — Intro]\nFirst.\n\n[chunk 1]\nSecond.')
+      expect(result.value).toContain(
+        'preserve explicit conditions, exceptions, limits, and distinctions'
+      )
+      expect(result.value).toContain('[chunk 0 — Intro]\nFirst.\n\n[chunk 1]\nSecond.')
     })
 
     it('explains an empty range instead of failing', async () => {

--- a/apps/backend/lib/tools/knowledge_box/implementation.ts
+++ b/apps/backend/lib/tools/knowledge_box/implementation.ts
@@ -52,6 +52,10 @@ const MAX_LIST_LIMIT = 50
  */
 const LIST_PROJECTION_BUDGET_CHARS = 6000
 
+/** Keeps retrieved passages anchored as evidence instead of inviting unsupported conclusions. */
+const SOURCE_EVIDENCE_INSTRUCTION =
+  'Treat the passages below as source evidence: preserve explicit conditions, exceptions, limits, and distinctions; do not turn an unstated inference into a fact.'
+
 const formatHeading = (heading: string | null) => (heading ? ` — ${heading}` : '')
 
 export class KnowledgeBoxTool extends KnowledgeBoxInterface implements ToolImplementation {
@@ -243,7 +247,10 @@ export class KnowledgeBoxTool extends KnowledgeBoxInterface implements ToolImple
             hit.text
           }`
         })
-        return { type: 'text', value: rendered.join('\n\n---\n\n') }
+        return {
+          type: 'text',
+          value: `${SOURCE_EVIDENCE_INSTRUCTION}\n\n${rendered.join('\n\n---\n\n')}`,
+        }
       },
     },
 
@@ -292,7 +299,10 @@ export class KnowledgeBoxTool extends KnowledgeBoxInterface implements ToolImple
         const rendered = chunks.map(
           (chunk) => `[chunk ${chunk.seq}${formatHeading(chunk.heading)}]\n${chunk.text}`
         )
-        return { type: 'text', value: rendered.join('\n\n') }
+        return {
+          type: 'text',
+          value: `${SOURCE_EVIDENCE_INSTRUCTION}\n\n${rendered.join('\n\n')}`,
+        }
       },
     },
   }

--- a/docs/knowledge-box.md
+++ b/docs/knowledge-box.md
@@ -57,6 +57,10 @@ flowchart TD
 `read` only accepts a file that is in the box's own configuration, and every query is scoped by box
 id, so there is no id a caller can pass to reach outside it.
 
+Search and read results are explicitly marked as source evidence. The marker reminds the model to
+preserve conditions, exceptions, limits, and distinctions stated in the retrieved text instead of
+turning an unstated inference into a fact.
+
 ### Why the listing is ranked and budgeted
 
 Projections cost about 250 tokens per document. Returning all of them for all documents makes the


### PR DESCRIPTION
## Summary

Mark Knowledge Box search and read results as source evidence, prompting the model to preserve explicit conditions, exceptions, limits, and distinctions instead of turning unstated inferences into facts. This improves source-grounded correctness without changing retrieval ranking or adding domain-specific rules.

## Details

- Add the evidence marker to `search` and `read` results.
- Document the contract and cover both result paths with unit tests.
- Manual replay of the reviewed tax case changed the response from an incorrect “fuori campo” classification to a source-correct distinction between the expired variation deadline and the separate non-payment regime.

## Tests

- `pnpm prettier --check apps/backend/lib/tools/knowledge_box/implementation.ts apps/backend/lib/tools/knowledge_box/__tests__/implementation.test.ts docs/knowledge-box.md`
- `pnpm vitest run apps/backend/lib/tools/knowledge_box/__tests__ apps/backend/lib/knowledge/__tests__` — 77 passed
- `pnpm check-types`
- `git diff --check`
- Manual source inspection and same-model replay of the reviewed production bundle
