### PR TITLE
Enforce Knowledge Box per-turn search budget

### DIFF
--- a/apps/backend/lib/tools/knowledge_box/__tests__/implementation.test.ts
+++ b/apps/backend/lib/tools/knowledge_box/__tests__/implementation.test.ts
@@ -338,6 +338,28 @@ describe('KnowledgeBoxTool', () => {
       )
       expect(nextTurn.value).toContain('Net 30 days.')
     })
+
+    it('enforces the per-turn search budget without choosing the search strategy', async () => {
+      const tool = buildTool()
+      const messages = [{ id: 'user-1', role: 'user' }] as unknown as ToolInvokeParams['messages']
+
+      for (let index = 0; index < 4; index += 1) {
+        await invoke(tool, 'search', { query: `query-${index}` }, messages)
+      }
+      const exhausted = await invoke(tool, 'search', { query: 'one-more-query' }, messages)
+
+      expect(exhausted).toEqual({
+        type: 'text',
+        value:
+          'Search budget exhausted after 4 calls in this turn. Use the passages already retrieved, or state that the source does not specify the missing detail.',
+      })
+      expect(mockSearchBox).toHaveBeenCalledTimes(4)
+
+      await invoke(tool, 'search', { query: 'new-turn-query' }, [
+        { id: 'user-2', role: 'user' },
+      ] as unknown as ToolInvokeParams['messages'])
+      expect(mockSearchBox).toHaveBeenCalledTimes(5)
+    })
   })
 
   describe('read', () => {

--- a/apps/backend/lib/tools/knowledge_box/implementation.ts
+++ b/apps/backend/lib/tools/knowledge_box/implementation.ts
@@ -55,9 +55,11 @@ const MAX_LIST_LIMIT = 50
  */
 const LIST_PROJECTION_BUDGET_CHARS = 6000
 
+/** Hard guardrail for retrieval cost; the model still chooses the queries and their order. */
+const MAX_SEARCH_CALLS_PER_TURN = 4
+
 /** Keeps retrieved passages anchored as evidence instead of inviting unsupported conclusions. */
-const SOURCE_EVIDENCE_INSTRUCTION =
-  'Treat the passages below as source evidence. For every source-specific claim, use only what the passages state; preserve explicit conditions, exceptions, limits, and distinctions. Cite each source-specific sentence or bullet with the exact marker [file · chunk N] shown above it. Previous assistant messages and general knowledge are not evidence, and a prior claim must not be repeated unless these passages support it. Do not fill gaps with general knowledge or customary legal rules. Do not cite or link a document, page, URL, or fact unless it appears in these passages. For multi-part questions, omit unsupported subclaims or say that the source does not specify them. If a subtopic is unsupported, do not mention remembered percentages, amounts, article numbers, or illustrative examples for it, even as a caveat or disclaimer. A citation about one tax or topic does not support a claim about another. Search one focused query per missing subtopic when possible; once a focused search establishes the relevant evidence, do not repeat broad searches just for confirmation. Make at most four search calls in this turn; then answer from the evidence you have or state the source boundary.'
+const SOURCE_EVIDENCE_INSTRUCTION = `Treat the passages below as source evidence. For every source-specific claim, use only what the passages state; preserve explicit conditions, exceptions, limits, and distinctions. Cite each source-specific sentence or bullet with the exact marker [file · chunk N] shown above it. Previous assistant messages and general knowledge are not evidence, and a prior claim must not be repeated unless these passages support it. Do not fill gaps with general knowledge or customary legal rules. Do not cite or link a document, page, URL, or fact unless it appears in these passages. For multi-part questions, omit unsupported subclaims or say that the source does not specify them. If a subtopic is unsupported, do not mention remembered percentages, amounts, article numbers, or illustrative examples for it, even as a caveat or disclaimer. A citation about one tax or topic does not support a claim about another. Search one focused query per missing subtopic when possible; once a focused search establishes the relevant evidence, do not repeat broad searches just for confirmation. Make at most ${MAX_SEARCH_CALLS_PER_TURN} search calls in this turn; then answer from the evidence you have or state the source boundary.`
 
 const KNOWLEDGE_BOX_SYSTEM_INSTRUCTION =
   '\nWhen researching with this knowledge box, treat retrieved passages as the only evidence for source-specific claims. Search results may be incomplete: search again or read surrounding chunks when needed, but prefer one focused query per subtopic and stop once the evidence is sufficient or the source clearly does not establish the detail. Every source-specific sentence or bullet in the final answer must have an inline citation to the exact [file · chunk N] marker that supports it. Do not use previous assistant messages, general knowledge, or customary rules to fill gaps. Do not invent or cite unsupported facts, pages, or URLs; if the source does not establish a requested detail, say so explicitly. For an unsupported subtopic, do not add remembered percentages, amounts, article numbers, or examples even as a disclaimer; state only the source boundary. Evidence for one tax or topic cannot support a claim about another. Make at most four search calls in this turn; after that, answer from the evidence you have or state the source boundary.\n'
@@ -77,6 +79,7 @@ export class KnowledgeBoxTool extends KnowledgeBoxInterface implements ToolImple
   /** Search results already shown during the current user turn. */
   private searchTurnKey: string | null = null
   private seenSearchChunks = new Set<string>()
+  private searchCallCount = 0
 
   constructor(
     toolParams: ToolParams,
@@ -144,6 +147,7 @@ export class KnowledgeBoxTool extends KnowledgeBoxInterface implements ToolImple
     if (turnKey === this.searchTurnKey) return
     this.searchTurnKey = turnKey
     this.seenSearchChunks.clear()
+    this.searchCallCount = 0
   }
 
   /**
@@ -275,8 +279,7 @@ export class KnowledgeBoxTool extends KnowledgeBoxInterface implements ToolImple
     },
 
     search: {
-      description:
-        'Full-text search across the documents of this knowledge box. Returns ranked passages with the document id and the chunk range they came from — use `read` with those to see more context. If you do not need to restrict the search, omit `fileIds` and search the whole box. Never use ids from conversation attachments or another tool as knowledge-box selectors.',
+      description: `Full-text search across the documents of this knowledge box. Returns ranked passages with the document id and the chunk range they came from — use \`read\` with those to see more context. At most ${MAX_SEARCH_CALLS_PER_TURN} searches are allowed per user turn. If you do not need to restrict the search, omit \`fileIds\` and search the whole box. Never use ids from conversation attachments or another tool as knowledge-box selectors.`,
       parameters: {
         type: 'object',
         properties: {
@@ -300,6 +303,15 @@ export class KnowledgeBoxTool extends KnowledgeBoxInterface implements ToolImple
         if (!query) {
           return { type: 'error-text', value: 'Empty search query' }
         }
+        if (this.searchCallCount >= MAX_SEARCH_CALLS_PER_TURN) {
+          return {
+            type: 'text',
+            value:
+              `Search budget exhausted after ${MAX_SEARCH_CALLS_PER_TURN} calls in this turn. ` +
+              'Use the passages already retrieved, or state that the source does not specify the missing detail.',
+          }
+        }
+        this.searchCallCount += 1
         const requestedFileIds = Array.isArray(params.fileIds)
           ? params.fileIds.filter((id): id is string => typeof id === 'string')
           : []

--- a/docs/evaluation-harness.md
+++ b/docs/evaluation-harness.md
@@ -534,6 +534,11 @@ retrieved. Conversely, a `knowledge_box__*` call on a turn where compression did
 knowledge-box test, not a combined test. Compression can be valid without a `context-retrieve__*`
 call because the changed history sent to the model is itself the treatment.
 
+Knowledge-box search has a hard per-turn budget of four calls. This is only a cost and runaway-search
+guardrail: the model still chooses whether to list documents, which languages or terms to query, and
+which passages to read. After the budget is exhausted, the model must answer from retrieved evidence
+or state the source boundary.
+
 #### Knowledge-box-only comparison
 
 Choose a message with a source-grounded question and no answer-bearing prior chat. Keep compression


### PR DESCRIPTION
## Summary

Knowledge Box search now enforces the four-call per-user-turn budget already described by its research guidance. The model remains responsible for query formulation, language choice, document selection, and evidence interpretation; the guardrail only stops runaway retrieval cost.

## Details

- Reset the search budget at each user turn.
- Return a source-boundary instruction after the budget is exhausted without querying the index again.
- Document the operational guardrail and cover it with unit tests.

## Tests

- `npm exec vitest run apps/backend/lib/tools/knowledge_box/__tests__/implementation.test.ts` — 37 tests passed.
- `npm run check-types` — passed.
- Prettier check and `git diff --check` — passed.
- Manual replay of the private case-020 bundle: four effective searches, fifth request stopped by the budget; response manually retained the source boundary for unsupported IRPEF claims.