### PR TITLE
fix: preserve subassistants in replay bundles

### DIFF
--- a/apps/backend/scripts/eval-build-replay-bundle.ts
+++ b/apps/backend/scripts/eval-build-replay-bundle.ts
@@ -185,12 +185,9 @@ try {
   if (!assistant) throw new Error('Assistant or its published version is unavailable')
   if (assistant.assistantDeleted !== 0) throw new Error('Assistant is deleted')
 
-  const subAssistants = assistant.subAssistants
-    ? (JSON.parse(String(assistant.subAssistants)) as unknown[])
-    : []
-  if (Array.isArray(subAssistants) && subAssistants.length > 0) {
-    throw new Error('Assistant has sub-assistants, which the offline replay cannot reconstruct')
-  }
+  // The replay runner can omit configured tools for a target turn that made no tool call. Keep
+  // the published version intact in the bundle so the case remains auditable; the runner decides
+  // whether the unsupported sub-assistant tool surface is relevant to the selected turn.
   const configuredTools = await source
     .selectFrom('AssistantVersionToolAssociation')
     .select('toolId')

--- a/apps/backend/scripts/eval-replay-production-chats.ts
+++ b/apps/backend/scripts/eval-replay-production-chats.ts
@@ -370,9 +370,10 @@ if (selectedAssistant.model !== selectedAudit.model && !explicitModelOverride) {
 const subAssistants = selectedAssistant.subAssistants
   ? (JSON.parse(String(selectedAssistant.subAssistants)) as unknown[])
   : []
-if (Array.isArray(subAssistants) && subAssistants.length > 0) {
+if (Array.isArray(subAssistants) && subAssistants.length > 0 && !disableConfiguredTools) {
   await abortReplay(
-    `Assistant ${selectedAudit.assistantId} has sub-assistants; replay has no fixture.`
+    `Assistant ${selectedAudit.assistantId} has sub-assistants; pass --disable-configured-tools ` +
+      `for a target turn that did not use them.`
   )
 }
 const configuredTool = await db


### PR DESCRIPTION
## Summary

Keep assistants with configured subassistants eligible for complete offline bundle creation. The replay runner preserves the explicit tool-safety guard and allows the optimizer to disable configured tools for target turns that made no production tool call.

## Details

- Stop rejecting a bundle solely because the published assistant has subassistants.
- Retain the published `AssistantVersion` metadata for auditability.
- Require `--disable-configured-tools` when subassistants are present.
- Continue rejecting a selected production turn that actually used a tool, because no offline tool fixture is available.

## Tests

- `npm run check-types`
- `npx vitest run apps/backend/lib/eval/__tests__/productionChatReplay.test.ts` (16 tests passed)
- Real GUBI bundle inspection and replay passed for a direct image+knowledge turn; Knowledge Box made live retrieval calls and returned the correct model and catalogue facts.
- Real tool-using GUBI turn remains explicitly rejected with the expected fixture error.