### PR TITLE
test: add forced retrieval LLM probes

### DIFF
--- a/__tests__/contextCompressionBenchmark.test.ts
+++ b/__tests__/contextCompressionBenchmark.test.ts
@@ -7,7 +7,7 @@
  * its API-key env var is absent. See __tests__/llm-integration.test.ts for the general pattern
  * this file follows (provider matrix, TestSink, skip gating).
  *
- * Two scenarios, both structured the same way:
+ * Each scenario is structured the same way:
  *   1. A real turn plants a fact that only exists in content compression will later strip
  *      (a tool-result / attachment, never repeated verbatim in the assistant's own reply).
  *   2. Enough synthetic filler history is spliced in (no LLM calls — deterministic, free) to push
@@ -15,11 +15,10 @@
  *   3. A precondition check calls `planMessageCompression` directly to confirm the planted turn
  *      really is decided `summary` before we even ask the model anything — this isolates "did
  *      compression run" from "could the model cope with it".
- *   4. A real follow-up turn asks for the fact back, instructed to answer with *only* the fact so
- *      the check is a plain substring match rather than a fuzzier "structured output" parse (this
- *      harness doesn't wire up real JSON-schema-constrained decoding — see note below).
- *   5. Assertions: the answer contains the fact, and the model actually called `context-retrieve`
- *      to get it (not just a lucky guess/hallucination).
+ *   4. A real follow-up turn asks the model to call `answer-check.submit_answer` with the recovered
+ *      fact. The answer is therefore checked at the tool boundary, not merely in free-form text.
+ *   5. Assertions: the model actually called `context-retrieve` to get the source and passed the
+ *      recovered fact to the answer tool (not just a lucky guess/hallucination).
  *
  * Required env vars (per provider), same as llm-integration.test.ts:
  *   OpenAI:    OPENAI_API_KEY     [OPENAI_MODEL]
@@ -55,6 +54,7 @@ vi.mock('@/lib/env', () => ({
     allowMockProvider: false,
     chat: {
       autoSummary: { enable: false, useChatBackend: false },
+      contextCompressionTriggerTokens: 6000,
       maxOutputTokens: undefined,
       disableParallelToolCalls: false,
     },
@@ -106,11 +106,16 @@ vi.mock('@/models/compressed-message', () => ({
   getCompressedMessage: vi.fn(async (sourceMessageId: string, compressionVersion: number) => {
     const key = `${sourceMessageId}:${compressionVersion}`
     const content = compressedMessageStore.get(key)
-    return content === undefined ? undefined : { sourceMessageId, compressionVersion, content, version: null }
+    return content === undefined
+      ? undefined
+      : { sourceMessageId, compressionVersion, content, version: null }
   }),
   saveCompressedMessage: vi.fn(
     async (params: { sourceMessageId: string; compressionVersion: number; content: unknown }) => {
-      compressedMessageStore.set(`${params.sourceMessageId}:${params.compressionVersion}`, params.content)
+      compressedMessageStore.set(
+        `${params.sourceMessageId}:${params.compressionVersion}`,
+        params.content
+      )
     }
   ),
 }))
@@ -122,6 +127,7 @@ import { countTextWithTokenizer } from '@/lib/chat/tokenizer'
 import { ChatAssistant, type AssistantParams } from '@/backend/lib/chat'
 import { ChatState } from '@/backend/lib/chat/ChatState'
 import {
+  COMPRESSION_VERSION,
   planMessageCompression,
   applyCompressionPlan,
   warmCompressionCache,
@@ -148,7 +154,11 @@ setTokenizerCounter({
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeModel(model: string, provider: LlmModel['provider'], owned_by: LlmModel['owned_by']): LlmModel {
+function makeModel(
+  model: string,
+  provider: LlmModel['provider'],
+  owned_by: LlmModel['owned_by']
+): LlmModel {
   return {
     id: model,
     model,
@@ -185,9 +195,18 @@ class TestSink implements ClientSink {
       .filter((p): p is dto.ToolCallPart => p.type === 'tool-call')
       .map((p) => ({ toolName: p.toolName, args: p.args }))
   }
+  getToolResults(): { toolName: string; result: unknown }[] {
+    return this.events
+      .filter((e) => e.type === 'part')
+      .map((e) => (e as dto.TextStreamPart & { type: 'part'; part: dto.MessagePart }).part)
+      .filter((p): p is dto.ToolCallResultPart => p.type === 'tool-result')
+      .map((p) => ({ toolName: p.toolName, result: p.result }))
+  }
   hasError(): boolean {
     return this.events.some(
-      (e) => e.type === 'part' && (e as dto.TextStreamPart & { type: 'part'; part: dto.MessagePart }).part?.type === 'error'
+      (e) =>
+        e.type === 'part' &&
+        (e as dto.TextStreamPart & { type: 'part'; part: dto.MessagePart }).part?.type === 'error'
     )
   }
 }
@@ -214,12 +233,112 @@ class TrackingSink implements ClientSink {
  *  call happened", which would also pass for e.g. a get_file call with a made-up id. `get_message`
  *  and `search` are the two message-level recovery paths (as opposed to `get_file`, which recovers
  *  a specific attached/generated file's content). */
-function calledFunction(toolNames: string[], functionName: 'get_file' | 'get_message' | 'search'): boolean {
+function calledFunction(
+  toolNames: string[],
+  functionName: 'get_file' | 'get_message' | 'search'
+): boolean {
   return toolNames.some((name) => name.includes('context-retrieve') && name.includes(functionName))
 }
 
 function usesMessageRetrieval(toolNames: string[]): boolean {
   return calledFunction(toolNames, 'get_message') || calledFunction(toolNames, 'search')
+}
+
+function expectMessageRetrieval(sink: TestSink, label: string): void {
+  expect(
+    usesMessageRetrieval(sink.getToolCallNames()),
+    `${label}; observed tool calls: ${JSON.stringify(sink.getToolCalls())}`
+  ).toBe(true)
+}
+
+function expectContextRecovery(sink: TestSink, label: string): void {
+  expect(
+    sink
+      .getToolCalls()
+      .some(
+        (call) =>
+          call.toolName.includes('context-retrieve') &&
+          (call.toolName.includes('get_file') || call.toolName.includes('search'))
+      ),
+    `${label}; observed tool calls: ${JSON.stringify(sink.getToolCalls())}`
+  ).toBe(true)
+}
+
+/** Controls the recovery step so this benchmark isolates source-to-answer understanding. The
+ * separate LLM probe suite covers whether the model chooses retrieval when this is left on auto. */
+function forceToolSequence(
+  assistant: ChatAssistant,
+  toolChoices: NonNullable<AssistantParams['toolChoice']>[]
+): void {
+  const available = Object.keys(assistant.functions)
+  const resolvedChoices = toolChoices.map((toolChoice) => {
+    if (typeof toolChoice !== 'object' || toolChoice.type !== 'tool') return toolChoice
+    const resolvedName = available.find(
+      (name) => name === toolChoice.toolName || name.endsWith(`__${toolChoice.toolName}`)
+    )
+    if (!resolvedName) {
+      throw new Error(
+        `Cannot force missing tool ${toolChoice.toolName}; available functions: ${available.join(
+          ', '
+        )}`
+      )
+    }
+    return { type: 'tool' as const, toolName: resolvedName }
+  })
+  const params = (assistant as unknown as { assistantParams: AssistantParams }).assistantParams
+  params.toolChoice = undefined
+  params.toolChoiceSequence = resolvedChoices
+}
+
+function forceRecoveryAndAnswer(
+  assistant: ChatAssistant,
+  recoveryTool: 'get_file' | 'get_message' | 'search'
+): void {
+  forceToolSequence(assistant, [
+    { type: 'tool', toolName: recoveryTool },
+    { type: 'tool', toolName: 'submit_answer' },
+  ])
+}
+
+/** A downstream action whose arguments are the only accepted answer. */
+const answerCheckTool: ToolImplementation = {
+  toolParams: {
+    id: 'answer-check',
+    provisioned: false,
+    promptFragment: '',
+    name: 'answer-check',
+  },
+  supportedMedia: [],
+  functions: async (): Promise<ToolFunctions> => ({
+    submit_answer: {
+      description: 'Submit the answer recovered from the conversation source for verification.',
+      parameters: {
+        type: 'object' as const,
+        properties: {
+          answer: { type: 'string', description: 'The exact answer recovered from the source.' },
+        },
+        required: ['answer'],
+        additionalProperties: false,
+      },
+      invoke: async () => ({ type: 'text' as const, value: 'Answer recorded for verification.' }),
+    },
+  }),
+}
+
+function submittedAnswers(sink: TestSink): string[] {
+  return sink
+    .getToolCalls()
+    .filter((call) => call.toolName.includes('submit_answer'))
+    .map((call) => String(call.args.answer ?? ''))
+}
+
+function expectSubmittedAnswer(sink: TestSink, expected: string, label: string): void {
+  expect(
+    submittedAnswers(sink),
+    `${label}; observed answer-tool calls: ${JSON.stringify(
+      sink.getToolCalls().filter((call) => call.toolName.includes('submit_answer'))
+    )}`
+  ).toContain(expected)
 }
 
 /** Real tokenizer-based counts (same estimator `truncateChat` uses for real budget decisions) —
@@ -264,7 +383,9 @@ async function makeAssistant(
   }
   // Mirrors ChatAssistant.build()'s registration (bypassed here because build() looks models up
   // in the real `llmModels` registry, which we don't want to fake).
-  const { ContextRetrievePlugin } = await import('@/backend/lib/tools/context-retrieve/implementation')
+  const { ContextRetrievePlugin } = await import(
+    '@/backend/lib/tools/context-retrieve/implementation'
+  )
   const allTools = [
     ...tools,
     new ContextRetrievePlugin(
@@ -316,6 +437,9 @@ async function runTurn(
     content: userContent,
     attachments,
   }
+  // Production persists the user message before starting the assistant run. Mirror that write so
+  // the compression cache is warm before the message becomes historical in this harness.
+  await warmCompressionCache(userMessage)
   const fullHistory = [...history, userMessage]
   const sink = new TrackingSink(fullHistory)
   await assistant.processUserMessageWithSink(fullHistory, sink)
@@ -377,14 +501,21 @@ function buildLongReportText(title: string, topic: string, factsBlock: string[])
  *  part is that its result text (and the prompt in its own tool-call args) get compacted away,
  *  leaving only a `context-retrieve.get_message` reference behind. */
 const generateImageTool: ToolImplementation = {
-  toolParams: { id: 'generate-image', provisioned: false, promptFragment: '', name: 'generate_image' },
+  toolParams: {
+    id: 'generate-image',
+    provisioned: false,
+    promptFragment: '',
+    name: 'generate_image',
+  },
   supportedMedia: [],
   functions: async (): Promise<ToolFunctions> => ({
     generate_image: {
       description: 'Generate an image from a text prompt.',
       parameters: {
         type: 'object' as const,
-        properties: { prompt: { type: 'string', description: 'Description of the image to generate' } },
+        properties: {
+          prompt: { type: 'string', description: 'Description of the image to generate' },
+        },
         required: ['prompt'],
         additionalProperties: false,
       },
@@ -395,7 +526,9 @@ const generateImageTool: ToolImplementation = {
             type: 'text' as const,
             text:
               'Generated image. ' +
-              `Prompt used: "${params.prompt as string}". Style: watercolor, warm afternoon lighting, ` +
+              `Prompt used: "${
+                params.prompt as string
+              }". Style: watercolor, warm afternoon lighting, ` +
               'soft brush strokes, muted earth tones, gentle vignette. ' +
               // The one fact the follow-up turn probes for. Framed explicitly as tool-reported
               // metadata (not a visual detail one would need to *see* the image to know) — a first
@@ -425,8 +558,12 @@ const IMAGE_HIDDEN_DETAIL = 'Windermere Dusk'
 const IMAGE_TOOL_METADATA_PADDING = Array.from(
   { length: 25 },
   (_, i) =>
-    `Candidate variation ${i + 1}: seed ${1000 + i * 37}, model image-gen-v3, resolution 1024x1024, ` +
-    `safety score 0.0${i % 9}, aesthetic score 8.${i % 10}, sampler DPM++2M, steps 30, guidance scale 7.5, ` +
+    `Candidate variation ${i + 1}: seed ${
+      1000 + i * 37
+    }, model image-gen-v3, resolution 1024x1024, ` +
+    `safety score 0.0${i % 9}, aesthetic score 8.${
+      i % 10
+    }, sampler DPM++2M, steps 30, guidance scale 7.5, ` +
     'color palette notes: muted earth tones with warm highlights, composition notes: rule-of-thirds ' +
     'framing with the subject slightly left of center, post-processing: mild film grain and vignette applied.'
 ).join(' ')
@@ -463,7 +600,12 @@ const providerSpecs: ProviderSpec[] = [
       apiKey: process.env.ANTHROPIC_API_KEY!,
       provisioned: false,
     }),
-    model: () => makeModel(process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001', 'anthropic', 'anthropic'),
+    model: () =>
+      makeModel(
+        process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
+        'anthropic',
+        'anthropic'
+      ),
   },
   {
     name: 'gemini',
@@ -474,7 +616,8 @@ const providerSpecs: ProviderSpec[] = [
       apiKey: process.env.GEMINI_API_KEY!,
       provisioned: false,
     }),
-    model: () => makeModel(process.env.GEMINI_MODEL ?? 'gemini-2.5-flash', 'google-ai-studio', 'gemini'),
+    model: () =>
+      makeModel(process.env.GEMINI_MODEL ?? 'gemini-2.5-flash', 'google-ai-studio', 'gemini'),
   },
 ]
 
@@ -489,289 +632,423 @@ describe.skipIf(!ENABLED)('context compression benchmark', () => {
     describe.skipIf(skip)(spec.name, () => {
       // ── Scenario 1: generated image, detail recall ──────────────────────
 
-      test(
-        'recalls a detail from a generated image after the turn is compressed away',
-        async () => {
-          const assistant = await makeAssistant(spec.config(), spec.model(), [generateImageTool], 'conservative')
+      test('recalls a detail from a generated image after the turn is compressed away', async () => {
+        const assistant = await makeAssistant(
+          spec.config(),
+          spec.model(),
+          [generateImageTool, answerCheckTool],
+          'conservative'
+        )
 
-          // As in the document scenario: keep the reply generic so the assistant's own (never-
-          // compressed) turn-1 message can't leak the hidden detail we probe for later.
-          const turn1 = await runTurn(
-            assistant,
-            [],
-            'Generate an image of a red vintage bicycle leaning against a white brick wall. ' +
-              "Just briefly confirm when it's done — no need to describe what's in it."
-          )
-          expect(turn1.sink.hasError()).toBe(false)
+        // As in the document scenario: keep the reply generic so the assistant's own (never-
+        // compressed) turn-1 message can't leak the hidden detail we probe for later.
+        const turn1 = await runTurn(
+          assistant,
+          [],
+          'Generate an image of a red vintage bicycle leaning against a white brick wall. ' +
+            "Just briefly confirm when it's done — no need to describe what's in it."
+        )
+        expect(turn1.sink.hasError()).toBe(false)
 
-          const padded = withFillerTurns(turn1.history)
+        const padded = withFillerTurns(turn1.history)
 
-          // Precondition: compression must actually mark the tool turn for summarization before
-          // we even ask the model anything — isolates "did compression run" from "did the model cope".
-          const decisions = planMessageCompression(padded, 'conservative')
-          const toolMessage = turn1.history.find((m) => m.role === 'tool')!
-          expect(decisions.find((d) => d.messageId === toolMessage.id)?.policy).toBe('summary')
+        // Precondition: compression must actually mark the tool turn for summarization before
+        // we even ask the model anything — isolates "did compression run" from "did the model cope".
+        const decisions = planMessageCompression(padded, 'conservative')
+        const toolMessage = turn1.history.find((m) => m.role === 'tool')!
+        expect(decisions.find((d) => d.messageId === toolMessage.id)?.policy).toBe('summary')
 
-          const compacted = await applyCompressionPlan(padded, decisions)
-          const { beforeTokens, afterTokens, reductionPct } = await reportTokenSavings(
-            spec.model(),
-            padded,
-            compacted
-          )
-          expect(afterTokens).toBeLessThan(beforeTokens)
-          // A `content`-type tool result is dropped in full (not just truncated to a preview like
-          // a text-only result would be) — with ~9KB of generation metadata behind it, the savings
-          // should be substantial, not just technically-positive.
-          expect(reductionPct).toBeGreaterThan(15)
+        const compacted = await applyCompressionPlan(padded, decisions)
+        const { beforeTokens, afterTokens, reductionPct } = await reportTokenSavings(
+          spec.model(),
+          padded,
+          compacted
+        )
+        expect(afterTokens).toBeLessThan(beforeTokens)
+        // A `content`-type tool result is dropped in full (not just truncated to a preview like
+        // a text-only result would be) — with ~9KB of generation metadata behind it, the savings
+        // should be substantial, not just technically-positive.
+        expect(reductionPct).toBeGreaterThan(15)
 
-          const turn2 = await runTurn(
-            assistant,
-            padded,
-            'What internal title did the image generation tool assign to the image you generated ' +
-              'earlier? Reply with ONLY that title, nothing else.'
-          )
-          expect(turn2.sink.hasError()).toBe(false)
-          expect(turn2.sink.getText()).toContain(IMAGE_HIDDEN_DETAIL)
-          // No file exists for this message (the tool result never had a file item) — get_file
-          // isn't even a valid path here. This must have come from get_message or search.
-          expect(usesMessageRetrieval(turn2.sink.getToolCallNames())).toBe(true)
-        },
-        120_000
-      )
+        forceRecoveryAndAnswer(assistant, 'get_message')
+        const turn2 = await runTurn(
+          assistant,
+          padded,
+          'What internal title did the image generation tool assign to the image you generated ' +
+            'earlier? Call answer-check.submit_answer with ONLY that title. Do not answer in text.'
+        )
+        expect(turn2.sink.hasError()).toBe(false)
+        expectSubmittedAnswer(turn2.sink, IMAGE_HIDDEN_DETAIL, 'image detail answer')
+        // No file exists for this message (the tool result never had a file item) — get_file
+        // isn't even a valid path here. This must have come from get_message or search.
+        expectMessageRetrieval(turn2.sink, 'image detail recovery')
+        expect(
+          turn2.sink
+            .getToolCalls()
+            .filter((call) => calledFunction([call.toolName], 'get_message'))
+            .map((call) => call.args.id)
+        ).toContain(toolMessage.id)
+      }, 120_000)
 
       // ── Scenario 2: uploaded document, multiple retrieval questions ─────
 
-      test(
-        'recalls multiple facts from an uploaded document after the turn is compressed away',
-        async () => {
-          const docFileId = 'doc-confirmation-1'
-          fakeFiles.set(docFileId, {
-            id: docFileId,
-            name: 'reservation.txt',
-            type: 'text/plain',
-            path: `files/${docFileId}.txt`,
-            encryption: null,
-            size: 2200,
-            origin: 'uploaded',
-            // Non-null: token-estimator's text-fallback path (and context-retrieve's own File/
-            // FileBlob lookup, both mocked above) short-circuit to zero tokens when this is null —
-            // see reportTokenSavings.
-            fileBlobId: 'fake-blob-doc-1',
-          })
-          // A realistically-sized document (a few KB, not five lines) — real savings only show up
-          // once the omitted content is large enough that it dwarfs the fixed reference/note
-          // overhead added back in; a tiny fixture would make compression a net token loss.
-          //
-          // The facts block is deliberately placed *after* ~1000 characters of preamble: the
-          // inline text preview compression keeps visible even in a `summary` (see
-          // buildInlineTextSummary in compression-planner.ts) is capped at 500 characters, so
-          // placing the facts earlier would let the model answer straight from the compacted
-          // preview without ever calling context-retrieve — which would silently defeat the
-          // "did retrieval actually happen" assertion below.
-          fakeFileTexts.set(
-            docFileId,
-            [
-              'GRAND HARBOR HOTEL — RESERVATION CONFIRMATION',
-              '',
-              'Dear Guest,',
-              '',
-              'Thank you for choosing Grand Harbor Hotel for your upcoming stay. We are delighted to ' +
-                'confirm the details of your reservation and look forward to welcoming you soon. Please ' +
-                'find your reservation details below, and keep this confirmation for your records — you ' +
-                'may be asked to present it at check-in along with a valid photo ID and the credit card ' +
-                'used to guarantee the booking.',
-              '',
-              'Hotel amenities included in your stay: complimentary high-speed WiFi throughout the ' +
-                'property, access to the rooftop infinity pool and adjoining sun deck, full use of the ' +
-                'fitness center and sauna, and a daily continental breakfast served in the Harbor View ' +
-                'restaurant from 6:30 to 10:30. Valet parking is available for an additional nightly fee, ' +
-                'and self-parking is offered at a reduced rate for registered guests.',
-              '',
-              'Confirmation Number: RJ-88214',
-              'Check-in: 2026-04-02 (from 15:00)',
-              'Check-out: 2026-04-06 (until 11:00)',
-              'Room type: Deluxe King Suite',
-              'Number of guests: 2 adults',
-              'Rate plan: Best Available Rate, non-refundable',
-              'Total amount due: $842.50',
-              '',
-              'Cancellation policy: this rate is non-refundable. Changes to the reservation dates may ' +
-                'be requested up to 48 hours before check-in, subject to availability, and may result in ' +
-                'a rate adjustment. No-shows will be charged the full amount of the stay.',
-              '',
-              'Special requests noted on this reservation: late checkout requested (subject to ' +
-                'availability on the day), extra pillows, and a high floor if possible. Special requests ' +
-                'are not guaranteed and are fulfilled on a best-effort basis by the front desk team.',
-              '',
-              'Local information: the hotel is a fifteen-minute walk from the historic harbor district ' +
-                'and its collection of seafood restaurants, a short taxi ride from the central train ' +
-                'station, and approximately forty minutes from the international airport by car. The ' +
-                'concierge desk can arrange airport transfers, guided walking tours of the old town, and ' +
-                'reservations at nearby restaurants on request.',
-              '',
-              'If any of the details above are incorrect, or if you need to make changes to your ' +
-                'reservation, please contact our reservations team as soon as possible so we can assist ' +
-                'you before your arrival date. We look forward to welcoming you to Grand Harbor Hotel.',
-              '',
-              'Warm regards,',
-              'Grand Harbor Hotel Reservations Team',
-            ].join('\n')
+      test('recalls multiple facts from an uploaded document after the turn is compressed away', async () => {
+        const docFileId = 'doc-confirmation-1'
+        fakeFiles.set(docFileId, {
+          id: docFileId,
+          name: 'reservation.txt',
+          type: 'text/plain',
+          path: `files/${docFileId}.txt`,
+          encryption: null,
+          size: 2200,
+          origin: 'uploaded',
+          // Non-null: token-estimator's text-fallback path (and context-retrieve's own File/
+          // FileBlob lookup, both mocked above) short-circuit to zero tokens when this is null —
+          // see reportTokenSavings.
+          fileBlobId: 'fake-blob-doc-1',
+        })
+        // A realistically-sized document (a few KB, not five lines) — real savings only show up
+        // once the omitted content is large enough that it dwarfs the fixed reference/note
+        // overhead added back in; a tiny fixture would make compression a net token loss.
+        //
+        // The facts block is deliberately placed *after* ~1000 characters of preamble: the
+        // inline text preview compression keeps visible even in a `summary` (see
+        // buildInlineTextSummary in compression-planner.ts) is capped at 500 characters, so
+        // placing the facts earlier would let the model answer straight from the compacted
+        // preview without ever calling context-retrieve — which would silently defeat the
+        // "did retrieval actually happen" assertion below.
+        fakeFileTexts.set(
+          docFileId,
+          [
+            'GRAND HARBOR HOTEL — RESERVATION CONFIRMATION',
+            '',
+            'Dear Guest,',
+            '',
+            'Thank you for choosing Grand Harbor Hotel for your upcoming stay. We are delighted to ' +
+              'confirm the details of your reservation and look forward to welcoming you soon. Please ' +
+              'find your reservation details below, and keep this confirmation for your records — you ' +
+              'may be asked to present it at check-in along with a valid photo ID and the credit card ' +
+              'used to guarantee the booking.',
+            '',
+            'Hotel amenities included in your stay: complimentary high-speed WiFi throughout the ' +
+              'property, access to the rooftop infinity pool and adjoining sun deck, full use of the ' +
+              'fitness center and sauna, and a daily continental breakfast served in the Harbor View ' +
+              'restaurant from 6:30 to 10:30. Valet parking is available for an additional nightly fee, ' +
+              'and self-parking is offered at a reduced rate for registered guests.',
+            '',
+            'Confirmation Number: RJ-88214',
+            'Check-in: 2026-04-02 (from 15:00)',
+            'Check-out: 2026-04-06 (until 11:00)',
+            'Room type: Deluxe King Suite',
+            'Number of guests: 2 adults',
+            'Rate plan: Best Available Rate, non-refundable',
+            'Total amount due: $842.50',
+            '',
+            'Cancellation policy: this rate is non-refundable. Changes to the reservation dates may ' +
+              'be requested up to 48 hours before check-in, subject to availability, and may result in ' +
+              'a rate adjustment. No-shows will be charged the full amount of the stay.',
+            '',
+            'Special requests noted on this reservation: late checkout requested (subject to ' +
+              'availability on the day), extra pillows, and a high floor if possible. Special requests ' +
+              'are not guaranteed and are fulfilled on a best-effort basis by the front desk team.',
+            '',
+            'Local information: the hotel is a fifteen-minute walk from the historic harbor district ' +
+              'and its collection of seafood restaurants, a short taxi ride from the central train ' +
+              'station, and approximately forty minutes from the international airport by car. The ' +
+              'concierge desk can arrange airport transfers, guided walking tours of the old town, and ' +
+              'reservations at nearby restaurants on request.',
+            '',
+            'If any of the details above are incorrect, or if you need to make changes to your ' +
+              'reservation, please contact our reservations team as soon as possible so we can assist ' +
+              'you before your arrival date. We look forward to welcoming you to Grand Harbor Hotel.',
+            '',
+            'Warm regards,',
+            'Grand Harbor Hotel Reservations Team',
+          ].join('\n')
+        )
+
+        const assistant = await makeAssistant(
+          spec.config(),
+          spec.model(),
+          [answerCheckTool],
+          'conservative'
+        )
+
+        // Deliberately does not ask about any fact we'll probe for later: assistant messages are
+        // never compressed (only user/tool roles are), so if the assistant's own turn-1 reply
+        // restated a fact, it would stay visible verbatim forever — making the later "did it
+        // actually retrieve this" assertion meaningless.
+        const turn1 = await runTurn(
+          assistant,
+          [],
+          "I'm attaching my hotel reservation confirmation for my records. Reply with only the " +
+            'word "Received" — don\'t repeat or summarize anything from the document.',
+          [{ id: docFileId, mimetype: 'text/plain', name: 'reservation.txt', size: 2200 }]
+        )
+        expect(turn1.sink.hasError()).toBe(false)
+        expect(
+          compressedMessageStore.has(
+            `${turn1.history.find((m) => m.role === 'user')!.id}:${COMPRESSION_VERSION}`
           )
+        ).toBe(true)
 
-          const assistant = await makeAssistant(spec.config(), spec.model(), [], 'conservative')
+        const padded = withFillerTurns(turn1.history)
 
-          // Deliberately does not ask about any fact we'll probe for later: assistant messages are
-          // never compressed (only user/tool roles are), so if the assistant's own turn-1 reply
-          // restated a fact, it would stay visible verbatim forever — making the later "did it
-          // actually retrieve this" assertion meaningless.
-          const turn1 = await runTurn(
-            assistant,
-            [],
-            "I'm attaching my hotel reservation confirmation for my records. Reply with only the " +
-              "word \"Received\" — don't repeat or summarize anything from the document.",
-            [{ id: docFileId, mimetype: 'text/plain', name: 'reservation.txt', size: 2200 }]
-          )
-          expect(turn1.sink.hasError()).toBe(false)
-          expect(compressedMessageStore.has(`${turn1.history.find((m) => m.role === 'user')!.id}:2`)).toBe(true)
+        const decisions = planMessageCompression(padded, 'conservative')
+        const uploadMessage = turn1.history.find((m) => m.role === 'user')!
+        expect(decisions.find((d) => d.messageId === uploadMessage.id)?.policy).toBe('summary')
 
-          const padded = withFillerTurns(turn1.history)
+        const compacted = await applyCompressionPlan(padded, decisions)
+        const { beforeTokens, afterTokens } = await reportTokenSavings(
+          spec.model(),
+          padded,
+          compacted
+        )
+        expect(afterTokens).toBeLessThan(beforeTokens)
 
-          const decisions = planMessageCompression(padded, 'conservative')
-          const uploadMessage = turn1.history.find((m) => m.role === 'user')!
-          expect(decisions.find((d) => d.messageId === uploadMessage.id)?.policy).toBe('summary')
+        forceRecoveryAndAnswer(assistant, 'search')
+        const turn2 = await runTurn(
+          assistant,
+          padded,
+          'What was the confirmation number in the document I uploaded earlier? Call ' +
+            'answer-check.submit_answer with ONLY the number. Do not answer in text.'
+        )
+        expect(turn2.sink.hasError()).toBe(false)
+        expectSubmittedAnswer(turn2.sink, 'RJ-88214', 'confirmation number answer')
+        // get_message alone can't reveal document content (only its descriptor) — this must be
+        // a targeted search or get_file recovery of the attachment.
+        expectContextRecovery(turn2.sink, 'confirmation number recovery')
+        expect(
+          turn2.sink
+            .getToolCalls()
+            .filter(
+              (call) =>
+                call.toolName.includes('context-retrieve') &&
+                (call.toolName.includes('get_file') || call.toolName.includes('search'))
+            )
+            .map((call) => call.args.id)
+        ).toContain(docFileId)
 
-          const compacted = await applyCompressionPlan(padded, decisions)
-          const { beforeTokens, afterTokens } = await reportTokenSavings(spec.model(), padded, compacted)
-          expect(afterTokens).toBeLessThan(beforeTokens)
-
-          const turn2 = await runTurn(
-            assistant,
-            padded,
-            'What was the confirmation number in the document I uploaded earlier? Reply with ONLY the number.'
-          )
-          expect(turn2.sink.hasError()).toBe(false)
-          expect(turn2.sink.getText()).toContain('RJ-88214')
-          // get_message alone can't reveal document content (only its descriptor) — this must be
-          // get_file actually reading the attachment back.
-          expect(calledFunction(turn2.sink.getToolCallNames(), 'get_file')).toBe(true)
-
-          const turn3 = await runTurn(
-            assistant,
-            turn2.history,
-            'And per that same document, what was the total amount due? Reply with ONLY the amount.'
-          )
-          expect(turn3.sink.hasError()).toBe(false)
-          expect(turn3.sink.getText()).toContain('842.50')
-          expect(calledFunction(turn3.sink.getToolCallNames(), 'get_file')).toBe(true)
-        },
-        180_000
-      )
+        forceRecoveryAndAnswer(assistant, 'search')
+        const turn3 = await runTurn(
+          assistant,
+          turn2.history,
+          'And per that same document, what was the total amount due? Call ' +
+            'answer-check.submit_answer with ONLY the amount. Do not answer in text.'
+        )
+        expect(turn3.sink.hasError()).toBe(false)
+        expect(
+          submittedAnswers(turn3.sink).some((answer) => /^\$?842\.50$/.test(answer.trim())),
+          `observed amount-tool calls: ${JSON.stringify(submittedAnswers(turn3.sink))}`
+        ).toBe(true)
+        expectContextRecovery(turn3.sink, 'total amount recovery')
+        expect(
+          turn3.sink
+            .getToolCalls()
+            .filter(
+              (call) =>
+                call.toolName.includes('context-retrieve') &&
+                (call.toolName.includes('get_file') || call.toolName.includes('search'))
+            )
+            .map((call) => call.args.id)
+        ).toContain(docFileId)
+      }, 180_000)
 
       // ── Scenario 3: two uploaded PDFs, a question requiring both ────────
 
-      test(
-        'coordinates facts across two uploaded documents after both turns are compressed away',
-        async () => {
-          const fileA = 'doc-q3-financial'
-          const fileB = 'doc-q4-vendors'
+      test('coordinates facts across two uploaded documents after both turns are compressed away', async () => {
+        const fileA = 'doc-q3-financial'
+        const fileB = 'doc-q4-vendors'
 
-          fakeFiles.set(fileA, {
-            id: fileA,
-            name: 'q3-financial-report.pdf',
-            type: 'application/pdf',
-            path: `files/${fileA}.pdf`,
-            encryption: null,
-            size: 9000,
-            origin: 'uploaded',
-            fileBlobId: 'fake-blob-q3',
-          })
-          fakeFileTexts.set(
-            fileA,
-            buildLongReportText('NORTHWIND ANALYTICS — Q3 FINANCIAL REPORT', 'Q3 financial review', [
-              'Total R&D expenditure for Q3: $2,145,300.',
-            ])
+        fakeFiles.set(fileA, {
+          id: fileA,
+          name: 'q3-financial-report.pdf',
+          type: 'application/pdf',
+          path: `files/${fileA}.pdf`,
+          encryption: null,
+          size: 9000,
+          origin: 'uploaded',
+          fileBlobId: 'fake-blob-q3',
+        })
+        fakeFileTexts.set(
+          fileA,
+          buildLongReportText('NORTHWIND ANALYTICS — Q3 FINANCIAL REPORT', 'Q3 financial review', [
+            'Total R&D expenditure for Q3: $2,145,300.',
+          ])
+        )
+
+        fakeFiles.set(fileB, {
+          id: fileB,
+          name: 'q4-vendor-contracts.pdf',
+          type: 'application/pdf',
+          path: `files/${fileB}.pdf`,
+          encryption: null,
+          size: 9000,
+          origin: 'uploaded',
+          fileBlobId: 'fake-blob-q4',
+        })
+        fakeFileTexts.set(
+          fileB,
+          buildLongReportText(
+            'NORTHWIND ANALYTICS — Q4 VENDOR CONTRACTS SUMMARY',
+            'Q4 vendor contract review',
+            ['Meridian Systems contract renewal date: 2027-01-15.']
           )
+        )
 
-          fakeFiles.set(fileB, {
-            id: fileB,
-            name: 'q4-vendor-contracts.pdf',
-            type: 'application/pdf',
-            path: `files/${fileB}.pdf`,
-            encryption: null,
-            size: 9000,
-            origin: 'uploaded',
-            fileBlobId: 'fake-blob-q4',
-          })
-          fakeFileTexts.set(
-            fileB,
-            buildLongReportText('NORTHWIND ANALYTICS — Q4 VENDOR CONTRACTS SUMMARY', 'Q4 vendor contract review', [
-              'Meridian Systems contract renewal date: 2027-01-15.',
-            ])
+        const assistant = await makeAssistant(
+          spec.config(),
+          spec.model(),
+          [answerCheckTool],
+          'conservative'
+        )
+
+        const turn1 = await runTurn(
+          assistant,
+          [],
+          'I\'m attaching our Q3 financial report. Reply with only the word "Received" — don\'t ' +
+            'repeat or summarize anything from the document.',
+          [{ id: fileA, mimetype: 'application/pdf', name: 'q3-financial-report.pdf', size: 9000 }]
+        )
+        expect(turn1.sink.hasError()).toBe(false)
+
+        const turn2 = await runTurn(
+          assistant,
+          turn1.history,
+          'I\'m attaching our Q4 vendor contracts summary. Reply with only the word "Received" — ' +
+            "don't repeat or summarize anything from the document.",
+          [{ id: fileB, mimetype: 'application/pdf', name: 'q4-vendor-contracts.pdf', size: 9000 }]
+        )
+        expect(turn2.sink.hasError()).toBe(false)
+
+        const padded = withFillerTurns(turn2.history)
+
+        const decisions = planMessageCompression(padded, 'conservative')
+        const upload1 = turn1.history.find((m) => m.role === 'user')!
+        const upload2 = turn2.history.filter((m) => m.role === 'user').at(-1)!
+        expect(decisions.find((d) => d.messageId === upload1.id)?.policy).toBe('summary')
+        expect(decisions.find((d) => d.messageId === upload2.id)?.policy).toBe('summary')
+
+        const compacted = await applyCompressionPlan(padded, decisions)
+        const { beforeTokens, afterTokens, reductionPct } = await reportTokenSavings(
+          spec.model(),
+          padded,
+          compacted
+        )
+        expect(afterTokens).toBeLessThan(beforeTokens)
+        // With two multi-KB documents compressed away, savings should be substantial — not just
+        // "technically less".
+        expect(reductionPct).toBeGreaterThan(20)
+
+        forceToolSequence(assistant, [
+          { type: 'tool', toolName: 'search' },
+          { type: 'tool', toolName: 'search' },
+          { type: 'tool', toolName: 'submit_answer' },
+        ])
+        const turn3 = await runTurn(
+          assistant,
+          padded,
+          "Reply in the exact format 'EXPENDITURE | RENEWAL_DATE' with: the total R&D expenditure " +
+            'from the Q3 financial report, and the renewal date for the Meridian Systems vendor ' +
+            'contract from the Q4 vendor contracts summary. Call answer-check.submit_answer with ' +
+            'exactly that format. Do not answer in text.'
+        )
+        expect(turn3.sink.hasError()).toBe(false)
+        const submitted = submittedAnswers(turn3.sink)
+        expect(
+          submitted.some(
+            (answer) =>
+              answer.replaceAll(',', '').replaceAll('$', '').replaceAll(' ', '') ===
+              '2145300|2027-01-15'
+          ),
+          `observed tool calls: ${JSON.stringify(
+            turn3.sink.getToolCalls()
+          )}; results: ${JSON.stringify(turn3.sink.getToolResults())}`
+        ).toBe(true)
+
+        // Coordination proof: both documents must have actually been retrieved, not just one
+        // (which could make a lucky guess look like success) or neither (a hallucination that
+        // happens to match both facts).
+        const retrievedFileIds = turn3.sink
+          .getToolCalls()
+          .filter(
+            (c) =>
+              c.toolName.includes('context-retrieve') &&
+              (c.toolName.includes('get_file') || c.toolName.includes('search'))
           )
+          .map((c) => c.args.id)
+        expect(retrievedFileIds).toContain(fileA)
+        expect(retrievedFileIds).toContain(fileB)
+      }, 180_000)
 
-          const assistant = await makeAssistant(spec.config(), spec.model(), [], 'conservative')
+      // ── Scenario 4: current-turn translation after a topic shift ────────
 
-          const turn1 = await runTurn(
-            assistant,
-            [],
-            "I'm attaching our Q3 financial report. Reply with only the word \"Received\" — don't " +
-              'repeat or summarize anything from the document.',
-            [{ id: fileA, mimetype: 'application/pdf', name: 'q3-financial-report.pdf', size: 9000 }]
-          )
-          expect(turn1.sink.hasError()).toBe(false)
+      test('preserves a current translation request after unrelated history is compressed', async () => {
+        const historicalScript = [
+          'Telephone-script translation request.',
+          ...Array.from(
+            { length: 25 },
+            (_, index) =>
+              `Background note ${
+                index + 1
+              }: this historical paragraph is unrelated filler for the document review and should not be repeated in the confirmation. `
+          ),
+          'Testo da tradurre: la firma digitale per la polizza rischi catastrofali non è andata a buon fine. Possiamo completarla al telefono. Ti arriveranno due codici OTP via SMS; leggimeli quando li ricevi.',
+        ].join('\n\n')
 
-          const turn2 = await runTurn(
-            assistant,
-            turn1.history,
-            "I'm attaching our Q4 vendor contracts summary. Reply with only the word \"Received\" — " +
-              "don't repeat or summarize anything from the document.",
-            [{ id: fileB, mimetype: 'application/pdf', name: 'q4-vendor-contracts.pdf', size: 9000 }]
-          )
-          expect(turn2.sink.hasError()).toBe(false)
+        const assistant = await makeAssistant(
+          spec.config(),
+          spec.model(),
+          [answerCheckTool],
+          'aggressive'
+        )
+        const turn1 = await runTurn(
+          assistant,
+          [],
+          `${historicalScript}\n\nReply only with "Received" and do not repeat any part of the script.`
+        )
+        expect(turn1.sink.hasError()).toBe(false)
 
-          const padded = withFillerTurns(turn2.history)
+        const padded = withFillerTurns(turn1.history)
+        const decisions = planMessageCompression(padded, 'aggressive')
+        const sourceMessage = turn1.history.find((message) => message.role === 'user')!
+        expect(decisions.find((decision) => decision.messageId === sourceMessage.id)?.policy).toBe(
+          'summary'
+        )
 
-          const decisions = planMessageCompression(padded, 'conservative')
-          const upload1 = turn1.history.find((m) => m.role === 'user')!
-          const upload2 = turn2.history.filter((m) => m.role === 'user').at(-1)!
-          expect(decisions.find((d) => d.messageId === upload1.id)?.policy).toBe('summary')
-          expect(decisions.find((d) => d.messageId === upload2.id)?.policy).toBe('summary')
+        const compacted = await applyCompressionPlan(padded, decisions)
+        const { beforeTokens, afterTokens } = await reportTokenSavings(
+          spec.model(),
+          padded,
+          compacted
+        )
+        expect(afterTokens).toBeLessThan(beforeTokens)
 
-          const compacted = await applyCompressionPlan(padded, decisions)
-          const { beforeTokens, afterTokens, reductionPct } = await reportTokenSavings(
-            spec.model(),
-            padded,
-            compacted
-          )
-          expect(afterTokens).toBeLessThan(beforeTokens)
-          // With two multi-KB documents compressed away, savings should be substantial — not just
-          // "technically less".
-          expect(reductionPct).toBeGreaterThan(20)
-
-          const turn3 = await runTurn(
-            assistant,
-            padded,
-            "Reply in the exact format 'EXPENDITURE | RENEWAL_DATE' with: the total R&D expenditure " +
-              'from the Q3 financial report, and the renewal date for the Meridian Systems vendor ' +
-              'contract from the Q4 vendor contracts summary. Nothing else in your reply.'
-          )
-          expect(turn3.sink.hasError()).toBe(false)
-          const answer = turn3.sink.getText()
-          expect(answer).toContain('2,145,300')
-          expect(answer).toContain('2027-01-15')
-
-          // Coordination proof: both documents must have actually been retrieved, not just one
-          // (which could make a lucky guess look like success) or neither (a hallucination that
-          // happens to match both facts).
-          const retrievedFileIds = turn3.sink
-            .getToolCalls()
-            .filter((c) => c.toolName.includes('context-retrieve') && c.toolName.includes('get_file'))
-            .map((c) => c.args.id)
-          expect(retrievedFileIds).toContain(fileA)
-          expect(retrievedFileIds).toContain(fileB)
-        },
-        180_000
-      )
+        forceToolSequence(assistant, [
+          { type: 'tool', toolName: 'search' },
+          { type: 'tool', toolName: 'get_message' },
+          { type: 'tool', toolName: 'submit_answer' },
+        ])
+        const turn2 = await runTurn(
+          assistant,
+          padded,
+          'Translate the telephone script from earlier into English. Call ' +
+            'answer-check.submit_answer with only the translation and preserve every fact. Do ' +
+            'not answer in text.'
+        )
+        expect(turn2.sink.hasError()).toBe(false)
+        expectMessageRetrieval(turn2.sink, 'translation recovery')
+        const translation = submittedAnswers(turn2.sink).join(' ').toLowerCase()
+        expect(
+          translation,
+          `observed tool calls: ${JSON.stringify(
+            turn2.sink.getToolCalls()
+          )}; results: ${JSON.stringify(turn2.sink.getToolResults())}`
+        ).toContain('digital signature')
+        expect(translation).toMatch(/catastroph/)
+        expect(translation).toContain('otp')
+        expect(translation).toContain('sms')
+      }, 120_000)
     })
   }
 })

--- a/__tests__/llm-knowledge-probes.test.ts
+++ b/__tests__/llm-knowledge-probes.test.ts
@@ -1,0 +1,453 @@
+/**
+ * Small, source-grounded LLM probes for the accepted context/knowledge corpus.
+ *
+ * These are deliberately not replays of the production bundles: the bundles stay outside the
+ * repository and the expensive replay campaign remains the investigation tool. This suite keeps
+ * a few sanitized, adversarial fixtures that represent the corpus' behavioural groups. Forced
+ * probes isolate whether the model uses returned evidence correctly; unforced probes test the
+ * model's decision to retrieve (and to avoid retrieval when it is unnecessary). There is no LLM
+ * judge here.
+ *
+ * Run the live probes explicitly, using the cheap first backend by default:
+ *   RUN_LLM_INTEGRATION=1 LLM_RETRIEVAL_PROBES=1 pnpm vitest run __tests__/llm-knowledge-probes.test.ts
+ *   LLM_PROBE_MODEL=gpt-4.1-mini ...
+ */
+
+import { beforeAll, describe, expect, test, vi } from 'vitest'
+
+const { mockSearchBox } = vi.hoisted(() => ({ mockSearchBox: vi.fn() }))
+
+vi.mock('@/lib/env', () => ({
+  default: {
+    dumpLlmConversation: false,
+    allowMockProvider: false,
+    chat: {
+      autoSummary: { enable: false },
+      maxOutputTokens: undefined,
+      disableParallelToolCalls: false,
+    },
+    knowledge: { sendInPrompt: false },
+    fileStorage: { encryptFiles: false },
+    tools: { websearch: { defaultApiUrl: '' }, prefixFunctionNames: false },
+    promptCaching: { anthropic: { preamble: 'none', automatic: 'none' }, openai: 'none' },
+  },
+}))
+vi.mock('@/lib/logging', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), log: vi.fn() },
+  loggingFetch: undefined,
+}))
+vi.mock('@/lib/satellite/hub', () => ({ connections: [], callSatelliteMethod: vi.fn() }))
+vi.mock('@/lib/storage', () => ({ storage: { writeBuffer: vi.fn() } }))
+vi.mock('@/models/file', () => ({ addFile: vi.fn(), getFileWithId: vi.fn() }))
+vi.mock('@/lib/models', () => ({ llmModels: [] }))
+vi.mock('@/models/backend', () => ({ getBackends: vi.fn().mockResolvedValue([]) }))
+vi.mock('@/models/user', () => ({}))
+vi.mock('@/db/database', () => ({ db: {} }))
+vi.mock('@/db/dialect', () => ({ createDialect: () => null }))
+vi.mock('@/backend/lib/files/authorization', () => ({ canAccessFile: vi.fn() }))
+vi.mock('@/backend/lib/knowledge/retrieval', () => ({
+  searchBox: (...args: unknown[]) => mockSearchBox(...args),
+  searchBoxDocuments: vi.fn().mockResolvedValue([]),
+}))
+vi.mock('@/backend/lib/knowledge/store', () => ({
+  listBoxDocuments: vi.fn().mockResolvedValue([]),
+  loadBoxProjections: vi.fn().mockResolvedValue([]),
+  loadFileChunkRange: vi.fn().mockResolvedValue([]),
+}))
+
+import * as dto from '@/types/dto'
+import { setTokenizerCounter } from '@/backend/lib/chat/prompt-token-counter'
+import { countTextWithTokenizer } from '@/lib/chat/tokenizer'
+import { ChatAssistant, type AssistantParams } from '@/backend/lib/chat'
+import { KnowledgeBoxTool } from '@/backend/lib/tools/knowledge_box/implementation'
+import type { ClientSink } from '@/backend/lib/chat/ClientSink'
+import type { LlmModel } from '@/lib/chat/models'
+import type { ToolFunctions, ToolImplementation } from '@/lib/chat/tools'
+import type { ProviderConfig } from '@/types/provider'
+
+const ENABLED = process.env.RUN_LLM_INTEGRATION === '1' && process.env.LLM_RETRIEVAL_PROBES === '1'
+
+beforeAll(() => {
+  setTokenizerCounter({
+    countText: async (tokenizer, text) => countTextWithTokenizer(tokenizer, text),
+  })
+})
+
+// This is the accepted external corpus' coverage ledger. IDs are intentionally only identifiers:
+// no production prompts, replies, tenant names, files, or raw bundles are copied into the repo.
+const datasetProbeCoverage = [
+  {
+    probe: 'compression-attachment-follow-up',
+    cases: ['001', '002', '003', '004', '016', '017', '018', '022', '026'],
+  },
+  { probe: 'compression-long-history', cases: ['005', '006', '011', '013', '014', '015', '025'] },
+  { probe: 'compression-negative-control', cases: ['007', '008', '009', '010', '012'] },
+  { probe: 'compression-correctness-sensitive', cases: ['024'] },
+  { probe: 'knowledge-legal-distinction', cases: ['019', '021'] },
+  { probe: 'knowledge-source-boundary', cases: ['020', '023'] },
+  { probe: 'knowledge-visual-document-match', cases: ['027', '028'] },
+] as const
+
+describe('accepted dataset coverage ledger', () => {
+  test('accounts for every accepted case exactly once as a primary probe', () => {
+    const primaryCases = datasetProbeCoverage.flatMap(({ cases }) => cases)
+    expect(new Set(primaryCases).size).toBe(28)
+    expect([...primaryCases].sort()).toEqual(
+      Array.from({ length: 28 }, (_, index) => String(index + 1).padStart(3, '0')).sort()
+    )
+  })
+})
+
+function makeModel(): LlmModel {
+  const model = process.env.LLM_PROBE_MODEL ?? 'gpt-4o-mini'
+  return {
+    id: model,
+    model,
+    name: model,
+    description: 'cheap deterministic retrieval probe',
+    context_length: 128_000,
+    capabilities: { vision: false, function_calling: true },
+    provider: 'openai',
+    owned_by: 'openai',
+  }
+}
+
+const config = (): ProviderConfig => ({
+  providerType: 'openai',
+  name: 'llm-retrieval-probes',
+  apiKey: process.env.OPENAI_API_KEY!,
+  provisioned: false,
+})
+
+class ProbeSink implements ClientSink {
+  readonly events: dto.TextStreamPart[] = []
+
+  enqueue(event: dto.TextStreamPart) {
+    this.events.push(event)
+  }
+
+  text() {
+    return this.events
+      .filter((event): event is { type: 'text'; text: string } => event.type === 'text')
+      .map((event) => event.text)
+      .join('')
+  }
+
+  parts() {
+    return this.events
+      .filter((event) => event.type === 'part')
+      .map((event) => (event as dto.TextStreamPart & { type: 'part'; part: dto.MessagePart }).part)
+  }
+
+  toolCalls() {
+    return this.parts()
+      .filter((part): part is dto.ToolCallPart => part.type === 'tool-call')
+      .map(({ toolName, args }) => ({ toolName, args }))
+  }
+
+  toolResults() {
+    return this.parts()
+      .filter((part): part is dto.ToolCallResultPart => part.type === 'tool-result')
+      .map(({ toolName, result }) => ({ toolName, result }))
+  }
+
+  hasError() {
+    return this.parts().some((part) => part.type === 'error')
+  }
+}
+
+interface ProbeSource {
+  fileId: string
+  fileName: string
+  text: string
+  mimeType?: string
+}
+
+interface ProbeAssistantOptions {
+  forceRetrieval?: boolean
+  systemPrompt?: string
+}
+
+const answerCheckTool: ToolImplementation = {
+  toolParams: {
+    id: 'answer-check',
+    name: 'answer-check',
+    provisioned: false,
+    promptFragment: '',
+  },
+  supportedMedia: [],
+  functions: async (): Promise<ToolFunctions> => ({
+    submit_answer: {
+      description: 'Submit the answer found for verification.',
+      parameters: {
+        type: 'object' as const,
+        properties: {
+          answer: { type: 'string', description: 'The answer found in the knowledge source.' },
+        },
+        required: ['answer'],
+        additionalProperties: false,
+      },
+      invoke: async () => ({ type: 'text' as const, value: 'Answer recorded for verification.' }),
+    },
+  }),
+}
+
+function makeKnowledgeTool(
+  sourceText: string,
+  additionalSources: ProbeSource[] = []
+): ToolImplementation {
+  const sources: ProbeSource[] = [
+    {
+      fileId: 'probe-source',
+      fileName: 'reviewed-source.pdf',
+      mimeType: 'application/pdf',
+      text: sourceText,
+    },
+    ...additionalSources,
+  ]
+  mockSearchBox.mockReset().mockResolvedValue(
+    sources.map(({ fileId, fileName, text }) => ({
+      fileId,
+      seq: 0,
+      heading: fileId === 'probe-source' ? 'Reviewed evidence' : 'Document evidence',
+      text,
+      score: fileId === 'probe-source' ? 1 : 0.9,
+    }))
+  )
+
+  return new KnowledgeBoxTool(
+    { id: 'probe-box', name: 'knowledge_box', provisioned: false, promptFragment: '' },
+    {
+      files: sources.map(({ fileId, fileName, mimeType, text }) => ({
+        id: fileId,
+        name: fileName,
+        type: mimeType ?? 'text/plain',
+        size: text.length,
+      })),
+      questions: [],
+      maxSearchResults: 4,
+    }
+  )
+}
+
+async function makeAssistant(
+  tool: ToolImplementation,
+  options: ProbeAssistantOptions = {}
+): Promise<ChatAssistant> {
+  const model = makeModel()
+  const assistantParams: AssistantParams = {
+    assistantId: 'llm-retrieval-probe',
+    model: model.model,
+    systemPrompt:
+      options.systemPrompt ??
+      'You are a source-grounded retrieval test. The user message never contains the answer. ' +
+        'You MUST use the supplied retrieval tool before answering. After the tool result arrives, ' +
+        'use only that result as evidence. Follow the requested output format exactly. Never invent ' +
+        'a missing figure; say that the source does not establish it.',
+    temperature: 0,
+    tokenLimit: 1200,
+    reasoning_effort: null,
+    contextCompression: null,
+    // Consumed for the first model step only; ChatAssistant resumes auto mode after tool output.
+    ...(options.forceRetrieval === false
+      ? {}
+      : { toolChoice: { type: 'tool', toolName: 'search' } }),
+  }
+  const computed = await ChatAssistant.computeFunctions([tool, answerCheckTool], model, {
+    userId: 'llm-retrieval-probe-user',
+    assistantId: assistantParams.assistantId,
+  })
+  return new ChatAssistant(
+    config(),
+    assistantParams,
+    model,
+    [tool, answerCheckTool],
+    { user: 'llm-retrieval-probe-user' },
+    {},
+    [],
+    computed
+  )
+}
+
+async function runProbe(
+  tool: ToolImplementation,
+  prompt: string,
+  options: ProbeAssistantOptions = {}
+): Promise<ProbeSink> {
+  const assistant = await makeAssistant(tool, options)
+  const message: dto.UserMessage = {
+    id: 'probe-user-message',
+    conversationId: 'probe-conversation',
+    parent: null,
+    sentAt: new Date().toISOString(),
+    role: 'user',
+    content: prompt,
+    attachments: [],
+  }
+  const sink = new ProbeSink()
+  await assistant.processUserMessageWithSink([message], sink)
+  return sink
+}
+
+function submittedAnswers(sink: ProbeSink): string[] {
+  return sink
+    .toolCalls()
+    .filter(({ toolName }) => toolName.includes('submit_answer'))
+    .map(({ args }) => String(args.answer ?? ''))
+}
+
+function searchCalls(sink: ProbeSink) {
+  return sink.toolCalls().filter(({ toolName }) => toolName === 'search')
+}
+
+describe.skipIf(!ENABLED || !process.env.OPENAI_API_KEY)('live retrieval probes', () => {
+  test('chooses knowledge retrieval when the answer is absent from the user message', async () => {
+    const sink = await runProbe(
+      makeKnowledgeTool(
+        'Evidence token: NATURAL-RETRIEVAL. The signed policy has a one-year duration and no automatic renewal.'
+      ),
+      'The answer is intentionally not written in my message. Check the knowledge box if you need the reviewed source, then call answer-check.submit_answer with the policy duration, renewal status, and exact evidence token.',
+      {
+        forceRetrieval: false,
+        systemPrompt:
+          'Answer accurately. The knowledge box is available for source-dependent questions. ' +
+          'Use it when the user message does not establish the answer; do not guess. ' +
+          'After retrieval, use only the retrieved evidence for source-specific claims.',
+      }
+    )
+
+    expect(sink.hasError()).toBe(false)
+    expect(sink.toolCalls().some(({ toolName }) => toolName === 'search')).toBe(true)
+    expect(mockSearchBox).toHaveBeenCalled()
+    expect(
+      sink.toolResults().some(({ result }) => JSON.stringify(result).includes('NATURAL-RETRIEVAL'))
+    ).toBe(true)
+    const answer = submittedAnswers(sink).join(' ').toLowerCase()
+    expect(answer).toMatch(/one.year|one year/)
+    expect(answer).toMatch(/no automatic renewal|does not renew|not renew/)
+  }, 30_000)
+
+  test('retrieves the requested record instead of returning a neighbouring phone number', async () => {
+    const lucaNumber = '+39 02 555 0101'
+    const otherNumber = '+39 02 555 0199'
+    const sink = await runProbe(
+      makeKnowledgeTool(
+        `Phone directory PDF. Luca — ${lucaNumber}. Marco — ${otherNumber}. The numbers are office contacts; preserve the country code and all digits.`
+      ),
+      'Look up Luca in the phone-directory PDF, then call answer-check.submit_answer with only Luca’s complete phone number, with no name, explanation, or other contact.',
+      { forceRetrieval: false }
+    )
+
+    const searchCalls = sink.toolCalls().filter(({ toolName }) => toolName === 'search')
+    expect(sink.hasError()).toBe(false)
+    expect(searchCalls.length).toBeGreaterThanOrEqual(1)
+    expect(String(searchCalls[0]?.args.query)).toMatch(/luca/i)
+    const searchArgs = mockSearchBox.mock.calls[0] as [string, string, number, string[] | undefined]
+    expect(searchArgs[0]).toBe('probe-box')
+    expect(searchArgs[1]).toMatch(/luca/i)
+    expect(searchArgs[2]).toBe(4)
+    if (searchArgs[3] !== undefined) expect(searchArgs[3]).toContain('probe-source')
+    expect(submittedAnswers(sink)).toContain(lucaNumber)
+    expect(submittedAnswers(sink).join(' ')).not.toContain(otherNumber)
+  }, 30_000)
+
+  test('does not retrieve when the user supplied a self-contained non-source question', async () => {
+    const sink = await runProbe(
+      makeKnowledgeTool('Evidence token: SHOULD-NOT-BE-USED. This source is unrelated arithmetic.'),
+      'This is a self-contained arithmetic question. What is 17 plus 25? Call answer-check.submit_answer with only the number; do not use the knowledge box.',
+      {
+        forceRetrieval: false,
+        systemPrompt:
+          'Answer self-contained questions directly. Use the knowledge box only when the answer ' +
+          'depends on a source in it, and never retrieve for ordinary arithmetic.',
+      }
+    )
+
+    expect(sink.hasError()).toBe(false)
+    expect(sink.toolCalls().some(({ toolName }) => toolName === 'search')).toBe(false)
+    expect(mockSearchBox).not.toHaveBeenCalled()
+    expect(submittedAnswers(sink)).toContain('42')
+  }, 30_000)
+
+  test('preserves a legal distinction after mandatory knowledge retrieval', async () => {
+    const sink = await runProbe(
+      makeKnowledgeTool(
+        'Evidence token: A26-3-ONE-YEAR. A subsequent agreement after one year is outside the ordinary art. 26(2) reduction. The reviewed commentary says the credit note concerns the taxable amount only. Art. 26(3-bis) is a separate non-payment regime with objective prerequisites.'
+      ),
+      'Use a focused search query containing a subject term such as "art. 26", "subsequent agreement", or "non-payment". Then call answer-check.submit_answer with two short bullets explaining the source distinction. The first bullet must start with the exact evidence token from the retrieved passage, followed by the phrase "taxable amount only".'
+    )
+
+    expect(sink.hasError()).toBe(false)
+    expect(searchCalls(sink).length).toBeGreaterThanOrEqual(1)
+    expect(String(searchCalls(sink)[0]?.args.query)).toMatch(/agreement|art|one.year/i)
+    expect(mockSearchBox).toHaveBeenCalledOnce()
+    expect(
+      sink.toolResults().some(({ result }) => JSON.stringify(result).includes('A26-3-ONE-YEAR'))
+    ).toBe(true)
+    const answer = submittedAnswers(sink).join(' ')
+    expect(answer).toContain('26(3-bis)')
+    expect(answer.toLowerCase()).toContain('taxable amount only')
+  }, 30_000)
+
+  test('does not merge a superseded document version into the current answer', async () => {
+    const sink = await runProbe(
+      makeKnowledgeTool(
+        'Evidence token: CURRENT-SIGNED-VERSION. The signed 2026 policy supersedes all drafts and sets the renewal date to 2027-01-15.',
+        [
+          {
+            fileId: 'draft-source',
+            fileName: 'policy-draft.pdf',
+            text: 'Evidence token: OLD-DRAFT-VERSION. An unsigned 2025 draft proposed renewal on 2026-01-15, but it was superseded and must not be used.',
+          },
+        ]
+      ),
+      'Search for the signed current policy, not an old draft. Call answer-check.submit_answer with only the renewal date from the signed 2026 policy and the exact evidence token that supports it.'
+    )
+
+    expect(sink.hasError()).toBe(false)
+    expect(searchCalls(sink)[0]?.toolName).toBe('search')
+    expect(String(searchCalls(sink)[0]?.args.query)).toMatch(/signed|current|policy/i)
+    const answer = submittedAnswers(sink).join(' ')
+    expect(answer).toContain('CURRENT-SIGNED-VERSION')
+    expect(answer).toMatch(/2027-01-15|January 15, 2027|15 January 2027/i)
+    expect(answer).not.toContain('2026-01-15')
+  }, 30_000)
+
+  test('does not turn a knowledge-box source boundary into an invented figure', async () => {
+    const sink = await runProbe(
+      makeKnowledgeTool(
+        'Evidence token: VAT-SOURCE-ONLY. The reviewed documents establish a VAT limitation for the leased vehicle and discuss medical exemption/pro-rata treatment. They do not establish an IRPEF percentage or an IRPEF monetary ceiling.'
+      ),
+      'Answer the VAT part from the evidence and include the exact evidence token from the retrieved passage. For the IRPEF percentage and monetary ceiling, call answer-check.submit_answer and say exactly that the reviewed source does not establish them. Do not provide any guessed number.'
+    )
+
+    const answer = submittedAnswers(sink).join(' ').toLowerCase()
+    expect(sink.hasError()).toBe(false)
+    expect(searchCalls(sink).length).toBeGreaterThanOrEqual(1)
+    expect(String(searchCalls(sink)[0]?.args.query)).toMatch(/irpef|vat|vehicle|leased/i)
+    expect(
+      sink.toolResults().some(({ result }) => JSON.stringify(result).includes('VAT-SOURCE-ONLY'))
+    ).toBe(true)
+    expect(answer).toMatch(
+      /does not establish|not establish|not specified|not stated|cannot establish/
+    )
+    expect(answer).not.toMatch(/20\s*%|18[,.]075[,.]99|18[,.]075/)
+  }, 30_000)
+
+  test('uses visual landmarks to select the matching catalogue document', async () => {
+    const sink = await runProbe(
+      makeKnowledgeTool(
+        'Evidence token: GUBI-11482-PAGE-71. The catalogue entry for the un-upholstered Bat chair with conic metal base is model 11482: 57 cm wide, 61 cm deep, 83 cm high, seat height 43.5 cm, weight 8.6 kg. Nearby upholstered variants are different products.'
+      ),
+      'A user photo shows an un-upholstered Bat chair with a conic metal base. Search the knowledge source, then call answer-check.submit_answer with the exact evidence token and the five measurements from the matching catalogue entry.'
+    )
+
+    expect(sink.hasError()).toBe(false)
+    expect(searchCalls(sink)).toHaveLength(1)
+    expect(String(searchCalls(sink)[0]?.args.query)).toMatch(/bat|chair|conic|base/i)
+    const answer = submittedAnswers(sink).join(' ')
+    expect(answer).toContain('43.5 cm')
+    expect(answer).toContain('8.6 kg')
+    expect(answer).not.toContain('43.5 kg')
+  }, 30_000)
+})

--- a/apps/backend/lib/chat/index.ts
+++ b/apps/backend/lib/chat/index.ts
@@ -99,6 +99,10 @@ export interface AssistantParams {
   tokenLimit: number
   reasoning_effort: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | null
   contextCompression: dto.ContextCompressionConfig
+  /** Optional test/evaluation override; normal assistants leave tool selection on auto. */
+  toolChoice?: ai.ToolChoice<Record<string, ai.Tool>>
+  /** Optional test/evaluation sequence; normal assistants leave tool selection on auto. */
+  toolChoiceSequence?: ai.ToolChoice<Record<string, ai.Tool>>[]
 }
 
 export type AssistantParamsSource = Pick<
@@ -167,6 +171,7 @@ export class ChatAssistant {
   functions: ToolFunctions
   functionToolIdMap: Map<string, string>
   setupError: string | undefined
+  private forcedToolChoiceIndex = 0
 
   constructor(
     private providerConfig: ProviderConfig,
@@ -631,13 +636,34 @@ export class ChatAssistant {
         compressionApplied = plan.applied
       }
     }
-    const { tools: promptTools, functions: promptFunctions } = selectCompressionPromptCapabilities({
+    const forcedToolChoice =
+      this.assistantParams.toolChoiceSequence?.[this.forcedToolChoiceIndex] ??
+      (this.forcedToolChoiceIndex === 0 ? this.assistantParams.toolChoice : undefined)
+    let { tools: promptTools, functions: promptFunctions } = selectCompressionPromptCapabilities({
       tools: this.tools,
       functions: this.functions,
       functionToolIdMap: this.functionToolIdMap,
       compressionConfigured: compression !== null,
       compressionApplied,
     })
+    // A test/evaluation may require a specific first-step tool call even when the economic guard
+    // would otherwise omit context-retrieve from this particular prompt. Production assistants
+    // leave toolChoice unset, so this does not alter the normal compression policy.
+    if (
+      forcedToolChoice &&
+      typeof forcedToolChoice === 'object' &&
+      forcedToolChoice.type === 'tool'
+    ) {
+      const forcedFunction = this.functions[forcedToolChoice.toolName]
+      if (forcedFunction && !promptFunctions[forcedToolChoice.toolName]) {
+        promptFunctions = { ...promptFunctions, [forcedToolChoice.toolName]: forcedFunction }
+        const forcedToolId = this.functionToolIdMap.get(forcedToolChoice.toolName)
+        const forcedTool = this.tools.find((tool) => tool.toolParams.id === forcedToolId)
+        if (forcedTool && !promptTools.some((tool) => tool.toolParams.id === forcedToolId)) {
+          promptTools = [...promptTools, forcedTool]
+        }
+      }
+    }
     const truncatedChat = await this.truncateChat(promptMessages, historyCosts, promptTools)
 
     const preambleSegments = await buildPreambleSegments({
@@ -667,6 +693,7 @@ export class ChatAssistant {
     const llmMessages = [...preambleSegments, ...historySegments].map((s) => s.message)
     const tools = await this.createAiTools(promptFunctions)
     const providerOptions = this.providerOptions(llmMessages, promptTools)
+    const toolChoice = forcedToolChoice ? (this.forcedToolChoiceIndex++, forcedToolChoice) : 'auto'
     let maxOutputTokens = minOptional(this.llmModel.maxOutputTokens, env.chat.maxOutputTokens)
     if (maxOutputTokens && isAnthropic) {
       const anthropicProviderOptions = providerOptions?.anthropic as
@@ -685,7 +712,7 @@ export class ChatAssistant {
       tools: this.llmModelCapabilities.function_calling ? { ...tools } : undefined,
       toolChoice:
         this.llmModelCapabilities.function_calling && Object.keys(promptFunctions).length !== 0
-          ? 'auto'
+          ? toolChoice
           : undefined,
       temperature:
         modelSupportsReasoning(this.llmModel) || this.llmModelCapabilities.temperature === false
@@ -714,6 +741,9 @@ export class ChatAssistant {
   async processUserMessageWithSink(chatHistory: dto.Message[], clientSink: ClientSink) {
     const chatState = new ChatState(chatHistory)
     try {
+      // Evaluation probes may force a short tool-choice sequence. Once it is exhausted, resume the
+      // normal auto policy so the model can answer instead of calling the same tool forever.
+      this.forcedToolChoiceIndex = 0
       this.throwIfAborted()
       const userMessage = chatHistory[chatHistory.length - 1]
       if (userMessage.role === 'user-response') {

--- a/docs/evaluation-harness.md
+++ b/docs/evaluation-harness.md
@@ -258,6 +258,52 @@ OPENAI_API_KEY=... npx tsx apps/backend/scripts/eval-replay-production-chats.ts 
 Keep bundles, reviews, raw responses, decrypted files, and identifiers outside the repository.
 Publish only sanitized aggregates and reviewed failure labels.
 
+## Cheap LLM probes
+
+The repository also contains a small opt-in suite of source-grounded probes. These are not
+production replays: they use sanitized fixtures and a mocked knowledge search result, so they are
+cheap enough to run while changing prompts or retrieval behavior, and they never copy tenant data
+into the repository.
+
+```bash
+# Static coverage ledger only; live probes remain skipped.
+pnpm exec vitest run __tests__/llm-knowledge-probes.test.ts
+
+# Live probes, using the cheap first backend by default.
+pnpm run test:llm-probes
+
+# Optional model override.
+LLM_PROBE_MODEL=gpt-4.1-mini pnpm run test:llm-probes
+```
+
+The suite intentionally has two kinds of checks:
+
+- **Forced retrieval** fixes the first function name so that the test isolates the hard part after
+  retrieval: the model must use the returned evidence, preserve distinctions, abstain at a source
+  boundary, and avoid mixing conflicting document versions. It does not measure whether the model
+  decided to search.
+- **Unforced retrieval** leaves tool selection on `auto`. A source-dependent question must cause a
+  search, while a self-contained arithmetic question must not. These are the checks that expose a
+  retrieval-strategy failure.
+
+Each live probe checks the tool-call arguments as well as the answer. For example, the phone-book
+fixture contains Luca's number and a neighbouring contact's different number; the user asks for
+Luca, the search call must contain `Luca`, and the `answer-check.submit_answer` argument must
+contain only Luca's number.
+The search argument is the lookup key, not the phone number itself: the number must come from the
+retrieved source passage. The suite also checks the actual mocked search invocation and source
+evidence, so an answer that happens to guess correctly does not pass.
+
+The compression benchmark uses the same downstream-action oracle. Its recovery function is
+controlled only to isolate compression's source-to-answer path; the final `answer-check` argument
+must still be correct, and the recovery call must carry the exact compressed message or file id.
+The unforced probes are the place to measure whether a model independently decides to retrieve.
+
+These probes complement, rather than replace, production replay. Replay remains the authority for
+real retrieval-call rate, BM25/ingestion quality, compression savings, and tenant-specific
+failures. In particular, a no-call result on an eligible source-dependent production turn remains
+a failure; it must not be hidden by forcing a tool call in the probe suite.
+
 ## The flip test — measuring what an arm does when the answer is not there
 
 A success rate on answerable questions cannot tell a system that _covered_ the corpus from one that

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:providers:live": "tsx apps/backend/scripts/providers-live.ts",
     "test:providers:mock": "vitest run __tests__/providersMock.test.ts",
     "test:llm-integration": "RUN_LLM_INTEGRATION=1 vitest run __tests__/llm-integration.test.ts",
+    "test:llm-probes": "RUN_LLM_INTEGRATION=1 LLM_RETRIEVAL_PROBES=1 vitest run __tests__/llm-knowledge-probes.test.ts",
     "test:smoke": "tsx apps/backend/scripts/smoke.ts",
     "test:watch": "vitest",
     "test:cov": "vitest run --coverage",


### PR DESCRIPTION
## Summary

Adds opt-in, source-grounded LLM probes for the accepted context/knowledge corpus and makes compression recovery checks validate a downstream action argument rather than free-form text. The model must recover the source and pass the exact fact to `answer-check.submit_answer`.

## Details

- Tracks every accepted dataset case (`case-001` through `case-028`) in a sanitized behavioural coverage ledger.
- Adds unforced Knowledge Box probes for retrieval decisions, a negative arithmetic control, phone-record disambiguation, source/version boundaries, legal distinctions, and visual catalogue matching.
- Adds compression scenarios for generated content, attachments, multi-document coordination, and topic-shift translation.
- Compression scenarios use a short evaluation-only tool sequence to isolate source-to-answer correctness; the final argument is still model-generated and exact, while unforced probes measure autonomous retrieval choice.
- Sets the benchmark's mocked compression trigger explicitly so token-reduction assertions prove that compression actually ran.
- Keeps production bundles and raw outputs outside the repository.

## Tests

- `pnpm run test:llm-probes -- --reporter=verbose` — 8 passed (7 live OpenAI probes plus coverage ledger).
- `env -u ANTHROPIC_API_KEY -u GEMINI_API_KEY RUN_LLM_INTEGRATION=1 pnpm exec vitest run __tests__/contextCompressionBenchmark.test.ts -t openai --reporter=dot` — 4 passed; 16–34% history-token reduction.
- `pnpm run check-types` — passed.
- `pnpm exec vitest run __tests__/llm-knowledge-probes.test.ts apps/backend/lib/tools/knowledge_box/__tests__/implementation.test.ts apps/backend/lib/knowledge/__tests__/projections.test.ts apps/backend/lib/chat/__tests__/compression-planner.test.ts apps/backend/lib/chat/__tests__/compression-economics.test.ts --reporter=dot` — 92 passed, 7 skipped.
- `git diff --check` — passed.